### PR TITLE
Fix type2 shifted value

### DIFF
--- a/packages/curves/src/Snarky/Curves/Pasta.js
+++ b/packages/curves/src/Snarky/Curves/Pasta.js
@@ -62,7 +62,7 @@ export function _pallasFromBigInt(bigint) {
 }
 
 export function _pallasModulus() {
-    return napi.pallasScalarfieldModulus();
+    return BigInt(napi.pallasScalarfieldModulus());
 }
 
 export function _pallasToBigInt(x) {
@@ -204,7 +204,7 @@ export function _vestaScalarFieldPow(base) {
 }
 
 export function _vestaScalarFieldModulus() {
-    return napi.vestaScalarfieldModulus();
+    return BigInt(napi.vestaScalarfieldModulus());
 }
 
 export function _vestaScalarFieldFromHexLe(hex) {

--- a/packages/schnorr/src/Data/Schnorr.purs
+++ b/packages/schnorr/src/Data/Schnorr.purs
@@ -3,7 +3,7 @@
 -- | This module provides the pure (non-circuit) implementation of
 -- | Schnorr signatures over elliptic curves with Poseidon hash.
 -- |
--- | For Pasta curves, the base field and scalar field are different,
+-- | The base field and scalar field are different,
 -- | so this implementation uses separate type parameters for each:
 -- | - fb: base field (for coordinates and message hashing)
 -- | - fs: scalar field (for private keys and scalar s)
@@ -53,11 +53,9 @@ truncateFieldCoerce x =
 -- | Schnorr signature: (r, s) where:
 -- | - r is an x-coordinate (base field element)
 -- | - s is the scalar component (scalar field element)
--- |
--- | For Pasta curves: Signature PallasBaseField PallasScalarField
 newtype Signature fb fs = Signature
-  { r :: fb -- x-coordinate (base field)
-  , s :: fs -- scalar component (scalar field)
+  { r :: fb
+  , s :: fs
   }
 
 derive instance Newtype (Signature fb fs) _
@@ -66,16 +64,13 @@ derive newtype instance (Show fb, Show fs) => Show (Signature fb fs)
 derive newtype instance (Eq fb, Eq fs) => Eq (Signature fb fs)
 
 -- | Check if a field element is even (LSB is 0).
--- | In the Schnorr scheme, we use this to normalize the nonce.
 isEven :: forall f. PrimeField f => f -> Boolean
 isEven x = not $ BigInt.odd (toBigInt x)
 
 -- | Hash the message for signature verification.
 -- |
--- | e = H(pk_x, pk_y, r, H(message))
--- |
+-- | e = H(pk_x, pk_y, r, message)
 -- | where (pk_x, pk_y) is the public key and r is the signature's r component.
--- | All inputs and outputs are in the base field.
 hashMessage
   :: forall fb
    . PoseidonField fb
@@ -90,16 +85,16 @@ hashMessage { x: px, y: py } r message =
 -- |
 -- | Algorithm:
 -- | 1. Compute public key: pk = [d] * G
--- | 2. Derive nonce: k' = H(pk_x, pk_y, H(message)) truncated to 254 bits
+-- | 2. Derive nonce: k' = H(pk_x, pk_y, message) truncated to 254 bits
 -- | 3. Compute R = [k'] * G
 -- | 4. r = x-coordinate of R
 -- | 5. If y-coordinate of R is odd, k = -k', else k = k'
--- | 6. e = H(pk_x, pk_y, r, H(message)) (in base field, coerced to scalar)
+-- | 6. e = H(pk_x, pk_y, r, message) (in base field, coerced to scalar)
 -- | 7. s = k + e * d (in scalar field)
 -- | 8. Return (r, s)
 -- |
 -- | Note: The nonce is truncated to 254 bits to ensure it fits in both Pasta
--- | field primes without modular reduction, matching Mina's approach.
+-- | field primes without modular reduction.
 sign
   :: forall fb fs g
    . PoseidonField fb
@@ -113,42 +108,28 @@ sign
   -> Array fb
   -> Maybe (Signature fb fs)
 sign privateKey message = do
-  -- Compute public key: pk = d * G
   publicKey <- toAffine $ scalarMul privateKey (generator @_ @g)
-
-  -- Derive nonce deterministically using Poseidon hash (in base field)
-  -- k' = H(pk_x, pk_y, H(message))
   let
-    kPrimeBase :: fb
-    kPrimeBase = Poseidon.hash $ publicKey.x : publicKey.y : message
-
     -- Convert base field to scalar field via bit truncation (254 bits)
-    -- This ensures the value fits in both fields without modular reduction,
-    -- matching Mina's approach for nonce derivation.
-    kPrime :: fs
-    kPrime = truncateFieldCoerce kPrimeBase
+    -- This ensures the value fits in both fields without modular reduction.
+    kPrime =
+      let
+        kPrimeBase = Poseidon.hash $ publicKey.x : publicKey.y : message
+      in
+        truncateFieldCoerce kPrimeBase
 
-  -- Guard against zero nonce
   if kPrime == zero then Nothing
   else do
-    -- Compute R = k' * G
     { x: r, y: ry } <- toAffine $ scalarMul kPrime (generator @_ @g)
-
-    -- Normalize k based on y parity (BIP-340 style)
-    let k = if isEven ry then kPrime else negate kPrime
-
-    -- Compute challenge hash: e = H(pk_x, pk_y, r, H(message)) (in base field)
     let
-      eBase :: fb
-      eBase = hashMessage publicKey r message
+      k = if isEven ry then kPrime else negate kPrime
 
-      -- Convert to scalar field via BigInt for arithmetic
-      e :: fs
-      e = fromBigInt (toBigInt eBase)
-
-    -- Compute s = k + e * d (in scalar field)
-    let s = k + e * privateKey
-
+      e =
+        let
+          eBase = hashMessage publicKey r message
+        in
+          fromBigInt (toBigInt eBase)
+      s = k + e * privateKey
     pure $ Signature { r, s }
 
 -- | Verify a Schnorr signature.
@@ -170,19 +151,15 @@ verify
   -> Boolean
 verify (Signature { r, s }) publicKey message =
   let
-    -- Compute challenge hash: e = H(pk_x, pk_y, r, H(message)) (in base field)
-    eBase :: fb
-    eBase = hashMessage publicKey r message
+    e =
+      let
+        eBase = hashMessage publicKey r message
+      in
+        fromBigInt (toBigInt eBase)
 
-    -- Convert to scalar field via BigInt
-    e :: fs
-    e = fromBigInt (toBigInt eBase)
-
-    -- Reconstruct the public key point from affine coordinates
     pkPoint :: g
     pkPoint = fromAffine publicKey
 
-    -- Compute R' = s*G - e*pk = s*G + (-e)*pk
     sG = scalarMul s generator
     ePk = scalarMul e pkPoint
     rPoint = sG <> inverse ePk

--- a/packages/schnorr/test/Test/Snarky/Circuit/Schnorr.purs
+++ b/packages/schnorr/test/Test/Snarky/Circuit/Schnorr.purs
@@ -10,13 +10,12 @@ import Data.Identity (Identity)
 import Data.Maybe (Maybe(..), fromJust, isJust)
 import Data.Newtype (class Newtype, un)
 import Data.Reflectable (class Reflectable)
-import Data.Schnorr (safeFieldCoerce)
+import Data.Schnorr (truncateFieldCoerce)
 import Data.Schnorr as Schnorr
 import Data.Vector (Vector)
 import Data.Vector as Vector
 import Effect.Aff (Aff)
 import Effect.Class (liftEffect)
-import JS.BigInt (fromInt, shl)
 import Partial.Unsafe (unsafePartial)
 import Poseidon (class PoseidonField)
 import Poseidon as Poseidon
@@ -24,16 +23,16 @@ import Snarky.Backend.Compile (compilePure, makeSolver)
 import Snarky.Backend.Kimchi.Class (class CircuitGateConstructor)
 import Snarky.Circuit.CVar (const_)
 import Snarky.Circuit.DSL (class CircuitM, BoolVar, FVar, Snarky)
-import Snarky.Circuit.DSL.Bits (packPure, unpackPure)
 import Snarky.Circuit.Kimchi.Utils (verifyCircuit)
 import Snarky.Circuit.Schnorr (SignatureVar(..), verifies)
 import Snarky.Circuit.Types (class CircuitType, F(..), genericFieldsToValue, genericFieldsToVar, genericSizeInFields, genericValueToFields, genericVarToFields)
 import Snarky.Constraint.Kimchi (class KimchiVerify, KimchiConstraint)
 import Snarky.Constraint.Kimchi as Kimchi
-import Snarky.Curves.Class (class FieldSizeInBits, class FrModule, class PrimeField, class WeierstrassCurve, fromAffine, fromBigInt, generator, inverse, scalarMul, toAffine, toBigInt)
+import Snarky.Curves.Class (class FieldSizeInBits, class FrModule, class PrimeField, class WeierstrassCurve, fromAffine, generator, inverse, scalarMul, toAffine)
 import Snarky.Curves.Pallas as Pallas
 import Snarky.Curves.Vesta as Vesta
 import Snarky.Data.EllipticCurve (AffinePoint)
+import Snarky.Types.Shifted (class Shifted, Type2, fromShifted, splitField, toShifted)
 import Test.QuickCheck (arbitrary)
 import Test.QuickCheck.Gen (Gen, suchThat)
 import Test.Snarky.Circuit.Utils (circuitSpecPure', satisfied)
@@ -42,42 +41,29 @@ import Type.Proxy (Proxy(..))
 
 --------------------------------------------------------------------------------
 -- | Input type for Schnorr verification circuit
--- | All values are in the circuit field f (base field of curve g)
-newtype VerifyInput n a = VerifyInput
+-- | sigR is the x-coordinate of R (circuit field element)
+-- | sigS is the signature s component as Type2 (scalar field element in circuit representation)
+-- | publicKey and message are in the circuit field
+newtype VerifyInput n a b = VerifyInput
   { sigR :: a
-  , sigS :: a
+  , sigS :: Type2 a b
   , publicKey :: AffinePoint a
   , message :: Vector n a
   }
 
-derive instance Newtype (VerifyInput n a) _
-derive instance Generic (VerifyInput n a) _
+derive instance Newtype (VerifyInput n a b) _
+derive instance Generic (VerifyInput n a b) _
 
-instance Reflectable n Int => CircuitType f (VerifyInput n (F f)) (VerifyInput n (FVar f)) where
+instance (Reflectable n Int, PrimeField f) => CircuitType f (VerifyInput n (F f) Boolean) (VerifyInput n (FVar f) (BoolVar f)) where
   valueToFields = genericValueToFields
   fieldsToValue = genericFieldsToValue
   sizeInFields = genericSizeInFields
-  varToFields = genericVarToFields @(VerifyInput n (F f))
-  fieldsToVar = genericFieldsToVar @(VerifyInput n (F f))
-
---------------------------------------------------------------------------------
--- | Convert between fields via bit representation (preserves integer value)
-coerceViaBits :: forall f f'. PrimeField f => PrimeField f' => FieldSizeInBits f 255 => FieldSizeInBits f' 255 => f -> f'
-coerceViaBits = packPure <<< unpackPure
-
--- | Apply the shift transformation used by scaleFast2 in the circuit.
--- | When the circuit computes [s]*G using scaleFast2, it internally shifts the value.
--- | The pure scalarMul needs the same shift to produce matching results.
-fieldShift2 :: forall f f'. FieldSizeInBits f 255 => FieldSizeInBits f' 255 => PrimeField f' => f -> f'
-fieldShift2 t =
-  let
-    twoToThe255 = fromBigInt $ one `shl` fromInt 255
-  in
-    coerceViaBits t + twoToThe255
+  varToFields = genericVarToFields @(VerifyInput n (F f) Boolean)
+  fieldsToVar = genericFieldsToVar @(VerifyInput n (F f) Boolean)
 
 --------------------------------------------------------------------------------
 -- | Generate a valid signature for testing using the library's sign function.
--- | Returns VerifyInput with all values in the circuit field (base field).
+-- | Returns VerifyInput with sigS as Type2 (proper scalar field representation).
 -- | f = base field of curve g (circuit field)
 -- | f' = scalar field of curve g
 genValidSignature
@@ -90,9 +76,10 @@ genValidSignature
   => PrimeField f
   => FieldSizeInBits f 255
   => FieldSizeInBits f' 255
+  => Shifted (F f') (Type2 (F f) Boolean)
   => Proxy g
   -> Proxy n
-  -> Gen (VerifyInput n (F f))
+  -> Gen (VerifyInput n (F f) Boolean)
 genValidSignature pg pn = do
   -- Generate random private key (in scalar field f')
   privateKey <- arbitrary @f' `suchThat` \sk ->
@@ -110,7 +97,7 @@ genValidSignature pg pn = do
     kPrimeBase = Poseidon.hash $ publicKey.x : publicKey.y : Vector.toUnfoldable message
 
     kPrime :: f'
-    kPrime = safeFieldCoerce kPrimeBase
+    kPrime = truncateFieldCoerce kPrimeBase
 
   if kPrime == zero then
     genValidSignature pg pn
@@ -123,18 +110,18 @@ genValidSignature pg pn = do
           eBase = Poseidon.hash $ publicKey.x : publicKey.y : r : Vector.toUnfoldable message
 
           e :: f'
-          e = fromBigInt (toBigInt eBase)
+          e = truncateFieldCoerce eBase
 
           s :: f'
           s = k + e * privateKey
 
-          -- Convert s from scalar field to base field via bits
-          sInBaseField :: f
-          sInBaseField = coerceViaBits s
+          -- Convert s to Type2 representation using toShifted
+          sigS :: Type2 (F f) Boolean
+          sigS = toShifted (F s)
 
         pure $ VerifyInput
           { sigR: F r
-          , sigS: F sInBaseField
+          , sigS
           , publicKey: { x: F publicKey.x, y: F publicKey.y }
           , message: map F message
           }
@@ -153,6 +140,7 @@ verifySpec
   => PrimeField f'
   => FieldSizeInBits f 255
   => FieldSizeInBits f' 255
+  => Shifted (F f') (Type2 (F f) Boolean)
   => Proxy f
   -> Proxy g
   -> Proxy k
@@ -174,22 +162,22 @@ verifySpec _ pg _pk = do
     -- | used by scaleFast2 for scalar multiplication.
     -- | f = base field of curve g (circuit field)
     -- | f' = scalar field of curve g
-    testFunction :: VerifyInput k (F f) -> Boolean
-    testFunction (VerifyInput { sigR: F r, sigS: F sInBaseField, publicKey: pk, message }) =
+    testFunction :: VerifyInput k (F f) Boolean -> Boolean
+    testFunction (VerifyInput { sigR: F r, sigS, publicKey: pk, message }) =
       let
         publicKey = { x: case pk.x of F x -> x, y: case pk.y of F y -> y }
 
-        -- Apply fieldShift2 to match scaleFast2's internal transformation
-        -- The circuit uses scaleFast2 which shifts the scalar by 2^255
+        -- Get effective scalar from Type2 using fromShifted
         s :: f'
-        s = fieldShift2 sInBaseField
+        s = case fromShifted sigS of F x -> x
 
         -- Compute e = H(pk_x, pk_y, r, msgHash)
         eBase = Poseidon.hash $ publicKey.x : publicKey.y : r : (un F <$> Vector.toUnfoldable message)
 
-        -- Apply fieldShift2 to e as well (circuit uses scaleFast2 for e*pk too)
+        -- e is a circuit field hash, split to Type2 and get effective scalar via Shifted
+        -- This mirrors what the circuit does with splitFieldVar
         e :: f'
-        e = fieldShift2 eBase
+        e = case fromShifted (splitField (F eBase)) of F x -> x
 
         -- Compute R' = s*G - e*pk (using shifted values for scalarMul)
         pkPoint = fromAffine @f @g publicKey
@@ -205,7 +193,7 @@ verifySpec _ pg _pk = do
     circuit
       :: forall t
        . CircuitM f (KimchiConstraint f) t Identity
-      => VerifyInput k (FVar f)
+      => VerifyInput k (FVar f) (BoolVar f)
       -> Snarky (KimchiConstraint f) t Identity (BoolVar f)
     circuit (VerifyInput { sigR, sigS, publicKey, message }) =
       let
@@ -215,7 +203,7 @@ verifySpec _ pg _pk = do
 
     solver = makeSolver (Proxy @(KimchiConstraint f)) circuit
     st = compilePure
-      (Proxy @(VerifyInput k (F f)))
+      (Proxy @(VerifyInput k (F f) Boolean))
       (Proxy @Boolean)
       (Proxy @(KimchiConstraint f))
       circuit
@@ -235,13 +223,10 @@ verifySpec _ pg _pk = do
 
 --------------------------------------------------------------------------------
 -- | Test spec
--- | For Pallas curve: base field = VestaScalarField, scalar field = PallasScalarField
--- | For Vesta curve: base field = PallasScalarField, scalar field = VestaScalarField
+-- | Uses Vesta curve where scalar field (Pallas.BaseField) > circuit field (Vesta.BaseField)
+-- | This is the foreign field case that scaleFast2 is designed for.
 spec :: Spec Unit
 spec = describe "Snarky.Circuit.Schnorr" do
   describe "verifies" do
-    it "Pallas curve verification circuit matches pure implementation" do
-      verifySpec (Proxy @Vesta.ScalarField) (Proxy @Pallas.G) (Proxy @4)
-
     it "Vesta curve verification circuit matches pure implementation" do
       verifySpec (Proxy @Pallas.ScalarField) (Proxy @Vesta.G) (Proxy @5)

--- a/packages/snarky-kimchi/src/Snarky/Types/Shifted.purs
+++ b/packages/snarky-kimchi/src/Snarky/Types/Shifted.purs
@@ -4,19 +4,25 @@ module Snarky.Types.Shifted
   , class Shifted
   , fromShifted
   , toShifted
+  , joinField
   ) where
 
 import Prelude
 
 import Data.Generic.Rep (class Generic)
-import Data.Reflectable (reflectType)
 import Data.Show.Generic (genericShow)
 import JS.BigInt (fromInt)
-import Snarky.Circuit.Types (class CircuitType, F(..), FVar, genericFieldsToValue, genericFieldsToVar, genericSizeInFields, genericValueToFields, genericVarToFields)
-import Snarky.Curves.Class (class FieldSizeInBits, class PrimeField, fromBigInt, pow)
+import JS.BigInt as BigInt
+import Snarky.Circuit.Types (class CheckedType, class CircuitType, BoolVar, F(..), FVar, genericCheck, genericFieldsToValue, genericFieldsToVar, genericSizeInFields, genericValueToFields, genericVarToFields)
+import Snarky.Constraint.Basic (class BasicSystem)
+import Snarky.Curves.Class (class PrimeField, fromBigInt, pow, toBigInt)
 import Snarky.Curves.Pallas as Pallas
 import Snarky.Curves.Vesta as Vesta
-import Type.Proxy (Proxy(..))
+
+--------------------------------------------------------------------------------
+-- Type1: Single field element with shift 2^n + 1
+-- Used when the scalar field is smaller than or equal to the circuit field
+--------------------------------------------------------------------------------
 
 newtype Type1 f = Type1 f
 
@@ -34,58 +40,134 @@ instance CircuitType f (Type1 (F f)) (Type1 (FVar f)) where
   varToFields = genericVarToFields @(Type1 (F f))
   fieldsToVar = genericFieldsToVar @(Type1 (F f))
 
-shift1 :: forall f. PrimeField f => Int -> { c :: f, scale :: f }
-shift1 fieldSizeInBits =
-  { c: fromBigInt (fromInt 2) `pow` (fromInt fieldSizeInBits) + one
+-- | Shift constants for Type1: c = 2^255 + 1, scale = 1/2
+shift1 :: forall f. PrimeField f => { c :: f, scale :: f }
+shift1 =
+  { c: fromBigInt (fromInt 2) `pow` (fromInt 255) + one
   , scale: recip (fromBigInt $ fromInt 2)
   }
 
-newtype Type2 f = Type2 f
+--------------------------------------------------------------------------------
+-- Shifted class: Unified interface for Type1 and Type2 shifted representations
+--
+-- Maps between scalar field values and their shifted circuit representations.
+-- The functional dependencies ensure:
+--   f -> sf: Each scalar field has exactly one shifted representation type
+--   sf -> f: Each shifted type corresponds to exactly one scalar field
+--
+-- For Pallas circuit (circuit field = Pallas.BaseField):
+--   - Scalar field: Pallas.ScalarField (= Vesta.BaseField), smaller
+--   - Uses Type1 with shift transformation
+--
+-- For Vesta circuit (circuit field = Vesta.BaseField):
+--   - Scalar field: Vesta.ScalarField (= Pallas.BaseField), larger
+--   - Uses Type2 with split representation
+--------------------------------------------------------------------------------
 
-derive instance Functor Type2
-derive instance Eq f => Eq (Type2 f)
-derive instance Generic (Type2 f) _
+class Shifted f sf | f -> sf, sf -> f where
+  toShifted :: f -> sf
+  fromShifted :: sf -> f
 
-instance Show f => Show (Type2 f) where
-  show x = genericShow x
-
-instance CircuitType f (Type2 (F f)) (Type2 (FVar f)) where
-  valueToFields = genericValueToFields
-  fieldsToValue = genericFieldsToValue
-  sizeInFields = genericSizeInFields
-  varToFields = genericVarToFields @(Type2 (F f))
-  fieldsToVar = genericFieldsToVar @(Type2 (F f))
-
-shift2 :: forall f. PrimeField f => Int -> { shift :: f }
-shift2 fieldSizeInBits =
-  { shift: (fromBigInt $ fromInt 2) `pow` (fromInt fieldSizeInBits) }
-
-class Shifted (t :: Type -> Type) f where
-  toShifted :: F f -> t (F f)
-  fromShifted :: t (F f) -> F f
-
-instance FieldSizeInBits Vesta.ScalarField n => Shifted Type1 Vesta.ScalarField where
+-- | Type1 instance for Pallas circuit
+-- | Scalar field: Pallas.ScalarField (= Vesta.BaseField)
+-- | Circuit field: Pallas.BaseField
+-- | Shift: t = (s - c) * scale, effective scalar = 2*t + 2^255 + 1
+instance Shifted (F Pallas.ScalarField) (Type1 (F Pallas.BaseField)) where
   toShifted (F s) =
     let
-      shift = shift1 (reflectType $ Proxy @n)
+      { c, scale } = shift1 :: { c :: Pallas.BaseField, scale :: Pallas.BaseField }
+
+      -- Coerce from smaller (ScalarField) to larger (BaseField)
+      sLarge :: Pallas.BaseField
+      sLarge = fromBigInt (toBigInt s)
     in
-      Type1 $ F $ (s - shift.c) * shift.scale
+      Type1 $ F $ (sLarge - c) * scale
 
   fromShifted (Type1 (F t)) =
     let
-      shift = shift1 (reflectType $ Proxy @n)
+      -- Coerce t to smaller field, then do arithmetic there
+      tSmall :: Pallas.ScalarField
+      tSmall = fromBigInt (toBigInt t)
+      { c, scale } = shift1 :: { c :: Pallas.ScalarField, scale :: Pallas.ScalarField }
     in
-      F $ recip shift.scale * t + shift.c
+      F $ recip scale * tSmall + c
 
-instance FieldSizeInBits Pallas.ScalarField n => Shifted Type2 Pallas.ScalarField where
+-- | Type2 instance for Vesta circuit
+-- | Scalar field: Vesta.ScalarField (= Pallas.BaseField)
+-- | Circuit field: Vesta.BaseField
+-- | Split: s = 2*sDiv2 + sOdd, effective scalar = s + 2^255
+instance Shifted (F Vesta.ScalarField) (Type2 (F Vesta.BaseField) Boolean) where
   toShifted (F s) =
     let
-      { shift } = shift2 (reflectType $ Proxy @n)
-    in
-      Type2 $ F $ (s - shift)
+      { sDiv2, sOdd } = splitField s
 
-  fromShifted (Type2 (F t)) =
-    let
-      { shift } = shift2 (reflectType $ Proxy @n)
+      -- sDiv2 is 254 bits, safe to coerce to smaller field
+      sDiv2Small :: Vesta.BaseField
+      sDiv2Small = fromBigInt (toBigInt sDiv2)
     in
-      F $ t + shift
+      Type2 { sDiv2: F sDiv2Small, sOdd }
+
+  fromShifted (Type2 { sDiv2: F d, sOdd }) =
+    let
+      -- Coerce sDiv2 to larger field FIRST, then do arithmetic there
+      dLarge :: Vesta.ScalarField
+      dLarge = fromBigInt (toBigInt d)
+      -- Reconstruct original value in larger field
+      sLarge = joinField { sDiv2: dLarge, sOdd }
+
+      -- Effective scalar includes the 2^255 shift (computed in larger field)
+      twoToThe255 :: Vesta.ScalarField
+      twoToThe255 = fromBigInt (fromInt 2) `pow` fromInt 255
+      effectiveScalar = sLarge + twoToThe255
+    in
+      F effectiveScalar
+
+--------------------------------------------------------------------------------
+-- Type2: Split representation (sDiv2, sOdd) where s = 2 * sDiv2 + sOdd
+-- Used when the scalar field is larger than the circuit field (foreign field)
+--
+-- When computing [s]*G where s is from the larger field:
+--   1. Split s into (sDiv2, sOdd) where s = 2*sDiv2 + sOdd
+--   2. sDiv2 fits in 254 bits (one less than field size)
+--   3. sOdd is a single bit (0 or 1)
+--   4. scaleFast2 computes [s]*G = sOdd ? h : (h - G) where h = [2*sDiv2 + 1 + 2^n]*G
+--------------------------------------------------------------------------------
+
+-- | Type2 represents a scalar split into (sDiv2, sOdd) where s = 2*sDiv2 + sOdd
+-- | f = field element type, b = boolean type
+newtype Type2 f b = Type2 { sDiv2 :: f, sOdd :: b }
+
+derive instance (Eq f, Eq b) => Eq (Type2 f b)
+derive instance Generic (Type2 f b) _
+
+instance (Show f, Show b) => Show (Type2 f b) where
+  show x = genericShow x
+
+instance PrimeField f => CircuitType f (Type2 (F f) Boolean) (Type2 (FVar f) (BoolVar f)) where
+  valueToFields = genericValueToFields
+  fieldsToValue = genericFieldsToValue
+  sizeInFields = genericSizeInFields
+  varToFields = genericVarToFields @(Type2 (F f) Boolean)
+  fieldsToVar = genericFieldsToVar @(Type2 (F f) Boolean)
+
+instance BasicSystem f c => CheckedType (Type2 (FVar f) (BoolVar f)) c where
+  check = genericCheck
+
+-- | Split a field element into (sDiv2, sOdd) where s = 2*sDiv2 + sOdd
+-- | This is a pure operation on field values
+splitField :: forall f. PrimeField f => f -> { sDiv2 :: f, sOdd :: Boolean }
+splitField s =
+  let
+    sBigInt = toBigInt s
+    sOdd = BigInt.odd sBigInt
+    sDiv2 = (if sOdd then s - one else s) / fromBigInt (fromInt 2)
+  in
+    { sDiv2, sOdd }
+
+-- | Join (sDiv2, sOdd) back into a field element: s = 2*sDiv2 + sOdd
+joinField :: forall f. PrimeField f => { sDiv2 :: f, sOdd :: Boolean } -> f
+joinField { sDiv2, sOdd } =
+  let
+    two = fromBigInt (fromInt 2)
+  in
+    two * sDiv2 + (if sOdd then one else zero)

--- a/packages/snarky-kimchi/src/Snarky/Types/Shifted.purs
+++ b/packages/snarky-kimchi/src/Snarky/Types/Shifted.purs
@@ -6,23 +6,27 @@ module Snarky.Types.Shifted
   , toShifted
   , splitField
   , joinField
+  , fieldSizeBits
   ) where
 
 import Prelude
 
+import Data.Bifunctor (class Bifunctor)
 import Data.Generic.Rep (class Generic)
+import Data.Reflectable (reflectType)
 import Data.Show.Generic (genericShow)
 import JS.BigInt (fromInt)
 import JS.BigInt as BigInt
 import Snarky.Circuit.Types (class CheckedType, class CircuitType, BoolVar, F(..), FVar, genericCheck, genericFieldsToValue, genericFieldsToVar, genericSizeInFields, genericValueToFields, genericVarToFields)
 import Snarky.Constraint.Basic (class BasicSystem)
-import Snarky.Curves.Class (class PrimeField, fromBigInt, pow, toBigInt)
+import Snarky.Curves.Class (class FieldSizeInBits, class PrimeField, fromBigInt, pow, toBigInt)
 import Snarky.Curves.Pallas as Pallas
 import Snarky.Curves.Vesta as Vesta
+import Type.Proxy (Proxy(..))
 
 --------------------------------------------------------------------------------
--- Type1: Single field element with shift 2^n + 1
--- Used when the scalar field is smaller than or equal to the circuit field
+-- Type1: Single field element with shift 2^n + 1 (n = field size in bits)
+-- Used when scalar field < circuit field
 --------------------------------------------------------------------------------
 
 newtype Type1 f = Type1 f
@@ -41,103 +45,57 @@ instance CircuitType f (Type1 (F f)) (Type1 (FVar f)) where
   varToFields = genericVarToFields @(Type1 (F f))
   fieldsToVar = genericFieldsToVar @(Type1 (F f))
 
--- | Shift constants for Type1: c = 2^255 + 1, scale = 1/2
-shift1 :: forall f. PrimeField f => { c :: f, scale :: f }
-shift1 =
-  { c: fromBigInt (fromInt 2) `pow` (fromInt 255) + one
-  , scale: recip (fromBigInt $ fromInt 2)
-  }
+fieldSizeBits :: forall f n. FieldSizeInBits f n => Proxy f -> Int
+fieldSizeBits _ = reflectType (Proxy :: Proxy n)
 
---------------------------------------------------------------------------------
--- Shifted class: Unified interface for Type1 and Type2 shifted representations
---
--- Maps between scalar field values and their shifted circuit representations.
--- The functional dependencies ensure:
---   f -> sf: Each scalar field has exactly one shifted representation type
---   sf -> f: Each shifted type corresponds to exactly one scalar field
---
--- For Pallas circuit (circuit field = Pallas.BaseField):
---   - Scalar field: Pallas.ScalarField (= Vesta.BaseField), smaller
---   - Uses Type1 with shift transformation
---
--- For Vesta circuit (circuit field = Vesta.BaseField):
---   - Scalar field: Vesta.ScalarField (= Pallas.BaseField), larger
---   - Uses Type2 with split representation
---------------------------------------------------------------------------------
+shift1 :: forall f n. FieldSizeInBits f n => Proxy f -> { c :: f, scale :: f }
+shift1 _ =
+  let
+    n = reflectType (Proxy :: Proxy n)
+  in
+    { c: fromBigInt (fromInt 2) `pow` (fromInt n) + one
+    , scale: recip (fromBigInt $ fromInt 2)
+    }
 
-class Shifted f sf | f -> sf, sf -> f where
-  toShifted :: f -> sf
-  fromShifted :: sf -> f
+toShifted1 :: forall f n. FieldSizeInBits f n => Proxy f -> F f -> Type1 (F f)
+toShifted1 p (F s) =
+  let
+    { c, scale } = shift1 p
+  in
+    Type1 $ F $ (s - c) * scale
 
--- | Type1 instance for Pallas circuit
--- | Scalar field: Pallas.ScalarField (= Vesta.BaseField)
--- | Circuit field: Pallas.BaseField
--- | Shift: t = (s - c) * scale, effective scalar = 2*t + 2^255 + 1
-instance Shifted (F Pallas.ScalarField) (Type1 (F Pallas.BaseField)) where
-  toShifted (F s) =
-    let
-      { c, scale } = shift1 :: { c :: Pallas.BaseField, scale :: Pallas.BaseField }
+fromShifted1 :: forall f n. FieldSizeInBits f n => Proxy f -> Type1 (F f) -> F f
+fromShifted1 p (Type1 (F t)) =
+  let
+    { c, scale } = shift1 p
+  in
+    F $ recip scale * t + c
 
-      -- Coerce from smaller (ScalarField) to larger (BaseField)
-      sLarge :: Pallas.BaseField
-      sLarge = fromBigInt (toBigInt s)
-    in
-      Type1 $ F $ (sLarge - c) * scale
+toShifted2 :: forall f n. FieldSizeInBits f n => Proxy f -> F f -> Type2 (F f) Boolean
+toShifted2 _ (F s) =
+  let
+    sBigInt = toBigInt s
+    sOdd = BigInt.odd sBigInt
+    sDiv2 = (if sOdd then s - one else s) / fromBigInt (fromInt 2)
+  in
+    Type2 { sDiv2: F sDiv2, sOdd }
 
-  fromShifted (Type1 (F t)) =
-    let
-      -- Coerce t to smaller field, then do arithmetic there
-      tSmall :: Pallas.ScalarField
-      tSmall = fromBigInt (toBigInt t)
-      { c, scale } = shift1 :: { c :: Pallas.ScalarField, scale :: Pallas.ScalarField }
-    in
-      F $ recip scale * tSmall + c
-
--- | Type2 instance for Vesta circuit
--- | Scalar field: Vesta.ScalarField (= Pallas.BaseField)
--- | Circuit field: Vesta.BaseField
--- | Split: s = 2*sDiv2 + sOdd, effective scalar = s + 2^255
-instance Shifted (F Vesta.ScalarField) (Type2 (F Vesta.BaseField) Boolean) where
-  toShifted (F s) =
-    let
-      sBigInt = toBigInt s
-      sOdd = BigInt.odd sBigInt
-      sDiv2 = (if sOdd then s - one else s) / fromBigInt (fromInt 2)
-
-      -- sDiv2 is 254 bits, safe to coerce to smaller field
-      sDiv2Small :: Vesta.BaseField
-      sDiv2Small = fromBigInt (toBigInt sDiv2)
-    in
-      Type2 { sDiv2: F sDiv2Small, sOdd }
-
-  fromShifted (Type2 { sDiv2: F d, sOdd }) =
-    let
-      -- Coerce sDiv2 to larger field FIRST, then do arithmetic there
-      dLarge :: Vesta.ScalarField
-      dLarge = fromBigInt (toBigInt d)
-      -- Reconstruct original value in larger field
-      sLarge = joinField { sDiv2: dLarge, sOdd }
-
-      -- Effective scalar includes the 2^255 shift (computed in larger field)
-      twoToThe255 :: Vesta.ScalarField
-      twoToThe255 = fromBigInt (fromInt 2) `pow` fromInt 255
-      effectiveScalar = sLarge + twoToThe255
-    in
-      F effectiveScalar
+fromShifted2 :: forall f n. FieldSizeInBits f n => Proxy f -> Type2 (F f) Boolean -> F f
+fromShifted2 _ (Type2 { sDiv2: F d, sOdd }) =
+  let
+    n = fieldSizeBits (Proxy :: Proxy f)
+    dBigInt = toBigInt d
+    sBigInt = BigInt.fromInt 2 * dBigInt + (if sOdd then BigInt.fromInt 1 else BigInt.fromInt 0)
+    twoToN = BigInt.pow (BigInt.fromInt 2) (BigInt.fromInt n)
+    effectiveScalar = sBigInt + twoToN
+  in
+    F $ fromBigInt effectiveScalar
 
 --------------------------------------------------------------------------------
 -- Type2: Split representation (sDiv2, sOdd) where s = 2 * sDiv2 + sOdd
--- Used when the scalar field is larger than the circuit field (foreign field)
---
--- When computing [s]*G where s is from the larger field:
---   1. Split s into (sDiv2, sOdd) where s = 2*sDiv2 + sOdd
---   2. sDiv2 fits in 254 bits (one less than field size)
---   3. sOdd is a single bit (0 or 1)
---   4. scaleFast2 computes [s]*G = sOdd ? h : (h - G) where h = [2*sDiv2 + 1 + 2^n]*G
+-- Used when scalar field > circuit field
 --------------------------------------------------------------------------------
 
--- | Type2 represents a scalar split into (sDiv2, sOdd) where s = 2*sDiv2 + sOdd
--- | f = field element type, b = boolean type
 newtype Type2 f b = Type2 { sDiv2 :: f, sOdd :: b }
 
 derive instance (Eq f, Eq b) => Eq (Type2 f b)
@@ -156,9 +114,100 @@ instance PrimeField f => CircuitType f (Type2 (F f) Boolean) (Type2 (FVar f) (Bo
 instance BasicSystem f c => CheckedType (Type2 (FVar f) (BoolVar f)) c where
   check = genericCheck
 
--- | Split a field element into Type2 representation where s = 2*sDiv2 + sOdd
--- | This is used when you have a circuit field value (e.g., a hash output)
--- | and need to compute the effective scalar for scaleFast2.
+instance Bifunctor Type2 where
+  bimap f g (Type2 x) = Type2 { sDiv2: f x.sDiv2, sOdd: g x.sOdd }
+
+--------------------------------------------------------------------------------
+-- Shifted class
+--
+-- Type1: t = (s - 2^n - 1) / 2, so s = 2*t + 2^n + 1
+-- Type2: s split into (sDiv2, sOdd) where s = 2*sDiv2 + sOdd + 2^n
+--------------------------------------------------------------------------------
+
+class Shifted f sf where
+  toShifted :: f -> sf
+  fromShifted :: sf -> f
+
+-- Type1 instances
+
+instance Shifted (F Vesta.ScalarField) (Type1 (F Vesta.ScalarField)) where
+  toShifted = toShifted1 (Proxy :: Proxy Vesta.ScalarField)
+  fromShifted = fromShifted1 (Proxy :: Proxy Vesta.ScalarField)
+
+instance Shifted (F Vesta.BaseField) (Type1 (F Vesta.BaseField)) where
+  toShifted = toShifted1 (Proxy :: Proxy Vesta.BaseField)
+  fromShifted = fromShifted1 (Proxy :: Proxy Vesta.BaseField)
+
+instance Shifted (F Vesta.ScalarField) (Type1 (F Vesta.BaseField)) where
+  toShifted (F s) =
+    let
+      { c, scale } = shift1 (Proxy :: Proxy Vesta.ScalarField)
+
+      t_scalar :: Vesta.ScalarField
+      t_scalar = (s - c) * scale
+    in
+      Type1 $ F $ fromBigInt (toBigInt t_scalar)
+  fromShifted (Type1 (F t)) =
+    let
+      n = fieldSizeBits (Proxy :: Proxy Vesta.BaseField)
+      tBigInt = toBigInt t
+      twoToN = BigInt.pow (BigInt.fromInt 2) (BigInt.fromInt n)
+    in
+      F $ fromBigInt (BigInt.fromInt 2 * tBigInt + twoToN + BigInt.fromInt 1)
+
+-- Type2 instances
+
+instance Shifted (F Vesta.ScalarField) (Type2 (F Vesta.ScalarField) Boolean) where
+  toShifted = toShifted2 (Proxy :: Proxy Vesta.ScalarField)
+  fromShifted = fromShifted2 (Proxy :: Proxy Vesta.ScalarField)
+
+instance Shifted (F Vesta.BaseField) (Type2 (F Vesta.BaseField) Boolean) where
+  toShifted = toShifted2 (Proxy :: Proxy Vesta.BaseField)
+  fromShifted = fromShifted2 (Proxy :: Proxy Vesta.BaseField)
+
+-- Cross-field Type2: scalar field → Type2 in circuit field (via BigInt)
+instance Shifted (F Pallas.ScalarField) (Type2 (F Pallas.BaseField) Boolean) where
+  toShifted (F s) =
+    let
+      sBigInt = toBigInt s
+      sOdd = BigInt.odd sBigInt
+
+      sDiv2 :: Pallas.BaseField
+      sDiv2 = fromBigInt $ (sBigInt - (if sOdd then BigInt.fromInt 1 else BigInt.fromInt 0)) / BigInt.fromInt 2
+    in
+      Type2 { sDiv2: F sDiv2, sOdd }
+  fromShifted (Type2 { sDiv2: F d, sOdd }) =
+    let
+      n = fieldSizeBits (Proxy :: Proxy Pallas.BaseField)
+      dBigInt = toBigInt d
+      sBigInt = BigInt.fromInt 2 * dBigInt + (if sOdd then BigInt.fromInt 1 else BigInt.fromInt 0)
+      twoToN = BigInt.pow (BigInt.fromInt 2) (BigInt.fromInt n)
+    in
+      F $ fromBigInt (sBigInt + twoToN)
+
+instance Shifted (F Vesta.ScalarField) (Type2 (F Vesta.BaseField) Boolean) where
+  toShifted (F s) =
+    let
+      sBigInt = toBigInt s
+      sOdd = BigInt.odd sBigInt
+
+      sDiv2 :: Vesta.BaseField
+      sDiv2 = fromBigInt $ (sBigInt - (if sOdd then BigInt.fromInt 1 else BigInt.fromInt 0)) / BigInt.fromInt 2
+    in
+      Type2 { sDiv2: F sDiv2, sOdd }
+  fromShifted (Type2 { sDiv2: F d, sOdd }) =
+    let
+      n = fieldSizeBits (Proxy :: Proxy Vesta.BaseField)
+      dBigInt = toBigInt d
+      sBigInt = BigInt.fromInt 2 * dBigInt + (if sOdd then BigInt.fromInt 1 else BigInt.fromInt 0)
+      twoToN = BigInt.pow (BigInt.fromInt 2) (BigInt.fromInt n)
+    in
+      F $ fromBigInt (sBigInt + twoToN)
+
+--------------------------------------------------------------------------------
+-- Utility functions
+--------------------------------------------------------------------------------
+
 splitField :: forall f. PrimeField f => F f -> Type2 (F f) Boolean
 splitField (F s) =
   let
@@ -168,7 +217,6 @@ splitField (F s) =
   in
     Type2 { sDiv2: F sDiv2, sOdd }
 
--- | Join (sDiv2, sOdd) back into a field element: s = 2*sDiv2 + sOdd
 joinField :: forall f. PrimeField f => { sDiv2 :: f, sOdd :: Boolean } -> f
 joinField { sDiv2, sOdd } =
   let

--- a/packages/snarky-kimchi/test/Test/Snarky/Circuit/Kimchi/EndoMul.purs
+++ b/packages/snarky-kimchi/test/Test/Snarky/Circuit/Kimchi/EndoMul.purs
@@ -50,7 +50,7 @@ endoSpec _ curveProxy curveName =
         f (Tuple { x: F x, y: F y } (F scalar)) =
           let
             base = fromAffine @f @g { x, y }
-            result = scalarMul (shift scalar) base
+            result = scalarMul (safeFieldCoerce scalar) base
             { x, y } = unsafePartial $ fromJust $ toAffine @f result
           in
             { x: F x, y: F y }
@@ -92,7 +92,8 @@ endoSpec _ curveProxy curveName =
 
       liftEffect $ verifyCircuit { s, gen, solver }
   where
-  shift f = toFieldConstant (coerceViaBits f) (endoScalar)
+  -- This works because the input has only 128 bits
+  safeFieldCoerce f = toFieldConstant (coerceViaBits f) (endoScalar)
 
     where
     coerceViaBits :: f -> f'

--- a/packages/snarky-kimchi/test/Test/Snarky/Circuit/Kimchi/Main.purs
+++ b/packages/snarky-kimchi/test/Test/Snarky/Circuit/Kimchi/Main.purs
@@ -15,6 +15,7 @@ import Test.Snarky.Circuit.Kimchi.GenericTest as GenericTests
 import Test.Snarky.Circuit.Kimchi.Poseidon as PoseidonTests
 import Test.Snarky.Circuit.Kimchi.VarBaseMul as VarBaseMulTests
 import Test.Snarky.Constraint.Kimchi.GenericPlonk as GenericPlonkSpec
+import Test.Snarky.Types.Shifted as ShiftedTests
 import Test.Spec (Spec, describe)
 import Test.Spec.Reporter.Console (consoleReporter)
 import Test.Spec.Runner.Node (runSpecAndExitProcess)
@@ -42,3 +43,4 @@ spec = do
   VarBaseMulTests.spec
   EndoMulTests.spec
   EndoScalarTests.spec
+  ShiftedTests.spec

--- a/packages/snarky-kimchi/test/Test/Snarky/Circuit/Kimchi/VarBaseMul.purs
+++ b/packages/snarky-kimchi/test/Test/Snarky/Circuit/Kimchi/VarBaseMul.purs
@@ -19,7 +19,7 @@ import Snarky.Curves.Pallas as Pallas
 import Snarky.Curves.Vesta as Vesta
 import Snarky.Data.EllipticCurve (AffinePoint)
 import Snarky.Data.EllipticCurve as EC
-import Snarky.Types.Shifted (Type1(..), Type2, fromShifted, toShifted)
+import Snarky.Types.Shifted (Type1, Type2, fromShifted, toShifted)
 import Test.QuickCheck (arbitrary)
 import Test.QuickCheck.Gen (Gen)
 import Test.Snarky.Circuit.Utils (circuitSpecPure', satisfied)
@@ -28,43 +28,47 @@ import Type.Proxy (Proxy(..))
 
 spec :: Spec Unit
 spec = do
-  describe "VarBaseMul Type1" do
+  -- Type1: Vesta circuit (field = Vesta.BaseField)
+  -- Uses Vesta.G curve (coordinates in Vesta.BaseField = circuit field)
+  -- Scalars are in Vesta.ScalarField (smaller than circuit field)
+  describe "VarBaseMul Type1 (Vesta circuit)" do
     it "varBaseMul Circuit is Valid for Type1" $ unsafePartial $
       let
-        f :: Tuple (AffinePoint (F Pallas.BaseField)) (Type1 (F Pallas.BaseField)) -> AffinePoint (F Pallas.BaseField)
-        f (Tuple { x: F x, y: F y } shifted) =
+        f :: Tuple (AffinePoint (F Vesta.BaseField)) (Type1 (F Vesta.BaseField)) -> AffinePoint (F Vesta.BaseField)
+        f (Tuple { x: F x, y: F y } scalar_) =
           let
-            base = fromAffine { x, y }
-            -- Use fromShifted to get the effective scalar
-            F scalar = fromShifted shifted
+            base = fromAffine @Vesta.BaseField @Vesta.G { x, y }
+            scalar = case fromShifted scalar_ of F a -> a
             result = scalarMul scalar base
-            { x, y } = unsafePartial $ fromJust $ toAffine @Pallas.BaseField @Pallas.G result
+            { x: x', y: y' } = unsafePartial $ fromJust $ toAffine @Vesta.BaseField result
           in
-            { x: F x, y: F y }
-        solver = makeSolver (Proxy @(KimchiConstraint Pallas.BaseField)) (uncurry circuit)
+            { x: F x', y: F y' }
+        solver = makeSolver (Proxy @(KimchiConstraint Vesta.BaseField)) (uncurry circuit)
 
         circuit
           :: forall t
-           . CircuitM Pallas.BaseField (KimchiConstraint Pallas.BaseField) t Identity
-          => AffinePoint (FVar Pallas.BaseField)
-          -> Type1 (FVar Pallas.BaseField)
-          -> Snarky (KimchiConstraint Pallas.BaseField) t Identity (AffinePoint (FVar Pallas.BaseField))
+           . CircuitM Vesta.BaseField (KimchiConstraint Vesta.BaseField) t Identity
+          => AffinePoint (FVar Vesta.BaseField)
+          -> Type1 (FVar Vesta.BaseField)
+          -> Snarky (KimchiConstraint Vesta.BaseField) t Identity (AffinePoint (FVar Vesta.BaseField))
         circuit p t = do
           g <- scaleFast1 @51 p t
           pure g
         s =
           compilePure
-            (Proxy @(Tuple (AffinePoint (F Pallas.BaseField)) (Type1 (F Pallas.BaseField))))
-            (Proxy @(AffinePoint (F Pallas.BaseField)))
-            (Proxy @(KimchiConstraint Pallas.BaseField))
+            (Proxy @(Tuple (AffinePoint (F Vesta.BaseField)) (Type1 (F Vesta.BaseField))))
+            (Proxy @(AffinePoint (F Vesta.BaseField)))
+            (Proxy @(KimchiConstraint Vesta.BaseField))
             (uncurry circuit)
             Kimchi.initialState
 
-        gen :: Gen (Tuple (AffinePoint (F Pallas.BaseField)) (Type1 (F Pallas.BaseField)))
+        gen :: Gen (Tuple (AffinePoint (F Vesta.BaseField)) (Type1 (F Vesta.BaseField)))
         gen = do
-          p <- EC.genAffinePoint (Proxy @Pallas.G)
-          t <- arbitrary
-          pure $ Tuple p (Type1 t)
+          p <- EC.genAffinePoint (Proxy @Vesta.G)
+          -- Generate the shifted value directly in the circuit field
+          -- (don't go through toShifted which crosses fields)
+          t <- arbitrary @(F Vesta.ScalarField)
+          pure $ Tuple p (toShifted t)
       in
         do
           circuitSpecPure' 100
@@ -77,40 +81,43 @@ spec = do
             gen
           liftEffect $ verifyCircuit { s, gen, solver }
 
-  describe "VarBaseMul Type2" do
+  -- Type2: Pallas circuit, scalar field (Pallas.ScalarField) is LARGER than circuit field (Pallas.BaseField)
+  describe "VarBaseMul Type2 (Pallas circuit)" do
     it "varBaseMul Circuit is Valid for Type2" $ unsafePartial $
       let
-        f :: Tuple (AffinePoint (F Vesta.BaseField)) (Type2 (F Vesta.BaseField) Boolean) -> AffinePoint (F Vesta.BaseField)
-        f = uncurry \{ x: F x, y: F y } shifted ->
+        f :: Tuple (AffinePoint (F Pallas.BaseField)) (Type2 (F Pallas.BaseField) Boolean) -> AffinePoint (F Pallas.BaseField)
+        f (Tuple { x: F x, y: F y } scalar_) =
           let
-            base = fromAffine @Vesta.BaseField @Vesta.G { x, y }
-            F effectiveScalar = fromShifted shifted
-            result = scalarMul effectiveScalar base
-            { x, y } = unsafePartial $ fromJust $ toAffine @Vesta.BaseField result
+            base = fromAffine @Pallas.BaseField @Pallas.G { x, y }
+
+            scalar :: Pallas.ScalarField
+            scalar = case fromShifted scalar_ of F a -> a
+            result = scalarMul scalar base
+            { x: x', y: y' } = unsafePartial $ fromJust $ toAffine @Pallas.BaseField result
           in
-            { x: F x, y: F y }
-        solver = makeSolver (Proxy @(KimchiConstraint Vesta.BaseField)) (uncurry circuit)
+            { x: F x', y: F y' }
+        solver = makeSolver (Proxy @(KimchiConstraint Pallas.BaseField)) (uncurry circuit)
 
         circuit
           :: forall t
-           . CircuitM Vesta.BaseField (KimchiConstraint Vesta.BaseField) t Identity
-          => AffinePoint (FVar Vesta.BaseField)
-          -> Type2 (FVar Vesta.BaseField) (BoolVar Vesta.BaseField)
-          -> Snarky (KimchiConstraint Vesta.BaseField) t Identity (AffinePoint (FVar Vesta.BaseField))
+           . CircuitM Pallas.BaseField (KimchiConstraint Pallas.BaseField) t Identity
+          => AffinePoint (FVar Pallas.BaseField)
+          -> Type2 (FVar Pallas.BaseField) (BoolVar Pallas.BaseField)
+          -> Snarky (KimchiConstraint Pallas.BaseField) t Identity (AffinePoint (FVar Pallas.BaseField))
         circuit p t = scaleFast2 @51 p t
         s =
           compilePure
-            (Proxy @(Tuple (AffinePoint (F Vesta.BaseField)) (Type2 (F Vesta.BaseField) Boolean)))
-            (Proxy @(AffinePoint (F Vesta.BaseField)))
-            (Proxy @(KimchiConstraint Vesta.BaseField))
+            (Proxy @(Tuple (AffinePoint (F Pallas.BaseField)) (Type2 (F Pallas.BaseField) Boolean)))
+            (Proxy @(AffinePoint (F Pallas.BaseField)))
+            (Proxy @(KimchiConstraint Pallas.BaseField))
             (uncurry circuit)
             Kimchi.initialState
 
-        gen :: Gen (Tuple (AffinePoint (F Vesta.BaseField)) (Type2 (F Vesta.BaseField) Boolean))
+        gen :: Gen (Tuple (AffinePoint (F Pallas.BaseField)) (Type2 (F Pallas.BaseField) Boolean))
         gen = do
-          p <- EC.genAffinePoint (Proxy @Vesta.G)
-          s <- arbitrary @(F Vesta.ScalarField)
-          pure $ Tuple p (toShifted s)
+          p <- EC.genAffinePoint (Proxy @Pallas.G)
+          circuitVal <- arbitrary @(F Pallas.ScalarField)
+          pure $ Tuple p (toShifted circuitVal)
       in
         do
           circuitSpecPure' 100

--- a/packages/snarky-kimchi/test/Test/Snarky/Circuit/Kimchi/VarBaseMul.purs
+++ b/packages/snarky-kimchi/test/Test/Snarky/Circuit/Kimchi/VarBaseMul.purs
@@ -19,7 +19,7 @@ import Snarky.Curves.Pallas as Pallas
 import Snarky.Curves.Vesta as Vesta
 import Snarky.Data.EllipticCurve (AffinePoint)
 import Snarky.Data.EllipticCurve as EC
-import Snarky.Types.Shifted (Type1(..), Type2(..), fromShifted, toShifted)
+import Snarky.Types.Shifted (Type1(..), Type2, fromShifted, toShifted)
 import Test.QuickCheck (arbitrary)
 import Test.QuickCheck.Gen (Gen)
 import Test.Snarky.Circuit.Utils (circuitSpecPure', satisfied)

--- a/packages/snarky-kimchi/test/Test/Snarky/Types/Shifted.purs
+++ b/packages/snarky-kimchi/test/Test/Snarky/Types/Shifted.purs
@@ -118,8 +118,8 @@ spec = do
     describe "Type1 Shifted (crossField)" do
       it "fromShifted (toShifted s) == s" $
         quickCheck (type1ShiftRoundtrip @Vesta.ScalarField @Vesta.BaseField)
-      it "fromShifted (toShifted s) == s + 2^n (danger zone)" $
-        quickCheck (type2ShiftRoundtrip @Vesta.ScalarField @Vesta.BaseField <$> genDangerZone)
+      it "fromShifted (toShifted s) == s (danger zone)" $
+        quickCheck (type1ShiftRoundtrip @Vesta.ScalarField @Vesta.BaseField <$> genDangerZone)
 
     describe "Type2 Shifted (same-field, adds 2^n)" do
       it "fromShifted (toShifted s) == s + 2^n (Vesta.BaseField)" $

--- a/packages/snarky-kimchi/test/Test/Snarky/Types/Shifted.purs
+++ b/packages/snarky-kimchi/test/Test/Snarky/Types/Shifted.purs
@@ -1,0 +1,138 @@
+module Test.Snarky.Types.Shifted where
+
+import Prelude
+
+import Data.Array.NonEmpty as NEA
+import JS.BigInt as BigInt
+import Snarky.Circuit.Types (F(..))
+import Snarky.Curves.Class (class FieldSizeInBits, class PrimeField, fromBigInt, modulus)
+import Snarky.Curves.Vesta as Vesta
+import Snarky.Types.Shifted (class Shifted, Type1, Type2(..), fieldSizeBits, fromShifted, joinField, splitField, toShifted)
+import Test.QuickCheck (Result, (===))
+import Test.QuickCheck.Gen (Gen, chooseInt, oneOf)
+import Test.Spec (Spec, describe, it)
+import Test.Spec.QuickCheck (quickCheck)
+import Type.Proxy (Proxy(..))
+
+--------------------------------------------------------------------------------
+-- splitField / joinField roundtrip (within same field)
+--------------------------------------------------------------------------------
+
+splitJoinRoundtrip :: forall @f. PrimeField f => F f -> Result
+splitJoinRoundtrip x =
+  let
+    Type2 { sDiv2: F d, sOdd } = splitField x
+    reconstructed = F (joinField { sDiv2: d, sOdd })
+  in
+    reconstructed === x
+
+--------------------------------------------------------------------------------
+-- Type1 roundtrip: fromShifted (toShifted s) == s
+--------------------------------------------------------------------------------
+
+type1ShiftRoundtrip
+  :: forall @f @f'
+   . PrimeField f
+  => Shifted (F f) (Type1 (F f'))
+  => F f
+  -> Result
+type1ShiftRoundtrip s =
+  let
+    shifted :: Type1 (F f')
+    shifted = toShifted s
+  in
+    fromShifted shifted === s
+
+--------------------------------------------------------------------------------
+-- Type2: fromShifted (toShifted s) == s + 2^n (mod field)
+--------------------------------------------------------------------------------
+
+type2ShiftRoundtrip
+  :: forall @f @f' n
+   . FieldSizeInBits f n
+  => Shifted (F f) (Type2 (F f') Boolean)
+  => F f
+  -> Result
+type2ShiftRoundtrip s =
+  let
+    shifted :: Type2 (F f') Boolean
+    shifted = toShifted s
+    unshifted = fromShifted shifted
+    n = fieldSizeBits (Proxy :: Proxy f)
+    twoToN = fromBigInt (BigInt.pow (BigInt.fromInt 2) (BigInt.fromInt n))
+    expected = case s of F x -> F (x + twoToN)
+  in
+    unshifted === expected
+
+--------------------------------------------------------------------------------
+-- Danger zone generators
+--------------------------------------------------------------------------------
+
+genDangerZone :: forall @f. PrimeField f => Gen (F f)
+genDangerZone =
+  let
+    m = modulus @f
+    two = BigInt.fromInt 2
+
+    genNearZero = do
+      small <- chooseInt 0 1000
+      pure $ F (fromBigInt (BigInt.fromInt small))
+
+    genNearMax = do
+      offset <- chooseInt 1 1000
+      pure $ F (fromBigInt (m - BigInt.fromInt offset))
+
+    genNearHalf = do
+      offset <- chooseInt 0 1000
+      pure $ F (fromBigInt (m / two + BigInt.fromInt offset))
+
+    genEven = do
+      k <- chooseInt 1 10000
+      pure $ F (fromBigInt (two * BigInt.fromInt k))
+  in
+    oneOf $ NEA.cons' genNearZero [ genNearMax, genNearHalf, genEven ]
+
+--------------------------------------------------------------------------------
+-- Spec
+--------------------------------------------------------------------------------
+
+spec :: Spec Unit
+spec = do
+  describe "Snarky.Types.Shifted" do
+    describe "splitField / joinField" do
+      it "roundtrips in Vesta.BaseField" $
+        quickCheck (splitJoinRoundtrip @Vesta.BaseField)
+      it "roundtrips in Vesta.ScalarField" $
+        quickCheck (splitJoinRoundtrip @Vesta.ScalarField)
+
+    describe "Type1 Shifted (same-field roundtrip)" do
+      it "fromShifted (toShifted s) == s (Vesta.BaseField)" $
+        quickCheck (type1ShiftRoundtrip @Vesta.BaseField @Vesta.BaseField)
+      it "fromShifted (toShifted s) == s (Vesta.ScalarField)" $
+        quickCheck (type1ShiftRoundtrip @Vesta.ScalarField @Vesta.ScalarField)
+      it "fromShifted (toShifted s) == s (danger zone, Vesta.BaseField)" $
+        quickCheck (type1ShiftRoundtrip @Vesta.BaseField @Vesta.BaseField <$> genDangerZone)
+      it "fromShifted (toShifted s) == s (danger zone, Vesta.ScalarField)" $
+        quickCheck (type1ShiftRoundtrip @Vesta.ScalarField @Vesta.ScalarField <$> genDangerZone)
+
+    describe "Type1 Shifted (crossField)" do
+      it "fromShifted (toShifted s) == s" $
+        quickCheck (type1ShiftRoundtrip @Vesta.ScalarField @Vesta.BaseField)
+      it "fromShifted (toShifted s) == s + 2^n (danger zone)" $
+        quickCheck (type2ShiftRoundtrip @Vesta.ScalarField @Vesta.BaseField <$> genDangerZone)
+
+    describe "Type2 Shifted (same-field, adds 2^n)" do
+      it "fromShifted (toShifted s) == s + 2^n (Vesta.BaseField)" $
+        quickCheck (type2ShiftRoundtrip @Vesta.BaseField @Vesta.BaseField)
+      it "fromShifted (toShifted s) == s + 2^n (Vesta.ScalarField)" $
+        quickCheck (type2ShiftRoundtrip @Vesta.ScalarField @Vesta.ScalarField)
+      it "fromShifted (toShifted s) == s + 2^n (danger zone, Vesta.BaseField)" $
+        quickCheck (type2ShiftRoundtrip @Vesta.BaseField @Vesta.BaseField <$> genDangerZone)
+      it "fromShifted (toShifted s) == s + 2^n (danger zone, Vesta.ScalarField)" $
+        quickCheck (type2ShiftRoundtrip @Vesta.ScalarField @Vesta.ScalarField <$> genDangerZone)
+
+    describe "Type2 Shifted (crossField)" do
+      it "fromShifted (toShifted s) == s" $
+        quickCheck (type2ShiftRoundtrip @Vesta.BaseField @Vesta.ScalarField)
+      it "fromShifted (toShifted s) == s + 2^n (danger zone)" $
+        quickCheck (type2ShiftRoundtrip @Vesta.BaseField @Vesta.ScalarField <$> genDangerZone)


### PR DESCRIPTION
This is a very solid PR that makes significant improvements to the scalar multiplication infrastructure. The introduction of the `Shifted` type class and the explicit `Type1`/`Type2` representations is a major step forward in terms of code clarity, correctness, and alignment with the underlying cryptographic concepts from the OCaml implementation. The new tests for the `Shifted` module are comprehensive and provide strong guarantees.

I've cross-referenced the `shifted_value.ml` from the `mina` submodule, and the logic in `Snarky.Types.Shifted.purs` is consistent with the OCaml implementation.