### PR TITLE
Combined inner product

### DIFF
--- a/packages/crypto-provider/src/kimchi/circuit.rs
+++ b/packages/crypto-provider/src/kimchi/circuit.rs
@@ -298,6 +298,7 @@ mod generic {
 
     /// Helper: compute oracles result from prover index and proof.
     /// Returns (verifier_index, oracles_result).
+    #[allow(clippy::type_complexity)]
     fn compute_oracles<G, EFqSponge, EFrSponge>(
         prover_index: &ProverIndex<G, OpeningProof<G>>,
         proof: &ProverProof<G, OpeningProof<G>>,
@@ -421,9 +422,7 @@ mod generic {
         )]);
 
         // Get the challenges using the endomorphism coefficient
-        let challenges = proof
-            .proof
-            .challenges(&verifier_index.endo, &mut fq_sponge);
+        let challenges = proof.proof.challenges(&verifier_index.endo, &mut fq_sponge);
 
         Ok(challenges.chal)
     }
@@ -1016,12 +1015,11 @@ pub fn pallas_proof_bulletproof_challenges(
     public_input: Vec<&VestaFieldExternal>,
 ) -> Result<Vec<VestaFieldExternal>> {
     let public: Vec<VestaScalarField> = public_input.iter().map(|f| ***f).collect();
-    let result =
-        generic::proof_bulletproof_challenges::<VestaGroup, VestaBaseSponge, VestaScalarSponge>(
-            &**prover_index,
-            &**proof,
-            &public,
-        )?;
+    let result = generic::proof_bulletproof_challenges::<
+        VestaGroup,
+        VestaBaseSponge,
+        VestaScalarSponge,
+    >(&**prover_index, &**proof, &public)?;
     Ok(result.into_iter().map(External::new).collect())
 }
 
@@ -1034,12 +1032,11 @@ pub fn vesta_proof_bulletproof_challenges(
     public_input: Vec<&PallasFieldExternal>,
 ) -> Result<Vec<PallasFieldExternal>> {
     let public: Vec<PallasScalarField> = public_input.iter().map(|f| ***f).collect();
-    let result =
-        generic::proof_bulletproof_challenges::<PallasGroup, PallasBaseSponge, PallasScalarSponge>(
-            &**prover_index,
-            &**proof,
-            &public,
-        )?;
+    let result = generic::proof_bulletproof_challenges::<
+        PallasGroup,
+        PallasBaseSponge,
+        PallasScalarSponge,
+    >(&**prover_index, &**proof, &public)?;
     Ok(result.into_iter().map(External::new).collect())
 }
 

--- a/packages/pickles/src/Pickles/Commitments.purs
+++ b/packages/pickles/src/Pickles/Commitments.purs
@@ -1,0 +1,121 @@
+-- | IPA commitment verification functions.
+-- |
+-- | This module provides PureScript implementations of the IPA (Inner Product Argument)
+-- | polynomial commitment verification functions, translated from the Rust proof-systems
+-- | crate's poly-commitment module.
+-- |
+-- | Key functions:
+-- | - `bPoly`: The challenge polynomial from the IPA protocol
+-- | - `computeB`: Combines bPoly evaluations at zeta and zeta*omega
+-- | - `combinedInnerProduct`: Batch all polynomial evaluations
+module Pickles.Commitments
+  ( bPoly
+  , computeB
+  , combinedInnerProduct
+  , CombinedInnerProductInput
+  , NumEvals
+  ) where
+
+import Prelude
+
+import Data.Foldable (foldl, product)
+import Data.Reflectable (class Reflectable)
+import Data.Vector (Vector)
+import Data.Vector as Vector
+import Pickles.Linearization.FFI (PointEval)
+import Snarky.Curves.Class (class PrimeField)
+
+-------------------------------------------------------------------------------
+-- | Challenge Polynomial (b_poly)
+-------------------------------------------------------------------------------
+
+-- | The challenge polynomial from the IPA protocol.
+-- |
+-- | Computes: b_poly(chals, x) = prod_{i=0}^{k-1} (1 + chals[i] * x^{2^{k-1-i}})
+-- |
+-- | This is "step 8: Define the univariate polynomial" of appendix A.2 of
+-- | https://eprint.iacr.org/2020/499
+-- |
+-- | The `d` parameter is the number of IPA rounds (= domain log2), which equals
+-- | the length of the challenges vector.
+bPoly :: forall d f. Reflectable d Int => PrimeField f => Vector d f -> f -> f
+bPoly chals x =
+  let
+    -- Build pow_twos where pow_twos[i] = x^{2^i} by repeated squaring
+    -- pow_twos = [x, x^2, x^4, ..., x^{2^{k-1}}]
+    powTwos :: Vector d f
+    powTwos = Vector.scanl (\acc _ -> acc * acc) x chals
+
+    -- Reverse to get [x^{2^{k-1}}, ..., x^4, x^2, x]
+    -- Then zip with chals to compute (1 + chal * pow) for each pair
+    terms :: Vector d f
+    terms = Vector.zipWith (\c p -> one + c * p) chals (Vector.reverse powTwos)
+  in
+    product terms
+
+-------------------------------------------------------------------------------
+-- | Combined b evaluation
+-------------------------------------------------------------------------------
+
+-- | Compute the combined b value at two evaluation points.
+-- |
+-- | This combines bPoly evaluations: b(zeta) + evalscale * b(zeta*omega)
+-- |
+-- | Corresponds to lines 201-210 of poly-commitment/src/ipa.rs in SRS::verify.
+computeB
+  :: forall d f
+   . Reflectable d Int
+  => PrimeField f
+  => Vector d f
+  -> { zeta :: f, zetaOmega :: f, evalscale :: f }
+  -> f
+computeB chals { zeta, zetaOmega, evalscale } =
+  bPoly chals zeta + evalscale * bPoly chals zetaOmega
+
+-------------------------------------------------------------------------------
+-- | Combined Inner Product
+-------------------------------------------------------------------------------
+
+-- | Number of polynomial evaluations for non-recursive, non-lookup circuits:
+-- | public (1) + ft (1) + Z (1) + index (6) + witness (15) + coefficient (15) + sigma (6) = 45
+type NumEvals = 45
+
+-- | Input for combined inner product computation.
+-- | Contains all polynomial evaluations in the order expected by the verifier.
+type CombinedInnerProductInput f =
+  { polyscale :: f -- v: polynomial batching scalar
+  , evalscale :: f -- u: evaluation point batching scalar
+  , evals :: Vector NumEvals (PointEval f) -- polynomial evaluations in order
+  }
+
+-- | Compute the combined inner product of all polynomial evaluations.
+-- |
+-- | This batches all polynomial evaluations using:
+-- |   sum_i (polyscale^i * (eval_zeta[i] + evalscale * eval_zeta_omega[i]))
+-- |
+-- | Corresponds to `combined_inner_product` in poly-commitment/src/commitment.rs:520.
+-- |
+-- | For non-recursive, non-lookup circuits, the polynomial order is:
+-- | 1. public_evals (1)
+-- | 2. ft (1)
+-- | 3. Z (1)
+-- | 4. Index: Generic, Poseidon, CompleteAdd, VarBaseMul, EndoMul, EndoMulScalar (6)
+-- | 5. Witness: 0..14 (15)
+-- | 6. Coefficient: 0..14 (15)
+-- | 7. Sigma: 0..5 (6)
+combinedInnerProduct :: forall f. Semiring f => CombinedInnerProductInput f -> f
+combinedInnerProduct { polyscale, evalscale, evals } =
+  let
+    -- For each polynomial: polyscale^i * (eval_zeta + evalscale * eval_zeta_omega)
+    -- We accumulate (result, polyscale^i) through the fold
+    step { result, scale } eval =
+      let
+        term = eval.zeta + evalscale * eval.omegaTimesZeta
+      in
+        { result: result + scale * term
+        , scale: scale * polyscale
+        }
+
+    init = { result: zero, scale: one }
+  in
+    (foldl step init evals).result

--- a/packages/pickles/src/Pickles/PlonkChecks/GateConstraints.purs
+++ b/packages/pickles/src/Pickles/PlonkChecks/GateConstraints.purs
@@ -102,13 +102,16 @@ buildEvalPoint { witnessEvals, coeffEvals, indexEvals, defaultVal } =
         let
           index :: Int -> Finite 6
           index = unsafeFinite
+          -- Gate order matches Kimchi verifier's column ordering:
+          -- Generic, Poseidon, CompleteAdd, VarBaseMul, EndoMul, EndoMulScalar
+          -- See kimchi/src/verifier.rs lines 485-490
           gateIdx = case gt of
-            Poseidon -> index 0
-            Generic -> index 1
-            VarBaseMul -> index 2
-            EndoMul -> index 3
-            EndoMulScalar -> index 4
-            CompleteAdd -> index 5
+            Generic -> index 0
+            Poseidon -> index 1
+            CompleteAdd -> index 2
+            VarBaseMul -> index 3
+            EndoMul -> index 4
+            EndoMulScalar -> index 5
             _ -> index 0
         in
           pointEvalAt indexEvals gateIdx row

--- a/packages/pickles/src/Pickles/PlonkChecks/GateConstraints.purs
+++ b/packages/pickles/src/Pickles/PlonkChecks/GateConstraints.purs
@@ -100,19 +100,20 @@ buildEvalPoint { witnessEvals, coeffEvals, indexEvals, defaultVal } =
     , coefficient: \col -> coeffEvals !! col
     , index: \row gt ->
         let
-          index :: Int -> Finite 6
-          index = unsafeFinite
+          idx :: Int -> Finite 6
+          idx = unsafeFinite
           -- Gate order matches Kimchi verifier's column ordering:
           -- Generic, Poseidon, CompleteAdd, VarBaseMul, EndoMul, EndoMulScalar
           -- See kimchi/src/verifier.rs lines 485-490
+          -- Only these 6 gate types are supported; others require additional FFI support.
           gateIdx = case gt of
-            Generic -> index 0
-            Poseidon -> index 1
-            CompleteAdd -> index 2
-            VarBaseMul -> index 3
-            EndoMul -> index 4
-            EndoMulScalar -> index 5
-            _ -> index 0
+            Generic -> idx 0
+            Poseidon -> idx 1
+            CompleteAdd -> idx 2
+            VarBaseMul -> idx 3
+            EndoMul -> idx 4
+            EndoMulScalar -> idx 5
+            _ -> unsafeThrow $ "buildEvalPoint: unsupported gate type " <> show gt
         in
           pointEvalAt indexEvals gateIdx row
     , lookupAggreg: \_ -> defaultVal

--- a/packages/pickles/test/Test/Pickles/Commitments.purs
+++ b/packages/pickles/test/Test/Pickles/Commitments.purs
@@ -1,0 +1,92 @@
+module Test.Pickles.Commitments where
+
+-- | Tests for the commitment verification circuit.
+-- | Verifies that the in-circuit computation of combinedInnerProduct matches
+-- | the field-level reference computation.
+
+import Prelude
+
+import Data.Vector as Vector
+import Pickles.Commitments (CombinedInnerProductInput, NumEvals, combinedInnerProduct, combinedInnerProductCircuit)
+import Pickles.Linearization.FFI (PointEval)
+import Poseidon (class PoseidonField)
+import Snarky.Backend.Compile (compilePure, makeSolver)
+import Snarky.Circuit.DSL (class CircuitM, FVar, Snarky)
+import Snarky.Circuit.Types (F)
+import Snarky.Constraint.Kimchi (class KimchiVerify, KimchiConstraint)
+import Snarky.Constraint.Kimchi as Kimchi
+import Snarky.Curves.Class (class HasEndo, class PrimeField)
+import Snarky.Curves.Pallas as Pallas
+import Snarky.Curves.Vesta as Vesta
+import Test.QuickCheck (arbitrary)
+import Test.QuickCheck.Gen (Gen)
+import Test.Snarky.Circuit.Utils (circuitSpecPure', satisfied)
+import Test.Spec (Spec, describe, it)
+import Type.Proxy (Proxy(..))
+
+spec :: Spec Unit
+spec = do
+  describe "Pickles.Commitments" do
+    describe "Pallas" do
+      commitmentsTests (Proxy :: Proxy Pallas.BaseField)
+    describe "Vesta" do
+      commitmentsTests (Proxy :: Proxy Vesta.BaseField)
+
+-------------------------------------------------------------------------------
+-- | Generator
+-------------------------------------------------------------------------------
+
+-- | Generate arbitrary PointEval
+genPointEval :: forall f. PrimeField f => Gen (PointEval (F f))
+genPointEval = do
+  zeta <- arbitrary
+  omegaTimesZeta <- arbitrary
+  pure { zeta, omegaTimesZeta }
+
+-- | Generate arbitrary CombinedInnerProductInput
+genCombinedInnerProductInput :: forall f. PrimeField f => Gen (CombinedInnerProductInput (F f))
+genCombinedInnerProductInput = do
+  polyscale <- arbitrary
+  evalscale <- arbitrary
+  evals <- Vector.generator (Proxy @NumEvals) genPointEval
+  pure { polyscale, evalscale, evals }
+
+-------------------------------------------------------------------------------
+-- | Parameterized tests
+-------------------------------------------------------------------------------
+
+commitmentsTests
+  :: forall f f'
+   . PrimeField f
+  => PoseidonField f
+  => HasEndo f f'
+  => KimchiVerify f f'
+  => Proxy f
+  -> Spec Unit
+commitmentsTests _ = do
+  it "combinedInnerProductCircuit matches combinedInnerProduct" do
+    let
+      circuit
+        :: forall t m
+         . CircuitM f (KimchiConstraint f) t m
+        => CombinedInnerProductInput (FVar f)
+        -> Snarky (KimchiConstraint f) t m (FVar f)
+      circuit = combinedInnerProductCircuit
+
+      solver = makeSolver (Proxy @(KimchiConstraint f)) circuit
+
+      builtState = compilePure
+        (Proxy @(CombinedInnerProductInput (F f)))
+        (Proxy @(F f))
+        (Proxy @(KimchiConstraint f))
+        circuit
+        Kimchi.initialState
+
+    circuitSpecPure' 1
+      { builtState
+      , checker: Kimchi.eval
+      , solver
+      , testFunction: satisfied (combinedInnerProduct :: CombinedInnerProductInput (F f) -> F f)
+      , postCondition: Kimchi.postCondition
+      }
+      (genCombinedInnerProductInput :: Gen (CombinedInnerProductInput (F f)))

--- a/packages/pickles/test/Test/Pickles/E2E.purs
+++ b/packages/pickles/test/Test/Pickles/E2E.purs
@@ -1,7 +1,5 @@
 module Test.Pickles.E2E
   ( computePublicEval
-  , gateConstraintTest
-  , permutationTest
   , schnorrBuiltState
   , schnorrCircuit
   , schnorrSolver
@@ -27,14 +25,16 @@ import Data.Maybe (fromJust)
 import Data.Newtype (un)
 import Data.Schnorr.Gen (VerifyInput, genValidSignature)
 import Data.Tuple (Tuple(..))
+import Data.Vector (Vector, (:<))
 import Data.Vector as Vector
-import Effect (Effect)
+import Effect.Aff (Aff)
 import Effect.Class (liftEffect)
 import Effect.Exception (error)
 import JS.BigInt as BigInt
 import Partial.Unsafe (unsafePartial)
+import Pickles.Commitments (combinedInnerProduct)
 import Pickles.Linearization.Env (fieldEnv)
-import Pickles.Linearization.FFI (evalCoefficientPolys, evalLinearization, evalSelectorPolys, evalWitnessPolys, proverIndexDomainLog2, unnormalizedLagrangeBasis, vanishesOnZkAndPreviousRows)
+import Pickles.Linearization.FFI (PointEval, evalCoefficientPolys, evalLinearization, evalSelectorPolys, evalWitnessPolys, proverIndexDomainLog2, unnormalizedLagrangeBasis, vanishesOnZkAndPreviousRows)
 import Pickles.Linearization.Interpreter (evaluate)
 import Pickles.Linearization.Pallas as PallasTokens
 import Pickles.PlonkChecks.GateConstraints (buildChallenges, buildEvalPoint, parseHex)
@@ -43,6 +43,7 @@ import Snarky.Backend.Builder (CircuitBuilderState)
 import Snarky.Backend.Compile (Solver, compilePure, makeSolver, runSolverT)
 import Snarky.Backend.Kimchi (makeConstraintSystem, makeWitness)
 import Snarky.Backend.Kimchi.Class (createCRS, createProverIndex)
+import Snarky.Backend.Kimchi.Types (ProverIndex)
 import Snarky.Circuit.CVar (const_)
 import Snarky.Circuit.DSL (class CircuitM, BoolVar, FVar, Snarky)
 import Snarky.Circuit.Schnorr (SignatureVar(..), verifies)
@@ -55,10 +56,11 @@ import Snarky.Curves.Pallas as Pallas
 import Snarky.Curves.Vesta as Vesta
 import Snarky.Data.EllipticCurve (AffinePoint)
 import Test.Pickles.Linearization (buildFFIInput)
+import Test.Pickles.ProofFFI (OraclesResult, Proof)
 import Test.Pickles.ProofFFI as ProofFFI
 import Test.QuickCheck (arbitrary)
 import Test.QuickCheck.Gen (randomSampleOne)
-import Test.Spec (Spec, describe, it)
+import Test.Spec (SpecT, beforeAll, describe, it)
 import Test.Spec.Assertions (shouldEqual)
 import Type.Proxy (Proxy(..))
 
@@ -102,122 +104,67 @@ schnorrSolver :: Solver Vesta.ScalarField (KimchiGate Vesta.ScalarField) (Verify
 schnorrSolver = makeSolver (Proxy @(KimchiConstraint Vesta.ScalarField)) schnorrCircuit
 
 -------------------------------------------------------------------------------
--- | Tests
+-- | Test setup types
 -------------------------------------------------------------------------------
 
--- | Test that PureScript linearization matches Rust for a valid Schnorr circuit.
--- | Uses Pallas linearization (Fp) with a Schnorr circuit over Vesta scalar field
--- | (which equals Pallas base field = Fp).
--- |
--- | Note: The linearization polynomial does NOT evaluate to zero at an arbitrary
--- | point zeta. It evaluates to t(zeta) * Z_H(zeta) where t is the quotient
--- | polynomial. What we test here is that our PureScript interpreter produces
--- | the same result as Rust when given real circuit witness evaluations.
-gateConstraintTest :: Spec Unit
-gateConstraintTest = do
-  it "PS gate constraint evaluation matches Rust for valid Schnorr witness" do
-    let gen = genValidSignature (Proxy @Pallas.G) (Proxy @4)
+-- | Shared test context created once by beforeAll.
+-- | Contains prover index, witness, proof, and oracles.
+type TestContext =
+  { proverIndex :: ProverIndex Vesta.G Vesta.ScalarField
+  , witness :: Vector 15 (Array Vesta.ScalarField)
+  , publicInputs :: Array Vesta.ScalarField
+  , domainLog2 :: Int
+  , proof :: Proof Vesta.G Vesta.ScalarField
+  , oracles :: OraclesResult Vesta.ScalarField
+  }
 
-    -- Generate a valid input and run the solver
-    input <- liftEffect $ randomSampleOne gen
-    crs <- liftEffect $ createCRS @Vesta.ScalarField
+-- | Create the shared test context.
+-- | Generates a valid Schnorr signature, runs the solver, creates the prover index,
+-- | generates a proof, and computes oracles.
+createTestContext :: Aff TestContext
+createTestContext = do
+  let gen = genValidSignature (Proxy @Pallas.G) (Proxy @4)
 
-    -- Run the solver
-    let
-      nat :: Identity ~> Effect
-      nat = pure <<< un Identity
+  -- Generate a valid input and run the solver
+  input <- liftEffect $ randomSampleOne gen
+  crs <- liftEffect $ createCRS @Vesta.ScalarField
 
-    eRes <- liftEffect $ runSolverT (\a -> hoist nat $ schnorrSolver a) input
-    case eRes of
-      Left e -> liftEffect $ throwError $ error (show e)
-      Right (Tuple _ assignments) -> do
-        let
-          -- Build constraint system and witness
-          { constraintSystem, constraints } = makeConstraintSystem @Vesta.ScalarField
-            { constraints: concatMap toKimchiRows schnorrBuiltState.constraints
-            , publicInputs: schnorrBuiltState.publicInputs
-            , unionFind: (un AuxState schnorrBuiltState.aux).wireState.unionFind
-            }
-          { witness, publicInputs: _ } = makeWitness
-            { assignments
-            , constraints: map _.variables constraints
-            , publicInputs: schnorrBuiltState.publicInputs
-            }
-          endo = endoBase @Vesta.ScalarField @Pallas.ScalarField
-          proverIndex = createProverIndex @Vesta.ScalarField @Vesta.G
-            { endo
-            , constraintSystem
-            , crs
-            }
+  let
+    nat :: Identity ~> Aff
+    nat = pure <<< un Identity
 
-        -- Generate random challenges
-        zeta <- liftEffect $ randomSampleOne (arbitrary @Vesta.ScalarField)
-        alpha <- liftEffect $ randomSampleOne (arbitrary @Vesta.ScalarField)
-        beta <- liftEffect $ randomSampleOne (arbitrary @Vesta.ScalarField)
-        gamma <- liftEffect $ randomSampleOne (arbitrary @Vesta.ScalarField)
-        jointCombiner <- liftEffect $ randomSampleOne (arbitrary @Vesta.ScalarField)
+  eRes <- runSolverT (\a -> hoist nat $ schnorrSolver a) input
+  case eRes of
+    Left e -> liftEffect $ throwError $ error (show e)
+    Right (Tuple _ assignments) -> do
+      let
+        -- Build constraint system and witness
+        { constraintSystem, constraints } = makeConstraintSystem @Vesta.ScalarField
+          { constraints: concatMap toKimchiRows schnorrBuiltState.constraints
+          , publicInputs: schnorrBuiltState.publicInputs
+          , unionFind: (un AuxState schnorrBuiltState.aux).wireState.unionFind
+          }
+        { witness, publicInputs } = makeWitness
+          { assignments
+          , constraints: map _.variables constraints
+          , publicInputs: schnorrBuiltState.publicInputs
+          }
+        endo = endoBase @Vesta.ScalarField @Pallas.ScalarField
+        proverIndex = createProverIndex @Vesta.ScalarField @Vesta.G
+          { endo
+          , constraintSystem
+          , crs
+          }
+        domainLog2 = proverIndexDomainLog2 proverIndex
 
-        let
-          -- Compute evaluations using FFI from prover index
-          witnessEvals = evalWitnessPolys proverIndex witness zeta
-          coeffEvals = evalCoefficientPolys proverIndex zeta
-          indexEvals = evalSelectorPolys proverIndex zeta
+        -- Create proof and get oracles
+        proof = ProofFFI.createProof { proverIndex, witness }
+        oracles = ProofFFI.proofOracles proverIndex { proof, publicInput: publicInputs }
 
-          -- Domain log2 from prover index
-          domainLog2 = proverIndexDomainLog2 proverIndex
-
-          -- Compute domain-dependent values
-          vanishesOnZk' = vanishesOnZkAndPreviousRows
-            { domainLog2, zkRows, pt: zeta }
-          lagrangeFalse0 = unnormalizedLagrangeBasis
-            { domainLog2, zkRows: 0, offset: 0, pt: zeta }
-          lagrangeTrue1 = unnormalizedLagrangeBasis
-            { domainLog2, zkRows, offset: -1, pt: zeta }
-
-          evalPoint = buildEvalPoint
-            { witnessEvals
-            , coeffEvals
-            , indexEvals
-            , defaultVal: zero
-            }
-
-          challenges = buildChallenges
-            { alpha
-            , beta
-            , gamma
-            , jointCombiner
-            , vanishesOnZk: vanishesOnZk'
-            , lagrangeFalse0
-            , lagrangeTrue1
-            }
-
-          env = fieldEnv evalPoint challenges parseHex
-
-          -- Evaluate using PureScript interpreter
-          psResult :: Vesta.ScalarField
-          psResult = evaluate PallasTokens.constantTermTokens env
-
-          -- Build FFI input for Rust evaluator
-          ffiInput = buildFFIInput
-            { witnessEvals
-            , coeffEvals
-            , indexEvals
-            , alpha
-            , beta
-            , gamma
-            , jointCombiner
-            , zeta
-            , domainLog2
-            }
-
-          -- Evaluate using Rust
-          rustResult = evalLinearization ffiInput
-
-        -- PureScript should match Rust
-        liftEffect $ psResult `shouldEqual` rustResult
+      pure { proverIndex, witness, publicInputs, domainLog2, proof, oracles }
 
 -------------------------------------------------------------------------------
--- | Permutation E2E test
+-- | Permutation helper
 -------------------------------------------------------------------------------
 
 -- | Compute the public input polynomial evaluation at zeta.
@@ -245,131 +192,209 @@ computePublicEval publicInputs domainLog2 zeta =
   in
     zetaToNMinus1 * acc / fromBigInt n
 
+-------------------------------------------------------------------------------
+-- | Tests
+-------------------------------------------------------------------------------
+
+-- | Test that PureScript linearization matches Rust for a valid Schnorr circuit.
+-- | Uses random challenges (not proof-derived) to test gate constraint evaluation.
+gateConstraintTest :: TestContext -> Aff Unit
+gateConstraintTest ctx = do
+  -- Generate random challenges (independent of the proof)
+  zeta <- liftEffect $ randomSampleOne (arbitrary @Vesta.ScalarField)
+  alpha <- liftEffect $ randomSampleOne (arbitrary @Vesta.ScalarField)
+  beta <- liftEffect $ randomSampleOne (arbitrary @Vesta.ScalarField)
+  gamma <- liftEffect $ randomSampleOne (arbitrary @Vesta.ScalarField)
+  jointCombiner <- liftEffect $ randomSampleOne (arbitrary @Vesta.ScalarField)
+
+  let
+    -- Compute evaluations using FFI from prover index
+    witnessEvals = evalWitnessPolys ctx.proverIndex ctx.witness zeta
+    coeffEvals = evalCoefficientPolys ctx.proverIndex zeta
+    indexEvals = evalSelectorPolys ctx.proverIndex zeta
+
+    -- Compute domain-dependent values
+    vanishesOnZk' = vanishesOnZkAndPreviousRows
+      { domainLog2: ctx.domainLog2, zkRows, pt: zeta }
+    lagrangeFalse0 = unnormalizedLagrangeBasis
+      { domainLog2: ctx.domainLog2, zkRows: 0, offset: 0, pt: zeta }
+    lagrangeTrue1 = unnormalizedLagrangeBasis
+      { domainLog2: ctx.domainLog2, zkRows, offset: -1, pt: zeta }
+
+    evalPoint = buildEvalPoint
+      { witnessEvals
+      , coeffEvals
+      , indexEvals
+      , defaultVal: zero
+      }
+
+    challenges = buildChallenges
+      { alpha
+      , beta
+      , gamma
+      , jointCombiner
+      , vanishesOnZk: vanishesOnZk'
+      , lagrangeFalse0
+      , lagrangeTrue1
+      }
+
+    env = fieldEnv evalPoint challenges parseHex
+
+    -- Evaluate using PureScript interpreter
+    psResult :: Vesta.ScalarField
+    psResult = evaluate PallasTokens.constantTermTokens env
+
+    -- Build FFI input for Rust evaluator
+    ffiInput = buildFFIInput
+      { witnessEvals
+      , coeffEvals
+      , indexEvals
+      , alpha
+      , beta
+      , gamma
+      , jointCombiner
+      , zeta
+      , domainLog2: ctx.domainLog2
+      }
+
+    -- Evaluate using Rust
+    rustResult = evalLinearization ffiInput
+
+  -- PureScript should match Rust
+  liftEffect $ psResult `shouldEqual` rustResult
+
 -- | Test that PureScript permContribution matches the oracle ft_eval0 value.
--- |
--- | Verifies: permContribution = ftEval0 - publicEval + gateConstraints
--- |
--- | This uses a real proof created from the Schnorr circuit, with oracles
--- | derived via Fiat-Shamir, ensuring the permutation argument implementation
--- | is correct against the Kimchi prover.
-permutationTest :: Spec Unit
-permutationTest = do
-  it "PS permContribution matches ftEval0 - publicEval + gateConstraints" do
-    let gen = genValidSignature (Proxy @Pallas.G) (Proxy @4)
+permutationTest :: TestContext -> Aff Unit
+permutationTest ctx = do
+  let
+    -- Get proof evaluations
+    witnessEvals = ProofFFI.proofWitnessEvals ctx.proof
+    zEvals = ProofFFI.proofZEvals ctx.proof
+    sigmaEvals = ProofFFI.proofSigmaEvals ctx.proof
+    shifts = ProofFFI.proverIndexShifts ctx.proverIndex
 
-    -- Generate a valid input and run the solver
-    input <- liftEffect $ randomSampleOne gen
-    crs <- liftEffect $ createCRS @Vesta.ScalarField
+    -- Compute domain-related values for permutation
+    n = BigInt.pow (BigInt.fromInt 2) (BigInt.fromInt ctx.domainLog2)
+    omega = ProofFFI.domainGenerator ctx.domainLog2
+    zetaToNMinus1 = pow ctx.oracles.zeta n - one
+    zkPoly = ProofFFI.permutationVanishingPolynomial
+      { domainLog2: ctx.domainLog2, zkRows, pt: ctx.oracles.zeta }
+    omegaToMinusZkRows = pow omega (n - BigInt.fromInt zkRows)
 
-    let
-      nat :: Identity ~> Effect
-      nat = pure <<< un Identity
+    -- Build permutation input and compute contribution
+    permInput =
+      { w: map _.zeta (Vector.take @7 witnessEvals)
+      , sigma: map _.zeta sigmaEvals
+      , z: zEvals
+      , shifts
+      , alpha: ctx.oracles.alpha
+      , beta: ctx.oracles.beta
+      , gamma: ctx.oracles.gamma
+      , zkPolynomial: zkPoly
+      , zetaToNMinus1
+      , omegaToMinusZkRows
+      , zeta: ctx.oracles.zeta
+      }
+    permResult = permContribution permInput
 
-    eRes <- liftEffect $ runSolverT (\a -> hoist nat $ schnorrSolver a) input
-    case eRes of
-      Left e -> liftEffect $ throwError $ error (show e)
-      Right (Tuple _ assignments) -> do
-        let
-          -- Build constraint system and witness
-          { constraintSystem, constraints } = makeConstraintSystem @Vesta.ScalarField
-            { constraints: concatMap toKimchiRows schnorrBuiltState.constraints
-            , publicInputs: schnorrBuiltState.publicInputs
-            , unionFind: (un AuxState schnorrBuiltState.aux).wireState.unionFind
-            }
-          { witness, publicInputs } = makeWitness
-            { assignments
-            , constraints: map _.variables constraints
-            , publicInputs: schnorrBuiltState.publicInputs
-            }
-          endo = endoBase @Vesta.ScalarField @Pallas.ScalarField
-          proverIndex = createProverIndex @Vesta.ScalarField @Vesta.G
-            { endo
-            , constraintSystem
-            , crs
-            }
+    -- Compute gate constraints using proof witness evals
+    coeffEvals = evalCoefficientPolys ctx.proverIndex ctx.oracles.zeta
+    indexEvals = evalSelectorPolys ctx.proverIndex ctx.oracles.zeta
+    vanishesOnZk' = vanishesOnZkAndPreviousRows
+      { domainLog2: ctx.domainLog2, zkRows, pt: ctx.oracles.zeta }
+    lagrangeFalse0 = unnormalizedLagrangeBasis
+      { domainLog2: ctx.domainLog2, zkRows: 0, offset: 0, pt: ctx.oracles.zeta }
+    lagrangeTrue1 = unnormalizedLagrangeBasis
+      { domainLog2: ctx.domainLog2, zkRows, offset: -1, pt: ctx.oracles.zeta }
+    evalPoint = buildEvalPoint
+      { witnessEvals
+      , coeffEvals
+      , indexEvals
+      , defaultVal: zero
+      }
+    challenges = buildChallenges
+      { alpha: ctx.oracles.alpha
+      , beta: ctx.oracles.beta
+      , gamma: ctx.oracles.gamma
+      , jointCombiner: zero
+      , vanishesOnZk: vanishesOnZk'
+      , lagrangeFalse0
+      , lagrangeTrue1
+      }
+    env = fieldEnv evalPoint challenges parseHex
+    gateResult = evaluate PallasTokens.constantTermTokens env
 
-        -- Create a real proof and get oracles via Fiat-Shamir
-        let
-          proof = ProofFFI.createProof { proverIndex, witness }
-          oracles = ProofFFI.proofOracles proverIndex { proof, publicInput: publicInputs }
+    -- Compute public input polynomial evaluation
+    publicEval = computePublicEval ctx.publicInputs ctx.domainLog2 ctx.oracles.zeta
 
-        -- Get proof evaluations
-        let
-          witnessEvals = ProofFFI.proofWitnessEvals proof
-          zEvals = ProofFFI.proofZEvals proof
-          sigmaEvals = ProofFFI.proofSigmaEvals proof
-          shifts = ProofFFI.proverIndexShifts proverIndex
-          domainLog2 = proverIndexDomainLog2 proverIndex
+  -- Verify: permContribution = ftEval0 - publicEval + gateConstraints
+  liftEffect $ permResult `shouldEqual` (ctx.oracles.ftEval0 - publicEval + gateResult)
 
-        -- Compute domain-related values for permutation
-        let
-          n = BigInt.pow (BigInt.fromInt 2) (BigInt.fromInt domainLog2)
-          omega = ProofFFI.domainGenerator domainLog2
-          zetaToNMinus1 = pow oracles.zeta n - one
-          zkPoly = ProofFFI.permutationVanishingPolynomial
-            { domainLog2, zkRows, pt: oracles.zeta }
-          omegaToMinusZkRows = pow omega (n - BigInt.fromInt zkRows)
+-- | Test that PureScript combinedInnerProduct matches the Rust FFI value.
+combinedInnerProductTest :: TestContext -> Aff Unit
+combinedInnerProductTest ctx = do
+  let
+    -- Get proof evaluations
+    witnessEvals = ProofFFI.proofWitnessEvals ctx.proof
+    zEvals = ProofFFI.proofZEvals ctx.proof
+    sigmaEvals = ProofFFI.proofSigmaEvals ctx.proof
+    coeffEvals = ProofFFI.proofCoefficientEvals ctx.proof
 
-        -- Build permutation input and compute contribution
-        let
-          permInput =
-            { w: map _.zeta (Vector.take @7 witnessEvals)
-            , sigma: map _.zeta sigmaEvals
-            , z: zEvals
-            , shifts
-            , alpha: oracles.alpha
-            , beta: oracles.beta
-            , gamma: oracles.gamma
-            , zkPolynomial: zkPoly
-            , zetaToNMinus1
-            , omegaToMinusZkRows
-            , zeta: oracles.zeta
-            }
-          permResult = permContribution permInput
+    -- Get selector evaluations from prover index
+    indexEvalsRaw = evalSelectorPolys ctx.proverIndex ctx.oracles.zeta
 
-        -- Compute gate constraints using proof witness evals
-        let
-          coeffEvals = evalCoefficientPolys proverIndex oracles.zeta
-          indexEvals = evalSelectorPolys proverIndex oracles.zeta
-          vanishesOnZk' = vanishesOnZkAndPreviousRows
-            { domainLog2, zkRows, pt: oracles.zeta }
-          lagrangeFalse0 = unnormalizedLagrangeBasis
-            { domainLog2, zkRows: 0, offset: 0, pt: oracles.zeta }
-          lagrangeTrue1 = unnormalizedLagrangeBasis
-            { domainLog2, zkRows, offset: -1, pt: oracles.zeta }
-          evalPoint = buildEvalPoint
-            { witnessEvals
-            , coeffEvals
-            , indexEvals
-            , defaultVal: zero
-            }
-          challenges = buildChallenges
-            { alpha: oracles.alpha
-            , beta: oracles.beta
-            , gamma: oracles.gamma
-            , jointCombiner: zero
-            , vanishesOnZk: vanishesOnZk'
-            , lagrangeFalse0
-            , lagrangeTrue1
-            }
-          env = fieldEnv evalPoint challenges parseHex
-          gateResult = evaluate PallasTokens.constantTermTokens env
+    -- Build the 45-element evaluation vector in the correct order:
+    -- 1. public (1)
+    -- 2. ft (1)
+    -- 3. z (1)
+    -- 4. Index: Generic, Poseidon, CompleteAdd, VarBaseMul, EndoMul, EndoMulScalar (6)
+    -- 5. Witness: 0..14 (15)
+    -- 6. Coefficient: 0..14 (15)
+    -- 7. Sigma: 0..5 (6)
 
-        -- Compute public input polynomial evaluation
-        let publicEval = computePublicEval publicInputs domainLog2 oracles.zeta
+    -- Public eval
+    publicEval :: PointEval Vesta.ScalarField
+    publicEval = { zeta: ctx.oracles.publicEvalZeta, omegaTimesZeta: ctx.oracles.publicEvalZetaOmega }
 
-        -- Verify: permContribution = ftEval0 - publicEval + gateConstraints
-        -- (The verifier subtracts -p(zeta) from ft_eval0, adding p(zeta),
-        --  so permContrib = ft_eval0 - p(zeta) + gateConstTerm)
-        liftEffect $ permResult `shouldEqual` (oracles.ftEval0 - publicEval + gateResult)
+    -- ft eval
+    ftEval :: PointEval Vesta.ScalarField
+    ftEval = { zeta: ctx.oracles.ftEval0, omegaTimesZeta: ctx.oracles.ftEval1 }
+
+    -- Build the full 45-element vector using type-safe append
+    -- Index selector order matches Kimchi verifier: Generic, Poseidon, CompleteAdd, VarBaseMul, EndoMul, EndoMulScalar
+    -- 3 + 6 + 15 + 15 + 6 = 45
+    allEvals :: Vector 45 (PointEval Vesta.ScalarField)
+    allEvals =
+      (publicEval :< ftEval :< zEvals :< Vector.nil)
+        `Vector.append` indexEvalsRaw
+        `Vector.append` witnessEvals
+        `Vector.append` coeffEvals
+        `Vector.append` sigmaEvals
+
+    -- Compute combined inner product using PureScript
+    psResult = combinedInnerProduct
+      { polyscale: ctx.oracles.v
+      , evalscale: ctx.oracles.u
+      , evals: allEvals
+      }
+
+  -- Compare against Rust combined_inner_product from oracles
+  liftEffect $ psResult `shouldEqual` ctx.oracles.combinedInnerProduct
+
+-- | Test that the opening proof verifies.
+openingProofTest :: TestContext -> Aff Unit
+openingProofTest ctx = do
+  let verified = ProofFFI.verifyOpeningProof ctx.proverIndex { proof: ctx.proof, publicInput: ctx.publicInputs }
+  liftEffect $ verified `shouldEqual` true
 
 -------------------------------------------------------------------------------
 -- | Main spec
 -------------------------------------------------------------------------------
 
-spec :: Spec Unit
-spec = describe "E2E Schnorr Circuit" do
-  describe "Gate Constraints" do
-    gateConstraintTest
-  describe "Permutation" do
-    permutationTest
+spec :: SpecT Aff Unit Aff Unit
+spec = beforeAll createTestContext $
+  describe "E2E Schnorr Circuit" do
+    it "PS gate constraint evaluation matches Rust for valid Schnorr witness" gateConstraintTest
+    it "PS permContribution matches ftEval0 - publicEval + gateConstraints" permutationTest
+    it "PS combinedInnerProduct matches Rust combined_inner_product" combinedInnerProductTest
+    it "opening proof verifies" openingProofTest

--- a/packages/pickles/test/Test/Pickles/E2E.purs
+++ b/packages/pickles/test/Test/Pickles/E2E.purs
@@ -291,7 +291,7 @@ permutationTest = do
         -- Create a real proof and get oracles via Fiat-Shamir
         let
           proof = ProofFFI.createProof { proverIndex, witness }
-          oracles = ProofFFI.proofOracles { proverIndex, proof, publicInput: publicInputs }
+          oracles = ProofFFI.proofOracles proverIndex { proof, publicInput: publicInputs }
 
         -- Get proof evaluations
         let

--- a/packages/pickles/test/Test/Pickles/Linearization.purs
+++ b/packages/pickles/test/Test/Pickles/Linearization.purs
@@ -96,12 +96,14 @@ buildFFIInput { witnessEvals, coeffEvals, indexEvals, alpha, beta, gamma, jointC
     , jointCombiner
     , witnessEvals
     , coefficientEvals: coeffEvals
-    , poseidonIndex: indexEvals !! index 0
-    , genericIndex: indexEvals !! index 1
-    , varbasemulIndex: indexEvals !! index 2
-    , endomulIndex: indexEvals !! index 3
-    , endomulScalarIndex: indexEvals !! index 4
-    , completeAddIndex: indexEvals !! index 5
+    -- Index order matches Kimchi verifier: Generic, Poseidon, CompleteAdd, VarBaseMul, EndoMul, EndoMulScalar
+    -- See kimchi/src/verifier.rs lines 485-490
+    , genericIndex: indexEvals !! index 0
+    , poseidonIndex: indexEvals !! index 1
+    , completeAddIndex: indexEvals !! index 2
+    , varbasemulIndex: indexEvals !! index 3
+    , endomulIndex: indexEvals !! index 4
+    , endomulScalarIndex: indexEvals !! index 5
     , vanishesOnZk: vanishesOnZkAndPreviousRows { domainLog2, zkRows, pt: zeta }
     , zeta
     , domainLog2

--- a/packages/pickles/test/Test/Pickles/Main.purs
+++ b/packages/pickles/test/Test/Pickles/Main.purs
@@ -6,6 +6,7 @@ import Data.Identity (Identity(..))
 import Data.Newtype (un)
 import Effect (Effect)
 import Effect.Aff (Aff)
+import Test.Pickles.Commitments as Commitments
 import Test.Pickles.E2E as E2E
 import Test.Pickles.Linearization as Linearization
 import Test.Pickles.Permutation as Permutation
@@ -22,6 +23,7 @@ main = runSpecAndExitProcess'
   do
     E2E.spec
     mapSpec nat do
+      Commitments.spec
       Linearization.spec
       Permutation.spec
       ScalarChallenge.spec

--- a/packages/pickles/test/Test/Pickles/Main.purs
+++ b/packages/pickles/test/Test/Pickles/Main.purs
@@ -2,18 +2,29 @@ module Test.Pickles.Main where
 
 import Prelude
 
+import Data.Identity (Identity(..))
+import Data.Newtype (un)
 import Effect (Effect)
+import Effect.Aff (Aff)
 import Test.Pickles.E2E as E2E
 import Test.Pickles.Linearization as Linearization
 import Test.Pickles.Permutation as Permutation
 import Test.Pickles.ScalarChallenge as ScalarChallenge
+import Test.Spec (mapSpec)
 import Test.Spec.Reporter.Console (consoleReporter)
-import Test.Spec.Runner.Node (runSpecAndExitProcess)
+import Test.Spec.Runner.Node (runSpecAndExitProcess')
+import Test.Spec.Runner.Node.Config as Cfg
 
 main :: Effect Unit
-main =
-  runSpecAndExitProcess [ consoleReporter ] do
+main = runSpecAndExitProcess'
+  { defaultConfig: Cfg.defaultConfig, parseCLIOptions: true }
+  [ consoleReporter ]
+  do
     E2E.spec
-    Linearization.spec
-    Permutation.spec
-    ScalarChallenge.spec
+    mapSpec nat do
+      Linearization.spec
+      Permutation.spec
+      ScalarChallenge.spec
+  where
+  nat :: Identity ~> Aff
+  nat x = pure $ un Identity x

--- a/packages/pickles/test/Test/Pickles/ProofFFI.js
+++ b/packages/pickles/test/Test/Pickles/ProofFFI.js
@@ -51,15 +51,55 @@ export const vestaProofSigmaEvals = (proof) =>
   pairEvals(crypto.vestaProofSigmaEvals(proof));
 
 // Proof oracles (Fiat-Shamir)
-export const pallasProofOracles = ({ proverIndex, proof, publicInput }) => {
+// Returns 11 values: [alpha, beta, gamma, zeta, ft_eval0, v, u,
+//                     combined_inner_product, ft_eval1, public_eval_zeta, public_eval_zeta_omega]
+export const pallasProofOracles = (proverIndex) => ({ proof, publicInput }) => {
   const flat = crypto.pallasProofOracles(proverIndex, proof, publicInput);
-  return { alpha: flat[0], beta: flat[1], gamma: flat[2], zeta: flat[3], ftEval0: flat[4] };
+  return {
+    alpha: flat[0],
+    beta: flat[1],
+    gamma: flat[2],
+    zeta: flat[3],
+    ftEval0: flat[4],
+    v: flat[5],
+    u: flat[6],
+    combinedInnerProduct: flat[7],
+    ftEval1: flat[8],
+    publicEvalZeta: flat[9],
+    publicEvalZetaOmega: flat[10]
+  };
 };
 
-export const vestaProofOracles = ({ proverIndex, proof, publicInput }) => {
+export const vestaProofOracles = (proverIndex) => ({ proof, publicInput }) => {
   const flat = crypto.vestaProofOracles(proverIndex, proof, publicInput);
-  return { alpha: flat[0], beta: flat[1], gamma: flat[2], zeta: flat[3], ftEval0: flat[4] };
+  return {
+    alpha: flat[0],
+    beta: flat[1],
+    gamma: flat[2],
+    zeta: flat[3],
+    ftEval0: flat[4],
+    v: flat[5],
+    u: flat[6],
+    combinedInnerProduct: flat[7],
+    ftEval1: flat[8],
+    publicEvalZeta: flat[9],
+    publicEvalZetaOmega: flat[10]
+  };
 };
+
+// Bulletproof challenges (IPA)
+export const pallasProofBulletproofChallenges = (proverIndex) => ({ proof, publicInput }) =>
+  crypto.pallasProofBulletproofChallenges(proverIndex, proof, publicInput);
+
+export const vestaProofBulletproofChallenges = (proverIndex) => ({ proof, publicInput }) =>
+  crypto.vestaProofBulletproofChallenges(proverIndex, proof, publicInput);
+
+// Verify opening proof
+export const pallasVerifyOpeningProof = (proverIndex) => ({ proof, publicInput }) =>
+  crypto.pallasVerifyOpeningProof(proverIndex, proof, publicInput);
+
+export const vestaVerifyOpeningProof = (proverIndex) => ({ proof, publicInput }) =>
+  crypto.vestaVerifyOpeningProof(proverIndex, proof, publicInput);
 
 // Permutation vanishing polynomial
 export const pallasPermutationVanishingPolynomial = ({ domainLog2, zkRows, pt }) =>

--- a/packages/pickles/test/Test/Pickles/ProofFFI.js
+++ b/packages/pickles/test/Test/Pickles/ProofFFI.js
@@ -50,6 +50,13 @@ export const pallasProofSigmaEvals = (proof) =>
 export const vestaProofSigmaEvals = (proof) =>
   pairEvals(crypto.vestaProofSigmaEvals(proof));
 
+// Proof evaluations - coefficient
+export const pallasProofCoefficientEvals = (proof) =>
+  pairEvals(crypto.pallasProofCoefficientEvals(proof));
+
+export const vestaProofCoefficientEvals = (proof) =>
+  pairEvals(crypto.vestaProofCoefficientEvals(proof));
+
 // Proof oracles (Fiat-Shamir)
 // Returns 11 values: [alpha, beta, gamma, zeta, ft_eval0, v, u,
 //                     combined_inner_product, ft_eval1, public_eval_zeta, public_eval_zeta_omega]

--- a/packages/pickles/test/Test/Pickles/ProofFFI.purs
+++ b/packages/pickles/test/Test/Pickles/ProofFFI.purs
@@ -6,6 +6,7 @@ module Test.Pickles.ProofFFI
   , proofWitnessEvals
   , proofZEvals
   , proofSigmaEvals
+  , proofCoefficientEvals
   , proofOracles
   , proofBulletproofChallenges
   , verifyOpeningProof
@@ -34,8 +35,8 @@ type OraclesResult f =
   , gamma :: f
   , zeta :: f
   , ftEval0 :: f
-  , v :: f               -- polyscale
-  , u :: f               -- evalscale
+  , v :: f -- polyscale
+  , u :: f -- evalscale
   , combinedInnerProduct :: f
   , ftEval1 :: f
   , publicEvalZeta :: f
@@ -52,6 +53,7 @@ class ProofFFI f g | f -> g where
   proofWitnessEvals :: Proof g f -> Vector 15 (PointEval f)
   proofZEvals :: Proof g f -> PointEval f
   proofSigmaEvals :: Proof g f -> Vector 6 (PointEval f)
+  proofCoefficientEvals :: Proof g f -> Vector 15 (PointEval f)
   proofOracles :: ProverIndex g f -> { proof :: Proof g f, publicInput :: Array f } -> OraclesResult f
   proofBulletproofChallenges :: ProverIndex g f -> { proof :: Proof g f, publicInput :: Array f } -> Array f
   verifyOpeningProof :: ProverIndex g f -> { proof :: Proof g f, publicInput :: Array f } -> Boolean
@@ -76,6 +78,9 @@ foreign import vestaProofZEvals :: Proof Pallas.G Vesta.BaseField -> PointEval V
 
 foreign import pallasProofSigmaEvals :: Proof Vesta.G Pallas.BaseField -> Vector 6 (PointEval Pallas.BaseField)
 foreign import vestaProofSigmaEvals :: Proof Pallas.G Vesta.BaseField -> Vector 6 (PointEval Vesta.BaseField)
+
+foreign import pallasProofCoefficientEvals :: Proof Vesta.G Pallas.BaseField -> Vector 15 (PointEval Pallas.BaseField)
+foreign import vestaProofCoefficientEvals :: Proof Pallas.G Vesta.BaseField -> Vector 15 (PointEval Vesta.BaseField)
 
 foreign import pallasProofOracles :: ProverIndex Vesta.G Pallas.BaseField -> { proof :: Proof Vesta.G Pallas.BaseField, publicInput :: Array Pallas.BaseField } -> OraclesResult Pallas.BaseField
 foreign import vestaProofOracles :: ProverIndex Pallas.G Vesta.BaseField -> { proof :: Proof Pallas.G Vesta.BaseField, publicInput :: Array Vesta.BaseField } -> OraclesResult Vesta.BaseField
@@ -102,6 +107,7 @@ instance ProofFFI Pallas.BaseField Vesta.G where
   proofWitnessEvals = pallasProofWitnessEvals
   proofZEvals = pallasProofZEvals
   proofSigmaEvals = pallasProofSigmaEvals
+  proofCoefficientEvals = pallasProofCoefficientEvals
   proofOracles = pallasProofOracles
   proofBulletproofChallenges = pallasProofBulletproofChallenges
   verifyOpeningProof = pallasVerifyOpeningProof
@@ -114,6 +120,7 @@ instance ProofFFI Vesta.BaseField Pallas.G where
   proofWitnessEvals = vestaProofWitnessEvals
   proofZEvals = vestaProofZEvals
   proofSigmaEvals = vestaProofSigmaEvals
+  proofCoefficientEvals = vestaProofCoefficientEvals
   proofOracles = vestaProofOracles
   proofBulletproofChallenges = vestaProofBulletproofChallenges
   verifyOpeningProof = vestaVerifyOpeningProof


### PR DESCRIPTION
  - Add combinedInnerProduct for IPA verification: Pure field function that batches all polynomial evaluations using sum_i (polyscale^i * (eval_zeta[i] +    
  evalscale * eval_zeta_omega[i]))                                                                                                                           
  - Add combinedInnerProductCircuit: In-circuit version for recursive verification, tested against pure implementation                                       
  - Add opening proof verification test: Confirms the full Kimchi opening proof verifies via FFI                                                             
  - Fix selector ordering: Aligned FFI and PureScript with Kimchi verifier's expected column order (Generic, Poseidon, CompleteAdd, VarBaseMul, EndoMul,     
  EndoMulScalar)                                                                                                                                             
  - Add coefficient evaluations FFI: Exposed proofCoefficientEvals for combinedInnerProduct                                                                  
  - Refactor E2E tests: Use beforeAll to share expensive setup across tests; use type-safe vector construction with append and :<                            
                                                                                                                                                             
  Test plan                                                                                                                                                  
                                                                                                                                                             
  - All 30 pickles tests pass                                                                                                                                
  - combinedInnerProduct matches Rust FFI value                                                                                                              
  - combinedInnerProductCircuit matches pure version (Pallas + Vesta)                                                                                        
  - Opening proof verifies       