### PR TITLE
Endo Inv and Group map

### DIFF
--- a/packages/curves/src/Snarky/Curves/Class.purs
+++ b/packages/curves/src/Snarky/Curves/Class.purs
@@ -17,6 +17,12 @@ module Snarky.Curves.Class
   , class HasEndo
   , endoBase
   , endoScalar
+  , class HasSqrt
+  , sqrt
+  , isSquare
+  , BW19Params
+  , class HasBW19
+  , bw19Params
   ) where
 
 import Prelude
@@ -55,3 +61,25 @@ class (PrimeField f, Reflectable n Int) <= FieldSizeInBits f (n :: Int) | f -> n
 class (PrimeField f, PrimeField f') <= HasEndo f f' | f -> f', f' -> f where
   endoBase :: f
   endoScalar :: f'
+
+-- | Square root and quadratic residue operations.
+-- | Used for hash-to-curve (group map) implementations.
+class PrimeField f <= HasSqrt f where
+  -- | Compute sqrt(x) if x is a quadratic residue, Nothing otherwise
+  sqrt :: f -> Maybe f
+  -- | Check if x is a quadratic residue (has a square root)
+  isSquare :: f -> Boolean
+
+-- | BW19 parameters for hash-to-curve (GroupMap)
+-- | These are precomputed constants for the BW19 algorithm on curves with a=0
+type BW19Params f =
+  { u :: f -- First valid u where u ≠ 0 and f(u) ≠ 0
+  , fu :: f -- f(u) = u³ + b
+  , sqrtNeg3U2MinusUOver2 :: f -- (sqrt(-3u²) - u) / 2
+  , sqrtNeg3U2 :: f -- sqrt(-3u²)
+  , inv3U2 :: f -- 1 / (3u²)
+  }
+
+-- | Typeclass for curves that support BW19 hash-to-curve
+class (PrimeField f, WeierstrassCurve f g) <= HasBW19 f g | g -> f where
+  bw19Params :: Proxy g -> BW19Params f

--- a/packages/curves/src/Snarky/Curves/Pasta.js
+++ b/packages/curves/src/Snarky/Curves/Pasta.js
@@ -126,7 +126,7 @@ export function _pallasGroupScale(scalar) {
 }
 
 export function _pallasToAffine(just, nothing, value) {
-  let p = napi.pallasGroupToAffine(value)
+  var p = napi.pallasGroupToAffine(value);
   if (p == null) {
     return nothing;
   } else {
@@ -297,4 +297,58 @@ export function _vestaEndoBase() {
 
 export function _vestaEndoScalar() {
     return napi.vestaEndoScalar();
+}
+
+// Square root and quadratic residue functions
+export function _pallasIsSquare(x) {
+    return napi.pallasScalarfieldIsSquare(x);
+}
+
+export function _pallasSqrt(just) {
+    return function(nothing) {
+        return function(x) {
+            const result = napi.pallasScalarfieldSqrt(x);
+            if (result == null) {
+                return nothing;
+            } else {
+                return just(result);
+            }
+        };
+    };
+}
+
+export function _vestaScalarFieldIsSquare(x) {
+    return napi.vestaScalarfieldIsSquare(x);
+}
+
+export function _vestaScalarFieldSqrt(just) {
+    return function(nothing) {
+        return function(x) {
+            const result = napi.vestaScalarfieldSqrt(x);
+            if (result == null) {
+                return nothing;
+            } else {
+                return just(result);
+            }
+        };
+    };
+}
+
+// BW19 GroupMap parameters
+// Returns array: [u, fu, sqrtNeg3U2MinusUOver2, sqrtNeg3U2, inv3U2]
+export function _pallasBW19Params() {
+    return napi.pallasBw19Params();
+}
+
+export function _vestaBW19Params() {
+    return napi.vestaBw19Params();
+}
+
+// Group map (hash-to-curve) functions
+export function _pallasGroupMap(t) {
+    return napi.pallasGroupMap(t);
+}
+
+export function _vestaGroupMap(t) {
+    return napi.vestaGroupMap(t);
 }

--- a/packages/snarky-kimchi/spago.yaml
+++ b/packages/snarky-kimchi/spago.yaml
@@ -17,6 +17,7 @@ package:
     - newtype
     - nonempty
     - ordered-collections
+    - partial
     - poseidon
     - prelude
     - quickcheck

--- a/packages/snarky-kimchi/src/Snarky/Circuit/Kimchi/GroupMap.purs
+++ b/packages/snarky-kimchi/src/Snarky/Circuit/Kimchi/GroupMap.purs
@@ -1,0 +1,205 @@
+-- | BW19 Hash-to-Curve algorithm (Wahby-Boneh 2019)
+-- | Maps a field element to a point on a Weierstrass curve y² = x³ + b (a=0)
+-- |
+-- | Reference: https://eprint.iacr.org/2019/403
+-- | Mina implementation: mina/src/lib/snarky/group_map/bw19.ml
+module Snarky.Circuit.Kimchi.GroupMap
+  ( GroupMapParams
+  , groupMapParams
+  , potentialXs
+  , groupMap
+  , groupMapCircuit
+  ) where
+
+import Prelude
+
+import Control.Alt ((<|>))
+import Data.Maybe (fromMaybe')
+import Effect.Exception.Unsafe (unsafeThrow)
+import Snarky.Circuit.DSL (class CircuitM, BoolVar, F(..), FVar, Snarky, add_, assertSquare_, const_, div_, exists, mul_, readCVar, scale_, sub_)
+import Snarky.Circuit.DSL.Assert (assert_)
+import Snarky.Circuit.DSL.Boolean (any_, if_)
+import Snarky.Constraint.Kimchi (KimchiConstraint)
+import Snarky.Curves.Class (class HasBW19, class HasSqrt, class PrimeField, bw19Params, curveParams, fromInt, isSquare, sqrt)
+import Snarky.Data.EllipticCurve (AffinePoint)
+import Type.Proxy (Proxy)
+
+-- | Full parameters needed for group map circuit
+-- | Combines FFI BW19 params with curve params and a computed non-residue
+type GroupMapParams f =
+  { u :: f -- First valid u where u ≠ 0 and f(u) ≠ 0
+  , fu :: f -- f(u) = u³ + b
+  , sqrtNeg3U2MinusUOver2 :: f -- (sqrt(-3u²) - u) / 2
+  , sqrtNeg3U2 :: f -- sqrt(-3u²)
+  , inv3U2 :: f -- 1 / (3u²)
+  , b :: f -- Curve parameter b
+  , nonResidue :: f -- A known quadratic non-residue
+  }
+
+-- | Build GroupMapParams from HasBW19 FFI params and curve params
+-- | The nonResidue is found by searching from 2
+groupMapParams
+  :: forall f g
+   . HasSqrt f
+  => HasBW19 f g
+  => Proxy g
+  -> GroupMapParams f
+groupMapParams proxy =
+  let
+    bw19 = bw19Params proxy
+    { b } = curveParams proxy
+
+    -- Find first non-residue (first non-square starting from 2)
+    findNonResidue i =
+      if not (isSquare i) then i else findNonResidue (i + one)
+    nonResidue = findNonResidue (fromInt @f 2)
+  in
+    { u: bw19.u
+    , fu: bw19.fu
+    , sqrtNeg3U2MinusUOver2: bw19.sqrtNeg3U2MinusUOver2
+    , sqrtNeg3U2: bw19.sqrtNeg3U2
+    , inv3U2: bw19.inv3U2
+    , b
+    , nonResidue
+    }
+
+-- | Compute three potential x-coordinates for the group map
+-- | One of these will have y² = x³ + b being a quadratic residue
+potentialXs
+  :: forall f
+   . PrimeField f
+  => GroupMapParams f
+  -> f
+  -> { x1 :: f, x2 :: f, x3 :: f }
+potentialXs params t =
+  let
+    t2 = t * t
+    alphaInv = (t2 + params.fu) * t2
+    alpha = one / alphaInv
+
+    t4 = t2 * t2
+    x1 = params.sqrtNeg3U2MinusUOver2 - t4 * alpha * params.sqrtNeg3U2
+    x2 = negate params.u - x1
+
+    t2PlusFu = t2 + params.fu
+    t2Inv = alpha * t2PlusFu -- = 1/t²
+    x3 = params.u - (t2PlusFu * t2PlusFu) * t2Inv * params.inv3U2
+  in
+    { x1, x2, x3 }
+
+-- | Pure groupMap: maps a field element to a curve point
+-- | For witness generation, not for in-circuit use
+groupMap
+  :: forall f
+   . HasSqrt f
+  => GroupMapParams f
+  -> f
+  -> AffinePoint f
+groupMap params t =
+  let
+    ySquared x = x * x * x + params.b
+
+    { x1, x2, x3 } = potentialXs params t
+
+    tryDecode x = sqrt (ySquared x) <#> \y -> { x, y }
+  in
+    fromMaybe' (\_ -> unsafeThrow "groupMap: no valid x-coordinate found (BW19 invariant violated)")
+      $ tryDecode x1 <|> tryDecode x2 <|> tryDecode x3
+
+-- | In-circuit sqrt with flag indicating if input is a quadratic residue
+-- | Uses the trick: exists is_square, y such that y² = if is_square then x else m*x
+-- | where m is a known non-residue
+sqrtFlagged
+  :: forall f t m
+   . PrimeField f
+  => HasSqrt f
+  => CircuitM f (KimchiConstraint f) t m
+  => f -- non-residue constant
+  -> FVar f
+  -> Snarky (KimchiConstraint f) t m { sqrtVal :: FVar f, isQR :: BoolVar f }
+sqrtFlagged nonResidue x = do
+  -- Witness: is x a quadratic residue?
+  -- exists with Boolean return type automatically gives BoolVar
+  isQRBool :: BoolVar f <- exists do
+    F xVal <- readCVar x
+    pure $ isSquare xVal
+
+  -- Witness: sqrt of x (if QR) or sqrt of m*x (if not)
+  sqrtVal <- exists do
+    F xVal <- readCVar x
+    let candidate = if isSquare xVal then xVal else nonResidue * xVal
+    pure $ F $ fromMaybe' (\_ -> unsafeThrow "sqrtFlagged: neither x nor m*x is a quadratic residue") $ sqrt candidate
+
+  -- Constraint: sqrtVal² = if isQR then x else m*x
+  let mX = scale_ nonResidue x
+  xOrMx <- if_ isQRBool x mX
+  assertSquare_ sqrtVal xOrMx
+
+  pure { sqrtVal, isQR: isQRBool }
+
+-- | In-circuit group map
+-- | Maps a field element to a curve point using the BW19 algorithm
+groupMapCircuit
+  :: forall f t m
+   . HasSqrt f
+  => CircuitM f (KimchiConstraint f) t m
+  => GroupMapParams f
+  -> FVar f
+  -> Snarky (KimchiConstraint f) t m (AffinePoint (FVar f))
+groupMapCircuit params t = do
+  -- Compute potential x-coordinates
+  -- t² requires mul_ (monadic)
+  t2 <- mul_ t t
+
+  -- alphaInv = (t² + f(u)) * t²
+  let t2PlusFu = add_ t2 (const_ params.fu)
+  alphaInv <- mul_ t2PlusFu t2
+
+  -- alpha = 1 / alphaInv
+  alpha <- div_ (const_ one) alphaInv
+
+  -- t⁴ = t² * t²
+  t4 <- mul_ t2 t2
+
+  -- x1 = sqrtNeg3U2MinusUOver2 - t⁴ * alpha * sqrtNeg3U2
+  t4Alpha <- mul_ t4 alpha
+  temp1 <- mul_ t4Alpha (const_ params.sqrtNeg3U2)
+  let x1 = sub_ (const_ params.sqrtNeg3U2MinusUOver2) temp1
+
+  -- x2 = -u - x1
+  let x2 = sub_ (const_ (negate params.u)) x1
+
+  -- x3 = u - (t² + f(u))² * (1/t²) * (1/(3u²))
+  -- Note: t2Inv = alpha * (t² + fu) = 1/t² (since alpha = 1/((t²+fu)*t²))
+  t2Inv <- mul_ alpha t2PlusFu
+  t2PlusFuSq <- mul_ t2PlusFu t2PlusFu
+  temp2a <- mul_ t2PlusFuSq t2Inv
+  temp2 <- mul_ temp2a (const_ params.inv3U2)
+  let x3 = sub_ (const_ params.u) temp2
+
+  -- y² for each candidate x: y² = x³ + b
+  let
+    ySquared x = do
+      xSq <- mul_ x x
+      xCu <- mul_ xSq x
+      pure $ add_ xCu (const_ params.b)
+
+  -- Try sqrt for each candidate
+  y1Sq <- ySquared x1
+  y2Sq <- ySquared x2
+  y3Sq <- ySquared x3
+  { sqrtVal: y1, isQR: b1 } <- sqrtFlagged params.nonResidue y1Sq
+  { sqrtVal: y2, isQR: b2 } <- sqrtFlagged params.nonResidue y2Sq
+  { sqrtVal: y3, isQR: b3 } <- sqrtFlagged params.nonResidue y3Sq
+
+  -- Assert at least one is a valid point
+  assert_ =<< any_ [ b1, b2, b3 ]
+
+  -- Select the first valid point: if b1 then (x1,y1) else if b2 then (x2,y2) else (x3,y3)
+  xInner <- if_ b2 x2 x3
+  xResult <- if_ b1 x1 xInner
+
+  yInner <- if_ b2 y2 y3
+  yResult <- if_ b1 y1 yInner
+
+  pure { x: xResult, y: yResult }

--- a/packages/snarky-kimchi/test/Test/Snarky/Circuit/Kimchi/EndoMul.purs
+++ b/packages/snarky-kimchi/test/Test/Snarky/Circuit/Kimchi/EndoMul.purs
@@ -11,13 +11,13 @@ import Snarky.Backend.Compile (compilePure, makeSolver)
 import Snarky.Backend.Kimchi.Class (class CircuitGateConstructor)
 import Snarky.Circuit.DSL (class CircuitM, F(..), Snarky)
 import Snarky.Circuit.DSL.Bits (packPure, unpackPure)
-import Snarky.Circuit.Kimchi.EndoMul (endo)
+import Snarky.Circuit.Kimchi.EndoMul (endo, endoInv)
 import Snarky.Circuit.Kimchi.EndoScalar (toFieldConstant)
 import Snarky.Circuit.Kimchi.Utils (verifyCircuit)
 import Snarky.Circuit.Types (F, FVar)
 import Snarky.Constraint.Kimchi (class KimchiVerify, KimchiConstraint)
 import Snarky.Constraint.Kimchi as Kimchi
-import Snarky.Curves.Class (class FieldSizeInBits, class FrModule, class WeierstrassCurve, endoScalar, fromAffine, scalarMul, toAffine)
+import Snarky.Curves.Class (class FieldSizeInBits, class FrModule, class HasEndo, class WeierstrassCurve, endoScalar, fromAffine, scalarMul, toAffine)
 import Snarky.Curves.Pallas as Pallas
 import Snarky.Curves.Vesta as Vesta
 import Snarky.Data.EllipticCurve (AffinePoint)
@@ -99,7 +99,80 @@ endoSpec _ curveProxy curveName =
     coerceViaBits :: f -> f'
     coerceViaBits = packPure <<< unpackPure
 
+endoInvSpec
+  :: forall f f' g g'
+   . FieldSizeInBits f 255
+  => FieldSizeInBits f' 255
+  => CircuitGateConstructor f g'
+  => KimchiVerify f f'
+  => HasEndo f f'
+  => Arbitrary g
+  => WeierstrassCurve f g
+  => FrModule f' g
+  => Proxy f
+  -> Proxy g
+  -> String
+  -> Spec Unit
+endoInvSpec _ curveProxy curveName =
+  describe ("EndoInv " <> curveName) do
+    it ("EndoInv circuit is valid for " <> curveName) $ unsafePartial $ do
+      let
+        -- Reference: compute g / scalar using constant operations
+        refFn :: Tuple (AffinePoint (F f)) (F f) -> AffinePoint (F f)
+        refFn (Tuple { x: F x, y: F y } (F scalar)) =
+          let
+            -- Convert scalar to effective scalar in f'
+            effectiveScalar = toFieldConstant (coerceViaBits scalar) (endoScalar :: f')
+            -- Compute inverse
+            invScalar = recip effectiveScalar
+            -- Scale the point
+            base = fromAffine { x, y } :: g
+            result = scalarMul invScalar base
+            { x, y } = unsafePartial $ fromJust $ toAffine result
+          in
+            { x: F x, y: F y }
+
+        solver = makeSolver (Proxy @(KimchiConstraint f)) (uncurry circuit)
+
+        circuit
+          :: forall t
+           . CircuitM f (KimchiConstraint f) t Identity
+          => AffinePoint (FVar f)
+          -> FVar f
+          -> Snarky (KimchiConstraint f) t Identity (AffinePoint (FVar f))
+        circuit p scalar = endoInv @f @f' @g p scalar
+
+        s =
+          compilePure
+            (Proxy @(Tuple (AffinePoint (F f)) (F f)))
+            (Proxy @(AffinePoint (F f)))
+            (Proxy @(KimchiConstraint f))
+            (uncurry circuit)
+            Kimchi.initialState
+
+        gen :: Gen (Tuple (AffinePoint (F f)) (F f))
+        gen = do
+          p <- EC.genAffinePoint curveProxy
+          scalar <- gen128BitElem
+          pure $ Tuple p scalar
+
+      circuitSpecPure' 100
+        { builtState: s
+        , checker: Kimchi.eval
+        , solver: solver
+        , testFunction: satisfied refFn
+        , postCondition: Kimchi.postCondition
+        }
+        gen
+
+      liftEffect $ verifyCircuit { s, gen, solver }
+  where
+  coerceViaBits :: f -> f'
+  coerceViaBits = packPure <<< unpackPure
+
 spec :: Spec Unit
 spec = do
   endoSpec (Proxy @Vesta.ScalarField) (Proxy @Pallas.G) "Pallas"
   endoSpec (Proxy @Pallas.ScalarField) (Proxy @Vesta.G) "Vesta"
+  endoInvSpec (Proxy @Vesta.ScalarField) (Proxy @Pallas.G) "Pallas"
+  endoInvSpec (Proxy @Pallas.ScalarField) (Proxy @Vesta.G) "Vesta"

--- a/packages/snarky-kimchi/test/Test/Snarky/Circuit/Kimchi/GroupMap.purs
+++ b/packages/snarky-kimchi/test/Test/Snarky/Circuit/Kimchi/GroupMap.purs
@@ -1,0 +1,121 @@
+module Test.Snarky.Circuit.Kimchi.GroupMap
+  ( spec
+  ) where
+
+import Prelude
+
+import Effect.Class (liftEffect)
+import Snarky.Backend.Compile (compilePure, makeSolver)
+import Snarky.Backend.Kimchi.Class (class CircuitGateConstructor)
+import Snarky.Circuit.DSL (class CircuitM, F(..), FVar, Snarky)
+import Snarky.Circuit.Kimchi.GroupMap (GroupMapParams, groupMap, groupMapCircuit, groupMapParams)
+import Snarky.Constraint.Kimchi (class KimchiVerify, KimchiConstraint)
+import Snarky.Constraint.Kimchi as Kimchi
+import Snarky.Curves.Class (class HasBW19, class HasSqrt)
+import Snarky.Curves.Pallas as Pallas
+import Snarky.Curves.Pasta (pallasGroupMap, vestaGroupMap)
+import Snarky.Curves.Vesta as Vesta
+import Snarky.Data.EllipticCurve (AffinePoint)
+import Test.QuickCheck (arbitrary, quickCheck')
+import Test.Snarky.Circuit.Utils (circuitSpecPure', satisfied)
+import Test.Spec (Spec, describe, it)
+import Type.Proxy (Proxy(..))
+
+-- | Test that groupMap produces valid curve points (y² = x³ + b)
+testValidCurvePoints
+  :: forall f
+   . HasSqrt f
+  => GroupMapParams f
+  -> F f
+  -> Boolean
+testValidCurvePoints params (F t) =
+  let
+    { x, y } = groupMap params t
+  in
+    y * y == x * x * x + params.b
+
+-- | Test that groupMap matches the Rust FFI implementation
+testMatchesRustFFI
+  :: forall f
+   . HasSqrt f
+  => Eq f
+  => GroupMapParams f
+  -> (f -> { x :: f, y :: f })
+  -> F f
+  -> Boolean
+testMatchesRustFFI params rustGroupMap (F t) =
+  let
+    psResult = groupMap params t
+    rustResult = rustGroupMap t
+  in
+    psResult.x == rustResult.x && psResult.y == rustResult.y
+
+spec'
+  :: forall f f' g g'
+   . HasSqrt f
+  => HasBW19 f g
+  => CircuitGateConstructor f g'
+  => KimchiVerify f f'
+  => Proxy g
+  -> String
+  -> Spec Unit
+spec' proxyG curveName = do
+  let params = groupMapParams proxyG
+
+  describe ("GroupMap: " <> curveName) do
+    it "produces valid curve points (y² = x³ + b)"
+      $ liftEffect
+      $ quickCheck' 100 (testValidCurvePoints params)
+
+    it "circuit matches groupMap and satisfies constraints" $
+      let
+        f :: F f -> AffinePoint (F f)
+        f (F t) =
+          let
+            { x, y } = groupMap params t
+          in
+            { x: F x, y: F y }
+
+        circuit
+          :: forall t m
+           . CircuitM f (KimchiConstraint f) t m
+          => FVar f
+          -> Snarky (KimchiConstraint f) t m (AffinePoint (FVar f))
+        circuit = groupMapCircuit params
+
+        solver = makeSolver (Proxy @(KimchiConstraint f)) circuit
+
+        s = compilePure
+          (Proxy @(F f))
+          (Proxy @(AffinePoint (F f)))
+          (Proxy @(KimchiConstraint f))
+          circuit
+          Kimchi.initialState
+
+      in
+        circuitSpecPure' 10
+          { builtState: s
+          , checker: Kimchi.eval
+          , solver: solver
+          , testFunction: satisfied f
+          , postCondition: Kimchi.postCondition
+          }
+          arbitrary
+
+spec :: Spec Unit
+spec = do
+  describe "GroupMap" do
+    spec' (Proxy @Pallas.G) "Pallas"
+    spec' (Proxy @Vesta.G) "Vesta"
+
+    it "Pallas groupMap matches Rust FFI"
+      $ liftEffect
+      $ quickCheck' 100
+      $
+        testMatchesRustFFI (groupMapParams (Proxy @Pallas.G)) pallasGroupMap
+
+    it "Vesta groupMap matches Rust FFI"
+      $ liftEffect
+      $ quickCheck' 100
+      $
+        testMatchesRustFFI (groupMapParams (Proxy @Vesta.G)) vestaGroupMap

--- a/packages/snarky-kimchi/test/Test/Snarky/Circuit/Kimchi/Main.purs
+++ b/packages/snarky-kimchi/test/Test/Snarky/Circuit/Kimchi/Main.purs
@@ -12,6 +12,7 @@ import Test.Snarky.Circuit.Kimchi.AddComplete as AddCompleteTests
 import Test.Snarky.Circuit.Kimchi.EndoMul as EndoMulTests
 import Test.Snarky.Circuit.Kimchi.EndoScalar as EndoScalarTests
 import Test.Snarky.Circuit.Kimchi.GenericTest as GenericTests
+import Test.Snarky.Circuit.Kimchi.GroupMap as GroupMapTests
 import Test.Snarky.Circuit.Kimchi.Poseidon as PoseidonTests
 import Test.Snarky.Circuit.Kimchi.VarBaseMul as VarBaseMulTests
 import Test.Snarky.Constraint.Kimchi.GenericPlonk as GenericPlonkSpec
@@ -44,3 +45,4 @@ spec = do
   EndoMulTests.spec
   EndoScalarTests.spec
   ShiftedTests.spec
+  GroupMapTests.spec

--- a/spago.lock
+++ b/spago.lock
@@ -2100,6 +2100,7 @@
             "newtype",
             "nonempty",
             "ordered-collections",
+            "partial",
             "poseidon",
             "prelude",
             "quickcheck",


### PR DESCRIPTION
  This PR implements two circuit primitives required for IPA verification:                                                                              
                                                                                                                                                        
  endoInv Circuit - Computes scalar multiplication by the inverse endomorphism scalar. Given a point P, it efficiently computes endo_scalar^{-1} * P    
  using the curve's endomorphism. This is needed for the IPA verifier's sg computation.                                                                 
                                                                                                                                                        
  groupMap Circuit (BW19 Hash-to-Curve) - Maps a field element to a curve point using the Wahby-Boneh 2019 algorithm. The implementation:               
  - Computes three candidate x-coordinates via potentialXs                                                                                              
  - Uses sqrtFlagged to test which candidate yields a valid y-coordinate (quadratic residue check)                                                      
  - Selects the first valid point using nested if_ expressions                                                                                          
                                                                                                                                                        
  FFI Additions:                                                                                                                                        
  - sqrt and isSquare for both Pallas and Vesta scalar fields                                                                                           
  - BW19 parameters (u, fu, sqrtNeg3U2, etc.) from Rust's kimchi                                                                                        
  - pallasGroupMap/vestaGroupMap for testing against Rust's implementation                                                                              
                                                                                                                                                        
  Tests:                                                                                                                                                
  - Pure groupMap produces valid curve points (y² = x³ + b)                                                                                             
  - Circuit matches pure implementation and satisfies constraints                                                                                       
  - PureScript implementation matches Rust FFI reference                                                                                                
                                                            