### PR TITLE
Bench: survivor-focused GC metrics + lazy prepareProve

### DIFF
--- a/packages/pickles-bench/parse_gclog.mjs
+++ b/packages/pickles-bench/parse_gclog.mjs
@@ -65,12 +65,20 @@ for (const line of lines) {
 
 const isScavenge = (k) => /Scavenge|Minor/.test(k);
 
+// NOTE on reading these: `reclaimedGB` (allocation churn) is NOT the cost
+// driver — scavenge pause cost tracks SURVIVORS, not reclaimed volume
+// (measured 2026-06-11: the transformer stack reclaims MORE GB than the
+// Run stack at half the GC pause, because its garbage dies young). Watch
+// `avgScavengeMs` (survivor copying per scavenge) and `majorGCs`/
+// `majorPauseMs` (promotion pressure) when comparing stacks.
 const summarize = (w) => {
   const evs = events.filter((e) => e.t >= w.start && e.t <= w.end);
   const scav = evs.filter((e) => isScavenge(e.kind));
   const major = evs.filter((e) => !isScavenge(e.kind));
   const wallMs = w.end - w.start;
   const pauseMs = evs.reduce((a, e) => a + e.pauseMs, 0);
+  const scavPauseMs = scav.reduce((a, e) => a + e.pauseMs, 0);
+  const majorPauseMs = major.reduce((a, e) => a + e.pauseMs, 0);
   return {
     label: w.label,
     wallMs,
@@ -80,6 +88,8 @@ const summarize = (w) => {
       evs.reduce((a, e) => a + Math.max(0, e.reclaimedMB), 0) / 1024,
     gcPauseMs: pauseMs,
     gcPausePct: wallMs > 0 ? (100 * pauseMs) / wallMs : 0,
+    avgScavengeMs: scav.length ? scavPauseMs / scav.length : 0,
+    majorPauseMs,
   };
 };
 
@@ -105,7 +115,8 @@ if (resultsPath) {
   for (const s of summaries) {
     console.log(
       `${s.label}: wall=${(s.wallMs / 1000).toFixed(1)}s  reclaimed=${s.reclaimedGB.toFixed(1)}GB  ` +
-        `scavenges=${s.scavenges}  major=${s.majorGCs}  gcPause=${s.gcPauseMs.toFixed(0)}ms (${s.gcPausePct.toFixed(1)}%)`
+        `scavenges=${s.scavenges} (avg ${s.avgScavengeMs.toFixed(2)}ms)  major=${s.majorGCs} (${s.majorPauseMs.toFixed(0)}ms)  ` +
+        `gcPause=${s.gcPauseMs.toFixed(0)}ms (${s.gcPausePct.toFixed(1)}%)`
     );
   }
 }

--- a/packages/pickles-bench/src/BenchUtils.js
+++ b/packages/pickles-bench/src/BenchUtils.js
@@ -168,6 +168,9 @@ export class BenchUtils {
       gitSha: process.env.GIT_SHA || sh("git rev-parse HEAD"),
       gitDirty: sh("git status --porcelain") ? true : false,
       node: process.version,
+      // V8 flags change GC behavior (e.g. --max-semi-space-size) — results
+      // are only comparable between runs with identical flags.
+      nodeFlags: process.execArgv,
       // Same-machine artifacts are only comparable at the same power
       // profile: power-saver clamps this box from 5.2GHz to ~1.5GHz
       // (observed 2026-06-11: identical code, 22s vs 42s compile).

--- a/packages/pickles-bench/src/Main.purs
+++ b/packages/pickles-bench/src/Main.purs
@@ -12,13 +12,15 @@
 -- |   * `mkBenchSrs` builds one SRS pair and pre-warms its lagrange
 -- |     cache (the cache lives inside the SRS object, so every group
 -- |     reusing this record pays nothing for SRS load or lagrange).
--- |   * `Prove.prepareProve` does the prove bench's compile + b0 once
--- |     (NOT via benchlib's `prepareInput`, which re-runs per iteration).
+-- |   * `Prove.prepareProve` (the prove bench's compile + b0) runs once,
+-- |     but LAZILY — memoized inside the prove group's `prepareInput`,
+-- |     i.e. after the compile group — so the compile bench is not
+-- |     measured with prove's prepared state resident (that residency
+-- |     measurably triples scavenge cost; see the note at the call site).
 -- |
--- | CLI: `--only compile | prove` runs ONLY the named group. The other
--- | group's setup (notably `Prove.prepareProve`, which is itself a full
--- | compile + b0) is skipped, so `--only compile` doesn't pay for the
--- | prove warmup and `--only prove` doesn't run the timed compile.
+-- | CLI: `--only compile | prove` runs ONLY the named group. The lazy
+-- | prove setup means `--only compile` never pays for the prove warmup,
+-- | and `--only prove` doesn't run the timed compile.
 -- | `--help` prints the parser usage.
 -- |
 -- | This package is its OWN spago workspace (its spago.yaml has a
@@ -41,9 +43,10 @@ import Bench.Pickles.Stats (statsReporter)
 import BenchLib (reportConsole, runNode, suite)
 import Data.Array as Array
 import Data.Either (Either(..))
-import Data.Foldable (elem)
 import Data.Maybe (Maybe(..), optional)
 import Effect (Effect)
+import Effect.Class (liftEffect)
+import Effect.Ref as Ref
 import Options.Applicative ((<**>))
 import Options.Applicative as Opt
 
@@ -101,18 +104,27 @@ main = do
   FfiTimer.install
   srs <- mkBenchSrs
 
-  -- prepareProve is itself a full compile + b0 — only pay for it when
-  -- Prove is actually going to run.
-  mProveThunk <-
-    if elem Prove selected then
-      map Just (Prove.prepareProve srs)
-    else
-      pure Nothing
+  -- prepareProve (itself a full compile + b0) runs LAZILY on the prove
+  -- group's first `prepareInput` — i.e. AFTER the compile group has
+  -- finished — so the compile bench is not measured with prove's prepared
+  -- state resident in the old gen. Measured 2026-06-11: that residency
+  -- costs the compile bench +2.1s wall (6.5s -> 8.7s) by making every
+  -- scavenge 4-13x more expensive (remembered-set scanning), 8% -> 21%
+  -- GC pause. Memoized via a Ref: benchlib re-runs `prepareInput` per
+  -- sample; only the first call does the work.
+  lazyProveThunk <- do
+    ref <- Ref.new Nothing
+    pure $ liftEffect (Ref.read ref) >>= case _ of
+      Just thunk -> pure thunk
+      Nothing -> do
+        thunk <- liftEffect (Prove.prepareProve srs)
+        liftEffect (Ref.write (Just thunk) ref)
+        pure thunk
 
   let
     groups = selected # Array.mapMaybe case _ of
       Compile -> Just (Compile.group srs)
-      Prove -> map Prove.group mProveThunk
+      Prove -> Just (Prove.group lazyProveThunk)
 
   runNode (\o -> o { reporters = [ reportConsole, statsReporter, jsonReporter ] }) $
     suite "pickles"

--- a/packages/pickles-bench/src/Prove.purs
+++ b/packages/pickles-bench/src/Prove.purs
@@ -3,9 +3,11 @@
 -- | `prepareProve` does all the untimed setup — compile (NRR + tree),
 -- | the NRR proof, and b0 — against the shared, pre-warmed SRS, and
 -- | returns the b1 prove as an `Aff Unit` thunk. `Bench.Pickles.Main`
--- | runs `prepareProve` exactly once (NOT inside benchlib's
--- | `prepareInput`, which re-runs per iteration) and hands the thunk to
--- | `group`, so only the b1 prove is measured.
+-- | wraps it in a memoized getter that `group` runs as benchlib's
+-- | `prepareInput` (untimed, outside `measureTime`): the first sample's
+-- | prepare does the real work — after the compile group, so compile is
+-- | never measured with prove state resident — and later samples hit
+-- | the memo. Only the b1 prove is measured.
 -- |
 -- | The prover-call shape mirrors the passing `Test.Pickles.Prove.
 -- | TreeProofReturn` (record `{ appInput, prevs, sideloadedVKs }` with
@@ -117,19 +119,22 @@ prepareProve srs = do
 benchLabel :: String
 benchLabel = "b1 recursive prove (shared warm SRS)"
 
-group :: Aff Unit -> BL.Group
-group proveThunk =
+group :: Aff (Aff Unit) -> BL.Group
+group getProveThunk =
   BL.group "prove: N=2 tree b1 (compile + b0 untimed)"
     -- iterations = 1, sizes = [0, 0, …, 0] of length `benchIterations`
     -- → benchIterations independent samples, each with its own time.
     (\o -> o { iterations = 1, sizes = Array.replicate benchIterations 0 })
     [ BL.benchAff_ benchLabel
-        (\_ -> pure unit)
-        ( \_ -> do
+        -- The untimed prepare: first call runs `prepareProve` (memoized
+        -- in Main), so the heavy setup happens here, outside the timed
+        -- region and after the compile group.
+        (\_ -> getProveThunk)
+        ( \proveThunk -> do
             liftEffect FfiTimer.start
             liftEffect $ BenchUtils.startFfiTracking benchLabel
             liftEffect BenchUtils.startGcTracking
-            _ <- proveThunk
+            proveThunk
             liftEffect $ BenchUtils.stopFfiTracking benchLabel
             liftEffect $ BenchUtils.captureTrial benchLabel
             liftEffect FfiTimer.reportSplit

--- a/tools/bench.sh
+++ b/tools/bench.sh
@@ -41,6 +41,13 @@ BENCH_DIR="$REPO_ROOT/packages/pickles-bench"
 export PATH="$HOME/.nvm/versions/node/v23.11.1/bin:$PATH"
 
 # Our one flag; the rest is forwarded to the bench CLI.
+#
+# Deliberately NO GC tuning (e.g. --max-semi-space-size): measured
+# 2026-06-11 as noise-level for this workload once the compile bench
+# stopped running with prove's prepared state resident, and changing node
+# flags breaks comparability with older baselines. The flags are recorded
+# in the results JSON (`nodeFlags`) — only compare runs with identical
+# flags.
 NODE_FLAGS=(--trace-gc)
 ARGS=()
 for a in "$@"; do
@@ -61,12 +68,12 @@ echo "==> Running suite (node ${NODE_FLAGS[*]}; log: $RUN_LOG) ..."
 # The raw --trace-gc firehose (one line per GC, thousands per trial) goes
 # to the LOG ONLY — it is input for parse_gclog.mjs, not for humans. The
 # terminal shows just the bench's own output (markers, splits, results).
-node "${NODE_FLAGS[@]}" packages/pickles-bench/run.mjs "${ARGS[@]}" 2>&1 \
+node "${NODE_FLAGS[@]}" packages/pickles-bench/run.mjs ${ARGS[@]+"${ARGS[@]}"} 2>&1 \
   | tee "$RUN_LOG" \
   | grep -vE '^\[[0-9]+(:0x[0-9a-f]+)?\] ' || true
 
 # The bench prints `[bench-results] <path>` for the JSON it wrote.
-RESULTS_FILE=$(grep -oP '(?<=^\[bench-results\] ).*' "$RUN_LOG" | tail -1)
+RESULTS_FILE=$(sed -n 's/^\[bench-results\] //p' "$RUN_LOG" | tail -1)
 if [ -z "$RESULTS_FILE" ]; then
   echo "ERROR: no [bench-results] line found in the run output" >&2
   exit 1


### PR DESCRIPTION
parse_gclog.mjs gains avgScavengeMs and majorPauseMs per trial, and the results JSON records nodeFlags — reclaimedGB alone is misleading (pause cost tracks survivors, not volume; flag changes break baseline comparability).

prepareProve (a full compile + b0) now runs lazily, memoized inside the prove group's untimed prepareInput, instead of before the suite. Its resident state was contaminating both groups' numbers: compile measured 8.7s/21% GC with it resident vs 6.5s/8% without (scavenges 4-13x more expensive over the fat old gen), and prove drops 10.3s -> 8.5s with the compile group's garbage collected against a small live set first.

No GC tuning flags in bench.sh: --max-semi-space-size=64 measured noise-level once the residency effect was removed.