### PR TITLE
Remove dead code (CoreFn-unreachable exports) + fix visualizer deps

### DIFF
--- a/packages/merkle-tree/src/Data/MerkleTree.purs
+++ b/packages/merkle-tree/src/Data/MerkleTree.purs
@@ -13,9 +13,6 @@ module Data.MerkleTree
   , set
   , getPath
   , impliedRoot
-  , getFreePath
-  , freeRoot
-  , impliedFreeRoot
   , root
   , toUnfoldable
   , ithBit
@@ -29,8 +26,8 @@ import Data.Foldable (class Foldable)
 import Data.List (List(..), (:))
 import Data.List as List
 import Data.Maybe (Maybe(..))
-import Data.MerkleTree.Hashable (class HashInput, class Hashable, class MergeHash, class MerkleHashable, FreeHash(..), defaultHash, hashInput, hashLeaf, merge, toHashInput) as ReExports
-import Data.MerkleTree.Hashable (class MergeHash, class MerkleHashable, FreeHash(..), defaultHash, hashLeaf, merge)
+import Data.MerkleTree.Hashable (class HashInput, class Hashable, class MergeHash, class MerkleHashable, defaultHash, hashInput, hashLeaf, merge, toHashInput) as ReExports
+import Data.MerkleTree.Hashable (class MergeHash, class MerkleHashable, defaultHash, hashLeaf, merge)
 import Data.Traversable (class Traversable)
 import Data.Unfoldable (class Unfoldable, class Unfoldable1)
 import Effect.Exception.Unsafe (unsafeThrow)
@@ -453,76 +450,6 @@ impliedRoot (Address addr0) entryHash (Path path0) =
         go (merge acc h) (i + 1) hs
   in
     go entryHash 0 path0
-
--- Get free hash path
-getFreePath
-  :: forall hash a
-   . MerkleTree hash a
-  -> Address
-  -> Maybe (Path (FreeHash a))
-getFreePath (MerkleTree t) (Address addr0) =
-  let
-    go :: List (FreeHash a) -> NonEmptyTree hash a -> Int -> Maybe (List (FreeHash a))
-    go acc tree i =
-      if i < 0 then Just acc
-      else
-        let
-          goRight = ithBit addr0 i
-        in
-          case tree of
-            Leaf _ _ -> Just acc -- We've reached the leaf, return accumulated path
-            Node _ l r ->
-              if goRight then
-                case r of
-                  Empty -> Nothing
-                  NonEmpty tr' -> go (treeFreeHash l : acc) tr' (i - 1)
-              else
-                case l of
-                  Empty -> Nothing
-                  NonEmpty tl' -> go (treeFreeHash r : acc) tl' (i - 1)
-  in
-    Path <$> go Nil t.tree (t.depth - 1)
-
--- Helper to convert tree to free hash
-treeFreeHash
-  :: forall hash a
-   . Tree hash a
-  -> FreeHash a
-treeFreeHash = case _ of
-  Empty -> HashEmpty
-  NonEmpty t -> nonEmptyFreeHash t
-
--- Helper to convert non-empty tree to free hash
-nonEmptyFreeHash
-  :: forall hash a
-   . NonEmptyTree hash a
-  -> FreeHash a
-nonEmptyFreeHash = case _ of
-  Leaf _ x -> HashValue x
-  Node _ l r -> Merge (treeFreeHash l) (treeFreeHash r)
-
--- Get free hash of root
-freeRoot :: forall hash a. MerkleTree hash a -> FreeHash a
-freeRoot (MerkleTree t) = nonEmptyFreeHash t.tree
-
--- Compute free root from value and path  
-impliedFreeRoot
-  :: forall a
-   . Address
-  -> a
-  -> Path (FreeHash a)
-  -> FreeHash a
-impliedFreeRoot (Address addr0) value (Path path0) =
-  let
-    go :: FreeHash a -> Int -> List (FreeHash a) -> FreeHash a
-    go acc _ Nil = acc
-    go acc i (h : hs) =
-      if ithBit addr0 i then
-        go (Merge h acc) (i + 1) hs
-      else
-        go (Merge acc h) (i + 1) hs
-  in
-    go (HashValue value) 0 path0
 
 -- Get root hash
 root :: forall hash a. MerkleTree hash a -> hash

--- a/packages/merkle-tree/src/Data/MerkleTree/Hashable.purs
+++ b/packages/merkle-tree/src/Data/MerkleTree/Hashable.purs
@@ -5,8 +5,6 @@ module Data.MerkleTree.Hashable
   , merge
   , module RO
   , defaultHash
-  , FreeHash(..)
-  , hashCircuit
   , mergeCircuit
   ) where
 
@@ -17,7 +15,7 @@ import Data.Maybe (Maybe(..))
 import Data.Newtype (un)
 import Poseidon (class PoseidonField)
 import Poseidon as Poseidon
-import Snarky.Circuit.DSL (FVar, Snarky, const_)
+import Snarky.Circuit.DSL (FVar, Snarky)
 import Snarky.Circuit.RandomOracle (class HashInput, class Hashable, hashInput, toHashInput) as RO
 import Snarky.Circuit.RandomOracle (Digest(..), hash2)
 import Snarky.Constraint.Kimchi (KimchiConstraint)
@@ -56,26 +54,6 @@ instance (MergeHash hash, RO.Hashable a b, RO.HashInput b hash) => MerkleHashabl
   hashLeaf = case _ of
     Nothing -> RO.hashInput ([] :: Array b)
     Just x -> RO.hashInput (RO.toHashInput x)
-
--- | Free hash type for lazy/symbolic hash computation
-data FreeHash a
-  = HashValue a
-  | HashEmpty
-  | Merge (FreeHash a) (FreeHash a)
-
-derive instance Eq a => Eq (FreeHash a)
-derive instance Functor FreeHash
-
--- | Circuit-level hash function for a single field element
-hashCircuit
-  :: forall f r
-   . PoseidonField f
-  => PrimeField f
-  => Maybe (FVar f)
-  -> Snarky f (KimchiConstraint f) r (Digest (FVar f))
-hashCircuit = case _ of
-  Nothing -> hash2 (const_ zero) (const_ zero)
-  Just a -> hash2 a (const_ zero)
 
 -- | Circuit-level merge of two digests
 mergeCircuit

--- a/packages/merkle-tree/src/Data/MerkleTree/Sized.purs
+++ b/packages/merkle-tree/src/Data/MerkleTree/Sized.purs
@@ -11,9 +11,6 @@ module Data.MerkleTree.Sized
   , set
   , getPath
   , impliedRoot
-  , getFreePath
-  , freeRoot
-  , impliedFreeRoot
   , root
   , toUnfoldable
   , module ReExports
@@ -27,9 +24,8 @@ import Data.FoldableWithIndex (foldlWithIndex)
 import Data.Generic.Rep (class Generic)
 import Data.List (List)
 import Data.Maybe (Maybe(..), fromJust, maybe)
-import Data.MerkleTree (FreeHash)
 import Data.MerkleTree as MT
-import Data.MerkleTree.Hashable (class HashInput, class Hashable, class MergeHash, class MerkleHashable, FreeHash(..), defaultHash, hashCircuit, hashInput, hashLeaf, merge, mergeCircuit, toHashInput) as ReExports
+import Data.MerkleTree.Hashable (class HashInput, class Hashable, class MergeHash, class MerkleHashable, defaultHash, hashInput, hashLeaf, merge, mergeCircuit, toHashInput) as ReExports
 import Data.MerkleTree.Hashable (class MergeHash, class MerkleHashable)
 import Data.Newtype (class Newtype)
 import Data.Reflectable (class Reflectable, reflectType)
@@ -206,33 +202,6 @@ impliedRoot
   -> hash
 impliedRoot (Address addr0) entryHash (Path path0) =
   MT.impliedRoot (MT.Address addr0) entryHash (Vector.toUnfoldable path0)
-
--- Get free hash path
-getFreePath
-  :: forall d hash a
-   . Reflectable d Int
-  => MerkleTree d hash a
-  -> Address d
-  -> Maybe (Path d (FreeHash a))
-getFreePath (MerkleTree t) (Address addr0) =
-  MT.getFreePath t (MT.Address addr0) <#> \path ->
-    case Vector.toVector (Array.fromFoldable path) of
-      Nothing -> unsafeThrow $ "Expected Merkle path of length " <> show (reflectType $ Proxy @d)
-      Just p -> Path p
-
--- Get free hash of root
-freeRoot :: forall d hash a. MerkleTree d hash a -> FreeHash a
-freeRoot (MerkleTree t) = MT.freeRoot t
-
--- Compute free root from value and path  
-impliedFreeRoot
-  :: forall d a
-   . Address d
-  -> a
-  -> Path d (FreeHash a)
-  -> FreeHash a
-impliedFreeRoot (Address addr0) value (Path path0) =
-  MT.impliedFreeRoot (MT.Address addr0) value (Vector.toUnfoldable path0)
 
 -- Get root hash
 root :: forall d hash a. MerkleTree d hash a -> hash

--- a/packages/pickles-circuit-diffs/visualizer/spago.yaml
+++ b/packages/pickles-circuit-diffs/visualizer/spago.yaml
@@ -11,16 +11,20 @@ package:
     - aff
     - affjax
     - affjax-web
+    - arrays
     - effect
     - either
     - maybe
-    - prelude
+    - ordered-collections
     - pickles-circuit-diffs-types
+    - prelude
     - react-basic
     - react-basic-dom
     - react-basic-hooks
     - refs
     - simple-json
+    - strings
+    - web-dom
     - web-events
     - web-html
     - web-uievents

--- a/packages/pickles/src/Pickles/PublicInputCommit.purs
+++ b/packages/pickles/src/Pickles/PublicInputCommit.purs
@@ -24,7 +24,6 @@ module Pickles.PublicInputCommit
   , class RPackStatement
   , PackedField
   , CorrectionMode(..)
-  , DeferredScaleMul(..)
   , DeferredScaleMul1(..)
   , MsmTerm(..)
   , ScalarMulResult
@@ -160,24 +159,6 @@ instance
 -- | PureCorrections: sum as pure field arithmetic (no circuit cost) — for Step verifier.
 -- | InCircuitCorrections: sum via in-circuit addComplete gates — for Wrap verifier.
 data CorrectionMode = PureCorrections | InCircuitCorrections
-
--- | A deferred scalar multiplication that captures type-level parameters.
--- | This lets scalarMulLeaf store the computation without executing it,
--- | so publicInputCommit can interleave scale_fast2' and add_fast inline
--- | during the fold (matching OCaml's step_verifier.ml:468-475).
--- |
--- | Returns a `Vector stepChunks (AffinePoint (FVar f))` — one curve point
--- | per chunk of the lagrange basis. For nc=1 this is a 1-element vector
--- | producing identical gates to a single scaleFast2'; for chunks2 (step
--- | domain > wrap SRS max_poly_size) it emits stepChunks scaleFast2' calls
--- | per PI slot. Mirrors OCaml's
--- | `Array.map2_exn acc chunks ~f:(... scale_fast2' g x ~num_bits ...)`
--- | (wrap_verifier.ml:1019-1023).
-newtype DeferredScaleMul (stepChunks :: Int) f = DeferredScaleMul
-  ( forall r
-     . PrimeField f
-    => Snarky f (KimchiConstraint f) r (Vector stepChunks (AffinePoint (FVar f)))
-  )
 
 -- | Per-chunk deferred scalar multiplication. Used by `InCircuitCorrections`
 -- | to interleave scale_fast2'+add_fast per chunk (matching OCaml's

--- a/packages/pickles/src/Pickles/Sponge.purs
+++ b/packages/pickles/src/Pickles/Sponge.purs
@@ -24,7 +24,6 @@ module Pickles.Sponge
   , labelM
   , getSponge
   , putSponge
-  , runSpongeM
   -- Pure sponge monad
   , PureSpongeM(..)
   , runPureSpongeM
@@ -103,14 +102,6 @@ instance Bind (SpongeM f c r) where
   bind (SpongeM g) f = SpongeM \s -> g s >>= \(Tuple a s') -> unwrap (f a) s'
 
 instance Monad (SpongeM f c r)
-
--- | Run a SpongeM computation, returning result and final sponge
-runSpongeM
-  :: forall f c r a
-   . Sponge (FVar f)
-  -> SpongeM f c r a
-  -> Snarky f c r (Tuple a (Sponge (FVar f)))
-runSpongeM initialState computation = unwrap computation initialState
 
 -- | Run a SpongeM computation, returning only the result
 evalSpongeM

--- a/packages/random-oracle/src/Snarky/Circuit/RandomOracle/Sponge.purs
+++ b/packages/random-oracle/src/Snarky/Circuit/RandomOracle/Sponge.purs
@@ -12,7 +12,6 @@ module Snarky.Circuit.RandomOracle.Sponge
   ( absorb
   , squeeze
   , initialState
-  , initialSpongeCircuit
   , spongeFromConstants
   , module ReExports
   ) where
@@ -37,11 +36,6 @@ import Snarky.Curves.Class (class PrimeField)
 -- | Initial state: all zeros (lifted from pure initialState)
 initialState :: forall f. PrimeField f => Vector 3 (FVar f)
 initialState = map const_ Sponge.initialState
-
--- | Zero-state sponge ready for `absorb`. Equivalent to
--- | `create initialState`.
-initialSpongeCircuit :: forall f. PrimeField f => Sponge (FVar f)
-initialSpongeCircuit = Sponge.create initialState
 
 -- | Build a sponge from a value-level state + mode. Used to seed the
 -- | sponge from a `Hash_prefix_states.*` constant (or any other

--- a/packages/schnorr/src/Snarky/Circuit/Schnorr/Shifted.purs
+++ b/packages/schnorr/src/Snarky/Circuit/Schnorr/Shifted.purs
@@ -25,7 +25,6 @@ module Snarky.Circuit.Schnorr.Shifted
   , assertOnCurveConst
   , createShifted
   , pallasScalarOps
-  , vestaScalarOps
   , scale
   , scaleKnown
   ) where
@@ -49,8 +48,7 @@ import Snarky.Constraint.Kimchi (KimchiConstraint)
 import Snarky.Curves.Class (class PrimeField)
 import Snarky.Curves.Class (class WeierstrassCurve, curveParams, fromAffine, generator, toAffine) as C
 import Snarky.Curves.Pallas as Pallas
-import Snarky.Curves.Pasta (PallasG, VestaG)
-import Snarky.Curves.Vesta as Vesta
+import Snarky.Curves.Pasta (PallasG)
 import Snarky.Data.EllipticCurve (AffinePoint(..), CurveParams)
 import Type.Proxy (Proxy(..))
 
@@ -168,15 +166,6 @@ pallasScalarOps
   => Snarky Pallas.BaseField (KimchiConstraint Pallas.BaseField) r (ShiftedOps Pallas.BaseField r)
 pallasScalarOps =
   createShifted (C.curveParams (Proxy :: Proxy PallasG)) (shiftFor (C.generator :: PallasG))
-
--- | Ready-to-use shifted scalar-mul ops for the Vesta curve (point
--- | coordinates in `Vesta.BaseField`).
-vestaScalarOps
-  :: forall r
-   . PrimeField Vesta.BaseField
-  => Snarky Vesta.BaseField (KimchiConstraint Vesta.BaseField) r (ShiftedOps Vesta.BaseField r)
-vestaScalarOps =
-  createShifted (C.curveParams (Proxy :: Proxy VestaG)) (shiftFor (C.generator :: VestaG))
 
 -- | LSB-first unbounded double-and-add. Direct port of
 -- | `Snarky_curves.Make_weierstrass_checked.scale`

--- a/packages/snarky-kimchi/src/Snarky/Backend/Kimchi/Impl/Pallas.js
+++ b/packages/snarky-kimchi/src/Snarky/Backend/Kimchi/Impl/Pallas.js
@@ -172,15 +172,6 @@ export function pallasSrsToBytes(crs) {
     };
 }
 
-// Reconstruct an SRS (generators only) from bytes, tagged with `size`.
-export function pallasSrsFromBytes(size) {
-    return function(bytes) {
-        return function() {
-            return { srs: k.caml_fq_srs_from_bytes(bytes), size };
-        };
-    };
-}
-
 // b_poly commitment: takes Pallas scalars (Fq), returns a `PolyComm<Pallas>`
 // whose points have Fp coords. PS-side currently expects a flat
 // `Array Pallas.BaseField` of length 2 (x, y); we expose the first

--- a/packages/snarky-kimchi/src/Snarky/Backend/Kimchi/Impl/Pallas.purs
+++ b/packages/snarky-kimchi/src/Snarky/Backend/Kimchi/Impl/Pallas.purs
@@ -51,10 +51,6 @@ foreign import pallasSrsSetLagrangeBasisFromBytes :: CRS Pallas.G -> Int -> Uint
 -- | `pallasSrsLagrangeBasisToBytes` per domain.
 foreign import pallasSrsToBytes :: CRS Pallas.G -> Effect Uint8Array
 
--- | Reconstruct an SRS (generators only) from `pallasSrsToBytes`, tagged with
--- | the given size. Deterministic alternative to `pallasCrsCreate size`.
-foreign import pallasSrsFromBytes :: Int -> Uint8Array -> Effect (CRS Pallas.G)
-
 -- | Compute challenge polynomial commitment from Pallas SRS.
 -- | Pallas scalar field = Fq, result coords in Fp (= Vesta.ScalarField).
 -- | OCaml: SRS.Fq.b_poly_commitment (Dummy.Ipa.Wrap.compute_sg)

--- a/packages/snarky-kimchi/src/Snarky/Backend/Kimchi/Impl/Vesta.js
+++ b/packages/snarky-kimchi/src/Snarky/Backend/Kimchi/Impl/Vesta.js
@@ -153,15 +153,6 @@ export function vestaSrsToBytes(crs) {
     };
 }
 
-// Reconstruct an SRS (generators only) from bytes, tagged with `size`.
-export function vestaSrsFromBytes(size) {
-    return function(bytes) {
-        return function() {
-            return { srs: k.caml_fp_srs_from_bytes(bytes), size };
-        };
-    };
-}
-
 // Vesta b_poly commitment: inputs in Fp, outputs Vesta points (coords in Fq).
 export function vestaSrsBPolyCommitment(crs) {
     return function(challenges) {

--- a/packages/snarky-kimchi/src/Snarky/Backend/Kimchi/Impl/Vesta.purs
+++ b/packages/snarky-kimchi/src/Snarky/Backend/Kimchi/Impl/Vesta.purs
@@ -51,10 +51,6 @@ foreign import vestaSrsSetLagrangeBasisFromBytes :: CRS Vesta.G -> Int -> Uint8A
 -- | `vestaSrsLagrangeBasisToBytes` per domain.
 foreign import vestaSrsToBytes :: CRS Vesta.G -> Effect Uint8Array
 
--- | Reconstruct an SRS (generators only) from `vestaSrsToBytes`, tagged with the
--- | given size. Deterministic alternative to `vestaCrsCreate size`.
-foreign import vestaSrsFromBytes :: Int -> Uint8Array -> Effect (CRS Vesta.G)
-
 -- | Compute challenge polynomial commitment from Vesta SRS.
 -- | Vesta scalar field = Fp, result coords in Fq (= Pallas.ScalarField).
 -- | OCaml: SRS.Fp.b_poly_commitment (Dummy.Ipa.Step.compute_sg)

--- a/packages/snarky/src/Snarky/Backend/Builder.purs
+++ b/packages/snarky/src/Snarky/Backend/Builder.purs
@@ -8,15 +8,11 @@ module Snarky.Backend.Builder
   ( emptyBuilderState
   , initialBuilderState
   , runCircuitBuilder
-  , execCircuitBuilder
   , CircuitBuilderState
   , class CompileCircuit
   , appendBuilderConstraint
   , finalize
   , Labeled
-  , labeled
-  , unlabel
-  , context
   , Constraints
   , emptyConstraints
   , snocConstraint
@@ -46,12 +42,6 @@ type Labeled c =
   { constraint :: c
   , context :: Array String
   }
-
-labeled :: forall c. Array String -> c -> Labeled c
-labeled ctx c = { constraint: c, context: ctx }
-
-unlabel :: forall c. Labeled c -> c
-unlabel = _.constraint
 
 -- | Append-efficient constraint accumulator.
 -- |
@@ -83,9 +73,6 @@ appendConstraintsBatch batch (Constraints xs) =
 -- | Materialise to forward (emission) order. O(m), once.
 constraintsToArray :: forall c. Constraints c -> Array (Labeled c)
 constraintsToArray (Constraints xs) = Array.fromFoldable (L.reverse xs)
-
-context :: forall c. Labeled c -> Array String
-context = _.context
 
 type CircuitBuilderState c aux =
   { nextVar :: Variable
@@ -191,11 +178,3 @@ builderOps ref = CircuitOps
   , popLabelOp: Ref.modify_ (\s -> s { labelStack = Array.init s.labelStack # fromMaybe [] }) ref
   }
 
-execCircuitBuilder
-  :: forall f c c' aux r a
-   . CompileCircuit f c c' aux
-  => AdviceHandler r
-  -> CircuitBuilderState c aux
-  -> Snarky f c' r a
-  -> Effect (CircuitBuilderState c aux)
-execCircuitBuilder h s = map (\(Tuple _ s') -> s') <<< runCircuitBuilder h s

--- a/packages/snarky/src/Snarky/Circuit/CVar.purs
+++ b/packages/snarky/src/Snarky/Circuit/CVar.purs
@@ -29,8 +29,6 @@ module Snarky.Circuit.CVar
   , genWithAssignments
   , reduceToAffineExpression
   , AffineExpression(..)
-  , scaleAffineExpression
-  , subAffineExpression
   , evalAffineExpression
   , EvaluationError(..)
   ) where
@@ -40,7 +38,7 @@ import Prelude
 import Data.Array ((..))
 import Data.Array as Array
 import Data.Array.NonEmpty as NEA
-import Data.Bifunctor (class Bifunctor, rmap)
+import Data.Bifunctor (class Bifunctor)
 import Data.Foldable (class Foldable, foldM, foldl)
 import Data.Generic.Rep (class Generic)
 import Data.Map (Map, toUnfoldable)
@@ -193,26 +191,6 @@ instance PrimeField f => Semigroup (AffineExpression f) where
 
 instance PrimeField f => Monoid (AffineExpression f) where
   mempty = AffineExpression { constant: Nothing, terms: mempty }
-
-scaleAffineExpression
-  :: forall f
-   . PrimeField f
-  => f
-  -> AffineExpression f
-  -> AffineExpression f
-scaleAffineExpression f (AffineExpression { constant, terms }) =
-  AffineExpression
-    { constant: mul f <$> constant
-    , terms: rmap (mul f) <$> terms
-    }
-
-subAffineExpression
-  :: forall f
-   . PrimeField f
-  => AffineExpression f
-  -> AffineExpression f
-  -> AffineExpression f
-subAffineExpression a b = a <> scaleAffineExpression (-one) b
 
 -- Reduce the affine circuit to the unique form \sum_{i} a_i * x_i + c,
 -- which we represent as {constant: c, terms: Map [(x_i, a_i)]}

--- a/packages/snarky/src/Snarky/Constraint/Basic.purs
+++ b/packages/snarky/src/Snarky/Constraint/Basic.purs
@@ -34,7 +34,6 @@ module Snarky.Constraint.Basic
   , debugCheck
   , genWithAssignments
   , class BasicSystem
-  , fromBasic
   , r1cs
   , boolean
   , equal
@@ -249,17 +248,6 @@ class PrimeField f <= BasicSystem f c | c -> f where
   square :: CVar f Variable -> CVar f Variable -> c
   -- | Create a boolean constraint: the expression must be 0 or 1
   boolean :: CVar f Variable -> c
-
--- | Convert a `Basic` constraint to any `BasicSystem` constraint type.
--- |
--- | This allows using the concrete `Basic` type as an intermediate
--- | representation before converting to backend-specific formats.
-fromBasic :: forall f c. BasicSystem f c => Basic f -> c
-fromBasic = case _ of
-  R1CS r -> r1cs r
-  Equal a b -> equal a b
-  Square a c -> square a c
-  Boolean b -> boolean b
 
 instance PrimeField f => BasicSystem f (Basic f) where
   r1cs = R1CS


### PR DESCRIPTION
Removed exports flagged by tools/dead-code.mjs and verified unused across all four workspaces (main, pickles-bench, example/app, visualizer):

  * Snarky internals: Builder.{context,execCircuitBuilder,labeled,unlabel}, CVar.{scaleAffineExpression,subAffineExpression}, Basic.fromBasic
  * Shifted.vestaScalarOps, Pickles.Sponge.runSpongeM, Snarky.Circuit.RandomOracle.Sponge.initialSpongeCircuit
  * Unused FFI: Kimchi.Impl.{Pallas,Vesta}.*SrsFromBytes (.purs + .js)
  * Dead newtype Pickles.PublicInputCommit.DeferredScaleMul
  * Merkle FreeHash subsystem: the FreeHash type + HashValue/HashEmpty/Merge, {Data.MerkleTree,Sized}.{freeRoot,getFreePath,impliedFreeRoot} + the private treeFreeHash/nonEmptyFreeHash helpers, and Hashable.hashCircuit

Kept as tool false positives: re-exported public API (fresh, state, runAdviceHandler) and Coercible/instance-only constructors (Bool, NoInput, IndexTerm). Dead exports 56 -> 33.

Also declare the visualizer's used-but-undeclared transitive deps (arrays, ordered-collections, strings, web-dom) so it passes --pedantic-packages.

All four workspaces build clean under --pedantic-packages --strict.