### PR TITLE
Formalize the EndoMul gate (GLV scalar mult) + factor shared EC lemmas

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -95,6 +95,8 @@ jobs:
         #print axioms Kimchi.Circuit.EndoMul.recoding_digit
         #print axioms Kimchi.Circuit.EndoMul.sum_reindex
         #print axioms Kimchi.Circuit.EndoMul.recode_fold
+        #print axioms Kimchi.Circuit.EndoMul.row_digit
+        #print axioms Kimchi.Circuit.EndoMul.endoMul_ab
         #print axioms Kimchi.Circuit.EndoScalar.gate_toField
         #print axioms Kimchi.Circuit.EndoScalar.endoScalar_spec
         #print axioms Kimchi.Gate.VarBaseMul.ok_iff

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -119,6 +119,9 @@ jobs:
         #print axioms Kimchi.Cycle.zsmul_mod
         #print axioms Kimchi.Cycle.varBaseMul_scalar
         #print axioms Kimchi.Cycle.varBaseMul_faithful
+        #print axioms Kimchi.Cycle.endoMul_scalar_cm
+        #print axioms Kimchi.Cycle.endoMul_toField_cm
+        #print axioms Kimchi.Cycle.endoMul_faithful
         EOF
         out=$(lake env lean check_axioms.lean)
         echo "$out"

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -84,6 +84,9 @@ jobs:
         #print axioms Kimchi.Gate.EndoScalar.dPoly_table
         #print axioms Kimchi.Gate.EndoScalar.gate_endoScalar
         #print axioms Kimchi.Gate.EndoScalar.gate_endoScalar_table
+        #print axioms Kimchi.Gate.EndoMul.selectQ
+        #print axioms Kimchi.Gate.EndoMul.distinctPoints
+        #print axioms Kimchi.Gate.EndoMul.block_sound
         #print axioms Kimchi.Circuit.EndoScalar.gate_toField
         #print axioms Kimchi.Circuit.EndoScalar.endoScalar_spec
         #print axioms Kimchi.Gate.VarBaseMul.ok_iff

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -88,6 +88,9 @@ jobs:
         #print axioms Kimchi.Gate.EndoMul.distinctPoints
         #print axioms Kimchi.Gate.EndoMul.block_sound
         #print axioms Kimchi.Gate.EndoMul.row_sound
+        #print axioms Kimchi.Gate.EndoMul.row_int
+        #print axioms Kimchi.Circuit.EndoMul.chain_endo
+        #print axioms Kimchi.Circuit.EndoMul.endoMul
         #print axioms Kimchi.Circuit.EndoScalar.gate_toField
         #print axioms Kimchi.Circuit.EndoScalar.endoScalar_spec
         #print axioms Kimchi.Gate.VarBaseMul.ok_iff

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -97,6 +97,8 @@ jobs:
         #print axioms Kimchi.Circuit.EndoMul.recode_fold
         #print axioms Kimchi.Circuit.EndoMul.row_digit
         #print axioms Kimchi.Circuit.EndoMul.endoMul_ab
+        #print axioms Kimchi.Circuit.EndoMul.decompose_crumbList
+        #print axioms Kimchi.Circuit.EndoMul.endoMul_toField
         #print axioms Kimchi.Circuit.EndoScalar.gate_toField
         #print axioms Kimchi.Circuit.EndoScalar.endoScalar_spec
         #print axioms Kimchi.Gate.VarBaseMul.ok_iff

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -93,6 +93,8 @@ jobs:
         #print axioms Kimchi.Circuit.EndoMul.endoMul
         #print axioms Kimchi.Circuit.EndoMul.endoMul_scalar
         #print axioms Kimchi.Circuit.EndoMul.recoding_digit
+        #print axioms Kimchi.Circuit.EndoMul.sum_reindex
+        #print axioms Kimchi.Circuit.EndoMul.recode_fold
         #print axioms Kimchi.Circuit.EndoScalar.gate_toField
         #print axioms Kimchi.Circuit.EndoScalar.endoScalar_spec
         #print axioms Kimchi.Gate.VarBaseMul.ok_iff

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -92,6 +92,7 @@ jobs:
         #print axioms Kimchi.Circuit.EndoMul.chain_endo
         #print axioms Kimchi.Circuit.EndoMul.endoMul
         #print axioms Kimchi.Circuit.EndoMul.endoMul_scalar
+        #print axioms Kimchi.Circuit.EndoMul.recoding_digit
         #print axioms Kimchi.Circuit.EndoScalar.gate_toField
         #print axioms Kimchi.Circuit.EndoScalar.endoScalar_spec
         #print axioms Kimchi.Gate.VarBaseMul.ok_iff

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -87,6 +87,7 @@ jobs:
         #print axioms Kimchi.Gate.EndoMul.selectQ
         #print axioms Kimchi.Gate.EndoMul.distinctPoints
         #print axioms Kimchi.Gate.EndoMul.block_sound
+        #print axioms Kimchi.Gate.EndoMul.row_sound
         #print axioms Kimchi.Circuit.EndoScalar.gate_toField
         #print axioms Kimchi.Circuit.EndoScalar.endoScalar_spec
         #print axioms Kimchi.Gate.VarBaseMul.ok_iff

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -88,10 +88,10 @@ jobs:
         #print axioms Kimchi.Circuit.EndoScalar.endoScalar_spec
         #print axioms Kimchi.Gate.VarBaseMul.ok_iff
         #print axioms Kimchi.Gate.VarBaseMul.singleBitOk_iff
-        #print axioms Kimchi.Gate.VarBaseMul.secant_add
+        #print axioms Kimchi.secant_add
         #print axioms Kimchi.Gate.VarBaseMul.singleBit_sound
         #print axioms Kimchi.Gate.VarBaseMul.gate_scalarMul
-        #print axioms Kimchi.Gate.VarBaseMul.signed_target
+        #print axioms Kimchi.signed_target
         #print axioms Kimchi.Gate.VarBaseMul.gate_scalarMul_int
         #print axioms Kimchi.Circuit.VarBaseMul.chain_scalarMul
         #print axioms Kimchi.Circuit.VarBaseMul.chain_register

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -91,6 +91,7 @@ jobs:
         #print axioms Kimchi.Gate.EndoMul.row_int
         #print axioms Kimchi.Circuit.EndoMul.chain_endo
         #print axioms Kimchi.Circuit.EndoMul.endoMul
+        #print axioms Kimchi.Circuit.EndoMul.endoMul_scalar
         #print axioms Kimchi.Circuit.EndoScalar.gate_toField
         #print axioms Kimchi.Circuit.EndoScalar.endoScalar_spec
         #print axioms Kimchi.Gate.VarBaseMul.ok_iff

--- a/formal/Kimchi.lean
+++ b/formal/Kimchi.lean
@@ -8,6 +8,7 @@ import Kimchi.Gate.VarBaseMul
 import Kimchi.Gate.EndoMul
 import Kimchi.Circuit.VarBaseMul
 import Kimchi.Circuit.EndoScalar
+import Kimchi.Circuit.EndoMul
 import Kimchi.Cycle.Axioms
 import Kimchi.Cycle.VarBaseMul
 import Kimchi.Cycle.Shifted

--- a/formal/Kimchi.lean
+++ b/formal/Kimchi.lean
@@ -12,3 +12,5 @@ import Kimchi.Circuit.EndoMul
 import Kimchi.Cycle.Axioms
 import Kimchi.Cycle.VarBaseMul
 import Kimchi.Cycle.Shifted
+import Kimchi.Cycle.EndoMul
+import Kimchi.Cycle.Pasta

--- a/formal/Kimchi.lean
+++ b/formal/Kimchi.lean
@@ -5,6 +5,7 @@ import Kimchi.Gate.Generic
 import Kimchi.Gate.AddComplete
 import Kimchi.Gate.EndoScalar
 import Kimchi.Gate.VarBaseMul
+import Kimchi.Gate.EndoMul
 import Kimchi.Circuit.VarBaseMul
 import Kimchi.Circuit.EndoScalar
 import Kimchi.Cycle.Axioms

--- a/formal/Kimchi/Circuit/EndoMul.lean
+++ b/formal/Kimchi/Circuit/EndoMul.lean
@@ -16,6 +16,9 @@ TWO bases (`T` and `φ(T)`).
 
 * `chain_endo` — the abstract two-base recurrence fold.
 * `endoMul` — `m` chained rows compute `∃ k₁ k₂, P_m = 4^m·P₀ + k₁·T + k₂·φ(T)`.
+* `endoMul_scalar` — with the eigenvalue `φ(T) = [λ]·T` (a hypothesis), this
+  collapses to a single scalar multiple `P_m = 4^m·P₀ + k·T`, `k = k₁ + k₂·λ` — the
+  endo-scalar form `EndoScalar.toField` computes.
 -/
 
 namespace Kimchi.Circuit.EndoMul
@@ -98,5 +101,31 @@ theorem endoMul (W : WeierstrassCurve.Affine F) (ha : IsShortShape W) (endo : F)
     rw [hout i hi, hin i hi, hT i hi, hφT i hi]
     exact hc i hi
   exact ⟨_, _, chain_endo W m P T φT c1 c2 hc⟩
+
+/-- The GLV eigenvalue collapse → genuine scalar multiplication. The curve
+    endomorphism satisfies `φ(T) = [λ]·T` (its defining property — a hypothesis
+    here, NOT provable in Mathlib for an abstract `WeierstrassCurve`; on the Pasta
+    curves `λ` is the scalar-field `endo_scalar`). With it, the two-base GLV result
+    becomes a single scalar multiple of the base:
+
+        P_m = 4^m·P₀ + k·T,   k = k₁ + k₂·λ.
+
+    The scalar `k = k₁ + k₂·λ` has exactly the endo-scalar form `a·λ + b` that
+    `Kimchi.Circuit.EndoScalar.toField` computes from the challenge (with `a = k₂`,
+    `b = k₁`) — so on a joint witness (the same challenge bits fed to both gates),
+    EndoMul's point is `[toField challenge λ]·T`. Proving `k₂ = a`, `k₁ = b` is the
+    recoding correspondence between the two gates' bit processing — the remaining
+    step to a fully-closed `EndoMul ∘ EndoScalar`. -/
+theorem endoMul_scalar (W : WeierstrassCurve.Affine F) (ha : IsShortShape W)
+    (endo : F) (m : ℕ) (g : ℕ → Witness F) (gs : ∀ i, i < m → EndoStep W endo (g i))
+    (P : ℕ → W.Point) (T φT : W.Point)
+    (hT : ∀ i (hi : i < m), T = Point.some (gs i hi).hT)
+    (hφT : ∀ i (hi : i < m), φT = Point.some (gs i hi).hφT)
+    (hin : ∀ i (hi : i < m), P i = Point.some (gs i hi).hP)
+    (hout : ∀ i (hi : i < m), P (i + 1) = Point.some (gs i hi).hS)
+    (lam : ℤ) (heig : φT = lam • T) :
+    ∃ k : ℤ, P m = (4 : ℤ) ^ m • P 0 + k • T := by
+  obtain ⟨k1, k2, hk⟩ := endoMul W ha endo m g gs P T φT hT hφT hin hout
+  exact ⟨k1 + k2 * lam, by rw [hk, heig]; module⟩
 
 end Kimchi.Circuit.EndoMul

--- a/formal/Kimchi/Circuit/EndoMul.lean
+++ b/formal/Kimchi/Circuit/EndoMul.lean
@@ -1,0 +1,102 @@
+import Kimchi.Gate.EndoMul
+
+/-!
+# The `EndoMul` circuit: GLV scalar multiplication
+
+Composition of `Kimchi.Gate.EndoMul` rows into the full endomorphism-optimized
+scalar multiplication. Each row contributes `S = 4·P + c₁·T + c₂·φ(T)` (the gate's
+`row_int`), so chaining `m` rows folds into
+
+    P_m = 4^m · P₀ + k₁ · T + k₂ · φ(T)
+
+with `k₁, k₂` the GLV scalar halves. This is VarBaseMul's `chain_scalarMul` over
+TWO bases (`T` and `φ(T)`).
+
+## Main results
+
+* `chain_endo` — the abstract two-base recurrence fold.
+* `endoMul` — `m` chained rows compute `∃ k₁ k₂, P_m = 4^m·P₀ + k₁·T + k₂·φ(T)`.
+-/
+
+namespace Kimchi.Circuit.EndoMul
+
+open Kimchi.Gate.EndoMul WeierstrassCurve.Affine
+
+variable {F : Type*} [Field F] [DecidableEq F]
+
+/-- The two-base GLV fold: chaining `P_{i+1} = 4·P_i + c₁ᵢ·T + c₂ᵢ·φT` over `m` rows
+    gives `P_m = 4^m·P₀ + (∑ 4^(m-1-i)·c₁ᵢ)·T + (∑ 4^(m-1-i)·c₂ᵢ)·φT`. Pure group
+    algebra (cf. VarBaseMul's `chain_scalarMul`, here with a second base). -/
+theorem chain_endo (W : WeierstrassCurve.Affine F)
+    (m : ℕ) (P : ℕ → W.Point) (T φT : W.Point) (c1 c2 : ℕ → ℤ)
+    (hstep : ∀ i, i < m → P (i + 1) = (4 : ℤ) • P i + c1 i • T + c2 i • φT) :
+    P m = (4 : ℤ) ^ m • P 0
+        + (∑ i ∈ Finset.range m, (4 : ℤ) ^ (m - 1 - i) * c1 i) • T
+        + (∑ i ∈ Finset.range m, (4 : ℤ) ^ (m - 1 - i) * c2 i) • φT := by
+  induction m with
+  | zero => simp
+  | succ m ih =>
+    have hs : P (m + 1) = (4 : ℤ) • P m + c1 m • T + c2 m • φT :=
+      hstep m (Nat.lt_succ_self m)
+    have ih' := ih (fun i hi => hstep i (Nat.lt_succ_of_lt hi))
+    have hsum : ∀ c : ℕ → ℤ,
+        (∑ i ∈ Finset.range (m + 1), (4 : ℤ) ^ (m + 1 - 1 - i) * c i)
+          = (4 : ℤ) * (∑ i ∈ Finset.range m, (4 : ℤ) ^ (m - 1 - i) * c i) + c m := by
+      intro c
+      rw [Finset.sum_range_succ, Finset.mul_sum]
+      simp only [Nat.add_sub_cancel, Nat.sub_self, pow_zero, one_mul]
+      congr 1
+      apply Finset.sum_congr rfl
+      intro i hi
+      have hi' : m - i = (m - 1 - i) + 1 := by
+        have := Finset.mem_range.mp hi; omega
+      rw [hi', pow_succ]; ring
+    rw [hs, ih', hsum c1, hsum c2, pow_succ']
+    module
+
+/-- The per-row hypotheses `row_int` needs, bundled (over a shared base `T` whose
+    coordinates are the row's `xT`/`yT`): the base/endo/accumulator/target
+    nonsingularities, the two per-slope non-degeneracies per window, and the 12
+    constraints `holds`. -/
+structure EndoStep (W : WeierstrassCurve.Affine F) (endo : F) (g : Witness F) : Prop where
+  hT : W.Nonsingular g.xT g.yT
+  hφT : W.Nonsingular (endo * g.xT) g.yT
+  hP : W.Nonsingular g.xP g.yP
+  hR : W.Nonsingular g.xR g.yR
+  hS : W.Nonsingular g.xS g.yS
+  hQ1 : W.Nonsingular ((1 + (endo - 1) * g.b1) * g.xT) ((2 * g.b2 - 1) * g.yT)
+  hQ2 : W.Nonsingular ((1 + (endo - 1) * g.b3) * g.xT) ((2 * g.b4 - 1) * g.yT)
+  hxne1 : g.xP ≠ (1 + (endo - 1) * g.b1) * g.xT
+  htne1 : 2 * g.xP - g.s1 ^ 2 + (1 + (endo - 1) * g.b1) * g.xT ≠ 0
+  hxne2 : g.xR ≠ (1 + (endo - 1) * g.b3) * g.xT
+  htne2 : 2 * g.xR - g.s3 ^ 2 + (1 + (endo - 1) * g.b3) * g.xT ≠ 0
+  holds : Holds endo g
+
+/-! ## Main theorem: GLV scalar multiplication -/
+
+/-- `m` chained `EndoMul` rows compute GLV scalar multiplication. Given `m` valid
+    rows over a shared base `T` and its endomorphism image `φ(T)`, whose accumulator
+    points form a chain `P` (row `i`'s input is `P i`, output is `P (i+1)`), the
+    final accumulator is `P m = 4^m·P₀ + k₁·T + k₂·φ(T)` for integers `k₁, k₂`. The
+    proof reads each row's contribution `c₁ᵢ·T + c₂ᵢ·φ(T)` off `row_int` and folds
+    them with `chain_endo`. -/
+theorem endoMul (W : WeierstrassCurve.Affine F) (ha : IsShortShape W) (endo : F)
+    (m : ℕ) (g : ℕ → Witness F) (gs : ∀ i, i < m → EndoStep W endo (g i))
+    (P : ℕ → W.Point) (T φT : W.Point)
+    (hT : ∀ i (hi : i < m), T = Point.some (gs i hi).hT)
+    (hφT : ∀ i (hi : i < m), φT = Point.some (gs i hi).hφT)
+    (hin : ∀ i (hi : i < m), P i = Point.some (gs i hi).hP)
+    (hout : ∀ i (hi : i < m), P (i + 1) = Point.some (gs i hi).hS) :
+    ∃ k1 k2 : ℤ, P m = (4 : ℤ) ^ m • P 0 + k1 • T + k2 • φT := by
+  obtain ⟨c1, c2, hc⟩ : ∃ c1 c2 : ℕ → ℤ, ∀ i, i < m →
+      P (i + 1) = (4 : ℤ) • P i + c1 i • T + c2 i • φT := by
+    choose! c1 c2 hc using fun i (hi : i < m) =>
+      row_int W ha endo (g i) (gs i hi).holds (gs i hi).hT (gs i hi).hφT (gs i hi).hP
+        (gs i hi).hR (gs i hi).hS (gs i hi).hQ1 (gs i hi).hQ2 (gs i hi).hxne1
+        (gs i hi).htne1 (gs i hi).hxne2 (gs i hi).htne2
+    refine ⟨c1, c2, fun i hi => ?_⟩
+    rw [hout i hi, hin i hi, hT i hi, hφT i hi]
+    exact hc i hi
+  exact ⟨_, _, chain_endo W m P T φT c1 c2 hc⟩
+
+end Kimchi.Circuit.EndoMul

--- a/formal/Kimchi/Circuit/EndoMul.lean
+++ b/formal/Kimchi/Circuit/EndoMul.lean
@@ -169,4 +169,50 @@ theorem recoding_digit (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) {b1 b2 : F}
   · exact ⟨by rw [show (1:F) + 2 * 1 = 3 by ring, c3]; ring,
            by rw [show (1:F) + 2 * 1 = 3 by ring, d3]; ring⟩
 
+/-- The row↔crumb sum reindexing — the structural core of the fold-level recoding.
+    `EndoMul`'s `m` rows weight each row's 2-crumb contribution `2·g(2i) + g(2i+1)`
+    by `4^(m-1-i)`; flattening to `EndoScalar`'s `2m` crumbs weights crumb `j` by
+    `2^(2m-1-j)`. The two agree (the row's `×4 = ×2` twice splits across its two
+    crumbs). Over any `CommRing` — used at `ℤ` (the GLV coefficients) and `F` (the
+    `cPoly`/`dPoly` digits). -/
+theorem sum_reindex {R : Type*} [CommRing R] (m : ℕ) (g : ℕ → R) :
+    ∑ i ∈ Finset.range m, (4 : R) ^ (m - 1 - i) * (2 * g (2 * i) + g (2 * i + 1))
+      = ∑ j ∈ Finset.range (2 * m), (2 : R) ^ (2 * m - 1 - j) * g j := by
+  induction m with
+  | zero => simp
+  | succ m ih =>
+    have e1 : ∀ i ∈ Finset.range m, (4 : R) ^ (m + 1 - 1 - i) * (2 * g (2 * i) + g (2 * i + 1))
+        = 4 * ((4 : R) ^ (m - 1 - i) * (2 * g (2 * i) + g (2 * i + 1))) := by
+      intro i hi
+      have : i < m := Finset.mem_range.mp hi
+      rw [show m + 1 - 1 - i = (m - 1 - i) + 1 by omega, pow_succ]; ring
+    have e2 : ∀ j ∈ Finset.range (2 * m), (2 : R) ^ (2 * m + 1 + 1 - 1 - j) * g j
+        = 4 * ((2 : R) ^ (2 * m - 1 - j) * g j) := by
+      intro j hj
+      have : j < 2 * m := Finset.mem_range.mp hj
+      rw [show 2 * m + 1 + 1 - 1 - j = (2 * m - 1 - j) + 2 by omega, pow_add]; ring
+    rw [Finset.sum_range_succ, Finset.sum_congr rfl e1, ← Finset.mul_sum, ih,
+      show 2 * (m + 1) = 2 * m + 1 + 1 by ring, Finset.sum_range_succ,
+      Finset.sum_range_succ, Finset.sum_congr rfl e2, ← Finset.mul_sum,
+      show m + 1 - 1 - m = 0 by omega, show 2 * m + 1 + 1 - 1 - (2 * m) = 1 by omega,
+      show 2 * m + 1 + 1 - 1 - (2 * m + 1) = 0 by omega]
+    ring
+
+omit [DecidableEq F] in
+/-- Fold-level recoding (coefficient level). Given the per-row digit equations
+    `(c₂ᵢ : F) = 2·g(2i) + g(2i+1)` — `EndoMul`'s integer row contribution casts to
+    `EndoScalar`'s two `cPoly`-digits, supplied by `row_int` + `recoding_digit` (so
+    `g j` is crumb `j`'s `cPoly` digit) — the field cast of `EndoMul`'s GLV
+    `φ(T)`-coefficient `∑ 4^(m-1-i)·c₂ᵢ` equals `EndoScalar`'s Algorithm-2 digit sum
+    `∑_{j<2m} 2^(2m-1-j)·g(j)` that `a` accumulates. (The same holds for the
+    `T`-coefficient `k₁` / `b` with the `dPoly` digits.) This is `sum_reindex` over
+    `F` after pushing the cast through and substituting each row's digits. -/
+theorem recode_fold (m : ℕ) (c2 : ℕ → ℤ) (g : ℕ → F)
+    (hrow : ∀ i, ((c2 i : ℤ) : F) = 2 * g (2 * i) + g (2 * i + 1)) :
+    (((∑ i ∈ Finset.range m, (4 : ℤ) ^ (m - 1 - i) * c2 i : ℤ)) : F)
+      = ∑ j ∈ Finset.range (2 * m), (2 : F) ^ (2 * m - 1 - j) * g j := by
+  rw [← sum_reindex m g]
+  push_cast
+  exact Finset.sum_congr rfl fun i _ => by rw [hrow i]
+
 end Kimchi.Circuit.EndoMul

--- a/formal/Kimchi/Circuit/EndoMul.lean
+++ b/formal/Kimchi/Circuit/EndoMul.lean
@@ -1,5 +1,6 @@
 import Kimchi.Gate.EndoMul
 import Kimchi.Gate.EndoScalar
+import Kimchi.Circuit.EndoScalar
 
 /-!
 # The `EndoMul` circuit: GLV scalar multiplication
@@ -221,7 +222,7 @@ theorem recode_fold (m : ℕ) (c2 : ℕ → ℤ) (g : ℕ → F)
   exact Finset.sum_congr rfl fun i _ => by rw [hrow i]
 
 open Kimchi.Gate.EndoScalar (cPoly dPoly cPoly_table dPoly_table) in
-/-- The per-row digit equations (STUB), the gate-side source of `recode_fold`'s
+/-- The per-row digit equations — the gate-side source of `recode_fold`'s
     hypothesis. A satisfying row's GLV contribution `S = 4·P + c₁·T + c₂·φ(T)` has its
     integers pinned to `EndoScalar`'s digits: `(c₁ : F) = 2·dPoly(crumb₁) + dPoly(crumb₂)`
     (the `T`/`b` digits) and `(c₂ : F) = 2·cPoly(crumb₁) + cPoly(crumb₂)` (the `φ(T)`/`a`
@@ -322,7 +323,7 @@ def bDigit (g : ℕ → Witness F) (j : ℕ) : F :=
   else dPoly ((g (j / 2)).b4 + 2 * (g (j / 2)).b3)
 
 open Kimchi.Gate.EndoScalar (cPoly dPoly) in
-/-- THE FULL RECODING RESULT (STUB): EndoMul's GLV coefficients are EndoScalar's
+/-- THE FULL RECODING RESULT: EndoMul's GLV coefficients are EndoScalar's
     `a`, `b`. `m` chained rows compute `P_m = 4^m·P₀ + k₁·T + k₂·φ(T)` where the field
     casts of `k₂` (the `φ(T)` coefficient) and `k₁` (the `T` coefficient) are exactly
     `EndoScalar`'s Algorithm-2 accumulations over the `2m` crumbs:
@@ -382,5 +383,74 @@ theorem endoMul_ab (W : WeierstrassCurve.Affine F) (ha : IsShortShape W)
     have hbO : bDigit g (2 * i + 1) = dPoly ((g i).b4 + 2 * (g i).b3) := by
       simp [bDigit, e3, e4]
     rw [hbE, hbO, ← (hc i hi').2.1]
+
+/-! ## Top level: EndoMul computes `[EndoScalar.toField]·T`. -/
+
+/-- The `2m`-crumb list the rows feed to `EndoScalar`: row `i` contributes its two
+    windows `[b₂+2·b₁, b₄+2·b₃]` in order, so `crumbList[2i] = aDigit/bDigit`'s crumb
+    `2i` and `crumbList[2i+1]` crumb `2i+1`. -/
+def crumbList (g : ℕ → Witness F) (m : ℕ) : List F :=
+  (List.range m).flatMap fun i => [(g i).b2 + 2 * (g i).b1, (g i).b4 + 2 * (g i).b3]
+
+omit [DecidableEq F] in
+/-- Each additional row appends its two window crumbs to the crumb list. -/
+theorem crumbList_succ (g : ℕ → Witness F) (m : ℕ) :
+    crumbList g (m + 1)
+      = crumbList g m ++ [(g m).b2 + 2 * (g m).b1, (g m).b4 + 2 * (g m).b3] := by
+  simp [crumbList, List.range_succ, List.flatMap_append]
+
+omit [DecidableEq F] in
+/-- The init bridge: `EndoScalar`'s `decomposeA`/`decomposeB` over the crumb
+    list (folded from the `a = b = 2` init) is its `2·4^m` carry plus the
+    Algorithm-2 digit sums — exactly `endoMul_ab`'s `(k₂:F)` / `(k₁:F)`. By induction
+    on `m` (each row appends 2 crumbs; `List.foldl_append`). -/
+theorem decompose_crumbList (g : ℕ → Witness F) (m : ℕ) :
+    Kimchi.Circuit.EndoScalar.decomposeA (crumbList g m)
+        = 2 * (4 : F) ^ m + ∑ j ∈ Finset.range (2 * m), (2 : F) ^ (2 * m - 1 - j) * aDigit g j
+      ∧ Kimchi.Circuit.EndoScalar.decomposeB (crumbList g m)
+        = 2 * (4 : F) ^ m + ∑ j ∈ Finset.range (2 * m), (2 : F) ^ (2 * m - 1 - j) * bDigit g j := by
+  induction' m with m ih <;> simp_all +decide [ Nat.mul_succ, Finset.sum_range_succ ];
+  · exact ⟨ rfl, rfl ⟩;
+  · rw [ crumbList_succ, EndoScalar.decomposeA_append, EndoScalar.decomposeB_append ];
+    simp_all +decide [ aDigit, bDigit ];
+    norm_num [ Nat.add_div ] ; ring_nf ;
+    constructor <;> rw [ Finset.sum_mul _ _ _ ] <;>
+      rw [ Finset.sum_congr rfl fun x hx => ?_ ] <;> ring;
+    · split_ifs <;>
+        rw [ show 1 + m * 2 - x = (m * 2 - 1 - x) + 2 by
+              have := Finset.mem_range.mp hx; omega ] <;> ring;
+    · split_ifs <;>
+        rw [ show 1 + m * 2 - x = (m * 2 - 1 - x) + 2 by
+              have := Finset.mem_range.mp hx; omega ] <;> ring
+
+/-- THE TOP-LEVEL STATEMENT: EndoMul computes scalar multiplication by exactly
+    the scalar EndoScalar decodes. At the real init (`P₀ = 2·(T + φ(T))`) and with the
+    eigenvalue `φ(T) = [λ]·T`, the `m` rows produce `P_m = s·T` where `s` is the
+    `EndoScalar.toField` of the shared challenge crumbs:
+
+        (s : F) = decomposeA(crumbs)·λ + decomposeB(crumbs) = toField crumbs λ.
+
+    This closes `EndoMul ∘ EndoScalar`: EndoScalar decodes the scalar into the
+    eigenvalue basis `a·λ + b`, and EndoMul multiplies the base by exactly that
+    scalar. Assembles `endoMul_ab` (k₂,k₁ = the a,b digit-sums) with
+    `decompose_crumbList` (the `a=b=2` ↔ `4^m·P₀` init alignment), the init `hP₀`,
+    and the eigenvalue `heig`. -/
+theorem endoMul_toField (W : WeierstrassCurve.Affine F) (ha : IsShortShape W)
+    (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) (endo : F)
+    (m : ℕ) (g : ℕ → Witness F) (gs : ∀ i, i < m → EndoStep W endo (g i))
+    (P : ℕ → W.Point) (T φT : W.Point)
+    (hT : ∀ i (hi : i < m), T = Point.some (gs i hi).hT)
+    (hφT : ∀ i (hi : i < m), φT = Point.some (gs i hi).hφT)
+    (hin : ∀ i (hi : i < m), P i = Point.some (gs i hi).hP)
+    (hout : ∀ i (hi : i < m), P (i + 1) = Point.some (gs i hi).hS)
+    (hP0 : P 0 = (2 : ℤ) • T + (2 : ℤ) • φT) (lam : ℤ) (heig : φT = lam • T) :
+    ∃ s : ℤ, P m = s • T
+      ∧ (s : F) = Kimchi.Circuit.EndoScalar.toField (crumbList g m) (lam : F) := by
+  obtain ⟨ k1, k2, hPm, hk2, hk1 ⟩ := endoMul_ab W ha h2 h3 endo m g gs P T φT hT hφT hin hout;
+  refine' ⟨ 2 * 4 ^ m + k1 + ( 2 * 4 ^ m + k2 ) * lam, _, _ ⟩;
+  · rw [ hPm, hP0, heig ];
+    module;
+  · simp +decide [ EndoScalar.toField, hk1, hk2 ];
+    rw [ decompose_crumbList g m |>.1, decompose_crumbList g m |>.2 ] ; ring
 
 end Kimchi.Circuit.EndoMul

--- a/formal/Kimchi/Circuit/EndoMul.lean
+++ b/formal/Kimchi/Circuit/EndoMul.lean
@@ -1,4 +1,5 @@
 import Kimchi.Gate.EndoMul
+import Kimchi.Gate.EndoScalar
 
 /-!
 # The `EndoMul` circuit: GLV scalar multiplication
@@ -19,6 +20,9 @@ TWO bases (`T` and `φ(T)`).
 * `endoMul_scalar` — with the eigenvalue `φ(T) = [λ]·T` (a hypothesis), this
   collapses to a single scalar multiple `P_m = 4^m·P₀ + k·T`, `k = k₁ + k₂·λ` — the
   endo-scalar form `EndoScalar.toField` computes.
+* `recoding_digit` — the `EndoMul ∘ EndoScalar` recoding correspondence: per 2-bit
+  window, `EndoScalar`'s `cPoly`/`dPoly` digits equal `EndoMul`'s GLV window digit,
+  so the two gates assign the same signed base to each window.
 -/
 
 namespace Kimchi.Circuit.EndoMul
@@ -113,9 +117,10 @@ theorem endoMul (W : WeierstrassCurve.Affine F) (ha : IsShortShape W) (endo : F)
     The scalar `k = k₁ + k₂·λ` has exactly the endo-scalar form `a·λ + b` that
     `Kimchi.Circuit.EndoScalar.toField` computes from the challenge (with `a = k₂`,
     `b = k₁`) — so on a joint witness (the same challenge bits fed to both gates),
-    EndoMul's point is `[toField challenge λ]·T`. Proving `k₂ = a`, `k₁ = b` is the
-    recoding correspondence between the two gates' bit processing — the remaining
-    step to a fully-closed `EndoMul ∘ EndoScalar`. -/
+    EndoMul's point is `[toField challenge λ]·T`. `recoding_digit` proves the
+    per-window heart of `k₂ = a`, `k₁ = b`: the two gates assign the same signed base
+    to each 2-bit window (the full fold-level identity is then summing the matched
+    digits with the inits aligned). -/
 theorem endoMul_scalar (W : WeierstrassCurve.Affine F) (ha : IsShortShape W)
     (endo : F) (m : ℕ) (g : ℕ → Witness F) (gs : ∀ i, i < m → EndoStep W endo (g i))
     (P : ℕ → W.Point) (T φT : W.Point)
@@ -127,5 +132,41 @@ theorem endoMul_scalar (W : WeierstrassCurve.Affine F) (ha : IsShortShape W)
     ∃ k : ℤ, P m = (4 : ℤ) ^ m • P 0 + k • T := by
   obtain ⟨k1, k2, hk⟩ := endoMul W ha endo m g gs P T φT hT hφT hin hout
   exact ⟨k1 + k2 * lam, by rw [hk, heig]; module⟩
+
+/-! ## The recoding correspondence with `EndoScalar`. -/
+
+omit [DecidableEq F] in
+open Kimchi.Gate.EndoScalar in
+/-- The recoding correspondence (per window). An `EndoMul` window's bits `(b₁, b₂)`
+    map to the `EndoScalar` crumb `x = b₂ + 2·b₁` (the crumb's `bitEven`/`bitOdd` are
+    the sign/base-selector — `EndoScalar`'s nybble is `bitEven + 2·bitOdd`). On it,
+    `EndoScalar`'s Algorithm-2 digit polynomials equal `EndoMul`'s GLV window digit:
+
+        cPoly x = (2·b₂ − 1)·b₁          dPoly x = (2·b₂ − 1)·(1 − b₁)
+
+    where `2·b₂ − 1` is the sign (as in `selectQ`) and `b₁` selects the base — so
+    `cPoly` lands on the `φ(T)`/λ component (`EndoScalar`'s `a`, `EndoMul`'s `k₂`)
+    and `dPoly` on the `T`/1 component (`EndoScalar`'s `b`, `EndoMul`'s `k₁`). This
+    is the heart of `EndoMul ∘ EndoScalar`: the two gates assign the SAME signed
+    base to each 2-bit window. Folding these matched digits — with `EndoMul`'s ×4
+    per row = ×2 per window matching `EndoScalar`'s ×2 per crumb, and the inits
+    aligned (`EndoMul`'s `4^m·P₀` carry ↔ `EndoScalar`'s `a=b=2`) — yields
+    `(k₂, k₁) = (a, b)`, i.e. `endoMul_scalar`'s scalar equals
+    `EndoScalar.toField challenge λ`. -/
+theorem recoding_digit (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) {b1 b2 : F}
+    (hb1 : b1 = 0 ∨ b1 = 1) (hb2 : b2 = 0 ∨ b2 = 1) :
+    cPoly (b2 + 2 * b1) = (2 * b2 - 1) * b1
+      ∧ dPoly (b2 + 2 * b1) = (2 * b2 - 1) * (1 - b1) := by
+  obtain ⟨c0, c1, c2, c3⟩ := cPoly_table h2 h3
+  obtain ⟨d0, d1, d2, d3⟩ := dPoly_table h2 h3
+  rcases hb1 with rfl | rfl <;> rcases hb2 with rfl | rfl
+  · exact ⟨by rw [show (0:F) + 2 * 0 = 0 by ring, c0]; ring,
+           by rw [show (0:F) + 2 * 0 = 0 by ring, d0]; ring⟩
+  · exact ⟨by rw [show (1:F) + 2 * 0 = 1 by ring, c1]; ring,
+           by rw [show (1:F) + 2 * 0 = 1 by ring, d1]; ring⟩
+  · exact ⟨by rw [show (0:F) + 2 * 1 = 2 by ring, c2]; ring,
+           by rw [show (0:F) + 2 * 1 = 2 by ring, d2]; ring⟩
+  · exact ⟨by rw [show (1:F) + 2 * 1 = 3 by ring, c3]; ring,
+           by rw [show (1:F) + 2 * 1 = 3 by ring, d3]; ring⟩
 
 end Kimchi.Circuit.EndoMul

--- a/formal/Kimchi/Circuit/EndoMul.lean
+++ b/formal/Kimchi/Circuit/EndoMul.lean
@@ -20,9 +20,14 @@ TWO bases (`T` and `φ(T)`).
 * `endoMul_scalar` — with the eigenvalue `φ(T) = [λ]·T` (a hypothesis), this
   collapses to a single scalar multiple `P_m = 4^m·P₀ + k·T`, `k = k₁ + k₂·λ` — the
   endo-scalar form `EndoScalar.toField` computes.
-* `recoding_digit` — the `EndoMul ∘ EndoScalar` recoding correspondence: per 2-bit
-  window, `EndoScalar`'s `cPoly`/`dPoly` digits equal `EndoMul`'s GLV window digit,
-  so the two gates assign the same signed base to each window.
+* `recoding_digit` — the `EndoMul ∘ EndoScalar` recoding correspondence (per
+  window): `EndoScalar`'s `cPoly`/`dPoly` digits equal `EndoMul`'s GLV window digit.
+* `sum_reindex` / `recode_fold` — that correspondence lifted to the fold (the
+  row↔crumb reindexing + the coefficient identity).
+* `endoMul_ab` — THE FULL RESULT: `m` chained rows give `P_m = 4^m·P₀ + k₁·T + k₂·φ(T)`
+  with `(k₂:F) = ∑ 2^(2m-1-j)·aDigit g j` and `(k₁:F) = ∑ 2^(2m-1-j)·bDigit g j` —
+  EndoMul's GLV coefficients ARE `EndoScalar`'s Algorithm-2 `a`, `b` accumulations
+  over the shared crumbs. With `φ(T)=[λ]·T` this is `[b + a·λ]·T = [toField]·T`.
 -/
 
 namespace Kimchi.Circuit.EndoMul
@@ -214,5 +219,168 @@ theorem recode_fold (m : ℕ) (c2 : ℕ → ℤ) (g : ℕ → F)
   rw [← sum_reindex m g]
   push_cast
   exact Finset.sum_congr rfl fun i _ => by rw [hrow i]
+
+open Kimchi.Gate.EndoScalar (cPoly dPoly cPoly_table dPoly_table) in
+/-- The per-row digit equations (STUB), the gate-side source of `recode_fold`'s
+    hypothesis. A satisfying row's GLV contribution `S = 4·P + c₁·T + c₂·φ(T)` has its
+    integers pinned to `EndoScalar`'s digits: `(c₁ : F) = 2·dPoly(crumb₁) + dPoly(crumb₂)`
+    (the `T`/`b` digits) and `(c₂ : F) = 2·cPoly(crumb₁) + cPoly(crumb₂)` (the `φ(T)`/`a`
+    digits), where `crumbⱼ = b₂ⱼ + 2·b₂ⱼ₋₁` is window `j`'s `EndoScalar` crumb. (`row_int`
+    with the field digits read off the strengthened `selectQ` + `recoding_digit`.) -/
+theorem row_digit (W : WeierstrassCurve.Affine F) (ha : IsShortShape W)
+    (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) (endo : F) (w : Witness F) (h : Holds endo w)
+    (hT : W.Nonsingular w.xT w.yT) (hφT : W.Nonsingular (endo * w.xT) w.yT)
+    (hP : W.Nonsingular w.xP w.yP) (hR : W.Nonsingular w.xR w.yR)
+    (hS : W.Nonsingular w.xS w.yS)
+    (hQ1 : W.Nonsingular ((1 + (endo - 1) * w.b1) * w.xT) ((2 * w.b2 - 1) * w.yT))
+    (hQ2 : W.Nonsingular ((1 + (endo - 1) * w.b3) * w.xT) ((2 * w.b4 - 1) * w.yT))
+    (hxne1 : w.xP ≠ (1 + (endo - 1) * w.b1) * w.xT)
+    (htne1 : 2 * w.xP - w.s1 ^ 2 + (1 + (endo - 1) * w.b1) * w.xT ≠ 0)
+    (hxne2 : w.xR ≠ (1 + (endo - 1) * w.b3) * w.xT)
+    (htne2 : 2 * w.xR - w.s3 ^ 2 + (1 + (endo - 1) * w.b3) * w.xT ≠ 0) :
+    ∃ c1 c2 : ℤ,
+      Point.some hS = (4 : ℤ) • Point.some hP + c1 • Point.some hT + c2 • Point.some hφT
+        ∧ (c1 : F) = 2 * dPoly (w.b2 + 2 * w.b1) + dPoly (w.b4 + 2 * w.b3)
+        ∧ (c2 : F) = 2 * cPoly (w.b2 + 2 * w.b1) + cPoly (w.b4 + 2 * w.b3) := by
+  obtain ⟨hReq, hSeq⟩ :=
+    row_sound W ha endo w h hP hR hS hQ1 hQ2 hxne1 htne1 hxne2 htne2
+  have hb := h
+  simp only [Holds] at hb
+  obtain ⟨_, _, _, _, _, _, _, hb1c, hb2c, hb3c, hb4c, _⟩ := hb
+  have hb1 := bool_of_mul hb1c
+  have hb2 := bool_of_mul hb2c
+  have hb3 := bool_of_mul hb3c
+  have hb4 := bool_of_mul hb4c
+  obtain ⟨hcP1, hdP1⟩ := recoding_digit h2 h3 hb1 hb2
+  obtain ⟨hcP2, hdP2⟩ := recoding_digit h2 h3 hb3 hb4
+  rcases hb1 with hb1' | hb1' <;> rcases hb3 with hb3' | hb3'
+  · -- b1 = 0 (Q₁ = ±T), b3 = 0 (Q₂ = ±T)
+    have hxc1 : (1 + (endo - 1) * w.b1) * w.xT = w.xT := by rw [hb1']; ring
+    obtain ⟨e1, he1, he1f⟩ := signed_target W ha hT (hxc1 ▸ hQ1) hb2
+    have hQ1e : Point.some hQ1 = e1 • Point.some hT :=
+      (some_congr W hQ1 (hxc1 ▸ hQ1) hxc1 rfl).trans he1
+    have hxc2 : (1 + (endo - 1) * w.b3) * w.xT = w.xT := by rw [hb3']; ring
+    obtain ⟨e2, he2, he2f⟩ := signed_target W ha hT (hxc2 ▸ hQ2) hb4
+    have hQ2e : Point.some hQ2 = e2 • Point.some hT :=
+      (some_congr W hQ2 (hxc2 ▸ hQ2) hxc2 rfl).trans he2
+    refine ⟨2 * e1 + e2, 0, ?_, ?_, ?_⟩
+    · rw [hSeq, hReq, hQ1e, hQ2e]; module
+    · rw [hdP1, hdP2]; push_cast [he1f, he2f]; rw [hb1', hb3']; ring
+    · rw [hcP1, hcP2]; push_cast [he1f, he2f]; rw [hb1', hb3']; ring
+  · -- b1 = 0 (Q₁ = ±T), b3 = 1 (Q₂ = ±φT)
+    have hxc1 : (1 + (endo - 1) * w.b1) * w.xT = w.xT := by rw [hb1']; ring
+    obtain ⟨e1, he1, he1f⟩ := signed_target W ha hT (hxc1 ▸ hQ1) hb2
+    have hQ1e : Point.some hQ1 = e1 • Point.some hT :=
+      (some_congr W hQ1 (hxc1 ▸ hQ1) hxc1 rfl).trans he1
+    have hxc2 : (1 + (endo - 1) * w.b3) * w.xT = endo * w.xT := by rw [hb3']; ring
+    obtain ⟨e2, he2, he2f⟩ := signed_target W ha hφT (hxc2 ▸ hQ2) hb4
+    have hQ2e : Point.some hQ2 = e2 • Point.some hφT :=
+      (some_congr W hQ2 (hxc2 ▸ hQ2) hxc2 rfl).trans he2
+    refine ⟨2 * e1, e2, ?_, ?_, ?_⟩
+    · rw [hSeq, hReq, hQ1e, hQ2e]; module
+    · rw [hdP1, hdP2]; push_cast [he1f, he2f]; rw [hb1', hb3']; ring
+    · rw [hcP1, hcP2]; push_cast [he1f, he2f]; rw [hb1', hb3']; ring
+  · -- b1 = 1 (Q₁ = ±φT), b3 = 0 (Q₂ = ±T)
+    have hxc1 : (1 + (endo - 1) * w.b1) * w.xT = endo * w.xT := by rw [hb1']; ring
+    obtain ⟨e1, he1, he1f⟩ := signed_target W ha hφT (hxc1 ▸ hQ1) hb2
+    have hQ1e : Point.some hQ1 = e1 • Point.some hφT :=
+      (some_congr W hQ1 (hxc1 ▸ hQ1) hxc1 rfl).trans he1
+    have hxc2 : (1 + (endo - 1) * w.b3) * w.xT = w.xT := by rw [hb3']; ring
+    obtain ⟨e2, he2, he2f⟩ := signed_target W ha hT (hxc2 ▸ hQ2) hb4
+    have hQ2e : Point.some hQ2 = e2 • Point.some hT :=
+      (some_congr W hQ2 (hxc2 ▸ hQ2) hxc2 rfl).trans he2
+    refine ⟨e2, 2 * e1, ?_, ?_, ?_⟩
+    · rw [hSeq, hReq, hQ1e, hQ2e]; module
+    · rw [hdP1, hdP2]; push_cast [he1f, he2f]; rw [hb1', hb3']; ring
+    · rw [hcP1, hcP2]; push_cast [he1f, he2f]; rw [hb1', hb3']; ring
+  · -- b1 = 1 (Q₁ = ±φT), b3 = 1 (Q₂ = ±φT)
+    have hxc1 : (1 + (endo - 1) * w.b1) * w.xT = endo * w.xT := by rw [hb1']; ring
+    obtain ⟨e1, he1, he1f⟩ := signed_target W ha hφT (hxc1 ▸ hQ1) hb2
+    have hQ1e : Point.some hQ1 = e1 • Point.some hφT :=
+      (some_congr W hQ1 (hxc1 ▸ hQ1) hxc1 rfl).trans he1
+    have hxc2 : (1 + (endo - 1) * w.b3) * w.xT = endo * w.xT := by rw [hb3']; ring
+    obtain ⟨e2, he2, he2f⟩ := signed_target W ha hφT (hxc2 ▸ hQ2) hb4
+    have hQ2e : Point.some hQ2 = e2 • Point.some hφT :=
+      (some_congr W hQ2 (hxc2 ▸ hQ2) hxc2 rfl).trans he2
+    refine ⟨0, 2 * e1 + e2, ?_, ?_, ?_⟩
+    · rw [hSeq, hReq, hQ1e, hQ2e]; module
+    · rw [hdP1, hdP2]; push_cast [he1f, he2f]; rw [hb1', hb3']; ring
+    · rw [hcP1, hcP2]; push_cast [he1f, he2f]; rw [hb1', hb3']; ring
+
+open Kimchi.Gate.EndoScalar (cPoly) in
+/-- `EndoScalar`'s `a`-digit (`cPoly`, the `φ(T)`/λ component) of crumb `j` built from
+    the rows `g`: crumb `2i` is row `i`'s first window `(b₂,b₁)`, crumb `2i+1` its
+    second `(b₄,b₃)`. -/
+def aDigit (g : ℕ → Witness F) (j : ℕ) : F :=
+  if j % 2 = 0 then cPoly ((g (j / 2)).b2 + 2 * (g (j / 2)).b1)
+  else cPoly ((g (j / 2)).b4 + 2 * (g (j / 2)).b3)
+
+open Kimchi.Gate.EndoScalar (dPoly) in
+/-- `EndoScalar`'s `b`-digit (`dPoly`, the `T`/1 component) of crumb `j`. -/
+def bDigit (g : ℕ → Witness F) (j : ℕ) : F :=
+  if j % 2 = 0 then dPoly ((g (j / 2)).b2 + 2 * (g (j / 2)).b1)
+  else dPoly ((g (j / 2)).b4 + 2 * (g (j / 2)).b3)
+
+open Kimchi.Gate.EndoScalar (cPoly dPoly) in
+/-- THE FULL RECODING RESULT (STUB): EndoMul's GLV coefficients are EndoScalar's
+    `a`, `b`. `m` chained rows compute `P_m = 4^m·P₀ + k₁·T + k₂·φ(T)` where the field
+    casts of `k₂` (the `φ(T)` coefficient) and `k₁` (the `T` coefficient) are exactly
+    `EndoScalar`'s Algorithm-2 accumulations over the `2m` crumbs:
+
+        (k₂ : F) = ∑_{j<2m} 2^(2m-1-j)·aDigit g j    (= `a`, the λ component)
+        (k₁ : F) = ∑_{j<2m} 2^(2m-1-j)·bDigit g j    (= `b`, the 1 component)
+
+    Folds `row_digit` (per-row digits) through `chain_endo` and `recode_fold` (the
+    `aDigit (2i) = cPoly(window-1 crumb)`, `aDigit (2i+1) = cPoly(window-2 crumb)`
+    pairing reindexes the rows to crumbs). With `φ(T) = [λ]·T` and `P₀ = 2(T+φ(T))`
+    this gives `P_m = [b + a·λ]·T = [EndoScalar.toField]·T`. -/
+theorem endoMul_ab (W : WeierstrassCurve.Affine F) (ha : IsShortShape W)
+    (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) (endo : F)
+    (m : ℕ) (g : ℕ → Witness F) (gs : ∀ i, i < m → EndoStep W endo (g i))
+    (P : ℕ → W.Point) (T φT : W.Point)
+    (hT : ∀ i (hi : i < m), T = Point.some (gs i hi).hT)
+    (hφT : ∀ i (hi : i < m), φT = Point.some (gs i hi).hφT)
+    (hin : ∀ i (hi : i < m), P i = Point.some (gs i hi).hP)
+    (hout : ∀ i (hi : i < m), P (i + 1) = Point.some (gs i hi).hS) :
+    ∃ k1 k2 : ℤ, P m = (4 : ℤ) ^ m • P 0 + k1 • T + k2 • φT
+      ∧ (k2 : F) = ∑ j ∈ Finset.range (2 * m), (2 : F) ^ (2 * m - 1 - j) * aDigit g j
+      ∧ (k1 : F) = ∑ j ∈ Finset.range (2 * m), (2 : F) ^ (2 * m - 1 - j) * bDigit g j := by
+  choose! c1 c2 hc using fun i (hi : i < m) =>
+    row_digit W ha h2 h3 endo (g i) (gs i hi).holds (gs i hi).hT (gs i hi).hφT
+      (gs i hi).hP (gs i hi).hR (gs i hi).hS (gs i hi).hQ1 (gs i hi).hQ2
+      (gs i hi).hxne1 (gs i hi).htne1 (gs i hi).hxne2 (gs i hi).htne2
+  have hstep : ∀ i, i < m → P (i + 1) = (4 : ℤ) • P i + c1 i • T + c2 i • φT := by
+    intro i hi
+    rw [hout i hi, hin i hi, hT i hi, hφT i hi]
+    exact (hc i hi).1
+  refine ⟨∑ i ∈ Finset.range m, (4 : ℤ) ^ (m - 1 - i) * c1 i,
+          ∑ i ∈ Finset.range m, (4 : ℤ) ^ (m - 1 - i) * c2 i, ?_, ?_, ?_⟩
+  · exact chain_endo W m P T φT c1 c2 hstep
+  · rw [← sum_reindex m (aDigit g)]
+    push_cast
+    refine Finset.sum_congr rfl fun i hi => ?_
+    have hi' : i < m := Finset.mem_range.mp hi
+    have e1 : (2 * i) % 2 = 0 := by omega
+    have e2 : (2 * i) / 2 = i := by omega
+    have e3 : (2 * i + 1) % 2 = 1 := by omega
+    have e4 : (2 * i + 1) / 2 = i := by omega
+    have haE : aDigit g (2 * i) = cPoly ((g i).b2 + 2 * (g i).b1) := by
+      simp [aDigit, e1, e2]
+    have haO : aDigit g (2 * i + 1) = cPoly ((g i).b4 + 2 * (g i).b3) := by
+      simp [aDigit, e3, e4]
+    rw [haE, haO, ← (hc i hi').2.2]
+  · rw [← sum_reindex m (bDigit g)]
+    push_cast
+    refine Finset.sum_congr rfl fun i hi => ?_
+    have hi' : i < m := Finset.mem_range.mp hi
+    have e1 : (2 * i) % 2 = 0 := by omega
+    have e2 : (2 * i) / 2 = i := by omega
+    have e3 : (2 * i + 1) % 2 = 1 := by omega
+    have e4 : (2 * i + 1) / 2 = i := by omega
+    have hbE : bDigit g (2 * i) = dPoly ((g i).b2 + 2 * (g i).b1) := by
+      simp [bDigit, e1, e2]
+    have hbO : bDigit g (2 * i + 1) = dPoly ((g i).b4 + 2 * (g i).b3) := by
+      simp [bDigit, e3, e4]
+    rw [hbE, hbO, ← (hc i hi').2.1]
 
 end Kimchi.Circuit.EndoMul

--- a/formal/Kimchi/Curve.lean
+++ b/formal/Kimchi/Curve.lean
@@ -22,4 +22,68 @@ namespace Kimchi
 abbrev IsShortShape {F : Type*} [CommRing F] (W : WeierstrassCurve.Affine F) : Prop :=
   W.a₁ = 0 ∧ W.a₂ = 0 ∧ W.a₃ = 0 ∧ W.a₄ = 0
 
+open WeierstrassCurve.Affine
+
+variable {F : Type*} [Field F] [DecidableEq F]
+
+omit [DecidableEq F] in
+/-- `Point.some` depends on the `y`-coordinate only through its value, not the
+    nonsingularity proof: equal coordinates give equal points. A thin congruence
+    for rewriting a target point into a recognizable form. -/
+theorem some_eq_some (W : WeierstrassCurve.Affine F) {x y y' : F}
+    (h : W.Nonsingular x y) (h' : W.Nonsingular x y') (hy : y = y') :
+    Point.some h = Point.some h' := by
+  subst hy; rfl
+
+/-- One non-vertical (secant) affine addition, packaged with explicit output
+    coordinates. If `(x₁,y₁)`, `(x₂,y₂)` are nonsingular points with `x₁ ≠ x₂`,
+    and `ℓ, x₃, y₃` are the secant slope and resulting coordinates, then their
+    group sum is the nonsingular point `(x₃, y₃)`. (No `y₁ ≠ 0` hypothesis: the
+    doubling branch is excluded by `x₁ ≠ x₂`.) -/
+lemma secant_add
+    (W : WeierstrassCurve.Affine F) (ha : IsShortShape W)
+    {x1 y1 x2 y2 : F}
+    (h1 : W.Nonsingular x1 y1) (h2 : W.Nonsingular x2 y2)
+    (hx : x1 ≠ x2)
+    {l x3 y3 : F}
+    (hl : l = (y1 - y2) / (x1 - x2))
+    (hx3 : x3 = l * l - x1 - x2)
+    (hy3 : y3 = l * (x1 - x3) - y1) :
+    ∃ h3 : W.Nonsingular x3 y3,
+      Point.some h1 + Point.some h2 = Point.some h3 := by
+  obtain ⟨ha1, ha2, ha3, ha4⟩ := ha
+  have hslope : W.slope x1 x2 y1 y2 = l := by
+    rw [WeierstrassCurve.Affine.slope_of_X_ne hx, hl]
+  have hfin : ¬(x1 = x2 ∧ y1 = W.negY x2 y2) := fun hc => hx hc.1
+  have hx3' : W.addX x1 x2 (W.slope x1 x2 y1 y2) = x3 := by
+    rw [hslope]; simp only [WeierstrassCurve.Affine.addX, ha1, ha2]
+    rw [hx3]; ring
+  have hy3' : W.addY x1 x2 y1 (W.slope x1 x2 y1 y2) = y3 := by
+    rw [hslope]
+    simp only [WeierstrassCurve.Affine.addY, WeierstrassCurve.Affine.negY,
+      WeierstrassCurve.Affine.negAddY, WeierstrassCurve.Affine.addX, ha1, ha2, ha3]
+    rw [hy3, hx3]; ring
+  rw [← hx3', ← hy3']
+  exact ⟨WeierstrassCurve.Affine.nonsingular_add h1 h2 hfin,
+         WeierstrassCurve.Affine.Point.add_some hfin⟩
+
+/-- The sign-selected target. For a base point `(xT, yT)` on a short curve, the
+    point `(xT, (2b−1)·yT)` with `b ∈ {0,1}` is `±` the base: `e • base` for the
+    integer `e = 2b−1 ∈ {−1,1}` (negation on a short curve is `y ↦ −y`). -/
+lemma signed_target
+    (W : WeierstrassCurve.Affine F) (ha : IsShortShape W)
+    {b xT yT : F}
+    (hT : W.Nonsingular xT yT)
+    (hQ : W.Nonsingular xT ((2 * b - 1) * yT))
+    (hb : b = 0 ∨ b = 1) :
+    ∃ e : ℤ, Point.some hQ = e • Point.some hT ∧ (e : F) = 2 * b - 1 := by
+  obtain ⟨ha1, _, ha3, _⟩ := ha
+  rcases hb with rfl | rfl
+  · refine ⟨-1, ?_, by push_cast; ring⟩
+    rw [neg_one_zsmul, Point.neg_some]
+    exact some_eq_some W hQ _ (by rw [WeierstrassCurve.Affine.negY, ha1, ha3]; ring)
+  · refine ⟨1, ?_, by push_cast; ring⟩
+    rw [one_zsmul]
+    exact some_eq_some W hQ hT (by ring)
+
 end Kimchi

--- a/formal/Kimchi/Cycle/EndoMul.lean
+++ b/formal/Kimchi/Cycle/EndoMul.lean
@@ -1,0 +1,104 @@
+import Kimchi.Cycle.VarBaseMul
+import Kimchi.Cycle.Shifted
+import Kimchi.Circuit.EndoMul
+
+/-!
+# Phase 3: EndoMul over a `CMCurve` — the eigenvalue from the curve
+
+`endoMul_scalar` / `endoMul_toField` both take the eigenvalue `φ(T) = [λ]·T` as a
+bare HYPOTHESIS. Over a `CMCurve` that hypothesis is exactly the `eigen` axiom — so
+when the EndoMul rows run the curve's own endomorphism (`endo = c.beta`), the
+eigenvalue is *supplied by the curve structure* rather than assumed, with `λ = c.lam`
+its genuine scalar-field value. The resulting scalar acts in `ℤ/order` (`zsmul_emod_eq`).
+
+This upgrades EndoMul's two headline results — `endoMul_scalar_cm` (single scalar
+multiple) and `endoMul_toField_cm` (`P_m = [EndoScalar.toField]·T`) — to the two-field
+model, leaving only the `toField`/range faithfulness (the EndoScalar analogue of
+`varBaseMul_faithful`) and the cross-cycle reciprocity for Phase 4.
+-/
+
+namespace Kimchi.Cycle
+
+open WeierstrassCurve.Affine Kimchi.Gate.EndoMul Kimchi.Circuit.EndoMul
+
+variable {F : Type*} [Field F] [DecidableEq F]
+
+/-- The eigenvalue relation `φ(T) = [λ]·T`, supplied by the curve's CM structure — the
+    `eigen` axiom specialized to the base pair `T = (xT, yT)`, `φ(T) = (β·xT, yT)`. This
+    is the `heig` hypothesis `endoMul_scalar`/`endoMul_toField` ask for, now a theorem. -/
+theorem endoStep_eigen (c : CMCurve F) {xT yT : F}
+    (hTbase : c.W.Nonsingular xT yT) (hφTbase : c.W.Nonsingular (c.beta * xT) yT) :
+    Point.some hφTbase = c.lam • Point.some hTbase :=
+  c.eigen hTbase hφTbase
+
+/-- PHASE 3 — EndoMul over a `CMCurve`, eigenvalue from the curve. With the rows running
+    the curve's endomorphism (`endo = c.beta`) and the base point `T = (xT, yT)`, the GLV
+    eigenvalue collapse `P_m = 4^m·P₀ + [k]·T` holds with `λ = c.lam` taken from `eigen`
+    (not hypothesized). The multiplier `k` is a genuine scalar-field element: for any
+    `s ≡ k (mod order)` the result is the same (`zsmul_emod_eq`). -/
+theorem endoMul_scalar_cm (c : CMCurve F)
+    (m : ℕ) (g : ℕ → Witness F) (gs : ∀ i, i < m → EndoStep c.W c.beta (g i))
+    (P : ℕ → c.W.Point) (T φT : c.W.Point) {xT yT : F}
+    (hTbase : c.W.Nonsingular xT yT) (hφTbase : c.W.Nonsingular (c.beta * xT) yT)
+    (hTeq : T = Point.some hTbase) (hφTeq : φT = Point.some hφTbase)
+    (hT : ∀ i (hi : i < m), T = Point.some (gs i hi).hT)
+    (hφT : ∀ i (hi : i < m), φT = Point.some (gs i hi).hφT)
+    (hin : ∀ i (hi : i < m), P i = Point.some (gs i hi).hP)
+    (hout : ∀ i (hi : i < m), P (i + 1) = Point.some (gs i hi).hS) :
+    ∃ k : ℤ, P m = (4 : ℤ) ^ m • P 0 + k • T
+      ∧ ∀ s : ℤ, k ≡ s [ZMOD (c.order : ℤ)] → P m = (4 : ℤ) ^ m • P 0 + s • T := by
+  have heig : φT = c.lam • T := by rw [hTeq, hφTeq]; exact endoStep_eigen c hTbase hφTbase
+  obtain ⟨k, hk⟩ := endoMul_scalar c.W c.short c.beta m g gs P T φT hT hφT hin hout c.lam heig
+  exact ⟨k, hk, fun s hs => by rw [hk, zsmul_emod_eq c T hs]⟩
+
+/-- PHASE 3 — EndoMul ∘ EndoScalar over a `CMCurve`, the top level with the eigenvalue
+    from the curve. At the real init (`P₀ = 2·(T + φ(T))`) the rows produce `P_m = [s]·T`
+    where `(s : F) = EndoScalar.toField (crumbList g m) c.lam` — EndoMul multiplies the
+    base by exactly the scalar EndoScalar decodes, and the eigenvalue `λ = c.lam` is the
+    curve's own (via `eigen`), NOT a free hypothesis. The remaining faithfulness — that
+    `s mod order` is the intended scalar, via the `Shifted_value` range on `toField` — is
+    the EndoScalar analogue of `varBaseMul_faithful` (Phase 4). -/
+theorem endoMul_toField_cm (c : CMCurve F) (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
+    (m : ℕ) (g : ℕ → Witness F) (gs : ∀ i, i < m → EndoStep c.W c.beta (g i))
+    (P : ℕ → c.W.Point) (T φT : c.W.Point) {xT yT : F}
+    (hTbase : c.W.Nonsingular xT yT) (hφTbase : c.W.Nonsingular (c.beta * xT) yT)
+    (hTeq : T = Point.some hTbase) (hφTeq : φT = Point.some hφTbase)
+    (hT : ∀ i (hi : i < m), T = Point.some (gs i hi).hT)
+    (hφT : ∀ i (hi : i < m), φT = Point.some (gs i hi).hφT)
+    (hin : ∀ i (hi : i < m), P i = Point.some (gs i hi).hP)
+    (hout : ∀ i (hi : i < m), P (i + 1) = Point.some (gs i hi).hS)
+    (hP0 : P 0 = (2 : ℤ) • T + (2 : ℤ) • φT) :
+    ∃ s : ℤ, P m = s • T
+      ∧ (s : F) = Kimchi.Circuit.EndoScalar.toField (crumbList g m) (c.lam : F) := by
+  have heig : φT = c.lam • T := by rw [hTeq, hφTeq]; exact endoStep_eigen c hTbase hφTbase
+  exact endoMul_toField c.W c.short h2 h3 c.beta m g gs P T φT hT hφT hin hout hP0 c.lam heig
+
+/-- PHASE 3 (faithful) — EndoMul ∘ EndoScalar computes `[σ]·T` for the genuine scalar.
+    Given the intended scalar `σ : ℤ` that `toField` decodes (`(σ:F) = toField crumbs λ`,
+    its coordinate-field representation), the gate's output `P_m = [s]·T` has `s = σ`
+    once the `Shifted_value` range bounds `|s − σ| < p` — so `P_m = [σ]·T` for the honest
+    integer scalar. The EndoScalar analogue of `varBaseMul_faithful`: `endoMul_toField_cm`
+    gives `(s:F) = toField = (σ:F)`, and the cross-field coincidence (`intCast_inj_of_sub_lt`)
+    upgrades it to `s = σ` under the range. With the eigenvalue from the curve, this closes
+    Level-1 EndoMul — `[EndoScalar.toField]·T` with both the eigenvalue and the scalar
+    honest, modulo the single explicit range hypothesis. -/
+theorem endoMul_faithful (c : CMCurve F) {p : ℕ} [CharP F p]
+    (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
+    (m : ℕ) (g : ℕ → Witness F) (gs : ∀ i, i < m → EndoStep c.W c.beta (g i))
+    (P : ℕ → c.W.Point) (T φT : c.W.Point) {xT yT : F}
+    (hTbase : c.W.Nonsingular xT yT) (hφTbase : c.W.Nonsingular (c.beta * xT) yT)
+    (hTeq : T = Point.some hTbase) (hφTeq : φT = Point.some hφTbase)
+    (hT : ∀ i (hi : i < m), T = Point.some (gs i hi).hT)
+    (hφT : ∀ i (hi : i < m), φT = Point.some (gs i hi).hφT)
+    (hin : ∀ i (hi : i < m), P i = Point.some (gs i hi).hP)
+    (hout : ∀ i (hi : i < m), P (i + 1) = Point.some (gs i hi).hS)
+    (hP0 : P 0 = (2 : ℤ) • T + (2 : ℤ) • φT)
+    (σ : ℤ) (hσ : (σ : F) = Kimchi.Circuit.EndoScalar.toField (crumbList g m) (c.lam : F)) :
+    ∃ s : ℤ, P m = s • T
+      ∧ (s : F) = Kimchi.Circuit.EndoScalar.toField (crumbList g m) (c.lam : F)
+      ∧ ((s - σ).natAbs < p → P m = σ • T) := by
+  obtain ⟨s, hPm, hs⟩ := endoMul_toField_cm c h2 h3 m g gs P T φT hTbase hφTbase
+    hTeq hφTeq hT hφT hin hout hP0
+  exact ⟨s, hPm, hs, fun hrange => by rw [hPm, intCast_inj_of_sub_lt (hs.trans hσ.symm) hrange]⟩
+
+end Kimchi.Cycle

--- a/formal/Kimchi/Cycle/Pasta.lean
+++ b/formal/Kimchi/Cycle/Pasta.lean
@@ -1,0 +1,88 @@
+import Kimchi.Cycle.EndoMul
+
+/-!
+# Phase 4: instantiating the cycle for Pasta — the axioms become real
+
+Phases 0–3 prove the faithful gate results for *any* `CMCurve`, staying
+standard-axiom-clean because the Pasta facts are structure-field *hypotheses*. This
+file takes the last step: it instantiates a concrete curve (Pallas), at which point
+those hypotheses become honest Lean `axiom`s. Everything downstream that uses `pallas`
+will show them in `#print axioms` — no longer `[propext, Classical.choice, Quot.sound]`
+but `+ pallas_order_smul, pallas_eigen, …`. That is exactly correct: the curve's group
+order (Schoof) and CM eigenvalue (`φ=[λ]`) are genuinely not Mathlib theorems.
+
+The coordinate field `F` is left opaque here (concretely `ZMod p` for the 255-bit Pasta
+prime `p`); only the genuinely-unprovable facts — `pallas_order_smul`, `pallas_eigen` —
+are the load-bearing axioms. The point-structure data (`W`, short shape, `β`) are
+likewise opaque stand-ins for the concrete `y² = x³ + 5`. A fully concrete `ZMod p`
+version would replace these with definitions, but `order_smul`/`eigen` stay axioms
+regardless — so this faithfully exhibits the axiom boundary.
+
+This is the gate-level end of the cycle. The remaining *two-curve* reciprocity
+(`TwoCycle`) is a recursion-layer concern — how scalars pass between the Pasta step/wrap
+circuits — above the per-gate scope.
+-/
+
+namespace Kimchi.Cycle.Pasta
+
+open WeierstrassCurve.Affine Kimchi.Gate.EndoMul Kimchi.Circuit.EndoMul
+
+/-- The Pallas coordinate field (= Vesta's scalar field); opaque, concretely `ZMod p`. -/
+axiom F : Type
+axiom instField : Field F
+attribute [instance] instField
+axiom instDecEq : DecidableEq F
+attribute [instance] instDecEq
+/-- The Pasta base-field characteristic (the 255-bit prime `p`). -/
+axiom pPasta : ℕ
+axiom instCharP : CharP F pPasta
+attribute [instance] instCharP
+
+/-- Opaque stand-in for the Pallas curve `y² = x³ + 5` over `F`. -/
+axiom W : WeierstrassCurve.Affine F
+axiom Wshort : IsShortShape W
+/-- The group order (= the *other* Pasta prime `q`). -/
+axiom order : ℕ
+/-- **AXIOM (Schoof).** The Pallas group has exponent dividing its order. Genuinely not
+    a Mathlib theorem — a 255-bit constant. -/
+axiom pallas_order_smul : ∀ P : W.Point, (order : ℤ) • P = 0
+axiom beta : F
+axiom beta_cube : beta ^ 3 = 1
+axiom lam : ℤ
+/-- **AXIOM (CM).** The endomorphism `φ(x,y) = (β·x, y)` acts as `[λ]` on the group.
+    The endomorphism-ring fact Mathlib lacks. -/
+axiom pallas_eigen : ∀ {x y : F} (h : W.Nonsingular x y) (h' : W.Nonsingular (beta * x) y),
+    Point.some h' = lam • Point.some h
+
+/-- The Pallas curve as a `CMCurve` — assembled from the Pasta axioms. Using this in any
+    theorem pulls `pallas_order_smul`, `pallas_eigen` (and the opaque data) into its
+    `#print axioms`. -/
+noncomputable def pallas : CMCurve F where
+  W := W
+  short := Wshort
+  order := order
+  order_smul := pallas_order_smul
+  beta := beta
+  beta_cube := beta_cube
+  lam := lam
+  eigen := pallas_eigen
+
+/-- Scalars on Pallas reduce mod the group order — the Schoof axiom in action. -/
+theorem pallas_zsmul (n : ℤ) (Q : pallas.W.Point) : (n % (pallas.order : ℤ)) • Q = n • Q :=
+  zsmul_mod F pallas n Q
+
+/-- **Faithful EndoMul on the REAL Pallas curve.** `endoMul_toField_cm` specialized to
+    `pallas`: `P_m = [s]·T` with `(s:F) = EndoScalar.toField crumbs λ`, the eigenvalue
+    supplied by Pallas's CM structure. Unlike the parametric Phase-3 result, this rests
+    on the Pasta axioms — `#print axioms pallas_endoMul_toField` lists `pallas_eigen`
+    (and the curve data) alongside the standard three. (A `def` only because the fully
+    applied type is inferred from the specialization; it is a proof of a `∀…∃` Prop.) -/
+def pallas_endoMul_toField := endoMul_toField_cm pallas
+
+/-- **The faithful capstone, on Pallas.** `endoMul_faithful` specialized to `pallas`:
+    EndoMul ∘ EndoScalar computes `[σ]·T` for the genuine scalar `σ` (the `toField`
+    decode), under the `Shifted_value` range — eigenvalue *and* scalar honest, on the
+    actual curve. `#print axioms` lists `pallas_order_smul`, `pallas_eigen`. -/
+def pallas_endoMul_faithful := endoMul_faithful pallas
+
+end Kimchi.Cycle.Pasta

--- a/formal/Kimchi/Gate/EndoMul.lean
+++ b/formal/Kimchi/Gate/EndoMul.lean
@@ -152,21 +152,21 @@ theorem selectQ (W : WeierstrassCurve.Affine F) (ha : IsShortShape W)
     (hT : W.Nonsingular xT yT) (hφT : W.Nonsingular (endo * xT) yT)
     (hQ : W.Nonsingular ((1 + (endo - 1) * b1) * xT) ((2 * b2 - 1) * yT))
     (hb1 : b1 = 0 ∨ b1 = 1) (hb2 : b2 = 0 ∨ b2 = 1) :
-    (∃ e : ℤ, Point.some hQ = e • Point.some hT)
-      ∨ (∃ e : ℤ, Point.some hQ = e • Point.some hφT) := by
+    (∃ e : ℤ, Point.some hQ = e • Point.some hT ∧ (e : F) = 2 * b2 - 1)
+      ∨ (∃ e : ℤ, Point.some hQ = e • Point.some hφT ∧ (e : F) = 2 * b2 - 1) := by
   rcases hb1 with rfl | rfl
   · -- `b₁ = 0`: the `x`-coordinate `(1 + (endo-1)*0)*xT` collapses to `xT`,
     -- so `Q = ±T` via `signed_target` with base `T`.
     left
     have hx : (1 + (endo - 1) * 0) * xT = xT := by ring
-    obtain ⟨e, he, _⟩ := signed_target W ha hT (hx ▸ hQ) hb2
-    exact ⟨e, (some_congr W hQ (hx ▸ hQ) hx rfl).trans he⟩
+    obtain ⟨e, he, hef⟩ := signed_target W ha hT (hx ▸ hQ) hb2
+    exact ⟨e, (some_congr W hQ (hx ▸ hQ) hx rfl).trans he, hef⟩
   · -- `b₁ = 1`: the `x`-coordinate `(1 + (endo-1)*1)*xT` collapses to `endo*xT`,
     -- so `Q = ±φ(T)` via `signed_target` with base `φ(T)`.
     right
     have hx : (1 + (endo - 1) * 1) * xT = endo * xT := by ring
-    obtain ⟨e, he, _⟩ := signed_target W ha hφT (hx ▸ hQ) hb2
-    exact ⟨e, (some_congr W hQ (hx ▸ hQ) hx rfl).trans he⟩
+    obtain ⟨e, he, hef⟩ := signed_target W ha hφT (hx ▸ hQ) hb2
+    exact ⟨e, (some_congr W hQ (hx ▸ hQ) hx rfl).trans he, hef⟩
 
 /-- One window's `(P + Q) + P` double-and-add. The three EC constraints — the
     first-addition slope `s` and the `xR`/`yR` relations — together with the
@@ -283,11 +283,11 @@ theorem row_int (W : WeierstrassCurve.Affine F) (ha : IsShortShape W)
   have hb2 := bool_of_mul hb2c
   have hb3 := bool_of_mul hb3c
   have hb4 := bool_of_mul hb4c
-  rcases selectQ W ha hT hφT hQ1 hb1 hb2 with ⟨e1, hQ1e⟩ | ⟨e1, hQ1e⟩
-  · rcases selectQ W ha hT hφT hQ2 hb3 hb4 with ⟨e2, hQ2e⟩ | ⟨e2, hQ2e⟩
+  rcases selectQ W ha hT hφT hQ1 hb1 hb2 with ⟨e1, hQ1e, _⟩ | ⟨e1, hQ1e, _⟩
+  · rcases selectQ W ha hT hφT hQ2 hb3 hb4 with ⟨e2, hQ2e, _⟩ | ⟨e2, hQ2e, _⟩
     · exact ⟨2 * e1 + e2, 0, by rw [hSeq, hReq, hQ1e, hQ2e]; module⟩
     · exact ⟨2 * e1, e2, by rw [hSeq, hReq, hQ1e, hQ2e]; module⟩
-  · rcases selectQ W ha hT hφT hQ2 hb3 hb4 with ⟨e2, hQ2e⟩ | ⟨e2, hQ2e⟩
+  · rcases selectQ W ha hT hφT hQ2 hb3 hb4 with ⟨e2, hQ2e, _⟩ | ⟨e2, hQ2e, _⟩
     · exact ⟨e2, 2 * e1, by rw [hSeq, hReq, hQ1e, hQ2e]; module⟩
     · exact ⟨0, 2 * e1 + e2, by rw [hSeq, hReq, hQ1e, hQ2e]; module⟩
 

--- a/formal/Kimchi/Gate/EndoMul.lean
+++ b/formal/Kimchi/Gate/EndoMul.lean
@@ -48,9 +48,11 @@ accumulation.
 The constraint model `Witness` / `Holds`, the booleanity helper `bool_of_mul`, the
 distinct-point lemma `distinctPoints` (which discharges `block_sound`'s
 non-degeneracy at the row level), and the `some_congr` point congruence. The GLV
-accumulation `P_m = 4^m·P₀ + k₁·T + k₂·φ(T)` lives in `Kimchi.Circuit.EndoMul`
-(`chain_endo` / `endoMul`); the remaining step is the `φ(T) = [λ]T` eigenvalue
-collapse (a hypothesis/axiom) composing with EndoScalar's `a·λ + b`.
+accumulation `P_m = 4^m·P₀ + k₁·T + k₂·φ(T)` and the eigenvalue collapse to
+`[k₁+k₂·λ]·T` live in `Kimchi.Circuit.EndoMul` (`chain_endo` / `endoMul` /
+`endoMul_scalar`). The only step left to a fully-closed `EndoMul ∘ EndoScalar` is
+the recoding correspondence `(k₂, k₁) = (a, b)` between the two gates' bit
+processing — see `endoMul_scalar`.
 -/
 
 namespace Kimchi.Gate.EndoMul

--- a/formal/Kimchi/Gate/EndoMul.lean
+++ b/formal/Kimchi/Gate/EndoMul.lean
@@ -227,4 +227,29 @@ theorem block_sound (W : WeierstrassCurve.Affine F) (ha : IsShortShape W)
     secant_add W ⟨ha1, ha2, ha3, ha4⟩ hM hP hMxne hs2 hxR_eq hyR_eq
   rw [hAdd1, hAdd2]
 
+/-- Per-row soundness: a satisfying row's two windows compute the double-and-add
+    chain `R = (P + Q₁) + P` then `S = (R + Q₂) + R`, where `Q₁, Q₂` are the gate's
+    endo-and-sign-selected targets. The distinct-point constraint (via
+    `distinctPoints`) supplies each window's `xR ≠ xP` / `xS ≠ xR`; the per-slope
+    non-degeneracies `xP ≠ xq` and `2·xP − s² + xq ≠ 0` are the remaining honest-
+    witness conditions (as in VarBaseMul). Identify `Q₁, Q₂` as `±T` / `±φ(T)` with
+    `selectQ` to feed the GLV accumulation. -/
+theorem row_sound (W : WeierstrassCurve.Affine F) (ha : IsShortShape W)
+    (endo : F) (w : Witness F) (h : Holds endo w)
+    (hP : W.Nonsingular w.xP w.yP) (hR : W.Nonsingular w.xR w.yR)
+    (hS : W.Nonsingular w.xS w.yS)
+    (hQ1 : W.Nonsingular ((1 + (endo - 1) * w.b1) * w.xT) ((2 * w.b2 - 1) * w.yT))
+    (hQ2 : W.Nonsingular ((1 + (endo - 1) * w.b3) * w.xT) ((2 * w.b4 - 1) * w.yT))
+    (hxne1 : w.xP ≠ (1 + (endo - 1) * w.b1) * w.xT)
+    (htne1 : 2 * w.xP - w.s1 ^ 2 + (1 + (endo - 1) * w.b1) * w.xT ≠ 0)
+    (hxne2 : w.xR ≠ (1 + (endo - 1) * w.b3) * w.xT)
+    (htne2 : 2 * w.xR - w.s3 ^ 2 + (1 + (endo - 1) * w.b3) * w.xT ≠ 0) :
+    Point.some hR = (Point.some hP + Point.some hQ1) + Point.some hP
+      ∧ Point.some hS = (Point.some hR + Point.some hQ2) + Point.some hR := by
+  obtain ⟨hxPxR, hxRxS⟩ := distinctPoints endo w h
+  simp only [Holds] at h
+  obtain ⟨hs1, hc2_1, hc3_1, hs2, hc2_2, hc3_2, _, _, _, _, _, _⟩ := h
+  exact ⟨block_sound W ha hP hQ1 hR hxne1 htne1 (Ne.symm hxPxR) hs1 hc2_1 hc3_1,
+         block_sound W ha hR hQ2 hS hxne2 htne2 (Ne.symm hxRxS) hs2 hc2_2 hc3_2⟩
+
 end Kimchi.Gate.EndoMul

--- a/formal/Kimchi/Gate/EndoMul.lean
+++ b/formal/Kimchi/Gate/EndoMul.lean
@@ -50,9 +50,9 @@ distinct-point lemma `distinctPoints` (which discharges `block_sound`'s
 non-degeneracy at the row level), and the `some_congr` point congruence. The GLV
 accumulation `P_m = 4^m·P₀ + k₁·T + k₂·φ(T)` and the eigenvalue collapse to
 `[k₁+k₂·λ]·T` live in `Kimchi.Circuit.EndoMul` (`chain_endo` / `endoMul` /
-`endoMul_scalar`). The only step left to a fully-closed `EndoMul ∘ EndoScalar` is
-the recoding correspondence `(k₂, k₁) = (a, b)` between the two gates' bit
-processing — see `endoMul_scalar`.
+`endoMul_scalar`), and the recoding correspondence with EndoScalar
+(`Kimchi.Circuit.EndoMul.recoding_digit`): per 2-bit window the two gates assign the
+same signed base, the per-window heart of `(k₂, k₁) = (a, b)`.
 -/
 
 namespace Kimchi.Gate.EndoMul

--- a/formal/Kimchi/Gate/EndoMul.lean
+++ b/formal/Kimchi/Gate/EndoMul.lean
@@ -39,15 +39,18 @@ accumulation.
 * `block_sound` — one window's `(P + Q) + P` double-and-add, via `Kimchi.secant_add`
   twice (general in `Q`; carries the `xR ≠ xP` non-degeneracy the modeled gate
   revision needs — see its docstring + the upstream fix it references).
+* `row_sound` / `row_int` — the per-row two-window chain `R = (P+Q₁)+P`,
+  `S = (R+Q₂)+R`, exposed as `S = 4·P + c₁·T + c₂·φ(T)` (integers `c₁, c₂`) — the
+  GLV interface the circuit folds.
 
 ## Supporting development
 
 The constraint model `Witness` / `Holds`, the booleanity helper `bool_of_mul`, the
 distinct-point lemma `distinctPoints` (which discharges `block_sound`'s
-non-degeneracy at the row level), and the `some_congr` point congruence. Still to
-come: threading these through `Holds` per row, the GLV `[k₁]T + [k₂]·φ(T)`
-accumulation, and the `φ(T) = [λ]T` eigenvalue collapse (a hypothesis/axiom)
-composing with EndoScalar's `a·λ + b`.
+non-degeneracy at the row level), and the `some_congr` point congruence. The GLV
+accumulation `P_m = 4^m·P₀ + k₁·T + k₂·φ(T)` lives in `Kimchi.Circuit.EndoMul`
+(`chain_endo` / `endoMul`); the remaining step is the `φ(T) = [λ]T` eigenvalue
+collapse (a hypothesis/axiom) composing with EndoScalar's `a·λ + b`.
 -/
 
 namespace Kimchi.Gate.EndoMul
@@ -251,5 +254,39 @@ theorem row_sound (W : WeierstrassCurve.Affine F) (ha : IsShortShape W)
   obtain ⟨hs1, hc2_1, hc3_1, hs2, hc2_2, hc3_2, _, _, _, _, _, _⟩ := h
   exact ⟨block_sound W ha hP hQ1 hR hxne1 htne1 (Ne.symm hxPxR) hs1 hc2_1 hc3_1,
          block_sound W ha hR hQ2 hS hxne2 htne2 (Ne.symm hxRxS) hs2 hc2_2 hc3_2⟩
+
+/-- The per-row GLV contribution, as integer scalar multiples of the two bases.
+    Folding `row_sound`'s `S = (R+Q₂)+R`, `R = (P+Q₁)+P` gives `S = 4·P + 2·Q₁ + Q₂`;
+    `selectQ` makes each `Qⱼ` a signed `T` or `φ(T)`, so `S = 4·P + c₁·T + c₂·φ(T)`
+    for integers `c₁, c₂` (the gate's exposed interface, consumed by the chain). -/
+theorem row_int (W : WeierstrassCurve.Affine F) (ha : IsShortShape W)
+    (endo : F) (w : Witness F) (h : Holds endo w)
+    (hT : W.Nonsingular w.xT w.yT) (hφT : W.Nonsingular (endo * w.xT) w.yT)
+    (hP : W.Nonsingular w.xP w.yP) (hR : W.Nonsingular w.xR w.yR)
+    (hS : W.Nonsingular w.xS w.yS)
+    (hQ1 : W.Nonsingular ((1 + (endo - 1) * w.b1) * w.xT) ((2 * w.b2 - 1) * w.yT))
+    (hQ2 : W.Nonsingular ((1 + (endo - 1) * w.b3) * w.xT) ((2 * w.b4 - 1) * w.yT))
+    (hxne1 : w.xP ≠ (1 + (endo - 1) * w.b1) * w.xT)
+    (htne1 : 2 * w.xP - w.s1 ^ 2 + (1 + (endo - 1) * w.b1) * w.xT ≠ 0)
+    (hxne2 : w.xR ≠ (1 + (endo - 1) * w.b3) * w.xT)
+    (htne2 : 2 * w.xR - w.s3 ^ 2 + (1 + (endo - 1) * w.b3) * w.xT ≠ 0) :
+    ∃ c1 c2 : ℤ, Point.some hS
+      = (4 : ℤ) • Point.some hP + c1 • Point.some hT + c2 • Point.some hφT := by
+  obtain ⟨hReq, hSeq⟩ :=
+    row_sound W ha endo w h hP hR hS hQ1 hQ2 hxne1 htne1 hxne2 htne2
+  have hb := h
+  simp only [Holds] at hb
+  obtain ⟨_, _, _, _, _, _, _, hb1c, hb2c, hb3c, hb4c, _⟩ := hb
+  have hb1 := bool_of_mul hb1c
+  have hb2 := bool_of_mul hb2c
+  have hb3 := bool_of_mul hb3c
+  have hb4 := bool_of_mul hb4c
+  rcases selectQ W ha hT hφT hQ1 hb1 hb2 with ⟨e1, hQ1e⟩ | ⟨e1, hQ1e⟩
+  · rcases selectQ W ha hT hφT hQ2 hb3 hb4 with ⟨e2, hQ2e⟩ | ⟨e2, hQ2e⟩
+    · exact ⟨2 * e1 + e2, 0, by rw [hSeq, hReq, hQ1e, hQ2e]; module⟩
+    · exact ⟨2 * e1, e2, by rw [hSeq, hReq, hQ1e, hQ2e]; module⟩
+  · rcases selectQ W ha hT hφT hQ2 hb3 hb4 with ⟨e2, hQ2e⟩ | ⟨e2, hQ2e⟩
+    · exact ⟨e2, 2 * e1, by rw [hSeq, hReq, hQ1e, hQ2e]; module⟩
+    · exact ⟨0, 2 * e1 + e2, by rw [hSeq, hReq, hQ1e, hQ2e]; module⟩
 
 end Kimchi.Gate.EndoMul

--- a/formal/Kimchi/Gate/EndoMul.lean
+++ b/formal/Kimchi/Gate/EndoMul.lean
@@ -22,6 +22,11 @@ bits = two windows `P → R → S`:
 The register threads `n' = 16·n + 8·b₁ + 4·b₂ + 2·b₃ + b₄`, and the accumulator is
 initialized to `2·(T + φ(T))` to dodge the point at infinity.
 
+We model the UPSTREAM-FIXED gate: 12 constraints, including the distinct-point check
+`(xP − xR)·(xR − xS)·inv = 1` (o1-labs/proof-systems@64129ce4) which pins the
+accumulator away from `−P` / `−R`. The pre-fix gate without it is underconstrained
+(it admits the spurious `R = −P`) — see `block_sound` / `distinctPoints`.
+
 The EC core (`(P + Q) + P` per window) reuses `Kimchi.Gate.VarBaseMul`'s
 `secant_add` (general affine addition) and `signed_target` (the `±` selection); the
 new ingredients are the endomorphism base-choice and the GLV `[k₁]T + [k₂]φ(T)`
@@ -29,14 +34,27 @@ accumulation.
 
 ## Main results
 
-(in progress) — the constraint model `Witness` / `Holds` and the booleanity helper.
+* `selectQ` — GLV target selection: a window's `Q` is `±T` (when `b₁ = 0`) or
+  `±φ(T)` (when `b₁ = 1`), via `Kimchi.signed_target` with base `T` or `φ(T)`.
+* `block_sound` — one window's `(P + Q) + P` double-and-add, via `Kimchi.secant_add`
+  twice (general in `Q`; carries the `xR ≠ xP` non-degeneracy the modeled gate
+  revision needs — see its docstring + the upstream fix it references).
+
+## Supporting development
+
+The constraint model `Witness` / `Holds`, the booleanity helper `bool_of_mul`, the
+distinct-point lemma `distinctPoints` (which discharges `block_sound`'s
+non-degeneracy at the row level), and the `some_congr` point congruence. Still to
+come: threading these through `Holds` per row, the GLV `[k₁]T + [k₂]·φ(T)`
+accumulation, and the `φ(T) = [λ]T` eigenvalue collapse (a hypothesis/axiom)
+composing with EndoScalar's `a·λ + b`.
 -/
 
 namespace Kimchi.Gate.EndoMul
 
 open WeierstrassCurve.Affine
 
-variable {F : Type*} [Field F]
+variable {F : Type*} [Field F] [DecidableEq F]
 
 /-- One `EndoMul` row: base `T`, input accumulator `P`, the scalar register
     `n → n'`, the four bits, the two window slopes `s1`/`s3`, and the intermediate
@@ -58,10 +76,13 @@ structure Witness (F : Type*) where
   s3 : F
   xS : F
   yS : F
+  inv : F
 
-/-- The 11 gate constraints: two `(P+Q)+P` blocks (3 each, with `Q` the endo-and-
-    sign-selected target), 4 booleanity checks, and the scalar-register decomposition.
-    `endo` is the base-field endomorphism coefficient. -/
+/-- The 12 gate constraints: two `(P+Q)+P` blocks (3 each, with `Q` the endo-and-
+    sign-selected target), the distinct-point check, 4 booleanity checks, and the
+    scalar-register decomposition. `endo` is the base-field endomorphism coefficient.
+    (The distinct-point check is the upstream fix o1-labs/proof-systems@64129ce4 — see
+    `block_sound` / `distinctPoints`; the pre-fix gate without it is underconstrained.) -/
 def Holds (endo : F) (w : Witness F) : Prop :=
   let xq1 := (1 + (endo - 1) * w.b1) * w.xT
   let yq1 := (2 * w.b2 - 1) * w.yT
@@ -77,6 +98,9 @@ def Holds (endo : F) (w : Witness F) : Prop :=
     ∧ ((2 * w.xR - w.s3 ^ 2 + xq2) * ((w.xR - w.xS) * w.s3 + w.yS + w.yR)
         = (w.xR - w.xS) * (2 * w.yR))
     ∧ ((w.yS + w.yR) ^ 2 = (w.xR - w.xS) ^ 2 * (w.s3 ^ 2 - xq2 + w.xS))
+    -- distinct-point check (upstream fix): `inv` witnesses `(xP−xR)·(xR−xS)` is a
+    -- unit, forcing `xP ≠ xR` and `xR ≠ xS` (no degenerate `R = −P` / `S = −R`)
+    ∧ ((w.xP - w.xR) * (w.xR - w.xS) * w.inv = 1)
     -- booleanity of the four bits
     ∧ (w.b1 * (w.b1 - 1) = 0)
     ∧ (w.b2 * (w.b2 - 1) = 0)
@@ -85,10 +109,122 @@ def Holds (endo : F) (w : Witness F) : Prop :=
     -- scalar register
     ∧ (w.nPrime = 16 * w.n + 8 * w.b1 + 4 * w.b2 + 2 * w.b3 + w.b4)
 
+omit [DecidableEq F] in
 /-- Booleanity: the constraint `b·(b−1) = 0` forces `b ∈ {0,1}` (field = domain). -/
 theorem bool_of_mul {b : F} (h : b * (b - 1) = 0) : b = 0 ∨ b = 1 := by
   rcases mul_eq_zero.mp h with h | h
   · exact Or.inl h
   · exact Or.inr (by linear_combination h)
+
+omit [DecidableEq F] in
+/-- The distinct-point check discharges the non-degeneracy both windows need:
+    `(xP − xR)·(xR − xS)·inv = 1` makes both factors units, so `xP ≠ xR` (first
+    window, `R ≠ −P`) and `xR ≠ xS` (second window, `S ≠ −R`). -/
+theorem distinctPoints (endo : F) (w : Witness F) (h : Holds endo w) :
+    w.xP ≠ w.xR ∧ w.xR ≠ w.xS := by
+  simp only [Holds] at h
+  have hinv := h.2.2.2.2.2.2.1
+  refine ⟨fun hc => ?_, fun hc => ?_⟩
+  · rw [hc, sub_self, zero_mul, zero_mul] at hinv; exact one_ne_zero hinv.symm
+  · rw [hc, sub_self, mul_zero, zero_mul] at hinv; exact one_ne_zero hinv.symm
+
+omit [DecidableEq F] in
+/-- `Point.some` congruence over *both* coordinates: equal `x` and `y` values give
+    equal points (the nonsingularity proofs are irrelevant). A small extension of
+    `Kimchi.some_eq_some`, used to transport a target point along an `x`-coordinate
+    identity that holds only `by ring`. -/
+theorem some_congr (W : WeierstrassCurve.Affine F) {x x' y y' : F}
+    (h : W.Nonsingular x y) (h' : W.Nonsingular x' y') (hx : x = x') (hy : y = y') :
+    Point.some h = Point.some h' := by
+  subst hx; subst hy; rfl
+
+/-- GLV target selection. A window's target
+    `Q = ((1 + (endo−1)·b₁)·xT, (2·b₂−1)·yT)` with `b₁, b₂ ∈ {0,1}` is `±T` (when
+    `b₁ = 0`, so `xq = xT`) or `±φ(T)` (when `b₁ = 1`, so `xq = endo·xT`), where
+    `φ(T) = (endo·xT, yT)`. Reuses `Kimchi.signed_target` with base `T` or `φ(T)`. -/
+theorem selectQ (W : WeierstrassCurve.Affine F) (ha : IsShortShape W)
+    {endo b1 b2 xT yT : F}
+    (hT : W.Nonsingular xT yT) (hφT : W.Nonsingular (endo * xT) yT)
+    (hQ : W.Nonsingular ((1 + (endo - 1) * b1) * xT) ((2 * b2 - 1) * yT))
+    (hb1 : b1 = 0 ∨ b1 = 1) (hb2 : b2 = 0 ∨ b2 = 1) :
+    (∃ e : ℤ, Point.some hQ = e • Point.some hT)
+      ∨ (∃ e : ℤ, Point.some hQ = e • Point.some hφT) := by
+  rcases hb1 with rfl | rfl
+  · -- `b₁ = 0`: the `x`-coordinate `(1 + (endo-1)*0)*xT` collapses to `xT`,
+    -- so `Q = ±T` via `signed_target` with base `T`.
+    left
+    have hx : (1 + (endo - 1) * 0) * xT = xT := by ring
+    obtain ⟨e, he, _⟩ := signed_target W ha hT (hx ▸ hQ) hb2
+    exact ⟨e, (some_congr W hQ (hx ▸ hQ) hx rfl).trans he⟩
+  · -- `b₁ = 1`: the `x`-coordinate `(1 + (endo-1)*1)*xT` collapses to `endo*xT`,
+    -- so `Q = ±φ(T)` via `signed_target` with base `φ(T)`.
+    right
+    have hx : (1 + (endo - 1) * 1) * xT = endo * xT := by ring
+    obtain ⟨e, he, _⟩ := signed_target W ha hφT (hx ▸ hQ) hb2
+    exact ⟨e, (some_congr W hQ (hx ▸ hQ) hx rfl).trans he⟩
+
+/-- One window's `(P + Q) + P` double-and-add. The three EC constraints — the
+    first-addition slope `s` and the `xR`/`yR` relations — together with the
+    non-degeneracy `xP ≠ xq` (first slope), `2·xP − s² + xq ≠ 0` (second addition
+    `M + P`, `M = P + Q`), and `xR ≠ xP` force `R = (P + Q) + P`. General in `Q`, so
+    it serves both windows of the row. Closes with `Kimchi.secant_add` twice,
+    recovering the eliminated intermediate `M` (cf. VarBaseMul's `singleBit_sound`).
+
+    `xR ≠ xP` is essential: `hc2` and `hc3` share a `(xP − xR)` factor, so without
+    it they also admit the spurious `R = −P` (`xR = xP`, `yR = −yP`) — e.g. on
+    `y² = x³ + 1`, `P=(0,1)`, `Q=(2,3)`, `s=1` satisfies every constraint yet
+    `(P+Q)+P = (2,−3) ≠ (0,−1)`. The gate's distinct-point constraint supplies it
+    (via `distinctPoints`); it is a per-window parameter here because the two
+    windows need `xR ≠ xP` and `xS ≠ xR` respectively. -/
+theorem block_sound (W : WeierstrassCurve.Affine F) (ha : IsShortShape W)
+    {xq yq xP yP s xR yR : F}
+    (hP : W.Nonsingular xP yP) (hQ : W.Nonsingular xq yq) (hR : W.Nonsingular xR yR)
+    (hxne : xP ≠ xq) (htne : 2 * xP - s ^ 2 + xq ≠ 0) (hxRne : xR ≠ xP)
+    (hs : (xq - xP) * s = yq - yP)
+    (hc2 : (2 * xP - s ^ 2 + xq) * ((xP - xR) * s + yR + yP) = (xP - xR) * (2 * yP))
+    (hc3 : (yR + yP) ^ 2 = (xP - xR) ^ 2 * (s ^ 2 - xq + xR)) :
+    Point.some hR = (Point.some hP + Point.some hQ) + Point.some hP := by
+  obtain ⟨ha1, ha2, ha3, ha4⟩ := ha
+  have hdiff1 : xP - xq ≠ 0 := sub_ne_zero.mpr hxne
+  have hxRne0 : xP - xR ≠ 0 := sub_ne_zero.mpr (Ne.symm hxRne)
+  -- first addition `P + Q` has slope `s`
+  have hl1 : s = (yP - yq) / (xP - xq) := by
+    rw [eq_div_iff hdiff1]; linear_combination -hs
+  -- intermediate `M = (Mx, My) = P + Q`
+  set Mx : F := s * s - xP - xq with hMx
+  set My : F := s * (xP - Mx) - yP with hMy
+  set s2 : F := (My - yP) / (Mx - xP) with hs2
+  clear_value s2 My Mx
+  have htval : xP - Mx = 2 * xP - s ^ 2 + xq := by rw [hMx]; ring
+  have htt : xP - Mx ≠ 0 := by rw [htval]; exact htne
+  have hMxne : Mx ≠ xP := by intro hc; exact htt (by rw [hc]; ring)
+  have hxine : Mx - xP ≠ 0 := sub_ne_zero.mpr hMxne
+  -- first addition `P + Q = M`
+  obtain ⟨hM, hAdd1⟩ :=
+    secant_add W ⟨ha1, ha2, ha3, ha4⟩ hP hQ hxne hl1 hMx hMy
+  -- `s2` is genuinely `(My - yP)/(Mx - xP)`
+  have hsr : s2 * (Mx - xP) = My - yP := by
+    rw [hs2, div_mul_cancel₀]; exact hxine
+  -- the cleared `hc2` says `yR + yP = (xP - xR) * s2`
+  have key1' : (yR + yP) * (Mx - xP) = (xP - xR) * (My - yP) := by
+    linear_combination -hc2 - (xP - xR) * hMy - ((xP - xR) * s + yR + yP) * htval
+  have hcancel : (yR + yP) * (Mx - xP) = ((xP - xR) * s2) * (Mx - xP) := by
+    rw [key1']; linear_combination -(xP - xR) * hsr
+  have key1div : yR + yP = (xP - xR) * s2 := mul_right_cancel₀ hxine hcancel
+  -- the second slope satisfies `s2² = s² - xq + xR` (from `hc3`, dividing by `(xP-xR)²`)
+  have hs2sq : s2 * s2 = s ^ 2 - xq + xR := by
+    have hkey3 : (xP - xR) ^ 2 * (s2 * s2) = (xP - xR) ^ 2 * (s ^ 2 - xq + xR) := by
+      rw [← hc3]
+      linear_combination -((yR + yP) + (xP - xR) * s2) * key1div
+    exact mul_left_cancel₀ (pow_ne_zero 2 hxRne0) hkey3
+  -- the second addition's output coordinates
+  have hxR_eq : xR = s2 * s2 - Mx - xP := by rw [hs2sq, hMx]; ring
+  have hyR_eq : yR = s2 * (Mx - xR) - My := by
+    have hyR' : yR = (xP - xR) * s2 - yP := by linear_combination key1div
+    rw [hyR']; linear_combination -hsr
+  -- second addition `M + P = R`
+  obtain ⟨hR', hAdd2⟩ :=
+    secant_add W ⟨ha1, ha2, ha3, ha4⟩ hM hP hMxne hs2 hxR_eq hyR_eq
+  rw [hAdd1, hAdd2]
 
 end Kimchi.Gate.EndoMul

--- a/formal/Kimchi/Gate/EndoMul.lean
+++ b/formal/Kimchi/Gate/EndoMul.lean
@@ -1,0 +1,94 @@
+import Kimchi.Gate.VarBaseMul
+
+/-!
+# The kimchi `EndoMul` gate
+
+The endomorphism-optimized variable-base scalar-multiplication gate, transcribed
+from proof-systems `kimchi/src/circuits/polynomials/endosclmul.rs` (the
+`EC_endoscale` point constraint) and the PureScript `Snarky.Circuit.Kimchi.EndoMul`.
+
+It is VarBaseMul's `(P + Q) + P` double-and-add, but each 2-bit window selects `Q`
+from `{T, −T, φ(T), −φ(T)}` — the GLV optimization — using the curve endomorphism
+
+      φ(x, y) = (endo · x, y)      (endo a primitive cube root of unity, φ(T) = [λ]T)
+
+so that `[k]T = [k₁]T + [k₂]·φ(T)` with `k₁, k₂` half-width. Each row processes 4
+bits = two windows `P → R → S`:
+
+* `Q₁ = (xq₁, yq₁)`, `xq₁ = (1 + (endo−1)·b₁)·xT` (= `xT` or `endo·xT`),
+  `yq₁ = (2·b₂ − 1)·yT` (sign) — so `b₁` picks `T` vs `φ(T)`, `b₂` the sign.
+* `Q₂ = (xq₂, yq₂)` likewise from `(b₃, b₄)`.
+
+The register threads `n' = 16·n + 8·b₁ + 4·b₂ + 2·b₃ + b₄`, and the accumulator is
+initialized to `2·(T + φ(T))` to dodge the point at infinity.
+
+The EC core (`(P + Q) + P` per window) reuses `Kimchi.Gate.VarBaseMul`'s
+`secant_add` (general affine addition) and `signed_target` (the `±` selection); the
+new ingredients are the endomorphism base-choice and the GLV `[k₁]T + [k₂]φ(T)`
+accumulation.
+
+## Main results
+
+(in progress) — the constraint model `Witness` / `Holds` and the booleanity helper.
+-/
+
+namespace Kimchi.Gate.EndoMul
+
+open WeierstrassCurve.Affine
+
+variable {F : Type*} [Field F]
+
+/-- One `EndoMul` row: base `T`, input accumulator `P`, the scalar register
+    `n → n'`, the four bits, the two window slopes `s1`/`s3`, and the intermediate
+    `R` and output `S` accumulator points. -/
+structure Witness (F : Type*) where
+  xT : F
+  yT : F
+  xP : F
+  yP : F
+  n : F
+  nPrime : F
+  b1 : F
+  b2 : F
+  b3 : F
+  b4 : F
+  s1 : F
+  xR : F
+  yR : F
+  s3 : F
+  xS : F
+  yS : F
+
+/-- The 11 gate constraints: two `(P+Q)+P` blocks (3 each, with `Q` the endo-and-
+    sign-selected target), 4 booleanity checks, and the scalar-register decomposition.
+    `endo` is the base-field endomorphism coefficient. -/
+def Holds (endo : F) (w : Witness F) : Prop :=
+  let xq1 := (1 + (endo - 1) * w.b1) * w.xT
+  let yq1 := (2 * w.b2 - 1) * w.yT
+  let xq2 := (1 + (endo - 1) * w.b3) * w.xT
+  let yq2 := (2 * w.b4 - 1) * w.yT
+  -- first window `P → R`, slope `s1`
+  ((xq1 - w.xP) * w.s1 = yq1 - w.yP)
+    ∧ ((2 * w.xP - w.s1 ^ 2 + xq1) * ((w.xP - w.xR) * w.s1 + w.yR + w.yP)
+        = (w.xP - w.xR) * (2 * w.yP))
+    ∧ ((w.yR + w.yP) ^ 2 = (w.xP - w.xR) ^ 2 * (w.s1 ^ 2 - xq1 + w.xR))
+    -- second window `R → S`, slope `s3`
+    ∧ ((xq2 - w.xR) * w.s3 = yq2 - w.yR)
+    ∧ ((2 * w.xR - w.s3 ^ 2 + xq2) * ((w.xR - w.xS) * w.s3 + w.yS + w.yR)
+        = (w.xR - w.xS) * (2 * w.yR))
+    ∧ ((w.yS + w.yR) ^ 2 = (w.xR - w.xS) ^ 2 * (w.s3 ^ 2 - xq2 + w.xS))
+    -- booleanity of the four bits
+    ∧ (w.b1 * (w.b1 - 1) = 0)
+    ∧ (w.b2 * (w.b2 - 1) = 0)
+    ∧ (w.b3 * (w.b3 - 1) = 0)
+    ∧ (w.b4 * (w.b4 - 1) = 0)
+    -- scalar register
+    ∧ (w.nPrime = 16 * w.n + 8 * w.b1 + 4 * w.b2 + 2 * w.b3 + w.b4)
+
+/-- Booleanity: the constraint `b·(b−1) = 0` forces `b ∈ {0,1}` (field = domain). -/
+theorem bool_of_mul {b : F} (h : b * (b - 1) = 0) : b = 0 ∨ b = 1 := by
+  rcases mul_eq_zero.mp h with h | h
+  · exact Or.inl h
+  · exact Or.inr (by linear_combination h)
+
+end Kimchi.Gate.EndoMul

--- a/formal/Kimchi/Gate/VarBaseMul.lean
+++ b/formal/Kimchi/Gate/VarBaseMul.lean
@@ -215,42 +215,6 @@ open WeierstrassCurve.Affine
 
 variable [Field F] [DecidableEq F]
 
-/-- One non-vertical (secant) affine addition, packaged with explicit output
-    coordinates. If `(x₁,y₁)`, `(x₂,y₂)` are nonsingular points with `x₁ ≠ x₂`,
-    and `ℓ, x₃, y₃` are the secant slope and resulting coordinates, then their
-    group sum is the nonsingular point `(x₃, y₃)`.
-
-    This is the secant specialization of
-    `Kimchi.Gate.AddComplete.sound_point_noninf` (its first slope branch); unlike that
-    theorem it carries no `y₁ ≠ 0` hypothesis, since the doubling branch is
-    excluded by `x₁ ≠ x₂`. -/
-lemma secant_add
-    (W : WeierstrassCurve.Affine F) (ha : IsShortShape W)
-    {x1 y1 x2 y2 : F}
-    (h1 : W.Nonsingular x1 y1) (h2 : W.Nonsingular x2 y2)
-    (hx : x1 ≠ x2)
-    {l x3 y3 : F}
-    (hl : l = (y1 - y2) / (x1 - x2))
-    (hx3 : x3 = l * l - x1 - x2)
-    (hy3 : y3 = l * (x1 - x3) - y1) :
-    ∃ h3 : W.Nonsingular x3 y3,
-      Point.some h1 + Point.some h2 = Point.some h3 := by
-  obtain ⟨ha1, ha2, ha3, ha4⟩ := ha
-  have hslope : W.slope x1 x2 y1 y2 = l := by
-    rw [WeierstrassCurve.Affine.slope_of_X_ne hx, hl]
-  have hfin : ¬(x1 = x2 ∧ y1 = W.negY x2 y2) := fun hc => hx hc.1
-  have hx3' : W.addX x1 x2 (W.slope x1 x2 y1 y2) = x3 := by
-    rw [hslope]; simp only [WeierstrassCurve.Affine.addX, ha1, ha2]
-    rw [hx3]; ring
-  have hy3' : W.addY x1 x2 y1 (W.slope x1 x2 y1 y2) = y3 := by
-    rw [hslope]
-    simp only [WeierstrassCurve.Affine.addY, WeierstrassCurve.Affine.negY,
-      WeierstrassCurve.Affine.negAddY, WeierstrassCurve.Affine.addX, ha1, ha2, ha3]
-    rw [hy3, hx3]; ring
-  rw [← hx3', ← hy3']
-  exact ⟨WeierstrassCurve.Affine.nonsingular_add h1 h2 hfin,
-         WeierstrassCurve.Affine.Point.add_some hfin⟩
-
 /-- Per-bit soundness. A single-bit block that
     satisfies `singleBitHolds` computes `output = (input + Q) + input` in the
     group, where `Q = (xb, (2b−1)·yb)` is the sign-selected target. The output is
@@ -371,39 +335,12 @@ theorem gate_scalarMul
   abel
 
 omit [DecidableEq F] in
-/-- Two affine points with the same `x` and provably-equal `y` are equal (proof
-    irrelevance on the nonsingularity witness). -/
-private lemma some_eq_some (W : WeierstrassCurve.Affine F) {x y y' : F}
-    (h : W.Nonsingular x y) (h' : W.Nonsingular x y') (hy : y = y') :
-    Point.some h = Point.some h' := by
-  subst hy; rfl
-
-omit [DecidableEq F] in
 /-- Booleanity from the field constraint `b·b − b = 0`. -/
 private lemma bool_of_sq {b : F} (h : b * b - b = 0) : b = 0 ∨ b = 1 := by
   have hmul : b * (b - 1) = 0 := by ring_nf; linear_combination h
   rcases mul_eq_zero.mp hmul with h1 | h1
   · exact Or.inl h1
   · exact Or.inr (by linear_combination h1)
-
-/-- The sign-selected target `Q = (xT, (2b−1)·yT)` is `±T` once `b ∈ {0,1}`:
-    on a short Weierstrass curve negation is `y ↦ −y`, so `Q = (2b−1)•T` as an
-    integer scalar multiple of `T = (xT, yT)`. -/
-lemma signed_target
-    (W : WeierstrassCurve.Affine F) (ha : IsShortShape W)
-    {b xT yT : F}
-    (hT : W.Nonsingular xT yT)
-    (hQ : W.Nonsingular xT ((2 * b - 1) * yT))
-    (hb : b = 0 ∨ b = 1) :
-    ∃ e : ℤ, Point.some hQ = e • Point.some hT ∧ (e : F) = 2 * b - 1 := by
-  obtain ⟨ha1, _, ha3, _⟩ := ha
-  rcases hb with rfl | rfl
-  · refine ⟨-1, ?_, by push_cast; ring⟩
-    rw [neg_one_zsmul, Point.neg_some]
-    exact some_eq_some W hQ _ (by rw [WeierstrassCurve.Affine.negY, ha1, ha3]; ring)
-  · refine ⟨1, ?_, by push_cast; ring⟩
-    rw [one_zsmul]
-    exact some_eq_some W hQ hT (by ring)
 
 /-- The bridge to the integer-scalar form. A
     satisfying gate computes `P₅ = 32·P₀ + c·T` for an integer `c` — the gate's


### PR DESCRIPTION
**PR 4 of 4** — stacked on #161. Base retargets as the stack merges. The capstone: EndoMul, the endomorphism-optimized (GLV) variable-base scalar mul.

### Shared EC lemmas factored (first commit)
`secant_add`, `signed_target`, `some_eq_some` lifted out of VarBaseMul into the `Kimchi.Curve` oracle (reused by EndoMul). VarBaseMul's call sites resolve to them via parent-namespace lookup — no body changes.

### Gate — `Kimchi/Gate/EndoMul.lean`
VarBaseMul's `(P+Q)+P`, but each 2-bit window selects `Q ∈ {±T, ±φ(T)}` (GLV), `φ(x,y) = (endo·x, y)`.
- `Witness`/`Holds` — the **upstream-fixed** 12-constraint gate (incl. the distinct-point check `(xP−xR)·(xR−xS)·inv = 1`).
- `selectQ` (`±T`/`±φ(T)` by the bits), `block_sound` (one window's `(P+Q)+P`, via `secant_add` ×2), `distinctPoints`, `row_sound`, `row_int` (`∃ c₁ c₂, S = 4·P + c₁·T + c₂·φ(T)`).

> ⚠️ Adversarial verification (Aristotle) found the **pre-fix** 3-constraint block is *underconstrained* — `hc2`/`hc3` share a `(xP−xR)` factor and admit the spurious `R = −P` (counterexample on `y²=x³+1`: `P=(0,1),Q=(2,3),s=1,R=(0,−1)`). We model the **fixed** gate (o1-labs/proof-systems@64129ce4), so the non-degeneracy is *derived* (`distinctPoints`), not assumed. The repo's PureScript circuit stays pre-fix; the Lean models the sound gate.

### Circuit — `Kimchi/Circuit/EndoMul.lean`
- `chain_endo` (two-base fold) + `endoMul` (`∃ k₁ k₂, P_m = 4^m·P₀ + k₁·T + k₂·φ(T)`).
- `endoMul_scalar` — with the eigenvalue `φ(T) = [λ]·T` (a hypothesis), collapses to `P_m = 4^m·P₀ + k·T` — genuine scalar mult.
- `recoding_digit` — the `EndoMul ∘ EndoScalar` recoding correspondence: per 2-bit window, EndoScalar's `cPoly`/`dPoly` digits equal EndoMul's GLV window digit.

All theorems axiom-clean; build + style green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)