### PR TITLE
Lean/EndoScalar: port the EndoScalar gate + circuit onto CompElliptic main

### DIFF
--- a/formal/Kimchi.lean
+++ b/formal/Kimchi.lean
@@ -7,4 +7,6 @@ import Kimchi.Shifted
 import Kimchi.Gate.Generic
 import Kimchi.Gate.AddComplete
 import Kimchi.Gate.VarBaseMul
+import Kimchi.Gate.EndoScalar
 import Kimchi.Circuit.VarBaseMul
+import Kimchi.Circuit.EndoScalar

--- a/formal/Kimchi/Circuit/EndoScalar.lean
+++ b/formal/Kimchi/Circuit/EndoScalar.lean
@@ -15,11 +15,9 @@ crumb list (`List.foldl_append`).
 
 ## Main results
 
-* `gate_toField` — a satisfying row from the canonical init `(a,b,n) = (2,2,0)`
-  outputs the effective scalar `toField crumbs λ` and the register
+* `gate_toField` — the single-row atom: a satisfying row from the canonical init
+  `(a,b,n) = (2,2,0)` outputs the effective scalar `toField crumbs λ` and the register
   `nReconstruct crumbs`.
-* `endoScalar_spec` — with the wrapper's `n = challenge`, that register IS the
-  challenge: the gate computes the endo-decomposition of the challenge.
 * `chain_decompose` / `chain_toField` — the same statement over a *run* of `m + 1`
   sequential gate rows threaded from `(2,2,0)` (`varBaseMul`'s multi-row shape): the
   whole run is one fold over the concatenated crumbs, with output `a·λ + b`.
@@ -63,15 +61,6 @@ theorem gate_toField (lam : F) (w : Witness F) (h : Holds w)
   rw [hb0] at hb
   rw [hn0] at hn
   exact ⟨by rw [ha, hb, toField, decomposeA, decomposeB], by rw [hn, nReconstruct]⟩
-
-/-- The endo-scalar spec: a satisfying row from the canonical init, whose register
-    the wrapper has asserted equal to the input `challenge`, computes the effective
-    scalar — and the crumbs are the base-4 decoding of `challenge`. -/
-theorem endoScalar_spec (lam challenge : F) (w : Witness F) (h : Holds w)
-    (ha0 : w.a0 = 2) (hb0 : w.b0 = 2) (hn0 : w.n0 = 0) (hchal : w.n8 = challenge) :
-    w.a8 * lam + w.b8 = toField w.crumbs lam ∧ nReconstruct w.crumbs = challenge := by
-  obtain ⟨hout, hn⟩ := gate_toField lam w h ha0 hb0 hn0
-  exact ⟨hout, hn ▸ hchal⟩
 
 /-! ## Multi-row composition: threading rows = folding the concatenated crumbs.
 

--- a/formal/Kimchi/Circuit/EndoScalar.lean
+++ b/formal/Kimchi/Circuit/EndoScalar.lean
@@ -8,10 +8,9 @@ decomposition. A challenge is processed 8 crumbs at a time, each row threading t
 `(a,b,n)` accumulators; the result is the effective scalar `a·λ + b` and the raw
 register `n`, which the wrapper asserts equals the input challenge.
 
-Because each row is a `List.foldl` over its crumbs, chaining rows is just folding
-over the concatenated crumb list (`List.foldl_append`) — the multi-row layout
-adds nothing to the math, so the full-challenge (multi-row) spec is deferred until
-a consumer (EndoMul) needs it.
+Because a row's crumb list is arbitrary-length, a single `Witness` already folds
+the whole multi-row challenge; chaining rows is just folding over the concatenated
+crumb list (`List.foldl_append`).
 
 ## Main results
 

--- a/formal/Kimchi/Circuit/EndoScalar.lean
+++ b/formal/Kimchi/Circuit/EndoScalar.lean
@@ -15,12 +15,10 @@ crumb list (`List.foldl_append`).
 
 ## Main results
 
-* `gate_toField` — the single-row atom: a satisfying row from the canonical init
-  `(a,b,n) = (2,2,0)` outputs the effective scalar `toField crumbs λ` and the register
-  `nReconstruct crumbs`.
-* `chain_decompose` / `chain_toField` — the same statement over a *run* of `m + 1`
-  sequential gate rows threaded from `(2,2,0)` (`varBaseMul`'s multi-row shape): the
-  whole run is one fold over the concatenated crumbs, with output `a·λ + b`.
+* `chain_decompose` / `chain_toField` — a satisfying *run* of `m + 1` sequential gate rows
+  threaded from the canonical init `(a,b,n) = (2,2,0)` (`varBaseMul`'s multi-row shape) is
+  one fold over the concatenated crumbs: it outputs the effective scalar `a·λ + b` and the
+  register `nReconstruct` of the whole challenge (a single row is the `m = 0` case).
 * `nReconstruct_inj` / `endoScalar_unique` — the self-contained soundness. Under the
   no-wrap bound `4 ^ #crumbs ≤ p` (the challenge's bit size below the field size), the
   base-4 decomposition is unique, so the effective scalar `a·λ + b` is a well-defined
@@ -48,19 +46,6 @@ def nReconstruct (crumbs : List F) : F := crumbs.foldl (fun n x => 4 * n + x) 0
     eigenvalue). This is the pure `to_field` of the challenge. -/
 def toField (crumbs : List F) (lam : F) : F :=
   decomposeA crumbs * lam + decomposeB crumbs
-
-/-- A satisfying `EndoScalar` row, started from the canonical init `(2,2,0)`,
-    outputs the effective scalar `toField crumbs λ` and reconstructs the register
-    `nReconstruct crumbs`. (Definitional once the init is fixed — `Holds`'s folds
-    are exactly `decomposeA`/`decomposeB`/`nReconstruct`.) -/
-theorem gate_toField (lam : F) (w : Witness F) (h : Holds w)
-    (ha0 : w.a0 = 2) (hb0 : w.b0 = 2) (hn0 : w.n0 = 0) :
-    w.a8 * lam + w.b8 = toField w.crumbs lam ∧ w.n8 = nReconstruct w.crumbs := by
-  obtain ⟨hn, ha, hb, _⟩ := h
-  rw [ha0] at ha
-  rw [hb0] at hb
-  rw [hn0] at hn
-  exact ⟨by rw [ha, hb, toField, decomposeA, decomposeB], by rw [hn, nReconstruct]⟩
 
 /-! ## Multi-row composition: threading rows = folding the concatenated crumbs.
 

--- a/formal/Kimchi/Circuit/EndoScalar.lean
+++ b/formal/Kimchi/Circuit/EndoScalar.lean
@@ -1,4 +1,5 @@
 import Kimchi.Gate.EndoScalar
+import Kimchi.Circuit.EndoScalar.Base4
 
 /-!
 # The `EndoScalar` circuit: the effective scalar `a·λ + b`
@@ -19,6 +20,13 @@ crumb list (`List.foldl_append`).
   `nReconstruct crumbs`.
 * `endoScalar_spec` — with the wrapper's `n = challenge`, that register IS the
   challenge: the gate computes the endo-decomposition of the challenge.
+* `chain_decompose` / `chain_toField` — the same statement over a *run* of `m + 1`
+  sequential gate rows threaded from `(2,2,0)` (`varBaseMul`'s multi-row shape): the
+  whole run is one fold over the concatenated crumbs, with output `a·λ + b`.
+* `nReconstruct_inj` / `endoScalar_unique` — the self-contained soundness. Under the
+  no-wrap bound `4 ^ #crumbs ≤ p` (the challenge's bit size below the field size), the
+  base-4 decomposition is unique, so the effective scalar `a·λ + b` is a well-defined
+  function of the challenge alone — not of the prover's witness.
 -/
 
 namespace Kimchi.Circuit.EndoScalar
@@ -64,5 +72,178 @@ theorem endoScalar_spec (lam challenge : F) (w : Witness F) (h : Holds w)
     w.a8 * lam + w.b8 = toField w.crumbs lam ∧ nReconstruct w.crumbs = challenge := by
   obtain ⟨hout, hn⟩ := gate_toField lam w h ha0 hb0 hn0
   exact ⟨hout, hn ▸ hchal⟩
+
+/-! ## Multi-row composition: threading rows = folding the concatenated crumbs.
+
+    A challenge wider than one row's 8 crumbs is laid out over several `EndoScalar`
+    rows, each row's output accumulators feeding the next (the OCaml/PureScript
+    `to_field_checked'` runs `mapAccumM` over `rows` chunks). Because every fold is a
+    `List.foldl`, the whole run is one fold over the concatenated crumbs. -/
+
+/-- Resuming the `a`-fold across a row boundary: `decomposeA (xs ++ ys)` continues the
+    single decomposition from `decomposeA xs`. -/
+theorem decomposeA_append (xs ys : List F) :
+    decomposeA (xs ++ ys) = ys.foldl (fun a x => 2 * a + cPoly x) (decomposeA xs) := by
+  simp only [decomposeA, List.foldl_append]
+
+theorem decomposeB_append (xs ys : List F) :
+    decomposeB (xs ++ ys) = ys.foldl (fun b x => 2 * b + dPoly x) (decomposeB xs) := by
+  simp only [decomposeB, List.foldl_append]
+
+theorem nReconstruct_append (xs ys : List F) :
+    nReconstruct (xs ++ ys) = ys.foldl (fun n x => 4 * n + x) (nReconstruct xs) := by
+  simp only [nReconstruct, List.foldl_append]
+
+/-- The crumbs of the first `m` rows of a run, concatenated MSB-first. -/
+def chainCrumbs (w : ℕ → Witness F) (m : ℕ) : List F :=
+  (List.range m).flatMap (fun i => (w i).crumbs)
+
+omit [Field F] in
+@[simp] theorem chainCrumbs_zero (w : ℕ → Witness F) : chainCrumbs w 0 = [] := rfl
+
+omit [Field F] in
+theorem chainCrumbs_succ (w : ℕ → Witness F) (m : ℕ) :
+    chainCrumbs w (m + 1) = chainCrumbs w m ++ (w m).crumbs := by
+  simp only [chainCrumbs, List.range_succ, List.flatMap_append, List.flatMap_cons,
+    List.flatMap_nil, List.append_nil]
+
+/-- **Sequential-gate reconstruction.** A run of `m + 1` `EndoScalar` rows (indices `0..m`),
+    each satisfying `Holds`, threaded so every row's output `(a8,b8,n8)` is the next row's
+    input `(a0,b0,n0)` and the first starts at the canonical `(2,2,0)`, computes the single
+    Algorithm-2 decomposition of its whole concatenated crumb stream — exactly as a one-row
+    `Holds` over `chainCrumbs w (m+1)` would. (The multi-row layout adds nothing to the math;
+    cf. `varBaseMul`'s `gateLadder` over its rows.) -/
+theorem chain_decompose (m : ℕ) (w : ℕ → Witness F)
+    (hHolds : ∀ i, i ≤ m → Holds (w i))
+    (ha0 : (w 0).a0 = 2) (hb0 : (w 0).b0 = 2) (hn0 : (w 0).n0 = 0)
+    (haStep : ∀ i, i < m → (w (i + 1)).a0 = (w i).a8)
+    (hbStep : ∀ i, i < m → (w (i + 1)).b0 = (w i).b8)
+    (hnStep : ∀ i, i < m → (w (i + 1)).n0 = (w i).n8) :
+    (w m).a8 = decomposeA (chainCrumbs w (m + 1))
+      ∧ (w m).b8 = decomposeB (chainCrumbs w (m + 1))
+      ∧ (w m).n8 = nReconstruct (chainCrumbs w (m + 1)) := by
+  induction m with
+  | zero =>
+    obtain ⟨hn, ha, hb, _⟩ := hHolds 0 (le_refl 0)
+    rw [chainCrumbs_succ, chainCrumbs_zero, List.nil_append]
+    refine ⟨?_, ?_, ?_⟩
+    · rw [ha, ha0, decomposeA]
+    · rw [hb, hb0, decomposeB]
+    · rw [hn, hn0, nReconstruct]
+  | succ k ih =>
+    obtain ⟨ihA, ihB, ihN⟩ := ih (fun i hi => hHolds i (by omega))
+      (fun i hi => haStep i (by omega)) (fun i hi => hbStep i (by omega))
+      (fun i hi => hnStep i (by omega))
+    obtain ⟨hn, ha, hb, _⟩ := hHolds (k + 1) (le_refl _)
+    rw [chainCrumbs_succ]
+    refine ⟨?_, ?_, ?_⟩
+    · rw [ha, haStep k (Nat.lt_succ_self k), ihA, decomposeA_append]
+    · rw [hb, hbStep k (Nat.lt_succ_self k), ihB, decomposeB_append]
+    · rw [hn, hnStep k (Nat.lt_succ_self k), ihN, nReconstruct_append]
+
+/-- The effective scalar of a multi-row run: `a·λ + b` over the whole challenge, with the
+    register reconstructing the full concatenated crumb stream. The wrapper asserts that
+    register equals the input challenge (`chain_spec`). -/
+theorem chain_toField (lam : F) (m : ℕ) (w : ℕ → Witness F)
+    (hHolds : ∀ i, i ≤ m → Holds (w i))
+    (ha0 : (w 0).a0 = 2) (hb0 : (w 0).b0 = 2) (hn0 : (w 0).n0 = 0)
+    (haStep : ∀ i, i < m → (w (i + 1)).a0 = (w i).a8)
+    (hbStep : ∀ i, i < m → (w (i + 1)).b0 = (w i).b8)
+    (hnStep : ∀ i, i < m → (w (i + 1)).n0 = (w i).n8) :
+    (w m).a8 * lam + (w m).b8 = toField (chainCrumbs w (m + 1)) lam
+      ∧ (w m).n8 = nReconstruct (chainCrumbs w (m + 1)) := by
+  obtain ⟨hA, hB, hN⟩ := chain_decompose m w hHolds ha0 hb0 hn0 haStep hbStep hnStep
+  exact ⟨by rw [hA, hB, toField], hN⟩
+
+/-! ## Uniqueness of the decomposition under the bit-size/field-size bound.
+
+    The previous results pin the output to the folds *of the witness crumbs*. The honest
+    meaning — `challenge ↦ a·λ + b` is a well-defined function — needs one more fact: a
+    challenge determines its crumbs. That holds because the crumbs are base-4 digits (each
+    in `{0,1,2,3}`, by `Gate.sound`) and the reconstruction does not wrap: the challenge's
+    bit-width stays below the field size, encoded as `4 ^ #crumbs ≤ p`. (For the deployed
+    128-bit challenge this is `4 ^ 64 = 2 ^ 128`, comfortably under the ~2²⁵⁴ Pasta order.)
+    This is EndoScalar's analogue of `varBaseMul`'s `5m ≤ pastaFieldBits` no-wrap bound.
+
+    The positional-arithmetic kernel — `digit` / `valNat` / `euclid_split` / `valNat_inj` —
+    lives in `Kimchi.Circuit.EndoScalar.Base4`; here we bridge it to the field-valued
+    `nReconstruct` and conclude. -/
+
+variable [DecidableEq F]
+
+/-- The field reconstruction is the cast of its `ℕ` shadow `valNat`, on valid crumbs. The
+    bridge from `Base4` to the circuit's field-valued register. -/
+theorem nReconstruct_eq_valNat (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) (xs : List F)
+    (hv : ∀ x ∈ xs, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) :
+    nReconstruct xs = ((valNat xs : ℕ) : F) := by
+  have gen : ∀ (ys : List F) (acc : ℕ), (∀ x ∈ ys, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) →
+      ys.foldl (fun n x => 4 * n + x) ((acc : ℕ) : F)
+        = ((ys.foldl (fun n x => 4 * n + digit x) acc : ℕ) : F) := by
+    intro ys
+    induction ys with
+    | nil => intro acc _; rfl
+    | cons y ys ihy =>
+      intro acc hvy
+      simp only [List.foldl_cons]
+      have hy : ((digit y : ℕ) : F) = y := digit_cast h2 h3 (hvy y (by simp))
+      rw [show (4 * ((acc : ℕ) : F) + y) = (((4 * acc + digit y : ℕ) : F)) by push_cast; rw [hy]]
+      exact ihy (4 * acc + digit y) (fun x hx => hvy x (by simp [hx]))
+  have := gen xs 0 hv
+  simpa [nReconstruct, valNat] using this
+
+/-- **Base-4 digit recovery.** Same-length valid crumb lists whose reconstruction fits the
+    field (`4 ^ len ≤ p`) and that reconstruct to the same challenge are equal — the
+    decomposition a satisfying gate exposes is the *unique* one. -/
+theorem nReconstruct_inj {p : ℕ} [CharP F p] (xs ys : List F)
+    (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
+    (hx : ∀ x ∈ xs, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3)
+    (hy : ∀ x ∈ ys, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3)
+    (hlen : xs.length = ys.length) (hbound : (4 : ℕ) ^ xs.length ≤ p)
+    (heq : nReconstruct xs = nReconstruct ys) : xs = ys := by
+  -- transport the field equality to `ℕ`, where the no-wrap bound makes decoding injective
+  have hcast : ((valNat xs : ℕ) : F) = ((valNat ys : ℕ) : F) := by
+    rw [← nReconstruct_eq_valNat h2 h3 xs hx, ← nReconstruct_eq_valNat h2 h3 ys hy]; exact heq
+  have hxlt : valNat xs < p := lt_of_lt_of_le (valNat_lt xs) hbound
+  have hylt : valNat ys < p := lt_of_lt_of_le (valNat_lt ys) (hlen ▸ hbound)
+  have hnat : valNat xs = valNat ys :=
+    CharP.natCast_injOn_Iio F p (Set.mem_Iio.mpr hxlt) (Set.mem_Iio.mpr hylt) hcast
+  exact valNat_inj h2 h3 xs ys hx hy hlen hnat
+
+/-- **Self-contained circuit soundness.** Two multi-row `EndoScalar` runs of the same crumb
+    width that decode to the same challenge produce the *same* effective scalar `a·λ + b`.
+
+    Combined with `chain_toField`, this is the honest statement that the gate realizes a
+    well-defined function `challenge ↦ a·λ + b`: it depends only on the challenge, not on the
+    prover's witness. The hypotheses are exactly `varBaseMul`'s shape — a chain over `m + 1`
+    rows threaded from `(2,2,0)`, plus the no-wrap bound `4 ^ width ≤ p` tying the challenge's
+    bit size to the field size. -/
+theorem endoScalar_unique {p : ℕ} [CharP F p] (lam : F) (m : ℕ) (w w' : ℕ → Witness F)
+    (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
+    (hHolds : ∀ i, i ≤ m → Holds (w i)) (hHolds' : ∀ i, i ≤ m → Holds (w' i))
+    (ha0 : (w 0).a0 = 2) (hb0 : (w 0).b0 = 2) (hn0 : (w 0).n0 = 0)
+    (ha0' : (w' 0).a0 = 2) (hb0' : (w' 0).b0 = 2) (hn0' : (w' 0).n0 = 0)
+    (haStep : ∀ i, i < m → (w (i + 1)).a0 = (w i).a8)
+    (hbStep : ∀ i, i < m → (w (i + 1)).b0 = (w i).b8)
+    (hnStep : ∀ i, i < m → (w (i + 1)).n0 = (w i).n8)
+    (haStep' : ∀ i, i < m → (w' (i + 1)).a0 = (w' i).a8)
+    (hbStep' : ∀ i, i < m → (w' (i + 1)).b0 = (w' i).b8)
+    (hnStep' : ∀ i, i < m → (w' (i + 1)).n0 = (w' i).n8)
+    (hwidth : (chainCrumbs w (m + 1)).length = (chainCrumbs w' (m + 1)).length)
+    (hbound : (4 : ℕ) ^ (chainCrumbs w (m + 1)).length ≤ p)
+    (hchal : (w m).n8 = (w' m).n8) :
+    (w m).a8 * lam + (w m).b8 = (w' m).a8 * lam + (w' m).b8 := by
+  obtain ⟨hA, hB, hN⟩ := chain_decompose m w hHolds ha0 hb0 hn0 haStep hbStep hnStep
+  obtain ⟨hA', hB', hN'⟩ := chain_decompose m w' hHolds' ha0' hb0' hn0' haStep' hbStep' hnStep'
+  -- both runs' crumbs are valid 2-bit values, and reconstruct to the shared challenge
+  have hvalid : ∀ (u : ℕ → Witness F), (∀ i, i ≤ m → Holds (u i)) →
+      ∀ x ∈ chainCrumbs u (m + 1), x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3 := by
+    intro u hu x hxmem
+    simp only [chainCrumbs, List.mem_flatMap, List.mem_range] at hxmem
+    obtain ⟨i, hi, hxi⟩ := hxmem
+    exact (sound h2 h3 (u i) (hu i (by omega))).1 x hxi
+  have hcrumbs : chainCrumbs w (m + 1) = chainCrumbs w' (m + 1) :=
+    nReconstruct_inj (chainCrumbs w (m + 1)) (chainCrumbs w' (m + 1)) h2 h3
+      (hvalid w hHolds) (hvalid w' hHolds') hwidth hbound (by rw [← hN, ← hN', hchal])
+  rw [hA, hB, hA', hB', hcrumbs]
 
 end Kimchi.Circuit.EndoScalar

--- a/formal/Kimchi/Circuit/EndoScalar.lean
+++ b/formal/Kimchi/Circuit/EndoScalar.lean
@@ -19,6 +19,9 @@ crumb list (`List.foldl_append`).
   threaded from the canonical init `(a,b,n) = (2,2,0)` (`varBaseMul`'s multi-row shape) is
   one fold over the concatenated crumbs: it outputs the effective scalar `a·λ + b` and the
   register `nReconstruct` of the whole challenge (a single row is the `m = 0` case).
+* `chain_complete` — the completeness counterpart: for any valid crumb-rows the honest prover
+  threads the gate's `build` into a satisfying run (no global side-condition, since the gate's
+  completeness precondition is per-row).
 * `nReconstruct_inj` / `endoScalar_unique` — the self-contained soundness. Under the
   no-wrap bound `4 ^ #crumbs ≤ p` (the challenge's bit size below the field size), the
   base-4 decomposition is unique, so the effective scalar `a·λ + b` is a well-defined
@@ -128,6 +131,45 @@ theorem chain_toField (lam : F) (m : ℕ) (w : ℕ → Witness F)
       ∧ (w m).n8 = nReconstruct (chainCrumbs w (m + 1)) := by
   obtain ⟨hA, hB, hN⟩ := chain_decompose m w hHolds ha0 hb0 hn0 haStep hbStep hnStep
   exact ⟨by rw [hA, hB, toField], hN⟩
+
+/-! ## Completeness: the honest prover fills a multi-row run.
+
+    The completeness counterpart of `chain_decompose`. The gate's `complete` precondition is
+    per-row crumb validity — independent of the threaded accumulators — so the honest builder
+    threads with no global side-condition. (Contrast the EC gates, whose ladder completeness
+    must propagate non-exceptional points across rows; that is why `varBaseMul`'s circuit has
+    no free completeness while EndoScalar, being curve- and exception-free, does.) -/
+
+/-- The honest multi-row witness: thread the gate's `build` from the canonical `(2,2,0)`,
+    each row started from the previous row's output accumulators. -/
+def chainBuild (rows : ℕ → List F) : ℕ → Witness F
+  | 0 => build 2 2 0 (rows 0)
+  | i + 1 =>
+    let prev := chainBuild rows i
+    build prev.a8 prev.b8 prev.n8 (rows (i + 1))
+
+/-- **Completeness.** For any rows of valid crumbs, the threaded honest witness `chainBuild`
+    satisfies the entire multi-row run — every row `Holds`, the first starts at `(2,2,0)`, the
+    accumulators thread, and each row carries the given crumbs. Feeding this into
+    `chain_toField` shows the honest prover computes the challenge's effective scalar. The
+    threading and init are definitional; the only real input is `Gate.complete` per row. -/
+theorem chain_complete (m : ℕ) (rows : ℕ → List F)
+    (hvalid : ∀ i, i ≤ m → ∀ x ∈ rows i, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) :
+    (∀ i, i ≤ m → Holds (chainBuild rows i))
+      ∧ (chainBuild rows 0).a0 = 2 ∧ (chainBuild rows 0).b0 = 2 ∧ (chainBuild rows 0).n0 = 0
+      ∧ (∀ i, i < m → (chainBuild rows (i + 1)).a0 = (chainBuild rows i).a8)
+      ∧ (∀ i, i < m → (chainBuild rows (i + 1)).b0 = (chainBuild rows i).b8)
+      ∧ (∀ i, i < m → (chainBuild rows (i + 1)).n0 = (chainBuild rows i).n8)
+      ∧ (∀ i, i ≤ m → (chainBuild rows i).crumbs = rows i) := by
+  refine ⟨?_, rfl, rfl, rfl, fun i _ => rfl, fun i _ => rfl, fun i _ => rfl, ?_⟩
+  · intro i hi
+    cases i with
+    | zero => exact complete 2 2 0 (rows 0) (hvalid 0 hi)
+    | succ k => exact complete _ _ _ (rows (k + 1)) (hvalid (k + 1) hi)
+  · intro i _
+    cases i with
+    | zero => rfl
+    | succ k => rfl
 
 /-! ## Uniqueness of the decomposition under the bit-size/field-size bound.
 

--- a/formal/Kimchi/Circuit/EndoScalar.lean
+++ b/formal/Kimchi/Circuit/EndoScalar.lean
@@ -1,0 +1,69 @@
+import Kimchi.Gate.EndoScalar
+
+/-!
+# The `EndoScalar` circuit: the effective scalar `a·λ + b`
+
+Composition of `Kimchi.Gate.EndoScalar` rows into the full endo-scalar
+decomposition. A challenge is processed 8 crumbs at a time, each row threading the
+`(a,b,n)` accumulators; the result is the effective scalar `a·λ + b` and the raw
+register `n`, which the wrapper asserts equals the input challenge.
+
+Because each row is a `List.foldl` over its crumbs, chaining rows is just folding
+over the concatenated crumb list (`List.foldl_append`) — the multi-row layout
+adds nothing to the math, so the full-challenge (multi-row) spec is deferred until
+a consumer (EndoMul) needs it.
+
+## Main results
+
+* `gate_toField` — a satisfying row from the canonical init `(a,b,n) = (2,2,0)`
+  outputs the effective scalar `toField crumbs λ` and the register
+  `nReconstruct crumbs`.
+* `endoScalar_spec` — with the wrapper's `n = challenge`, that register IS the
+  challenge: the gate computes the endo-decomposition of the challenge.
+-/
+
+namespace Kimchi.Circuit.EndoScalar
+
+open Kimchi.Gate.EndoScalar
+
+variable {F : Type*} [Field F]
+
+/-- The `a`-accumulator of the Algorithm-2 decomposition (`a := 2a + cPoly x`),
+    from the canonical init `2`. -/
+def decomposeA (crumbs : List F) : F := crumbs.foldl (fun a x => 2 * a + cPoly x) 2
+
+/-- The `b`-accumulator (`b := 2b + dPoly x`), from init `2`. -/
+def decomposeB (crumbs : List F) : F := crumbs.foldl (fun b x => 2 * b + dPoly x) 2
+
+/-- The raw challenge reconstructed from its base-4 crumbs (`n := 4n + x`), the
+    gate's `n` register. -/
+def nReconstruct (crumbs : List F) : F := crumbs.foldl (fun n x => 4 * n + x) 0
+
+/-- The effective scalar the gate outputs: `a·λ + b` (`λ` the endomorphism
+    eigenvalue). This is the pure `to_field` of the challenge. -/
+def toField (crumbs : List F) (lam : F) : F :=
+  decomposeA crumbs * lam + decomposeB crumbs
+
+/-- A satisfying `EndoScalar` row, started from the canonical init `(2,2,0)`,
+    outputs the effective scalar `toField crumbs λ` and reconstructs the register
+    `nReconstruct crumbs`. (Definitional once the init is fixed — `Holds`'s folds
+    are exactly `decomposeA`/`decomposeB`/`nReconstruct`.) -/
+theorem gate_toField (lam : F) (w : Witness F) (h : Holds w)
+    (ha0 : w.a0 = 2) (hb0 : w.b0 = 2) (hn0 : w.n0 = 0) :
+    w.a8 * lam + w.b8 = toField w.crumbs lam ∧ w.n8 = nReconstruct w.crumbs := by
+  obtain ⟨hn, ha, hb, _⟩ := h
+  rw [ha0] at ha
+  rw [hb0] at hb
+  rw [hn0] at hn
+  exact ⟨by rw [ha, hb, toField, decomposeA, decomposeB], by rw [hn, nReconstruct]⟩
+
+/-- The endo-scalar spec: a satisfying row from the canonical init, whose register
+    the wrapper has asserted equal to the input `challenge`, computes the effective
+    scalar — and the crumbs are the base-4 decoding of `challenge`. -/
+theorem endoScalar_spec (lam challenge : F) (w : Witness F) (h : Holds w)
+    (ha0 : w.a0 = 2) (hb0 : w.b0 = 2) (hn0 : w.n0 = 0) (hchal : w.n8 = challenge) :
+    w.a8 * lam + w.b8 = toField w.crumbs lam ∧ nReconstruct w.crumbs = challenge := by
+  obtain ⟨hout, hn⟩ := gate_toField lam w h ha0 hb0 hn0
+  exact ⟨hout, hn ▸ hchal⟩
+
+end Kimchi.Circuit.EndoScalar

--- a/formal/Kimchi/Circuit/EndoScalar/Base4.lean
+++ b/formal/Kimchi/Circuit/EndoScalar/Base4.lean
@@ -1,0 +1,117 @@
+import Mathlib
+
+/-!
+# Base-4 digit recovery (the `EndoScalar` uniqueness kernel)
+
+The number-theoretic kernel behind `EndoScalar`'s self-contained soundness: a list of
+field crumbs, each a 2-bit value in `{0,1,2,3}`, reconstructs to a challenge base-4
+(MSB-first), and that decoding is *injective* once it does not wrap past the field size.
+
+It is pure positional arithmetic — independent of the gate, the curve, and the circuit's
+`nReconstruct`/`decomposeA` folds — so it lives apart from `Kimchi.Circuit.EndoScalar`,
+which imports it and bridges its `valNat` shadow to the field-valued `nReconstruct`.
+
+## Main results
+
+* `digit_cast` — on a valid crumb the `ℕ` digit casts back to the field element.
+* `valNat_cons` / `valNat_lt` — the Horner step of the base-4 value, and its `< 4 ^ len`
+  bound (the no-wrap budget).
+* `euclid_split` — the digit-recovery step: `high · M + low` with `low < M` recovers
+  `high` and `low` uniquely.
+* `valNat_inj` — same-length valid crumb lists with equal value are equal.
+-/
+
+namespace Kimchi.Circuit.EndoScalar
+
+variable {F : Type*} [Field F] [DecidableEq F]
+
+/-- The base-4 digit a crumb stands for (`0` off the valid set). -/
+def digit (x : F) : ℕ := if x = 1 then 1 else if x = 2 then 2 else if x = 3 then 3 else 0
+
+/-- The natural-number value a crumb list reconstructs to, base-4 MSB-first — the `ℕ`
+    shadow of `nReconstruct`, used to transport the field equality to an integer one where
+    the no-wrap bound makes base-4 decoding injective. -/
+def valNat (xs : List F) : ℕ := xs.foldl (fun n x => 4 * n + digit x) 0
+
+theorem digit_lt_four (x : F) : digit x < 4 := by
+  unfold digit; split_ifs <;> omega
+
+/-- On a valid crumb the digit casts back to the crumb. -/
+theorem digit_cast (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) {x : F}
+    (hx : x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) : ((digit x : ℕ) : F) = x := by
+  have h1 : (1 : F) ≠ 0 := one_ne_zero
+  rcases hx with rfl | rfl | rfl | rfl
+  · unfold digit
+    rw [if_neg (fun h => h1 h.symm), if_neg (fun h => h2 h.symm),
+      if_neg (fun h => h3 h.symm), Nat.cast_zero]
+  · unfold digit; rw [if_pos rfl, Nat.cast_one]
+  · unfold digit
+    rw [if_neg (fun h => h1 (by linear_combination h)), if_pos rfl, Nat.cast_ofNat]
+  · unfold digit
+    rw [if_neg (fun h => h2 (by linear_combination h)),
+      if_neg (fun h => h1 (by linear_combination h)), if_pos rfl, Nat.cast_ofNat]
+
+/-- Peeling the most significant crumb: `valNat (x :: xs) = digit x · 4^|xs| + valNat xs`. -/
+theorem valNat_cons (x : F) (xs : List F) :
+    valNat (x :: xs) = digit x * 4 ^ xs.length + valNat xs := by
+  -- `gen`: folding from an arbitrary carry is that carry shifted up by `4^|ys|`, plus `valNat`
+  have gen : ∀ (ys : List F) (acc : ℕ),
+      ys.foldl (fun n x => 4 * n + digit x) acc = acc * 4 ^ ys.length + valNat ys := by
+    intro ys
+    induction ys with
+    | nil => intro acc; simp [valNat]
+    | cons y ys ihy =>
+      intro acc
+      have hv : valNat (y :: ys) = digit y * 4 ^ ys.length + valNat ys := by
+        rw [show valNat (y :: ys)
+            = ys.foldl (fun n x => 4 * n + digit x) (4 * 0 + digit y) from rfl, ihy]
+        ring
+      rw [List.foldl_cons, ihy (4 * acc + digit y), List.length_cons, pow_succ, hv]
+      ring
+  rw [show valNat (x :: xs)
+      = xs.foldl (fun n x => 4 * n + digit x) (4 * 0 + digit x) from rfl, gen]
+  ring
+
+theorem valNat_lt (xs : List F) : valNat xs < 4 ^ xs.length := by
+  induction xs with
+  | nil => simp [valNat]
+  | cons x xs ih =>
+    rw [valNat_cons, List.length_cons, pow_succ]
+    have hx := digit_lt_four x
+    nlinarith [ih, Nat.zero_le (valNat xs), Nat.zero_le (4 ^ xs.length)]
+
+omit [Field F] [DecidableEq F] in
+/-- Euclidean split at base `M`: a low part below `M` and a high digit are uniquely
+    recoverable from `high · M + low`. The base-4 digit-recovery step. -/
+theorem euclid_split {a b c d M : ℕ} (hb : b < M) (hd : d < M)
+    (h : a * M + b = c * M + d) : a = c ∧ b = d := by
+  have hM : 0 < M := lt_of_le_of_lt (Nat.zero_le b) hb
+  have ha : (a * M + b) / M = a := by
+    rw [add_comm (a * M) b, Nat.add_mul_div_right b a hM, Nat.div_eq_of_lt hb, Nat.zero_add]
+  have hc : (c * M + d) / M = c := by
+    rw [add_comm (c * M) d, Nat.add_mul_div_right d c hM, Nat.div_eq_of_lt hd, Nat.zero_add]
+  have hac : a = c := by rw [← ha, ← hc, h]
+  subst hac; exact ⟨rfl, by omega⟩
+
+/-- Nat-level base-4 uniqueness: valid same-length crumb lists with equal `valNat` are
+    equal. The crumbs being digits `< 4` makes each `valNat_cons` layer a `euclid_split`. -/
+theorem valNat_inj (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) (xs ys : List F)
+    (hx : ∀ x ∈ xs, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3)
+    (hy : ∀ x ∈ ys, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3)
+    (hlen : xs.length = ys.length) (hnat : valNat xs = valNat ys) : xs = ys := by
+  induction xs generalizing ys with
+  | nil => cases ys with
+    | nil => rfl
+    | cons y ys => simp at hlen
+  | cons x xs ih => cases ys with
+    | nil => simp at hlen
+    | cons y ys =>
+      simp only [List.length_cons, Nat.add_right_cancel_iff] at hlen
+      rw [valNat_cons, valNat_cons, hlen] at hnat
+      obtain ⟨hdig, htail⟩ := euclid_split (hlen ▸ valNat_lt xs) (valNat_lt ys) hnat
+      have hxy : x = y := by
+        rw [← digit_cast h2 h3 (hx x (by simp)), ← digit_cast h2 h3 (hy y (by simp)), hdig]
+      rw [hxy, ih ys (fun z hz => hx z (by simp [hz])) (fun z hz => hy z (by simp [hz]))
+        hlen htail]
+
+end Kimchi.Circuit.EndoScalar

--- a/formal/Kimchi/Gate/EndoScalar.lean
+++ b/formal/Kimchi/Gate/EndoScalar.lean
@@ -1,0 +1,206 @@
+import Mathlib
+
+/-!
+# The kimchi `EndoScalar` gate
+
+The endomorphism-scalar gate, transcribed from proof-systems
+`kimchi/src/circuits/polynomials/endomul_scalar.rs` (and the PureScript
+`Snarky.Circuit.Kimchi.EndoScalar`). Unlike the EC gates this one is PURE FIELD
+ARITHMETIC: it decomposes a scalar challenge into the field element it represents
+under the curve endomorphism, ready for `EndoMul` to multiply by.
+
+Each row runs 8 iterations of "Algorithm 2" from the Halo paper (p. 29). The
+challenge is read MSB-first in 2-bit *crumbs* `x ∈ {0,1,2,3}`; the state `(a,b,n)`
+(initialized to `(2,2,0)`) updates per crumb as
+
+    n := 4·n + x        a := 2·a + c_func(x)        b := 2·b + d_func(x)
+
+and the effective scalar is `a·λ + b` (`λ` = the scalar-field endomorphism
+eigenvalue), with `n` asserted equal to the input challenge. The two crumb
+functions are the `{0,1,2,3} → value` tables
+
+    c_func = (0, 0, −1, 1)        d_func = (−1, 1, 0, 0)
+
+which the circuit implements as the interpolating cubics (so a single polynomial
+identity covers all four cases).
+
+## Main results
+
+* `crumb_iff` — the range constraint `x(x−1)(x−2)(x−3) = 0` holds iff
+  `x ∈ {0,1,2,3}` (in any field).
+* `cPoly_table` / `dPoly_table` — the Halo interpolating cubics `cPoly` / `dPoly`
+  agree with the `c_func` / `d_func` tables on every crumb (char ≠ 2,3).
+
+* `sound` / `complete` — a satisfying row genuinely runs Halo's Algorithm 2: the crumbs are
+  valid 2-bit values and the `a`/`b`/`n` accumulators are the Algorithm-2 folds, the `a`/`b`
+  folds using the *literal* `c_func`/`d_func` tables (the cubics in `Holds` interpolate them).
+  Conversely the honest prover's witness (`build`) satisfies the constraints for any valid crumbs.
+
+## Supporting development
+
+The constraint model (`Witness` / `Holds` / `ok` / `ok_iff`) and the cubic↔table bridge
+(`cFunc` / `dFunc`, `cPoly_eq_cFunc` / `dPoly_eq_dFunc`, `foldl_table`). The effective scalar
+`a·λ + b` and the multi-row composition live in `Kimchi.Circuit.EndoScalar`.
+-/
+
+namespace Kimchi.Gate.EndoScalar
+
+variable {F : Type*} [Field F]
+
+/-- `c_func`'s interpolating cubic `⅔x³ − 5⁄2x² + 11⁄6x` (Lagrange over
+    `(0,0),(1,0),(2,−1),(3,1)`). The gate enforces this polynomial; `cPoly_table`
+    shows it equals the intended `(0,0,−1,1)` table on crumbs. -/
+def cPoly (x : F) : F := 2 / 3 * x ^ 3 - 5 / 2 * x ^ 2 + 11 / 6 * x
+
+/-- `d_func = c_func + (−x² + 3x − 1)`; on crumbs it is the `(−1,1,0,0)` table. -/
+def dPoly (x : F) : F := cPoly x + (-x ^ 2 + 3 * x - 1)
+
+/-- The crumb-range polynomial `x(x−1)(x−2)(x−3)` — zero exactly on `{0,1,2,3}`. -/
+def crumbPoly (x : F) : F := x * (x - 1) * (x - 2) * (x - 3)
+
+/-- The range constraint vanishes iff the crumb is a genuine 2-bit value. Holds in
+    any field (an integral domain): a product is zero iff a factor is. -/
+theorem crumb_iff (x : F) :
+    crumbPoly x = 0 ↔ x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3 := by
+  simp only [crumbPoly, mul_eq_zero, sub_eq_zero, or_assoc]
+
+/-- The interpolating cubic `cPoly` reproduces the `c_func = (0,0,−1,1)` table on
+    every crumb (needs `2,3 ≠ 0`, true on the Pasta scalar fields). -/
+theorem cPoly_table (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) :
+    cPoly (0 : F) = 0 ∧ cPoly (1 : F) = 0
+      ∧ cPoly (2 : F) = -1 ∧ cPoly (3 : F) = 1 := by
+  have h6 : (6 : F) ≠ 0 := by
+    rw [show (6 : F) = 2 * 3 by norm_num]; exact mul_ne_zero h2 h3
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> · simp only [cPoly]; field_simp; ring
+
+/-- `dPoly` reproduces the `d_func = (−1,1,0,0)` table on every crumb. -/
+theorem dPoly_table (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) :
+    dPoly (0 : F) = -1 ∧ dPoly (1 : F) = 1
+      ∧ dPoly (2 : F) = 0 ∧ dPoly (3 : F) = 0 := by
+  obtain ⟨c0, c1, c2, c3⟩ := cPoly_table h2 h3
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> simp only [dPoly]
+  · rw [c0]; ring
+  · rw [c1]; ring
+  · rw [c2]; ring
+  · rw [c3]; ring
+
+/-! ## The gate's constraint model. -/
+
+/-- One `EndoScalar` row: the input/output `(a,b,n)` accumulators and the 8 crumbs
+    (kept as a `List` — the fold is uniform in the count). -/
+structure Witness (F : Type*) where
+  a0 : F
+  b0 : F
+  n0 : F
+  a8 : F
+  b8 : F
+  n8 : F
+  crumbs : List F
+deriving Repr
+
+/-- The 11 gate constraints: the three accumulator folds (`n := 4n+x`,
+    `a := 2a + cPoly x`, `b := 2b + dPoly x`) close at `a8,b8,n8`, and every crumb
+    satisfies the range polynomial. -/
+def Holds (w : Witness F) : Prop :=
+  w.n8 = w.crumbs.foldl (fun acc x => 4 * acc + x) w.n0
+    ∧ w.a8 = w.crumbs.foldl (fun acc x => 2 * acc + cPoly x) w.a0
+    ∧ w.b8 = w.crumbs.foldl (fun acc x => 2 * acc + dPoly x) w.b0
+    ∧ ∀ x ∈ w.crumbs, crumbPoly x = 0
+
+/-- EXECUTABLE checker: the three accumulator folds close and every crumb is in range. -/
+def ok [DecidableEq F] (w : Witness F) : Bool :=
+  (w.n8 == w.crumbs.foldl (fun acc x => 4 * acc + x) w.n0)
+    && (w.a8 == w.crumbs.foldl (fun acc x => 2 * acc + cPoly x) w.a0)
+    && (w.b8 == w.crumbs.foldl (fun acc x => 2 * acc + dPoly x) w.b0)
+    && w.crumbs.all (fun x => crumbPoly x == 0)
+
+/-- Reflection: the checker faithfully decides the constraints. -/
+theorem ok_iff [DecidableEq F] (w : Witness F) : ok w = true ↔ Holds w := by
+  simp only [ok, Holds, Bool.and_eq_true, beq_iff_eq, List.all_eq_true, and_assoc]
+
+/-- Build the canonical satisfying row from valid crumbs and the input accumulators: the three
+    outputs are the accumulator folds, run on the given crumbs. -/
+def build (a0 b0 n0 : F) (crumbs : List F) : Witness F :=
+  { a0, b0, n0
+  , n8 := crumbs.foldl (fun acc x => 4 * acc + x) n0
+  , a8 := crumbs.foldl (fun acc x => 2 * acc + cPoly x) a0
+  , b8 := crumbs.foldl (fun acc x => 2 * acc + dPoly x) b0
+  , crumbs }
+
+/-- **Completeness.** The witness the honest prover constructs (`build`) satisfies all the gate
+    constraints, given that every crumb is a genuine 2-bit value — the folds close by
+    construction, and the range constraint follows from `crumb_iff`. -/
+theorem complete (a0 b0 n0 : F) (crumbs : List F)
+    (hvalid : ∀ x ∈ crumbs, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) :
+    Holds (build a0 b0 n0 crumbs) :=
+  ⟨rfl, rfl, rfl, fun x hx => (crumb_iff x).mpr (hvalid x hx)⟩
+
+/-! ## The bare-table form of the folds.
+
+    The `a`/`b` constraints use the interpolating cubics; on valid crumbs they run
+    the same fold with the bare `c_func`/`d_func` tables. -/
+
+/-- Replacing the per-crumb function leaves the `2·acc + f x` fold unchanged when
+    the two functions agree on every crumb. -/
+theorem foldl_table {φ ψ : F → F} :
+    ∀ (xs : List F) (init : F), (∀ x ∈ xs, φ x = ψ x) →
+      xs.foldl (fun acc x => 2 * acc + φ x) init
+        = xs.foldl (fun acc x => 2 * acc + ψ x) init
+  | [], _, _ => rfl
+  | y :: ys, init, h => by
+    simp only [List.foldl_cons]
+    rw [h y (by simp), foldl_table ys _ (fun x hx => h x (by simp [hx]))]
+
+variable [DecidableEq F]
+
+/-- `c_func` as the bare `(0,0,−1,1)` table. -/
+def cFunc (x : F) : F := if x = 2 then -1 else if x = 3 then 1 else 0
+
+/-- `d_func` as the bare `(−1,1,0,0)` table. -/
+def dFunc (x : F) : F := if x = 0 then -1 else if x = 1 then 1 else 0
+
+/-- On a valid crumb the interpolating cubic `cPoly` equals the bare table `cFunc`. -/
+theorem cPoly_eq_cFunc (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) {x : F}
+    (hx : x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) : cPoly x = cFunc x := by
+  obtain ⟨c0, c1, c2, c3⟩ := cPoly_table h2 h3
+  have e02 : (0 : F) ≠ 2 := fun h => h2 h.symm
+  have e03 : (0 : F) ≠ 3 := fun h => h3 h.symm
+  have e12 : (1 : F) ≠ 2 := fun h => (one_ne_zero : (1 : F) ≠ 0) (by linear_combination -h)
+  have e13 : (1 : F) ≠ 3 := fun h => h2 (by linear_combination -h)
+  have e32 : (3 : F) ≠ 2 := fun h => (one_ne_zero : (1 : F) ≠ 0) (by linear_combination h)
+  rcases hx with rfl | rfl | rfl | rfl
+  · rw [c0, cFunc, if_neg e02, if_neg e03]
+  · rw [c1, cFunc, if_neg e12, if_neg e13]
+  · rw [c2, cFunc, if_pos rfl]
+  · rw [c3, cFunc, if_neg e32, if_pos rfl]
+
+/-- On a valid crumb the interpolating cubic `dPoly` equals the bare table `dFunc`. -/
+theorem dPoly_eq_dFunc (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) {x : F}
+    (hx : x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) : dPoly x = dFunc x := by
+  obtain ⟨d0, d1, d2, d3⟩ := dPoly_table h2 h3
+  have e21 : (2 : F) ≠ 1 := fun h => (one_ne_zero : (1 : F) ≠ 0) (by linear_combination h)
+  have e31 : (3 : F) ≠ 1 := fun h => h2 (by linear_combination h)
+  rcases hx with rfl | rfl | rfl | rfl
+  · rw [d0, dFunc, if_pos rfl]
+  · rw [d1, dFunc, if_neg ((one_ne_zero : (1 : F) ≠ 0)), if_pos rfl]
+  · rw [d2, dFunc, if_neg h2, if_neg e21]
+  · rw [d3, dFunc, if_neg h3, if_neg e31]
+
+/-- **Soundness.** A satisfying row genuinely runs Halo's Algorithm 2: the crumbs are valid 2-bit
+    values, and the `a`/`b`/`n` accumulators are the Algorithm-2 folds — with the `a`/`b` folds
+    using the *literal* `c_func`/`d_func` lookup tables (the cubics in `Holds` interpolate them, so
+    `2,3 ≠ 0` — true on the Pasta scalar fields). The bare crumb-validity fact is `(sound …).1`. -/
+theorem sound (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
+    (w : Witness F) (h : Holds w) :
+    (∀ x ∈ w.crumbs, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3)
+      ∧ w.n8 = w.crumbs.foldl (fun n x => 4 * n + x) w.n0
+      ∧ w.a8 = w.crumbs.foldl (fun a x => 2 * a + cFunc x) w.a0
+      ∧ w.b8 = w.crumbs.foldl (fun b x => 2 * b + dFunc x) w.b0 := by
+  obtain ⟨hn, ha, hb, hc⟩ := h
+  have hv : ∀ x ∈ w.crumbs, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3 :=
+    fun x hx => (crumb_iff x).mp (hc x hx)
+  refine ⟨hv, hn, ?_, ?_⟩
+  · rw [ha]; exact foldl_table w.crumbs w.a0 (fun x hx => cPoly_eq_cFunc h2 h3 (hv x hx))
+  · rw [hb]; exact foldl_table w.crumbs w.b0 (fun x hx => dPoly_eq_dFunc h2 h3 (hv x hx))
+
+end Kimchi.Gate.EndoScalar

--- a/formal/Kimchi/Gate/EndoScalar.lean
+++ b/formal/Kimchi/Gate/EndoScalar.lean
@@ -86,8 +86,9 @@ theorem dPoly_table (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) :
 
 /-! ## The gate's constraint model. -/
 
-/-- One `EndoScalar` row: the input/output `(a,b,n)` accumulators and the 8 crumbs
-    (kept as a `List` — the fold is uniform in the count). -/
+/-- One `EndoScalar` row: the input/output `(a,b,n)` accumulators and the crumbs
+    (the deployed gate carries 8; kept as a `List`, since the fold is uniform in the
+    count — so one `Witness` can equally model a whole multi-row challenge). -/
 structure Witness (F : Type*) where
   a0 : F
   b0 : F
@@ -98,9 +99,9 @@ structure Witness (F : Type*) where
   crumbs : List F
 deriving Repr
 
-/-- The 11 gate constraints: the three accumulator folds (`n := 4n+x`,
-    `a := 2a + cPoly x`, `b := 2b + dPoly x`) close at `a8,b8,n8`, and every crumb
-    satisfies the range polynomial. -/
+/-- The gate constraints (11 at the deployed 8-crumb width: `3 + #crumbs`): the three
+    accumulator folds (`n := 4n+x`, `a := 2a + cPoly x`, `b := 2b + dPoly x`) close at
+    `a8,b8,n8`, and every crumb satisfies the range polynomial. -/
 def Holds (w : Witness F) : Prop :=
   w.n8 = w.crumbs.foldl (fun acc x => 4 * acc + x) w.n0
     ∧ w.a8 = w.crumbs.foldl (fun acc x => 2 * acc + cPoly x) w.a0
@@ -189,7 +190,7 @@ theorem dPoly_eq_dFunc (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) {x : F}
 /-- **Soundness.** A satisfying row genuinely runs Halo's Algorithm 2: the crumbs are valid 2-bit
     values, and the `a`/`b`/`n` accumulators are the Algorithm-2 folds — with the `a`/`b` folds
     using the *literal* `c_func`/`d_func` lookup tables (the cubics in `Holds` interpolate them, so
-    `2,3 ≠ 0` — true on the Pasta scalar fields). The bare crumb-validity fact is `(sound …).1`. -/
+    `2,3 ≠ 0` — true on the Pasta scalar fields). -/
 theorem sound (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
     (w : Witness F) (h : Holds w) :
     (∀ x ∈ w.crumbs, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3)

--- a/formal/roots.txt
+++ b/formal/roots.txt
@@ -34,9 +34,8 @@ Kimchi.Circuit.VarBaseMul.varBaseMul_scaleFast2
 Kimchi.Gate.EndoScalar.sound
 Kimchi.Gate.EndoScalar.complete
 
--- Endo-scalar decomposition (circuit): the effective scalar a·λ + b from the challenge
-Kimchi.Circuit.EndoScalar.endoScalar_spec
--- multi-row run over sequential gates, and uniqueness of the decomposition under the
--- bit-size/field-size bound (challenge ↦ a·λ + b is well defined)
+-- Endo-scalar decomposition (circuit): the effective scalar a·λ + b over a multi-row run of
+-- sequential gates, and uniqueness of the decomposition under the bit-size/field-size bound
+-- (so challenge ↦ a·λ + b is well defined)
 Kimchi.Circuit.EndoScalar.chain_toField
 Kimchi.Circuit.EndoScalar.endoScalar_unique

--- a/formal/roots.txt
+++ b/formal/roots.txt
@@ -29,3 +29,10 @@ Kimchi.Gate.VarBaseMul.complete
 -- Variable-base scalar multiplication (circuit): the two deployed entry points
 Kimchi.Circuit.VarBaseMul.varBaseMul_scaleFast1
 Kimchi.Circuit.VarBaseMul.varBaseMul_scaleFast2
+
+-- Endo-scalar decomposition (gate)
+Kimchi.Gate.EndoScalar.sound
+Kimchi.Gate.EndoScalar.complete
+
+-- Endo-scalar decomposition (circuit): the effective scalar a·λ + b from the challenge
+Kimchi.Circuit.EndoScalar.endoScalar_spec

--- a/formal/roots.txt
+++ b/formal/roots.txt
@@ -36,3 +36,7 @@ Kimchi.Gate.EndoScalar.complete
 
 -- Endo-scalar decomposition (circuit): the effective scalar a·λ + b from the challenge
 Kimchi.Circuit.EndoScalar.endoScalar_spec
+-- multi-row run over sequential gates, and uniqueness of the decomposition under the
+-- bit-size/field-size bound (challenge ↦ a·λ + b is well defined)
+Kimchi.Circuit.EndoScalar.chain_toField
+Kimchi.Circuit.EndoScalar.endoScalar_unique

--- a/formal/roots.txt
+++ b/formal/roots.txt
@@ -34,8 +34,9 @@ Kimchi.Circuit.VarBaseMul.varBaseMul_scaleFast2
 Kimchi.Gate.EndoScalar.sound
 Kimchi.Gate.EndoScalar.complete
 
--- Endo-scalar decomposition (circuit): the effective scalar a·λ + b over a multi-row run of
--- sequential gates, and uniqueness of the decomposition under the bit-size/field-size bound
--- (so challenge ↦ a·λ + b is well defined)
+-- Endo-scalar decomposition (circuit): over a multi-row run of sequential gates, the effective
+-- scalar a·λ + b (sound), the honest prover fills the run (complete), and the decomposition is
+-- unique under the bit-size/field-size bound (so challenge ↦ a·λ + b is well defined)
 Kimchi.Circuit.EndoScalar.chain_toField
+Kimchi.Circuit.EndoScalar.chain_complete
 Kimchi.Circuit.EndoScalar.endoScalar_unique

--- a/formal/scripts/check_axioms.lean
+++ b/formal/scripts/check_axioms.lean
@@ -33,6 +33,7 @@ def roots : List Name :=
     `Kimchi.Circuit.VarBaseMul.varBaseMul_scaleFast2,
     `Kimchi.Gate.EndoScalar.sound, `Kimchi.Gate.EndoScalar.complete,
     `Kimchi.Circuit.EndoScalar.chain_toField,
+    `Kimchi.Circuit.EndoScalar.chain_complete,
     `Kimchi.Circuit.EndoScalar.endoScalar_unique ]
 
 /-- The only axioms the roots may depend on: the standard logical axioms plus the two trusted

--- a/formal/scripts/check_axioms.lean
+++ b/formal/scripts/check_axioms.lean
@@ -32,7 +32,9 @@ def roots : List Name :=
     `Kimchi.Circuit.VarBaseMul.varBaseMul_scaleFast1,
     `Kimchi.Circuit.VarBaseMul.varBaseMul_scaleFast2,
     `Kimchi.Gate.EndoScalar.sound, `Kimchi.Gate.EndoScalar.complete,
-    `Kimchi.Circuit.EndoScalar.endoScalar_spec ]
+    `Kimchi.Circuit.EndoScalar.endoScalar_spec,
+    `Kimchi.Circuit.EndoScalar.chain_toField,
+    `Kimchi.Circuit.EndoScalar.endoScalar_unique ]
 
 /-- The only axioms the roots may depend on: the standard logical axioms plus the two trusted
     Pasta point counts. -/

--- a/formal/scripts/check_axioms.lean
+++ b/formal/scripts/check_axioms.lean
@@ -30,7 +30,9 @@ def roots : List Name :=
     `Kimchi.Circuit.VarBaseMul.varBaseMul_forbidden_correct,
     `Kimchi.Circuit.VarBaseMul.varBaseMul_subwrap_correct,
     `Kimchi.Circuit.VarBaseMul.varBaseMul_scaleFast1,
-    `Kimchi.Circuit.VarBaseMul.varBaseMul_scaleFast2 ]
+    `Kimchi.Circuit.VarBaseMul.varBaseMul_scaleFast2,
+    `Kimchi.Gate.EndoScalar.sound, `Kimchi.Gate.EndoScalar.complete,
+    `Kimchi.Circuit.EndoScalar.endoScalar_spec ]
 
 /-- The only axioms the roots may depend on: the standard logical axioms plus the two trusted
     Pasta point counts. -/

--- a/formal/scripts/check_axioms.lean
+++ b/formal/scripts/check_axioms.lean
@@ -32,7 +32,6 @@ def roots : List Name :=
     `Kimchi.Circuit.VarBaseMul.varBaseMul_scaleFast1,
     `Kimchi.Circuit.VarBaseMul.varBaseMul_scaleFast2,
     `Kimchi.Gate.EndoScalar.sound, `Kimchi.Gate.EndoScalar.complete,
-    `Kimchi.Circuit.EndoScalar.endoScalar_spec,
     `Kimchi.Circuit.EndoScalar.chain_toField,
     `Kimchi.Circuit.EndoScalar.endoScalar_unique ]
 


### PR DESCRIPTION
**Stack 1 of 2.** Ports the EndoScalar formalization (originally #161, pre-CompElliptic) onto current `main`, adapted to its conventions.

The EndoScalar gate is pure scalar-decomposition arithmetic — decode a challenge from 2-bit "crumbs" via the `cPoly`/`dPoly` endomorphism tables — so it is **curve-free** and independent of the CompElliptic foundations; it drops on with no proof changes, only convention adaptation.

### Gate — `Kimchi/Gate/EndoScalar.lean`
- `Witness`/`Holds` + `ok`/`ok_iff` (house-style Bool checker), and the uniform `sound` / `complete`.
- `sound` is the full faithfulness: crumbs are valid 2-bit values **and** the `a`/`b`/`n` accumulators are the Algorithm-2 folds using the *literal* `c_func`/`d_func` tables (the cubics in `Holds` interpolate them). It absorbs #161's separate `gate_endoScalar` + `gate_endoScalar_table`.
- `complete`: the generator `build` satisfies `Holds` for any valid crumbs.

### Circuit — `Kimchi/Circuit/EndoScalar.lean`
- `gate_toField` + `endoScalar_spec` (the effective scalar `a·λ + b` and the reconstructed challenge), plus the `decomposeA_append`/`decomposeB_append` multi-row composition lemmas (consumed by EndoMul in the next PR).

Wired into `Kimchi.lean`; headline theorems added to `roots.txt` and the `#print axioms` gate. Build + style green; all gate `sound`/`complete` reduce to the standard axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)