### PR TITLE
formal: kimchi IPA batched opening — multi-poly/multi-point soundness

### DIFF
--- a/formal/Kimchi.lean
+++ b/formal/Kimchi.lean
@@ -13,3 +13,4 @@ import Kimchi.Circuit.VarBaseMul
 import Kimchi.Circuit.EndoScalar
 import Kimchi.Circuit.EndoMul
 import Kimchi.Commitment.IPA.Soundness
+import Kimchi.Commitment.IPA.Soundness.Batch

--- a/formal/Kimchi/Commitment/IPA/Batch.lean
+++ b/formal/Kimchi/Commitment/IPA/Batch.lean
@@ -1,0 +1,113 @@
+import Mathlib
+import Kimchi.Commitment.IPA.Verify
+
+/-!
+# Batched multi-polynomial, multi-point opening of the kimchi IPA commitment
+
+The kimchi verifier never opens one polynomial at one point: it opens ~20
+commitments at the two points `{ζ, ζω}` through ONE IPA opening of a random linear
+combination — `polyscale ξ` across polynomials, `evalscale r` across evaluation
+points. This file gives the definitions of that batching, on top of the
+single-opening IPA stack (`Basic`/`Verify`); nothing there is redefined.
+
+The batched setting fixes:
+
+* `n` committed polynomials, indexed `i : Fin n`, with commitments `C : Fin n → G`
+  (one chunk each, `nc = 1`);
+* `m` evaluation points `x : Fin m → F` (for vanilla PlonK, `m = 2`);
+* claimed evaluations `e : Fin n → Fin m → F`, where `e i j` is the prover's
+  claimed value of polynomial `i` at point `x j`.
+
+These combiners are definitional transcriptions of the deployed verifier's
+commitment/value aggregation and its `b₀` evaluation slot: their faithfulness is by
+transcription, not by proof. The soundness theorem (`Soundness/Batch.lean`) consumes
+them as given and never re-derives the verifier's acceptance equation from them — see
+its header for the trust boundary. Scope: `nc = 1` throughout; the
+`rand_base`/`sg_rand_base` cross-proof MSM batching and the Fiat–Shamir sponge are
+out of scope.
+-/
+
+namespace Kimchi.Commitment.IPA
+
+variable {F G : Type*} [Field F] [AddCommGroup G] [Module F G]
+
+/-! ## Batch definitions -/
+
+/-- Combined commitment: the random linear combination of the commitments by
+powers of the polyscale `ξ`,
+`combinedCommitment ξ C = ∑ i, ξ ^ i • C i`.
+
+At `rand_base = 1` and `nc = 1` (one chunk per commitment); the `rand_base`
+cross-proof MSM randomiser is out of scope. -/
+def combinedCommitment (ξ : F) {n : ℕ} (C : Fin n → G) : G :=
+  ∑ i : Fin n, ξ ^ (i : ℕ) • C i
+
+/-- Combined inner product: the aggregated claimed evaluation. Each polynomial `i`
+contributes one segment scaled by `ξ ^ i`; within a segment, the point-values are
+read as coefficients of a polynomial in `r` and evaluated at `r`,
+`combinedInnerProduct ξ r e = ∑ i, ξ ^ i * (∑ j, e i j * r ^ j)`.
+
+At `nc = 1` (one segment per polynomial), the general exponent `k * n + i` collapses
+to `i`. -/
+def combinedInnerProduct (ξ r : F) {n m : ℕ} (e : Fin n → Fin m → F) : F :=
+  ∑ i : Fin n, ξ ^ (i : ℕ) * (∑ j : Fin m, e i j * r ^ (j : ℕ))
+
+/-- Combined `b₀`: the single-scalar evaluation slot of the batched verifier — the
+challenge polynomial `bPoly u ·` evaluated at each point and combined by powers of
+the evalscale `r`,
+`combinedB u r x = ∑ j, r ^ j * bPoly u (x j)`.
+
+This is the scalar fed into the `b0` slot of `VerifierAcceptsAt`. -/
+def combinedB {k : ℕ} (u : Fin k → F) (r : F) {m : ℕ} (x : Fin m → F) : F :=
+  ∑ j : Fin m, r ^ (j : ℕ) * bPoly u (x j)
+
+/-- Combined evaluation vector: the length-`N` vector against which the extracted
+witness is opened — the evalscale-combination of the per-point evaluation vectors,
+`combinedEvalVector N r x = ∑ j, r ^ j • evalVector N (x j)`, so componentwise
+`combinedEvalVector N r x ℓ = ∑ j, r ^ j * (x j) ^ ℓ`.
+
+It is the vector-level analogue of `combinedB`; stated as a `•`-combination of
+`evalVector`s so the bridge lemma `innerProduct_combinedEvalVector` is pure
+linearity. -/
+def combinedEvalVector (N : ℕ) (r : F) {m : ℕ} (x : Fin m → F) : Fin N → F :=
+  ∑ j : Fin m, r ^ (j : ℕ) • evalVector N (x j)
+
+/-- Generalized opening relation: `openingRelation` with the eval vector abstracted
+to an arbitrary `b : Fin (2 ^ σ.k) → F`. A witness `(a, ρ)` opens `P` against `b`
+to value `v` iff `commit σ a ρ = P ∧ v = ⟨a, b⟩`.
+
+The original is the specialization
+`openingRelation σ P x v a ρ = openingRelationB σ P (evalVector (2 ^ σ.k) x) v a ρ`. -/
+def openingRelationB (σ : SRS G) (P : G) (b : Fin (2 ^ σ.k) → F) (v : F)
+    (a : Fin (2 ^ σ.k) → F) (ρ : F) : Prop :=
+  commit σ a ρ = P ∧ v = innerProduct a b
+
+/-- Batched verifier acceptance: the single-opening `VerifierAcceptsAt` check
+instantiated at the combined commitment, combined `b₀`, and combined value. No new
+verifier equation is invented — this is `VerifierAcceptsAt` with
+`P = combinedCommitment ξ C`, `b0 = combinedB u r x`, and
+`v = combinedInnerProduct ξ r e`. -/
+def BatchAccepts (σ : SRS G) (proof : OpeningProof F G σ.k) (ξ r c : F)
+    (u : Fin σ.k → F) {n m : ℕ} (C : Fin n → G) (x : Fin m → F)
+    (e : Fin n → Fin m → F) : Prop :=
+  VerifierAcceptsAt σ proof (combinedCommitment ξ C) (combinedB u r x)
+    (combinedInnerProduct ξ r e) c u
+
+/-- Inner product of the combined eval vector: for any witness `a : Fin N → F`,
+`⟨a, combinedEvalVector N r x⟩ = ∑ j, r ^ j * ⟨a, evalVector N (x j)⟩`.
+
+`⟨a, ·⟩` is `F`-linear in its second argument and `combinedEvalVector N r x` is by
+definition `∑ j, r ^ j • evalVector N (x j)`; distribute the sum and pull out the
+scalars `r ^ j`. -/
+theorem innerProduct_combinedEvalVector {N : ℕ} (a : Fin N → F) (r : F) {m : ℕ}
+    (x : Fin m → F) :
+    innerProduct a (combinedEvalVector N r x)
+      = ∑ j : Fin m, r ^ (j : ℕ) * innerProduct a (evalVector N (x j)) := by
+  simp only [innerProduct, combinedEvalVector, Finset.sum_apply, Pi.smul_apply,
+    smul_eq_mul, Finset.mul_sum]
+  rw [Finset.sum_comm]
+  refine Finset.sum_congr rfl fun j _ => ?_
+  refine Finset.sum_congr rfl fun i _ => ?_
+  ring
+
+end Kimchi.Commitment.IPA

--- a/formal/Kimchi/Commitment/IPA/Soundness/Batch.lean
+++ b/formal/Kimchi/Commitment/IPA/Soundness/Batch.lean
@@ -1,0 +1,270 @@
+import Mathlib
+import Kimchi.Commitment.IPA.Batch
+import Kimchi.Commitment.IPA.Soundness
+import Kimchi.Commitment.IPA.Soundness.Vandermonde
+
+/-!
+# Knowledge soundness of the batched kimchi IPA opening
+
+The headline of the batch development (`batch_soundness`): correct combined openings
+at enough distinct `(polyscale ξ, evalscale r)` pairs imply that every individual
+claimed evaluation is the true evaluation of the committed polynomial. Built on the
+single-opening IPA stack (`Basic`/`Verify`/`Soundness`/`Soundness/{Linear,Tree,Binding}`)
+and the batch definitions (`Batch`, `Soundness/Vandermonde`); nothing there is
+redefined.
+
+The extraction is the standard multi-poly/multi-point PCS reduction, specialized to
+the kimchi IPA relation:
+
+1. generalize the single-opening extractor to an arbitrary eval vector
+   (`ipa_soundnessB`);
+2. separate commitments by a Vandermonde combination in the polyscale
+   (`perCommitment_separation`), using commitment linearity (`commit_sum_smul`);
+3. use binding to force one witness per commitment, then a second Vandermonde in the
+   evalscale to pin every individual evaluation (`batch_soundness`).
+
+## Scope: what is proved, and what is assumed
+
+What is *proved* is the algebraic core: from accepting transcript trees, the
+special-soundness extraction of the single-opening stack, the two Vandermonde
+separations, and binding-uniqueness together yield per-commitment witnesses whose
+claimed evaluations are genuine. Two hypotheses are *assumed*, and they carry the
+cryptographic weight:
+
+* **`BatchFiatShamir`** — the grid analogue of `FiatShamirTree`: an accepting
+  verifier run yields a de-blinded accepting transcript tree. This is the entire
+  rewinding / Fiat–Shamir extraction step, taken as a hypothesis rather than proved.
+  It also carries the correspondence between the verifier's scalar acceptance
+  equation (through `combinedB`, `bPoly`, `sg`) and the tree over
+  `combinedEvalVector`: that equation is never exercised by a proof here —
+  `ipa_soundnessB` holds for *any* `b0`, since `b0` occurs only in the antecedent.
+  The witness opens against whatever eval vector the hypothesis is instantiated at
+  (here `combinedEvalVector`); the tie to the deployed verifier rests on this
+  hypothesis plus the transcription of the `Batch` combiners, not on a derivation.
+
+* **Binding** (`hbind` / no nontrivial discrete-log relation) — the idealization of
+  computational DL-relation hardness. It is *information-theoretically false* for a
+  real single-curve SRS: among `2 ^ k + 1` generators in a group of order `|F|`
+  there is always a nontrivial relation, so at real parameters the hypothesis is
+  unsatisfiable and the theorem is vacuous there. It is meaningful only as the
+  computational assumption, discharged outside this development.
+
+So this is the machine-checked algebraic skeleton of batch knowledge soundness, not
+an unconditional soundness proof of the deployed verifier: a clean axiom closure
+certifies the derivation is `sorry`-free, not that these hypotheses hold. Closing the
+gap would take formalizing the rewinding (to discharge `BatchFiatShamir`) and a
+computational layer (to discharge binding).
+-/
+
+namespace Kimchi.Commitment.IPA
+
+variable {F G : Type*} [Field F] [AddCommGroup G] [Module F G]
+
+/-! ## Per-commitment separation -/
+
+/-- Generalized Fiat–Shamir tree hypothesis: `FiatShamirTree` with the eval vector
+abstracted to an arbitrary `b : Fin (2 ^ σ.k) → F`. An accepting run yields a
+de-blinded accepting tree over `b`,
+`accepts → ∃ (ρ : F) (t : IpaTreeV F G σ.k), IpaAcceptV σ.g b (P - ρ • σ.h) v t`.
+
+The original is the specialization
+`FiatShamirTree σ P x v accepts = FiatShamirTreeB σ P (evalVector (2 ^ σ.k) x) v accepts`. -/
+def FiatShamirTreeB (σ : SRS G) (P : G) (b : Fin (2 ^ σ.k) → F) (v : F)
+    (accepts : Prop) : Prop :=
+  accepts → ∃ (ρ : F) (t : IpaTreeV F G σ.k),
+    IpaAcceptV σ.g b (P - ρ • σ.h) v t
+
+/-- **Generalized single-opening soundness.** The verbatim generalization of
+`ipa_soundness` to an arbitrary eval vector `b`: under
+`FiatShamirTreeB σ P b v (VerifierAcceptsAt σ proof P b0 v c u)`, an accepting run
+yields an opening witness for `openingRelationB`. -/
+theorem ipa_soundnessB (σ : SRS G) (proof : OpeningProof F G σ.k) (P : G)
+    (b : Fin (2 ^ σ.k) → F) (b0 v c : F) (u : Fin σ.k → F)
+    (hFS : FiatShamirTreeB σ P b v (VerifierAcceptsAt σ proof P b0 v c u))
+    (hacc : VerifierAcceptsAt σ proof P b0 v c u) :
+    ∃ (a : Fin (2 ^ σ.k) → F) (ρ : F), openingRelationB σ P b v a ρ := by
+  obtain ⟨ρ, t, ht⟩ := hFS hacc
+  obtain ⟨a, hP, hv⟩ := ipaRelation_of_acceptV σ b (P - ρ • σ.h) v t ht
+  refine ⟨a, ρ, ?_, hv⟩
+  show commitGen σ.g a + ρ • σ.h = P
+  rw [hP]
+  abel
+
+/-- **Generator-commitment linearity over finite combinations.** Pushes a
+`•`-combination of witnesses through `commitGen`. Pure glue for `commit_sum_smul`. -/
+private theorem commitGen_sum_smul {n N : ℕ} (g : Fin N → G) (l : Fin n → F)
+    (a : Fin n → (Fin N → F)) :
+    commitGen g (∑ s, l s • a s) = ∑ s, l s • commitGen g (a s) := by
+  simp only [commitGen, Finset.sum_apply, Pi.smul_apply, smul_eq_mul, Finset.sum_smul,
+    mul_smul, Finset.smul_sum]
+  rw [Finset.sum_comm]
+
+/-- **Commitment linearity over finite combinations.** For coefficients
+`l : Fin n → F`, witnesses `a : Fin n → (Fin (2 ^ σ.k) → F)`, and blinders
+`ρ : Fin n → F`,
+`commit σ (∑ s, l s • a s) (∑ s, l s * ρ s) = ∑ s, l s • commit σ (a s) (ρ s)`. -/
+theorem commit_sum_smul (σ : SRS G) {n : ℕ} (l : Fin n → F)
+    (a : Fin n → (Fin (2 ^ σ.k) → F)) (ρ : Fin n → F) :
+    commit σ (∑ s, l s • a s) (∑ s, l s * ρ s)
+      = ∑ s, l s • commit σ (a s) (ρ s) := by
+  simp only [commit, commitGen_sum_smul, smul_add, Finset.sum_add_distrib]
+  congr 1
+  rw [Finset.sum_smul]
+  refine Finset.sum_congr rfl fun s _ => ?_
+  rw [mul_smul]
+
+/-- **Inner-product linearity over finite combinations (first slot).** Pushes a
+`•`-combination of witnesses through `innerProduct`. Pure glue for
+`perCommitment_separation`. -/
+private theorem innerProduct_sum_smul {n N : ℕ} (l : Fin n → F)
+    (a : Fin n → (Fin N → F)) (b : Fin N → F) :
+    innerProduct (∑ s, l s • a s) b = ∑ s, l s * innerProduct (a s) b := by
+  simp only [innerProduct, Finset.sum_apply, Pi.smul_apply, smul_eq_mul, Finset.sum_mul,
+    mul_assoc, Finset.mul_sum]
+  rw [Finset.sum_comm]
+
+/-- **Per-commitment separation.** Fix an evalscale `r` and eval vector
+`b := combinedEvalVector (2 ^ σ.k) r x`. If `ξ` is injective and for each `s` there
+is an opening witness `(a s, ρ s)` of the combined relation at polyscale `ξ s`, then
+for every commitment `d` there is a witness `(A, P)` opening `C d` to
+`∑ j, e d j * r ^ j`. -/
+theorem perCommitment_separation (σ : SRS G) {n m : ℕ}
+    (ξ : Fin n → F) (hξ : Function.Injective ξ) (r : F) (x : Fin m → F)
+    (C : Fin n → G) (e : Fin n → Fin m → F)
+    (a : Fin n → (Fin (2 ^ σ.k) → F)) (ρ : Fin n → F)
+    (hcommit : ∀ s, commit σ (a s) (ρ s) = combinedCommitment (ξ s) C)
+    (hvalue : ∀ s, innerProduct (a s) (combinedEvalVector (2 ^ σ.k) r x)
+      = combinedInnerProduct (ξ s) r e)
+    (d : Fin n) : ∃ (A : Fin (2 ^ σ.k) → F) (P : F),
+      commit σ A P = C d
+        ∧ innerProduct A (combinedEvalVector (2 ^ σ.k) r x)
+            = ∑ j, e d j * r ^ (j : ℕ) := by
+  classical
+  obtain ⟨l, hl⟩ := vandermondeN ξ hξ d
+  refine ⟨∑ s, l s • a s, ∑ s, l s * ρ s, ?_, ?_⟩
+  · -- Commitment: Vandermonde combination collapses to C d.
+    rw [commit_sum_smul]
+    simp only [hcommit, combinedCommitment, Finset.smul_sum, smul_smul]
+    rw [Finset.sum_comm]
+    simp only [← Finset.sum_smul, hl]
+    simp only [ite_smul, one_smul, zero_smul, Finset.sum_ite_eq', Finset.mem_univ, if_true]
+  · -- Value: linearity + Vandermonde in ξ.
+    -- Keep the inner `∑ j` opaque (as `f`) so the ξ-distribution mirrors the
+    -- commitment branch exactly.
+    have key : ∀ f : Fin n → F,
+        (∑ s, l s * ∑ i : Fin n, ξ s ^ (i : ℕ) * f i)
+          = ∑ i : Fin n, (∑ s, l s * ξ s ^ (i : ℕ)) * f i := by
+      intro f
+      simp only [Finset.mul_sum, ← mul_assoc, Finset.sum_mul]
+      rw [Finset.sum_comm]
+    rw [innerProduct_sum_smul]
+    simp only [hvalue, combinedInnerProduct]
+    rw [key]
+    simp only [hl, ite_mul, one_mul, zero_mul, Finset.sum_ite_eq', Finset.mem_univ, if_true]
+
+/-! ## Per-point separation and the headline -/
+
+/-- Batch Fiat–Shamir hypothesis: the single new trust assumption, the grid analogue
+of `FiatShamirTree`. Given a grid of proofs, final challenges, and IPA challenge
+vectors, an accepting batched run at each grid point `(s, t)` (polyscale `ξ s`,
+evalscale `r t`) yields a de-blinded accepting tree over the combined eval vector. -/
+def BatchFiatShamir (σ : SRS G) {n m : ℕ} (ξ : Fin n → F) (r : Fin m → F)
+    (C : Fin n → G) (x : Fin m → F) (e : Fin n → Fin m → F)
+    (proofs : Fin n → Fin m → OpeningProof F G σ.k)
+    (c : Fin n → Fin m → F) (u : Fin n → Fin m → (Fin σ.k → F)) : Prop :=
+  ∀ (s : Fin n) (t : Fin m),
+    FiatShamirTreeB σ (combinedCommitment (ξ s) C)
+      (combinedEvalVector (2 ^ σ.k) (r t) x)
+      (combinedInnerProduct (ξ s) (r t) e)
+      (BatchAccepts σ (proofs s t) (ξ s) (r t) (c s t) (u s t) C x e)
+
+/-- **Batched opening soundness.** Let `ξ` and `r` be injective (pairwise-distinct
+polyscales and evalscales). Under the batch Fiat–Shamir hypothesis, the no-DL-relation
+binding hypothesis, and batched acceptance at every grid point, every individual
+claimed evaluation is the true evaluation of the committed polynomial:
+`∃ a ρ, ∀ i, commit σ (a i) (ρ i) = C i ∧ ∀ j, e i j = ⟨a i, evalVector N (x j)⟩`. -/
+theorem batch_soundness (σ : SRS G) {n m : ℕ}
+    (ξ : Fin n → F) (hξ : Function.Injective ξ)
+    (r : Fin m → F) (hr : Function.Injective r) (hm : 0 < m)
+    (C : Fin n → G) (x : Fin m → F) (e : Fin n → Fin m → F)
+    (proofs : Fin n → Fin m → OpeningProof F G σ.k)
+    (c : Fin n → Fin m → F) (u : Fin n → Fin m → (Fin σ.k → F))
+    (hFS : BatchFiatShamir σ ξ r C x e proofs c u)
+    (hbind : ∀ (w : Fin (2 ^ σ.k) → F) (w_h : F),
+      DLRelation σ w w_h → w = 0 ∧ w_h = 0)
+    (hacc : ∀ s t, BatchAccepts σ (proofs s t) (ξ s) (r t) (c s t) (u s t) C x e) :
+    ∃ (a : Fin n → Fin (2 ^ σ.k) → F) (ρ : Fin n → F), ∀ i,
+      commit σ (a i) (ρ i) = C i
+        ∧ ∀ j, e i j = innerProduct (a i) (evalVector (2 ^ σ.k) (x j)) := by
+  classical
+  -- **Step 1 (grid witnesses).** Extract a per-grid opening `(a1 s t, ρ1 s t)`.
+  have h1 : ∀ (s : Fin n) (t : Fin m), ∃ (aw : Fin (2 ^ σ.k) → F) (ρw : F),
+      commit σ aw ρw = combinedCommitment (ξ s) C
+        ∧ combinedInnerProduct (ξ s) (r t) e
+            = innerProduct aw (combinedEvalVector (2 ^ σ.k) (r t) x) := by
+    intro s t
+    exact ipa_soundnessB σ (proofs s t) (combinedCommitment (ξ s) C)
+      (combinedEvalVector (2 ^ σ.k) (r t) x) (combinedB (u s t) (r t) x)
+      (combinedInnerProduct (ξ s) (r t) e) (c s t) (u s t) (hFS s t) (hacc s t)
+  choose a1 ρ1 hcommit1 hvalue1 using h1
+  -- **Step 2 (per commitment).** Vandermonde in `ξ` separates each `C i`.
+  have h2 : ∀ (i : Fin n) (t : Fin m), ∃ (A : Fin (2 ^ σ.k) → F) (P : F),
+      commit σ A P = C i
+        ∧ innerProduct A (combinedEvalVector (2 ^ σ.k) (r t) x)
+            = ∑ j, e i j * (r t) ^ (j : ℕ) := by
+    intro i t
+    exact perCommitment_separation σ ξ hξ (r t) x C e (fun s => a1 s t) (fun s => ρ1 s t)
+      (fun s => hcommit1 s t) (fun s => (hvalue1 s t).symm) i
+  choose A2 P2 hAcommit hAvalue using h2
+  -- Rewrite the combined-eval inner product into per-point evaluations (∗).
+  have hstar : ∀ (i : Fin n) (t : Fin m),
+      (∑ j : Fin m, (r t) ^ (j : ℕ) * innerProduct (A2 i t) (evalVector (2 ^ σ.k) (x j)))
+        = ∑ j, e i j * (r t) ^ (j : ℕ) := by
+    intro i t
+    rw [← innerProduct_combinedEvalVector]
+    exact hAvalue i t
+  -- **Step 3 (binding).** One witness per commitment, at the base evalscale `t₀`.
+  have hbd : CommitmentBinding (F := F) σ := (commitmentBinding_iff_no_relation σ).mpr hbind
+  set t₀ : Fin m := ⟨0, hm⟩ with ht₀
+  have hAeq : ∀ (i : Fin n) (t : Fin m), A2 i t = A2 i t₀ := by
+    intro i t
+    have hcol : commit σ (A2 i t) (P2 i t) = commit σ (A2 i t₀) (P2 i t₀) := by
+      rw [hAcommit i t, hAcommit i t₀]
+    have hpair := @hbd (A2 i t, P2 i t) (A2 i t₀, P2 i t₀) hcol
+    exact congrArg Prod.fst hpair
+  -- **Step 4 (per point).** Vandermonde in `r` pins every evaluation.
+  refine ⟨fun i => A2 i t₀, fun i => P2 i t₀, ?_⟩
+  intro i
+  refine ⟨hAcommit i t₀, ?_⟩
+  intro j0
+  -- The vanishing sums `∀ t, ∑ j, (w i j - e i j) * (r t)^j = 0`.
+  have hvan : ∀ t : Fin m,
+      (∑ j : Fin m,
+        (innerProduct (A2 i t₀) (evalVector (2 ^ σ.k) (x j)) - e i j)
+          * (r t) ^ (j : ℕ)) = 0 := by
+    intro t
+    have h := hstar i t
+    rw [hAeq i t] at h
+    simp only [sub_mul]
+    rw [Finset.sum_sub_distrib, sub_eq_zero, ← h]
+    exact Finset.sum_congr rfl fun j _ => by ring
+  obtain ⟨L, hL⟩ := vandermondeN r hr j0
+  -- Reorder + factor the double sum, treating the coefficient function abstractly.
+  have key3 : ∀ g : Fin m → F,
+      (∑ t, L t * ∑ j : Fin m, g j * (r t) ^ (j : ℕ))
+        = ∑ j : Fin m, g j * ∑ t, L t * (r t) ^ (j : ℕ) := by
+    intro g
+    simp only [Finset.mul_sum]
+    rw [Finset.sum_comm]
+    exact Finset.sum_congr rfl fun j _ => Finset.sum_congr rfl fun t _ => by ring
+  have hzero : (∑ t, L t * ∑ j : Fin m,
+      (innerProduct (A2 i t₀) (evalVector (2 ^ σ.k) (x j)) - e i j)
+        * (r t) ^ (j : ℕ)) = 0 := by
+    apply Finset.sum_eq_zero
+    intro t _
+    rw [hvan t, mul_zero]
+  rw [key3 (fun j => innerProduct (A2 i t₀) (evalVector (2 ^ σ.k) (x j)) - e i j)] at hzero
+  simp only [hL, mul_ite, mul_one, mul_zero, Finset.sum_ite_eq', Finset.mem_univ, if_true] at hzero
+  exact (sub_eq_zero.mp hzero).symm
+
+end Kimchi.Commitment.IPA

--- a/formal/Kimchi/Commitment/IPA/Soundness/Vandermonde.lean
+++ b/formal/Kimchi/Commitment/IPA/Soundness/Vandermonde.lean
@@ -1,0 +1,55 @@
+import Mathlib
+
+/-!
+# The `n`-point Vandermonde dual basis
+
+The algebraic engine of the batched-opening extraction: reading off one coefficient
+of a degree-`< n` polynomial from its values at `n` distinct nodes.
+
+Given `n` pairwise-distinct nodes `ξ : Fin n → F` and a target index `d : Fin n`,
+there is a coefficient vector `l : Fin n → F` such that the functional
+`p ↦ ∑ s, l s * p (ξ s)` reads off the coefficient of `X ^ d`. Concretely,
+`∑ s, l s * (ξ s) ^ i = [i = d]`.
+
+This generalizes the three-node `vandermonde3` (Soundness/Linear.lean) to any
+`n`. The engine is Mathlib's `Matrix.vandermonde` together with
+`Matrix.det_vandermonde` (the determinant is `∏_{s < s'} (ξ s' - ξ s)`, nonzero
+under injectivity, so the Vandermonde matrix is invertible over the field).
+-/
+
+namespace Kimchi.Commitment.IPA
+
+variable {F : Type*} [Field F] [DecidableEq F]
+
+omit [DecidableEq F] in
+/-- **`n`-point Vandermonde dual basis.** For pairwise-distinct nodes
+`ξ : Fin n → F` (injective) and a target index `d`, there exist coefficients
+`l : Fin n → F` with `∑ s, l s * (ξ s) ^ i = [i = d]` for every `i`. Equivalently,
+the functional `p ↦ ∑ s, l s * p (ξ s)` reads off the coefficient of `X ^ d` of any
+polynomial of degree `< n`. Generalizes `vandermonde3`; the engine is
+`Matrix.vandermonde` + `Matrix.det_vandermonde`. -/
+theorem vandermondeN {n : ℕ} (ξ : Fin n → F) (hξ : Function.Injective ξ)
+    (d : Fin n) :
+    ∃ l : Fin n → F,
+      ∀ i : Fin n, ∑ s, l s * (ξ s) ^ (i : ℕ) = if i = d then 1 else 0 := by
+  -- `M` is the transpose of Mathlib's Vandermonde matrix: `M i s = (ξ s) ^ i`.
+  set M : Matrix (Fin n) (Fin n) F := (Matrix.vandermonde ξ).transpose with hM
+  -- `M` is invertible: its determinant equals that of `Matrix.vandermonde ξ`,
+  -- which is nonzero because `ξ` is injective.
+  have hdet : M.det ≠ 0 := by
+    rw [hM, Matrix.det_transpose]
+    exact Matrix.det_vandermonde_ne_zero_iff.mpr hξ
+  have hunit : IsUnit M.det := isUnit_iff_ne_zero.mpr hdet
+  -- Take `l` as the preimage of the `d`-th standard basis vector under `M`.
+  refine ⟨M⁻¹.mulVec (Pi.single d 1), fun i => ?_⟩
+  have hmul : M.mulVec (M⁻¹.mulVec (Pi.single d 1)) = Pi.single d 1 := by
+    rw [Matrix.mulVec_mulVec, Matrix.mul_nonsing_inv M hunit, Matrix.one_mulVec]
+  -- The functional `∑ s, l s * (ξ s) ^ i` is exactly `(M.mulVec l) i`.
+  have hval : ∑ s, M⁻¹.mulVec (Pi.single d 1) s * (ξ s) ^ (i : ℕ)
+      = (M.mulVec (M⁻¹.mulVec (Pi.single d 1))) i := by
+    simp only [Matrix.mulVec, dotProduct, hM, Matrix.transpose_apply,
+      Matrix.vandermonde_apply]
+    exact Finset.sum_congr rfl fun s _ => by ring
+  rw [hval, hmul, Pi.single_apply]
+
+end Kimchi.Commitment.IPA

--- a/formal/Kimchi/Commitment/IPA/Verify.lean
+++ b/formal/Kimchi/Commitment/IPA/Verify.lean
@@ -49,7 +49,23 @@ def recombine (σ : SRS G) (P : G) (v : F) {k : ℕ} (u : Fin k → F)
 
 /-! ## The verifier acceptance equation -/
 
-/-- The verifier accepts, with final Schnorr challenge `c`, iff both hold:
+/-- The verifier acceptance equation with the evaluation slot abstracted to a free
+scalar `b0`. With final Schnorr challenge `c`, accepts iff both hold:
+
+* `c • Q + δ = z1 • sg + (z1 · b0) • σ.U + z2 • σ.h` (Schnorr check, with
+  `Q = recombine σ P v u proof.lr`);
+* `sg = ⟨bPolyCoefficients u, σ.g⟩` (the `sg`-correctness check).
+
+`VerifierAccepts` is the specialization at `b0 = bPoly u x`; the batched verifier
+feeds `b0 = combinedB u r x` (see `IPA/Batch.lean`). -/
+def VerifierAcceptsAt (σ : SRS G) (proof : OpeningProof F G σ.k) (P : G) (b0 v c : F)
+    (u : Fin σ.k → F) : Prop :=
+  (c • recombine σ P v u proof.lr + proof.delta
+      = proof.z1 • proof.sg + (proof.z1 * b0) • σ.U + proof.z2 • σ.h)
+  ∧ (proof.sg = commitGen σ.g (bPolyCoefficients u))
+
+/-- The verifier accepts, with final Schnorr challenge `c`, iff both hold. This is
+`VerifierAcceptsAt` at `b0 = bPoly u x`:
 
 * `c • Q + δ = z1 • sg + (z1 · bPoly(u, x)) • σ.U + z2 • σ.h` (the Schnorr check,
   with `Q = recombine σ P v u proof.lr`);
@@ -57,8 +73,6 @@ def recombine (σ : SRS G) (P : G) (v : F) {k : ℕ} (u : Fin k → F)
   generator is the challenge-coefficient combination of the generators). -/
 def VerifierAccepts (σ : SRS G) (proof : OpeningProof F G σ.k) (P : G) (x v c : F)
     (u : Fin σ.k → F) : Prop :=
-  (c • recombine σ P v u proof.lr + proof.delta
-      = proof.z1 • proof.sg + (proof.z1 * bPoly u x) • σ.U + proof.z2 • σ.h)
-  ∧ (proof.sg = commitGen σ.g (bPolyCoefficients u))
+  VerifierAcceptsAt σ proof P (bPoly u x) v c u
 
 end Kimchi.Commitment.IPA

--- a/formal/roots.txt
+++ b/formal/roots.txt
@@ -67,3 +67,11 @@ Kimchi.Circuit.EndoMul.vesta_endoMul
 Kimchi.Commitment.IPA.ipa_soundness
 Kimchi.Commitment.IPA.commitmentBinding_iff_no_relation
 Kimchi.Commitment.IPA.ipaRelation_unique
+
+-- Kimchi IPA batched opening (multi-polynomial, multi-point — the form the kimchi verifier
+-- actually calls). Under the grid Fiat–Shamir hypothesis and no-DL-relation binding, batched
+-- acceptance at pairwise-distinct (polyscale, evalscale) pairs yields per-commitment openings
+-- with every individual claimed evaluation genuine (`batch_soundness`); the algebraic engine is
+-- the n-point Vandermonde dual basis (`vandermondeN`).
+Kimchi.Commitment.IPA.vandermondeN
+Kimchi.Commitment.IPA.batch_soundness

--- a/formal/scripts/check_axioms.lean
+++ b/formal/scripts/check_axioms.lean
@@ -42,7 +42,9 @@ def roots : List Name :=
     `Kimchi.Circuit.EndoMul.vesta_combo_off_targets,
     `Kimchi.Commitment.IPA.ipa_soundness,
     `Kimchi.Commitment.IPA.commitmentBinding_iff_no_relation,
-    `Kimchi.Commitment.IPA.ipaRelation_unique ]
+    `Kimchi.Commitment.IPA.ipaRelation_unique,
+    `Kimchi.Commitment.IPA.vandermondeN,
+    `Kimchi.Commitment.IPA.batch_soundness ]
 
 /-- The only axioms the roots may depend on: the standard logical axioms; the Pasta Hasse bounds
     (`{pallas,vesta}_hasse`); `Lean.ofReduceBool`; and the Pasta GLV endomorphism inputs (`β`, `λ`,


### PR DESCRIPTION
Extends the IPA polynomial-commitment formalization (#179/#180) one layer up, to the opening the kimchi verifier actually performs: ~20 commitments opened at the two points {ζ, ζω} through ONE combined IPA opening — `polyscale` ξ across polynomials, `evalscale` r across points.

## New modules

- **`Commitment/IPA/Batch.lean`** — the batch definitions, faithful to proof-systems at nc = 1:
  - `combinedCommitment ξ C = Σᵢ ξ^i • Cᵢ` (`combine_commitments`, commitment.rs:714)
  - `combinedInnerProduct ξ r e = Σᵢ ξ^i·(Σⱼ e i j·r^j)` (`combined_inner_product`, commitment.rs:612)
  - `combinedB u r x = Σⱼ r^j·bPoly u (xⱼ)` (the `b0` in ipa.rs `verify`, l.195)
  - `BatchAccepts` — the existing single-opening check instantiated at the combined data; no new verifier equation.
- **`Commitment/IPA/Soundness/Vandermonde.lean`** — `vandermondeN`, the n-point Vandermonde dual basis (generalizes `vandermonde3`), via `Matrix.det_vandermonde`.
- **`Commitment/IPA/Soundness/Batch.lean`** — the extraction: `ipa_soundnessB` (single-opening soundness at an arbitrary eval vector), `perCommitment_separation` (Vandermonde in ξ, binding-free), and the headline `batch_soundness` — under the grid Fiat–Shamir hypothesis (`BatchFiatShamir`, the grid analogue of `FiatShamirTree`) and no-DL-relation binding, batched acceptance at pairwise-distinct (ξ, r) pairs yields per-commitment openings with **every individual claimed evaluation genuine**. The `0 < m` premise is necessary (statement is false for an empty point grid).

## Modified

- **`Verify.lean`** — `VerifierAccepts` factored through `VerifierAcceptsAt` (the `bPoly u x` slot abstracted to a free `b0`); the original statement is its literal specialization.
- `Kimchi.lean`, `scripts/check_axioms.lean`, `roots.txt` — wire the new modules into the default target and the axiom gate (34 → 36 roots).

## Trust surface

Unchanged in kind: one new FS-style `def` hypothesis (`BatchFiatShamir`) plus the DL/binding hypothesis already formulated in `Soundness/Binding.lean`. Axiom closure of `batch_soundness` and `vandermondeN`: `[propext, Classical.choice, Quot.sound]`. No new axioms, no `native_decide`, no `sorry`.

Scope exclusions (documented in the module headers): chunking (nc = 1 throughout) and the `rand_base`/`sg_rand_base` cross-proof MSM batching in ipa.rs `verify` (an implementation optimization, not part of the per-proof relation).

Full `lake build` green (11440 jobs), `check-style.sh` clean, `check_axioms` gate: all 36 roots reduce to the allowed axiom set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)