### PR TITLE
formal: kimchi quotient/vanishing argument — domain + double generic gate

### DIFF
--- a/formal/Kimchi.lean
+++ b/formal/Kimchi.lean
@@ -14,3 +14,4 @@ import Kimchi.Circuit.EndoScalar
 import Kimchi.Circuit.EndoMul
 import Kimchi.Commitment.IPA.Soundness
 import Kimchi.Commitment.IPA.Soundness.Batch
+import Kimchi.Quotient.Generic

--- a/formal/Kimchi/Quotient/Domain.lean
+++ b/formal/Kimchi/Quotient/Domain.lean
@@ -1,0 +1,106 @@
+import Mathlib
+
+/-!
+# Evaluation domain and vanishing–divisibility
+
+This file is the **polynomial-algebra substrate** of kimchi's quotient/vanishing argument.
+It is **commitment-free**: everything lives over an abstract field `[Field F]`, with a
+primitive `n`-th root of unity supplied as a hypothesis (`ω : F`,
+`hω : IsPrimitiveRoot ω n`, together with `0 < n`). There is no group, no SRS, no
+Fiat–Shamir. The Pasta instantiation (constructing `ω` for a concrete field) is out of scope.
+
+The evaluation domain is the finite set
+`H = {ω^0, ω^1, …, ω^(n-1)} ⊆ F`, kimchi's domain `d1` of size `n`. Only `d1` is modelled;
+the FFT working domains `d4`/`d8` are prover-side and out of scope.
+
+Source: kimchi `domains.rs` (`EvaluationDomains::d1`, the size-`n` radix-2 domain).
+
+## Contents
+
+* `zH` — the vanishing polynomial `X^n - 1`.
+* `zH_eq_prod` — its cyclotomic factorization `∏_{i<n} (X - ω^i)`.
+* `zH_dvd_iff` — `Z_H ∣ E ↔ E` vanishes on the whole domain.
+* `columnPoly` — the degree-`<n` Lagrange interpolant of a column `v : Fin n → F`.
+* `eval_columnPoly` — the interpolant reproduces its column on `H`.
+* `eq_of_eval_eq_on_domain` — uniqueness of degree-`<n` interpolants.
+-/
+
+namespace Kimchi.Quotient
+
+open Polynomial
+
+variable {F : Type*} [Field F] {n : ℕ} {ω : F}
+
+/-! ## The vanishing polynomial -/
+
+/-- The vanishing polynomial of the size-`n` domain: `Z_H = X^n - 1 ∈ F[X]`. -/
+noncomputable def zH (F : Type*) [Field F] (n : ℕ) : Polynomial F := X ^ n - 1
+
+/-- **Factorization of `Z_H`.** For a primitive `n`-th root of unity `ω` with `0 < n`,
+`Z_H = ∏_{i<n} (X - ω^i)`. -/
+theorem zH_eq_prod (hω : IsPrimitiveRoot ω n) (hn : 0 < n) :
+    zH F n = ∏ i ∈ Finset.range n, (X - C (ω ^ i)) := by
+  unfold zH
+  rw [← C_1, X_pow_sub_C_eq_prod hω hn (one_pow n)]
+  simp only [mul_one]
+
+/-! ## Vanishing ⟺ divisibility -/
+
+/-- **`Z_H` divides `E` iff `E` vanishes on the domain.** Under a primitive-root hypothesis
+and `0 < n`, `Z_H ∣ E ↔ ∀ i < n, E(ω^i) = 0`. -/
+theorem zH_dvd_iff (hω : IsPrimitiveRoot ω n) (hn : 0 < n) (E : Polynomial F) :
+    zH F n ∣ E ↔ ∀ i < n, E.eval (ω ^ i) = 0 := by
+  constructor
+  · rintro ⟨q, rfl⟩ i hi
+    simp only [zH, eval_mul, eval_sub, eval_pow, eval_X, eval_one]
+    have hpow : (ω ^ i) ^ n = 1 := by
+      rw [← pow_mul, mul_comm, pow_mul, hω.pow_eq_one, one_pow]
+    rw [hpow]
+    ring
+  · intro h
+    rw [zH_eq_prod hω hn]
+    apply Finset.prod_dvd_of_coprime
+    · intro i hi j hj hij
+      simp only [Function.onFun]
+      apply Polynomial.isCoprime_X_sub_C_of_isUnit_sub
+      rw [isUnit_iff_ne_zero, sub_ne_zero]
+      intro heq
+      exact hij (hω.injOn_pow hi hj heq)
+    · intro i hi
+      rw [Polynomial.dvd_iff_isRoot]
+      exact h i (Finset.mem_range.mp hi)
+
+/-! ## Column interpolants -/
+
+/-- The interpolant of a column `v : Fin n → F` through the domain nodes `i ↦ ω^i`:
+`columnPoly v = Lagrange.interpolate univ (fun i => ω^i) v ∈ F[X]`. -/
+noncomputable def columnPoly (ω : F) (v : Fin n → F) : Polynomial F :=
+  Lagrange.interpolate Finset.univ (fun i : Fin n => ω ^ (i : ℕ)) v
+
+/-- **The column polynomial reproduces its column on the domain.** For a primitive-root `ω`
+and every `v : Fin n → F`, `(columnPoly v)(ω^i) = v i`. -/
+theorem eval_columnPoly (hω : IsPrimitiveRoot ω n) (v : Fin n → F) (i : Fin n) :
+    (columnPoly ω v).eval (ω ^ (i : ℕ)) = v i := by
+  have hinj : Set.InjOn (fun j : Fin n => ω ^ (j : ℕ)) ↑(Finset.univ : Finset (Fin n)) := by
+    intro a _ b _ heq
+    apply Fin.val_injective
+    exact hω.injOn_pow (Finset.mem_range.mpr a.isLt) (Finset.mem_range.mpr b.isLt) heq
+  exact Lagrange.eval_interpolate_at_node v hinj (Finset.mem_univ i)
+
+/-- **Uniqueness of degree-`<n` interpolants.** Two polynomials of degree `< n` that agree on
+the whole domain are equal. -/
+theorem eq_of_eval_eq_on_domain (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
+    {p q : Polynomial F} (hp : p.degree < n) (hq : q.degree < n)
+    (h : ∀ i < n, p.eval (ω ^ i) = q.eval (ω ^ i)) : p = q := by
+  rw [← sub_eq_zero]
+  apply Polynomial.eq_zero_of_dvd_of_degree_lt (p := zH F n)
+  · rw [zH_dvd_iff hω hn]
+    intro i hi
+    rw [eval_sub, sub_eq_zero]
+    exact h i hi
+  · have hdeg : (zH F n).degree = n := by
+      rw [zH, ← C_1, degree_X_pow_sub_C hn]
+    rw [hdeg]
+    exact lt_of_le_of_lt (degree_sub_le p q) (max_lt hp hq)
+
+end Kimchi.Quotient

--- a/formal/Kimchi/Quotient/Generic.lean
+++ b/formal/Kimchi/Quotient/Generic.lean
@@ -1,0 +1,127 @@
+import Kimchi.Quotient.Domain
+
+/-!
+# The double generic gate and the divisibility checkpoint
+
+Field-valued model of kimchi's **double** generic gate (`generic.rs`,
+`CONSTRAINTS = 2`) and the first end-to-end "gate holds on every row iff the
+constraint polynomials are divisible by `Z_H`" thread. Commitment-free, built
+directly on `Kimchi.Quotient.Domain`.
+
+The existing `Kimchi/Gate/Generic.lean` is a single-op runnable demo over
+`Array Int`; this is a fresh field-valued model living over an abstract field
+`[Field F]` with a primitive `n`-th root of unity `ω`.
+
+## Column layout (from `generic.rs`)
+
+A generic row carries 15 witness cells `w : Fin 15 → F` and 15 coefficient cells
+`q : Fin 15 → F`. The row packs **two** generic gates: the first uses registers
+`w 0, w 1, w 2` with coefficients `q 0 … q 4`; the second uses `w 3, w 4, w 5`
+with coefficients `q 5 … q 9` (`q 10 … q 14` are unused here).
+
+Source: kimchi `generic.rs` (module doc + `constraint_checks`, l.245–250):
+
+    * w0·c0 + w1·c1 + w2·c2 + w0·w1·c3 + c4
+    * w3·c5 + w4·c6 + w5·c7 + w3·w4·c8 + c9
+
+where the `cᵢ` are the coefficients (`q` here).
+-/
+
+namespace Kimchi.Quotient
+
+open Polynomial
+
+variable {F : Type*} [Field F] {n : ℕ} {ω : F}
+
+/-! ## One row: the two constraints -/
+
+/-- The **double generic gate** holds at a row given coefficient cells `q` and
+witness cells `w`: the conjunction of the two generic constraints. Mirrors
+`generic.rs` l.245–250 verbatim (the `qᵢ` here are the `cᵢ` / `coeffs` there). -/
+def GenericHolds (q w : Fin 15 → F) : Prop :=
+  q 0 * w 0 + q 1 * w 1 + q 2 * w 2 + q 3 * (w 0 * w 1) + q 4 = 0 ∧
+  q 5 * w 3 + q 6 * w 4 + q 7 * w 5 + q 8 * (w 3 * w 4) + q 9 = 0
+
+/-! ## The constraint polynomials of a circuit
+
+Given witness/coefficient column polynomials `W, Q : Fin 15 → F[X]`, the gate's
+two constraints lift verbatim to the polynomial ring: replace each cell by its
+column polynomial. -/
+
+/-- The first constraint polynomial
+`E₁ = Q₀·W₀ + Q₁·W₁ + Q₂·W₂ + Q₃·(W₀·W₁) + Q₄`. -/
+noncomputable def genericE1 (Q W : Fin 15 → Polynomial F) : Polynomial F :=
+  Q 0 * W 0 + Q 1 * W 1 + Q 2 * W 2 + Q 3 * (W 0 * W 1) + Q 4
+
+/-- The second constraint polynomial
+`E₂ = Q₅·W₃ + Q₆·W₄ + Q₇·W₅ + Q₈·(W₃·W₄) + Q₉`. -/
+noncomputable def genericE2 (Q W : Fin 15 → Polynomial F) : Polynomial F :=
+  Q 5 * W 3 + Q 6 * W 4 + Q 7 * W 5 + Q 8 * (W 3 * W 4) + Q 9
+
+/-- **Per-row bridge, first constraint.** For a circuit table `wTab, qTab` with
+column polynomials `W c = columnPoly (fun i => wTab i c)` and
+`Q c = columnPoly (fun i => qTab i c)`, evaluating `E₁` at the node `ω^i`
+recovers the left-hand side of the first constraint at row `i`.
+
+Evaluation at `ω^i` is a ring homomorphism, so it distributes over the sums and
+products of `genericE1`; then `eval_columnPoly` reduces each `W c` / `Q c` to
+the corresponding cell value. -/
+theorem eval_genericE1 (hω : IsPrimitiveRoot ω n)
+    (wTab qTab : Fin n → Fin 15 → F) (i : Fin n) :
+    (genericE1 (fun c => columnPoly ω (fun j => qTab j c))
+        (fun c => columnPoly ω (fun j => wTab j c))).eval (ω ^ (i : ℕ))
+      = qTab i 0 * wTab i 0 + qTab i 1 * wTab i 1 + qTab i 2 * wTab i 2
+        + qTab i 3 * (wTab i 0 * wTab i 1) + qTab i 4 := by
+  simp only [genericE1, eval_add, eval_mul, eval_columnPoly hω]
+
+/-- **Per-row bridge, second constraint.** Identical to `eval_genericE1`, using
+columns `3, 4, 5` and coefficients `5 … 9`. -/
+theorem eval_genericE2 (hω : IsPrimitiveRoot ω n)
+    (wTab qTab : Fin n → Fin 15 → F) (i : Fin n) :
+    (genericE2 (fun c => columnPoly ω (fun j => qTab j c))
+        (fun c => columnPoly ω (fun j => wTab j c))).eval (ω ^ (i : ℕ))
+      = qTab i 5 * wTab i 3 + qTab i 6 * wTab i 4 + qTab i 7 * wTab i 5
+        + qTab i 8 * (wTab i 3 * wTab i 4) + qTab i 9 := by
+  simp only [genericE2, eval_add, eval_mul, eval_columnPoly hω]
+
+/-! ## The divisibility checkpoint
+
+The first end-to-end gate-to-divisibility theorem: the gate holds on every row
+of the table iff both constraint polynomials vanish on `H`, i.e. are divisible
+by `Z_H`. Mirrors kimchi's prover-side check (`generic.rs` `verify_generic`,
+l.364–368): the combined generic polynomial is accepted iff
+`res.divide_by_vanishing_poly(d1)` has zero remainder. -/
+
+/-- **Generic rows hold iff constraint polynomials are divisible.** Fix a
+primitive `n`-th root `ω` (`0 < n`) and a circuit table `wTab, qTab` with column
+polynomials `W c = columnPoly (fun i => wTab i c)`,
+`Q c = columnPoly (fun i => qTab i c)`. Then both constraint polynomials are
+divisible by `Z_H` iff the double generic gate holds at every row.
+
+By `zH_dvd_iff`, `Z_H ∣ E ↔ ∀ i < n, E(ω^i) = 0`; by `eval_genericE1/2`,
+`E₁(ω^i) = 0` (resp. `E₂`) is exactly the first (resp. second) constraint at
+row `i`. Commuting `∧` past `∀` merges the two per-constraint statements into
+`GenericHolds`. Pure polynomial algebra — no probabilistic content here. -/
+theorem genericRows_iff_dvd (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
+    (wTab qTab : Fin n → Fin 15 → F) :
+    (zH F n ∣
+        genericE1 (fun c => columnPoly ω (fun i => qTab i c))
+          (fun c => columnPoly ω (fun i => wTab i c)) ∧
+      zH F n ∣
+        genericE2 (fun c => columnPoly ω (fun i => qTab i c))
+          (fun c => columnPoly ω (fun i => wTab i c))) ↔
+      ∀ i, GenericHolds (qTab i) (wTab i) := by
+  rw [zH_dvd_iff hω hn, zH_dvd_iff hω hn]
+  constructor
+  · rintro ⟨h1, h2⟩ i
+    refine ⟨?_, ?_⟩
+    · have := h1 i i.isLt; rwa [eval_genericE1 hω] at this
+    · have := h2 i i.isLt; rwa [eval_genericE2 hω] at this
+  · intro h
+    refine ⟨fun i hi => ?_, fun i hi => ?_⟩
+    · have := (h ⟨i, hi⟩).1
+      rw [← eval_genericE1 hω wTab qTab ⟨i, hi⟩] at this; exact this
+    · have := (h ⟨i, hi⟩).2
+      rw [← eval_genericE2 hω wTab qTab ⟨i, hi⟩] at this; exact this
+
+end Kimchi.Quotient

--- a/formal/roots.txt
+++ b/formal/roots.txt
@@ -75,3 +75,10 @@ Kimchi.Commitment.IPA.ipaRelation_unique
 -- the n-point Vandermonde dual basis (`vandermondeN`).
 Kimchi.Commitment.IPA.vandermondeN
 Kimchi.Commitment.IPA.batch_soundness
+
+-- Kimchi quotient/vanishing argument (implementation checkpoint). Over the size-n evaluation
+-- domain, a constraint polynomial is divisible by Z_H = X^n - 1 iff it vanishes on every row
+-- (`zH_dvd_iff`); instantiated at the double generic gate: both constraint polynomials divisible
+-- iff the gate's two constraints hold at every row of the table (`genericRows_iff_dvd`).
+Kimchi.Quotient.zH_dvd_iff
+Kimchi.Quotient.genericRows_iff_dvd

--- a/formal/scripts/check_axioms.lean
+++ b/formal/scripts/check_axioms.lean
@@ -44,7 +44,9 @@ def roots : List Name :=
     `Kimchi.Commitment.IPA.commitmentBinding_iff_no_relation,
     `Kimchi.Commitment.IPA.ipaRelation_unique,
     `Kimchi.Commitment.IPA.vandermondeN,
-    `Kimchi.Commitment.IPA.batch_soundness ]
+    `Kimchi.Commitment.IPA.batch_soundness,
+    `Kimchi.Quotient.zH_dvd_iff,
+    `Kimchi.Quotient.genericRows_iff_dvd ]
 
 /-- The only axioms the roots may depend on: the standard logical axioms; the Pasta Hasse bounds
     (`{pallas,vesta}_hasse`); `Lean.ofReduceBool`; and the Pasta GLV endomorphism inputs (`β`, `λ`,


### PR DESCRIPTION
Opens the polynomial (PLONK) layer of the kimchi formalization: the quotient/vanishing argument, which is what will ultimately connect the gate `Holds` theorems to the polynomial protocol. Stacked on #181 (shares the `Kimchi.lean`/`check_axioms`/`roots.txt` wiring).

New subtree `Kimchi/Quotient/`, **commitment-free** — no group, no SRS, no Fiat–Shamir, not even an FS-style hypothesis. Everything is polynomial algebra over `[Field F]` with `(ω : F) (hω : IsPrimitiveRoot ω n)`.

## `Quotient/Domain.lean`
- `zH = X^n − 1` and its factorization `∏_{i<n} (X − ω^i)`
- **`zH_dvd_iff`** — `Z_H ∣ E ↔ ∀ i < n, E(ω^i) = 0` (vanishing ⟺ divisibility)
- `columnPoly` — degree-<n Lagrange interpolant of a witness/coefficient column, with node evaluation and uniqueness

Models kimchi's `d1` domain (`domains.rs`); `d4`/`d8` are prover-side FFT working domains, out of scope.

## `Quotient/Generic.lean`
- `GenericHolds` — kimchi's **double** generic gate, faithful to `generic.rs` l.245–250: two constraints per row, registers `w₀‥w₂`/`w₃‥w₅`, coefficients `c₀‥c₄`/`c₅‥c₉`
- `genericE1`/`genericE2` — the constraint polynomials over column interpolants, plus the per-row evaluation bridges
- **`genericRows_iff_dvd`** — the checkpoint: both constraint polynomials divisible by `Z_H` ⟺ the double generic constraints hold at **every row** of the table (mirrors `verify_generic`'s `divide_by_vanishing_poly` check, l.364–368)

## Trust surface
None added — this layer has no probabilistic or cryptographic content. Axiom closure of both roots: `[propext, Classical.choice, Quot.sound]`. check_axioms roots 36 → 38.

## Deferred (documented in the module headers)
α-aggregation and its Vandermonde separation, random-ζ evaluation soundness (degree bookkeeping), the two-row custom gates (`E(W(X), W(ωX))`), selectors, permutation, linearization/`ft`.

Full `lake build` green (11442 jobs), `check-style.sh` clean (31 files), axiom gate: all 38 roots reduce to the allowed set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)