### PR TITLE
formal: define the double generic gate in Gate/Generic.lean; Quotient consumes it

### DIFF
--- a/formal/Kimchi/Gate/Generic.lean
+++ b/formal/Kimchi/Gate/Generic.lean
@@ -69,6 +69,45 @@ theorem satisfies_iff [DecidableEq F] (gs : List (Generic F)) (a : Assignment F)
     satisfies gs a = true ↔ Satisfies gs a := by
   simp [satisfies, Satisfies, List.all_eq_true, Generic.ok_iff]
 
+/-! ## The double generic gate row
+
+kimchi's generic gate row (`generic.rs`) packs **two** generic gates: the first on registers
+`w 0, w 1, w 2` with coefficients `q 0 … q 4`, the second on `w 3, w 4, w 5` with `q 5 … q 9`
+(coefficient order per gate: `l, r, o, m, c`). A row is 15 witness cells `w : Fin 15 → F` and
+15 coefficient cells `q : Fin 15 → F` (`q 10 … q 14` unused). The two halves are literal
+`Generic` gates over the row's first six cells viewed as an `Assignment`. -/
+
+/-- The first generic gate of a double generic row: coefficients `q 0 … q 4`, registers at
+assignment slots `0, 1, 2` (row cells `w 0, w 1, w 2`). -/
+def DoubleGeneric.fst (q : Fin 15 → F) : Generic F :=
+  { cl := q 0, vl := some 0, cr := q 1, vr := some 1, co := q 2, vo := some 2
+  , m := q 3, c := q 4 }
+
+/-- The second generic gate of a double generic row: coefficients `q 5 … q 9`, registers at
+assignment slots `3, 4, 5` (row cells `w 3, w 4, w 5`). -/
+def DoubleGeneric.snd (q : Fin 15 → F) : Generic F :=
+  { cl := q 5, vl := some 3, cr := q 6, vr := some 4, co := q 7, vo := some 5
+  , m := q 8, c := q 9 }
+
+/-- The row's first six witness cells as an `Assignment` (the registers both halves read). -/
+def DoubleGeneric.registers (w : Fin 15 → F) : Assignment F :=
+  #[w 0, w 1, w 2, w 3, w 4, w 5]
+
+/-- **The double generic gate holds at a row**: both packed `Generic` gates hold on the row's
+registers. This is the row-level predicate the polynomial layer (`Kimchi/Quotient`) lifts. -/
+def DoubleGeneric.Holds (q w : Fin 15 → F) : Prop :=
+  (DoubleGeneric.fst q).holds (DoubleGeneric.registers w)
+    ∧ (DoubleGeneric.snd q).holds (DoubleGeneric.registers w)
+
+/-- `DoubleGeneric.Holds` unfolded to the two raw cell equations of `generic.rs` (l.245–250):
+`q₀w₀ + q₁w₁ + q₂w₂ + q₃(w₀w₁) + q₄ = 0` and `q₅w₃ + q₆w₄ + q₇w₅ + q₈(w₃w₄) + q₉ = 0`. -/
+theorem DoubleGeneric.holds_iff (q w : Fin 15 → F) :
+    DoubleGeneric.Holds q w
+      ↔ (q 0 * w 0 + q 1 * w 1 + q 2 * w 2 + q 3 * (w 0 * w 1) + q 4 = 0
+          ∧ q 5 * w 3 + q 6 * w 4 + q 7 * w 5 + q 8 * (w 3 * w 4) + q 9 = 0) := by
+  simp [DoubleGeneric.Holds, DoubleGeneric.fst, DoubleGeneric.snd, DoubleGeneric.registers,
+    Generic.holds, slot, Assignment.get]
+
 /-- Example: `w0 * w1 = w2`, as `1·w2 + (-1)·(w0·w1) = 0`, over the field `ZMod 17`. -/
 instance : Fact (Nat.Prime 17) := ⟨by norm_num⟩
 

--- a/formal/Kimchi/Quotient/Generic.lean
+++ b/formal/Kimchi/Quotient/Generic.lean
@@ -1,16 +1,18 @@
 import Kimchi.Quotient.Domain
+import Kimchi.Gate.Generic
 
 /-!
-# The double generic gate and the divisibility checkpoint
+# The double generic gate's constraint polynomials and the divisibility checkpoint
 
-Field-valued model of kimchi's **double** generic gate (`generic.rs`,
+The polynomial lift of kimchi's **double** generic gate (`generic.rs`,
 `CONSTRAINTS = 2`) and the first end-to-end "gate holds on every row iff the
 constraint polynomials are divisible by `Z_H`" thread. Commitment-free, built
 directly on `Kimchi.Quotient.Domain`.
 
-The existing `Kimchi/Gate/Generic.lean` is a single-op runnable demo over
-`Array Int`; this is a fresh field-valued model living over an abstract field
-`[Field F]` with a primitive `n`-th root of unity `ω`.
+The row-level gate predicate is `Kimchi.Gate.DoubleGeneric.Holds` (defined in
+`Kimchi/Gate/Generic.lean` as two `Generic` gates packed in one row); this file
+owns only the *polynomial* side — the constraint polynomials over column
+interpolants and the divisibility bridge.
 
 ## Column layout (from `generic.rs`)
 
@@ -32,15 +34,6 @@ namespace Kimchi.Quotient
 open Polynomial
 
 variable {F : Type*} [Field F] {n : ℕ} {ω : F}
-
-/-! ## One row: the two constraints -/
-
-/-- The **double generic gate** holds at a row given coefficient cells `q` and
-witness cells `w`: the conjunction of the two generic constraints. Mirrors
-`generic.rs` l.245–250 verbatim (the `qᵢ` here are the `cᵢ` / `coeffs` there). -/
-def GenericHolds (q w : Fin 15 → F) : Prop :=
-  q 0 * w 0 + q 1 * w 1 + q 2 * w 2 + q 3 * (w 0 * w 1) + q 4 = 0 ∧
-  q 5 * w 3 + q 6 * w 4 + q 7 * w 5 + q 8 * (w 3 * w 4) + q 9 = 0
 
 /-! ## The constraint polynomials of a circuit
 
@@ -99,9 +92,10 @@ polynomials `W c = columnPoly (fun i => wTab i c)`,
 divisible by `Z_H` iff the double generic gate holds at every row.
 
 By `zH_dvd_iff`, `Z_H ∣ E ↔ ∀ i < n, E(ω^i) = 0`; by `eval_genericE1/2`,
-`E₁(ω^i) = 0` (resp. `E₂`) is exactly the first (resp. second) constraint at
-row `i`. Commuting `∧` past `∀` merges the two per-constraint statements into
-`GenericHolds`. Pure polynomial algebra — no probabilistic content here. -/
+`E₁(ω^i) = 0` (resp. `E₂`) is exactly the first (resp. second) constraint of
+`Gate.DoubleGeneric.holds_iff` at row `i`. Commuting `∧` past `∀` merges the
+two per-constraint statements. Pure polynomial algebra — no probabilistic
+content here. -/
 theorem genericRows_iff_dvd (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
     (wTab qTab : Fin n → Fin 15 → F) :
     (zH F n ∣
@@ -110,7 +104,8 @@ theorem genericRows_iff_dvd (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
       zH F n ∣
         genericE2 (fun c => columnPoly ω (fun i => qTab i c))
           (fun c => columnPoly ω (fun i => wTab i c))) ↔
-      ∀ i, GenericHolds (qTab i) (wTab i) := by
+      ∀ i, Gate.DoubleGeneric.Holds (qTab i) (wTab i) := by
+  simp only [Gate.DoubleGeneric.holds_iff]
   rw [zH_dvd_iff hω hn, zH_dvd_iff hω hn]
   constructor
   · rintro ⟨h1, h2⟩ i


### PR DESCRIPTION
Follow-up to #182, fixing a layering mistake: `Quotient/Generic.lean` defined its own row predicate (`GenericHolds`) instead of working out of the `Kimchi/Gate` modules. Gate semantics belong in `Gate/`; higher layers lift them.

- **`Gate/Generic.lean`** gains the double generic row, defined as **literally two existing `Generic` gates** packed on one row (`DoubleGeneric.fst/snd` from the coefficient cells, `registers` as the row's first six cells, `Holds` as the conjunction of the two `Generic.holds`), plus `holds_iff` unfolding to the raw `generic.rs` l.245–250 cell equations.
- **`Quotient/Generic.lean`**: quotient-local `GenericHolds` deleted; `genericRows_iff_dvd` restated against `Gate.DoubleGeneric.Holds`. The file now owns only the polynomial side (constraint polynomials over column interpolants + the divisibility bridge).

No statement content changes beyond the predicate's home; roots unchanged (38), axiom closure unchanged (`genericRows_iff_dvd` still `[propext, Classical.choice, Quot.sound]`). Full build green (11442 jobs), style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)