### PR TITLE
formal: quotient gate lifts through a single Argument primitive

### DIFF
--- a/formal/Kimchi/Gate/Generic.lean
+++ b/formal/Kimchi/Gate/Generic.lean
@@ -27,18 +27,45 @@ structure Generic (F : Type*) where
   /-- The 15 witness cells. -/
   w : Fin 15 → F
 
-/-- Relational spec — both packed constraints hold (a `Prop`). -/
-def Generic.Holds (g : Generic F) : Prop :=
-  g.q 0 * g.w 0 + g.q 1 * g.w 1 + g.q 2 * g.w 2 + g.q 3 * (g.w 0 * g.w 1) + g.q 4 = 0
-    ∧ g.q 5 * g.w 3 + g.q 6 * g.w 4 + g.q 7 * g.w 5 + g.q 8 * (g.w 3 * g.w 4) + g.q 9 = 0
+/-- Relabel both cell families through `f` — the functorial action of `Generic`. Instantiating
+    at a ring homomorphism moves a row between rings, in particular between
+    `Generic (Polynomial F)` (the quotient layer's column polynomials) and `Generic F` (their
+    values at a domain node). -/
+def Generic.map {R S : Type*} (f : R → S) (g : Generic R) : Generic S :=
+  ⟨f ∘ g.q, f ∘ g.w⟩
 
-/-- Executable checker — both constraints as a `Bool`. -/
+/-- The two constraint expressions, as ring elements — the single transcription; the relational
+    spec (`Holds`), the checker (`ok`), and the quotient layer's constraint polynomials are all
+    read from it. -/
+def Generic.constraints {R : Type*} [CommRing R] (g : Generic R) : List R :=
+  [ g.q 0 * g.w 0 + g.q 1 * g.w 1 + g.q 2 * g.w 2 + g.q 3 * (g.w 0 * g.w 1) + g.q 4
+  , g.q 5 * g.w 3 + g.q 6 * g.w 4 + g.q 7 * g.w 5 + g.q 8 * (g.w 3 * g.w 4) + g.q 9 ]
+
+/-- Relational spec — both constraint expressions vanish (a `Prop`). -/
+def Generic.Holds (g : Generic F) : Prop :=
+  ∀ e ∈ g.constraints, e = 0
+
+/-- `Holds` as the two readable cell equations. -/
+theorem Generic.holds_iff (g : Generic F) :
+    g.Holds ↔
+      (g.q 0 * g.w 0 + g.q 1 * g.w 1 + g.q 2 * g.w 2 + g.q 3 * (g.w 0 * g.w 1) + g.q 4 = 0
+        ∧ g.q 5 * g.w 3 + g.q 6 * g.w 4 + g.q 7 * g.w 5 + g.q 8 * (g.w 3 * g.w 4) + g.q 9 = 0) := by
+  simp only [Generic.Holds, Generic.constraints, List.forall_mem_cons, List.not_mem_nil,
+    false_implies, implies_true, and_true]
+
+/-- Executable checker — every constraint expression evaluates to zero. -/
 def Generic.ok [DecidableEq F] (g : Generic F) : Bool :=
-  (g.q 0 * g.w 0 + g.q 1 * g.w 1 + g.q 2 * g.w 2 + g.q 3 * (g.w 0 * g.w 1) + g.q 4 == 0)
-    && (g.q 5 * g.w 3 + g.q 6 * g.w 4 + g.q 7 * g.w 5 + g.q 8 * (g.w 3 * g.w 4) + g.q 9 == 0)
+  g.constraints.all (· == 0)
 
 theorem Generic.ok_iff [DecidableEq F] (g : Generic F) : g.ok = true ↔ g.Holds := by
-  simp [Generic.ok, Generic.Holds]
+  simp only [Generic.ok, Generic.Holds, List.all_eq_true, beq_iff_eq]
+
+/-- Naturality: the constraint expressions commute with ring homomorphisms applied cellwise
+    via `Generic.map`. At `f = eval (ω^i) : F[X] →+* F` this turns the quotient layer's
+    constraint polynomials' values at a domain node into the gate constraints of that row. -/
+theorem Generic.constraints_map {R S : Type*} [CommRing R] [CommRing S] (f : R →+* S)
+    (g : Generic R) : g.constraints.map f = (g.map f).constraints := by
+  simp [Generic.constraints, Generic.map]
 
 /-- **Soundness:** a row accepted by the executable checker satisfies both constraints.
     (The gate is a decidable predicate, so soundness is one direction of `ok_iff`; the

--- a/formal/Kimchi/Quotient/AddComplete.lean
+++ b/formal/Kimchi/Quotient/AddComplete.lean
@@ -17,10 +17,9 @@ naturality of `constraints` under evaluation at the domain nodes.
 * `cellMap` — assemble a `Gate.AddComplete.Witness R` from a row `cur : Fin 15 → R`.
 * `rowWitness` / `polyWitness` — the row-values and column-interpolant witnesses, both via
   the same `cellMap`.
-* `bridge` — evaluating the gate's constraint polynomials at `ω^i` reproduces the gate's
-  constraints at row `i` (pure naturality).
+* `argument` — the CompleteAdd `Argument F` instance (single-row layout).
 * `rows_iff_dvd` / `rowsSel_iff_dvd` — the two divisibility corollaries, immediate instances
-  of the engine theorems.
+  of the `Argument` engine theorems.
 
 Source of truth: `blueprint/src/chapters/Kimchi_Quotient_AddComplete.tex`.
 -/
@@ -68,45 +67,34 @@ noncomputable def polyWitness (ω : F) (wTab : Fin n → Fin 15 → F) :
     Gate.AddComplete.Witness (Polynomial F) :=
   cellMap (fun c => columnPoly ω (fun j => wTab j c))
 
-/-! ## The naturality bridge -/
+/-! ## The `Argument` instance -/
 
-/-- **CompleteAdd per-row bridge.** Evaluating the gate's constraint polynomials at the node
-`ω^i` reproduces the gate's constraints at row `i` — pure naturality of `constraints` under
-`evalRingHom (ω^i)`, discharged via `constraints_map` and `eval_columnPoly`. -/
-theorem bridge (hω : IsPrimitiveRoot ω n) (wTab : Fin n → Fin 15 → F) (i : Fin n) :
-    (Gate.AddComplete.constraints (polyWitness ω wTab)).map (·.eval (ω ^ (i : ℕ)))
-      = Gate.AddComplete.constraints (rowWitness wTab i) := by
-  -- Evaluation at `ω^i` is the ring hom `evalRingHom (ω^i)`; rewrite the plain map by it.
-  have hfun : (fun E : Polynomial F => E.eval (ω ^ (i : ℕ)))
-      = ⇑(evalRingHom (ω ^ (i : ℕ))) := by
-    funext E; rw [Polynomial.coe_evalRingHom]
-  rw [hfun, Gate.AddComplete.constraints_map]
-  -- Now identify the mapped poly-witness with the row witness, cell by cell.
-  congr 1
-  simp only [polyWitness, rowWitness, cellMap, Gate.AddComplete.Witness.map,
-    Polynomial.coe_evalRingHom, eval_columnPoly hω]
+/-- **CompleteAdd `Argument` instance.** The gate's constraints read through the single-row
+cell map (`cellMap env.witnessCurr`; the next-row and coefficient families are unused);
+naturality is the gate's `Gate.AddComplete.constraints_map` at the underlying ring hom. -/
+def argument : Argument F where
+  constraints env := Gate.AddComplete.constraints (cellMap env.witnessCurr)
+  constraints_map f env := Gate.AddComplete.constraints_map f.toRingHom (cellMap env.witnessCurr)
 
 /-! ## Divisibility corollaries -/
 
-/-- **CompleteAdd rows hold iff divisible.** Instance of the ungated engine
-`rows_iff_dvd_of` at the CompleteAdd bridge. -/
-theorem rows_iff_dvd (hω : IsPrimitiveRoot ω n) (hn : 0 < n) (wTab : Fin n → Fin 15 → F) :
+/-- **CompleteAdd rows hold iff divisible.** Immediate specialization of
+`Argument.rows_iff_dvd` at the instance `argument`; single-row, so `qTab := wTab` and the
+next-row / coefficient families are unused. -/
+theorem rows_iff_dvd [NeZero n] (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
+    (wTab : Fin n → Fin 15 → F) :
     (∀ E ∈ Gate.AddComplete.constraints (polyWitness ω wTab), zH F n ∣ E)
-      ↔ ∀ i, Gate.AddComplete.Holds (rowWitness wTab i) := by
-  -- Instantiate the ungated engine; `Holds w` is defeq to `∀ e ∈ constraints w, e = 0`.
-  exact Kimchi.Quotient.rows_iff_dvd_of hω hn _
-    (fun i => Gate.AddComplete.constraints (rowWitness wTab i)) (bridge hω wTab)
+      ↔ ∀ i, Gate.AddComplete.Holds (rowWitness wTab i) :=
+  (argument (F := F)).rows_iff_dvd hω hn wTab wTab
 
-/-- **CompleteAdd selector-gated rows iff divisible.** Instance of the selector-gated engine
-`rowsSel_iff_dvd` at the CompleteAdd bridge; the boolean selector column `S = columnPoly ω sel`
-is `1` on the rows the gate occupies and `0` elsewhere. -/
-theorem rowsSel_iff_dvd (hω : IsPrimitiveRoot ω n) (hn : 0 < n) (wTab : Fin n → Fin 15 → F)
-    (sel : Fin n → F) (hsel : ∀ i, sel i = 0 ∨ sel i = 1) :
+/-- **CompleteAdd selector-gated rows iff divisible.** Immediate specialization of
+`Argument.rowsSel_iff_dvd` at the instance `argument`; the boolean selector column
+`S = columnPoly ω sel` is `1` on the rows the gate occupies and `0` elsewhere. -/
+theorem rowsSel_iff_dvd [NeZero n] (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
+    (wTab : Fin n → Fin 15 → F) (sel : Fin n → F) (hsel : ∀ i, sel i = 0 ∨ sel i = 1) :
     (∀ E ∈ Gate.AddComplete.constraints (polyWitness ω wTab),
         zH F n ∣ (columnPoly ω sel) * E)
-      ↔ ∀ i, sel i = 1 → Gate.AddComplete.Holds (rowWitness wTab i) := by
-  -- Instantiate the selector-gated engine; `Holds w` is defeq to `∀ e ∈ constraints w, e = 0`.
-  exact Kimchi.Quotient.rowsSel_iff_dvd hω hn _
-    (fun i => Gate.AddComplete.constraints (rowWitness wTab i)) sel hsel (bridge hω wTab)
+      ↔ ∀ i, sel i = 1 → Gate.AddComplete.Holds (rowWitness wTab i) :=
+  (argument (F := F)).rowsSel_iff_dvd hω hn wTab wTab sel hsel
 
 end Kimchi.Quotient.AddComplete

--- a/formal/Kimchi/Quotient/AddComplete.lean
+++ b/formal/Kimchi/Quotient/AddComplete.lean
@@ -18,8 +18,8 @@ naturality of `constraints` under evaluation at the domain nodes.
 * `rowWitness` / `polyWitness` — the row-values and column-interpolant witnesses, both via
   the same `cellMap`.
 * `argument` — the CompleteAdd `Argument F` instance (single-row layout).
-* `rows_iff_dvd` / `rowsSel_iff_dvd` — the two divisibility corollaries, immediate instances
-  of the `Argument` engine theorems.
+* `rows_iff_dvd` — the divisibility corollary, an immediate instance of the `Argument`
+  engine theorems.
 
 Source of truth: `blueprint/src/chapters/Kimchi_Quotient_AddComplete.tex`.
 -/
@@ -76,25 +76,16 @@ def argument : Argument F where
   constraints env := Gate.AddComplete.constraints (cellMap env.witnessCurr)
   constraints_map f env := Gate.AddComplete.constraints_map f.toRingHom (cellMap env.witnessCurr)
 
-/-! ## Divisibility corollaries -/
+/-! ## Divisibility corollary -/
 
 /-- **CompleteAdd rows hold iff divisible.** Immediate specialization of
 `Argument.rows_iff_dvd` at the instance `argument`; single-row, so `qTab := wTab` and the
 next-row / coefficient families are unused. -/
-theorem rows_iff_dvd [NeZero n] (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
+theorem rows_iff_dvd (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
     (wTab : Fin n → Fin 15 → F) :
     (∀ E ∈ Gate.AddComplete.constraints (polyWitness ω wTab), zH F n ∣ E)
-      ↔ ∀ i, Gate.AddComplete.Holds (rowWitness wTab i) :=
-  (argument (F := F)).rows_iff_dvd hω hn wTab wTab
-
-/-- **CompleteAdd selector-gated rows iff divisible.** Immediate specialization of
-`Argument.rowsSel_iff_dvd` at the instance `argument`; the boolean selector column
-`S = columnPoly ω sel` is `1` on the rows the gate occupies and `0` elsewhere. -/
-theorem rowsSel_iff_dvd [NeZero n] (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
-    (wTab : Fin n → Fin 15 → F) (sel : Fin n → F) (hsel : ∀ i, sel i = 0 ∨ sel i = 1) :
-    (∀ E ∈ Gate.AddComplete.constraints (polyWitness ω wTab),
-        zH F n ∣ (columnPoly ω sel) * E)
-      ↔ ∀ i, sel i = 1 → Gate.AddComplete.Holds (rowWitness wTab i) :=
-  (argument (F := F)).rowsSel_iff_dvd hω hn wTab wTab sel hsel
+      ↔ ∀ i, Gate.AddComplete.Holds (rowWitness wTab i) := by
+  haveI : NeZero n := ⟨Nat.pos_iff_ne_zero.mp hn⟩
+  exact argument.rows_iff_dvd hω wTab wTab
 
 end Kimchi.Quotient.AddComplete

--- a/formal/Kimchi/Quotient/EndoMul.lean
+++ b/formal/Kimchi/Quotient/EndoMul.lean
@@ -44,8 +44,9 @@ Source: kimchi `endosclmul.rs`, module-doc layout table and `constraint_checks`.
 
 * `cellMap` — reads the two rows into a `Gate.EndoMul.Witness`.
 * `rowWitness` / `polyWitness` — the field-valued row witness and its polynomial lift.
-* `bridge` — evaluating the poly constraints at the node `ω^i` reproduces the row constraints.
-* `rows_iff_dvd` / `rowsSel_iff_dvd` — the two engine-instance divisibility corollaries.
+* `argument` — the EndoMul `Argument F` instance, parametrized by `endo : F` (two-row layout).
+* `rows_iff_dvd` / `rowsSel_iff_dvd` — the two divisibility corollaries, specializations of the
+  `Argument` engine theorems.
 
 Source of truth: `blueprint/src/chapters/Kimchi_Quotient_EndoMul.tex`.
 -/
@@ -95,53 +96,48 @@ noncomputable def polyWitness (ω : F) (wTab : Fin n → Fin 15 → F) :
   cellMap (fun c => columnPoly ω (fun j => wTab j c))
     (fun c => shift ω (columnPoly ω (fun j => wTab j c)))
 
-/-! ## The naturality bridge -/
+/-! ## The `Argument` instance -/
 
-/-- **EndoMul per-row bridge.** Evaluating the poly-witness constraints (with `endo = C endo`)
-at the node `ω^i` reproduces the row-witness constraints (with `endo = endo`). This is
-naturality of `Gate.EndoMul.constraints_map` at `f = evalRingHom (ω^i)`, transporting `C endo`
-to `endo` via `eval_C` and matching the witness cells via `eval_columnPoly` (current) and
-`eval_shift_columnPoly` (next). -/
-theorem bridge [NeZero n] (endo : F) (hω : IsPrimitiveRoot ω n)
-    (wTab : Fin n → Fin 15 → F) (i : Fin n) :
-    (Gate.EndoMul.constraints (C endo) (polyWitness ω wTab)).map (·.eval (ω ^ (i : ℕ)))
-      = Gate.EndoMul.constraints endo (rowWitness wTab i) := by
-  -- Evaluation at `ω^i` is the ring hom `evalRingHom (ω^i)`; rewrite the plain map by it.
-  have hfun : (fun E : Polynomial F => E.eval (ω ^ (i : ℕ)))
-      = ⇑(evalRingHom (ω ^ (i : ℕ))) := by
-    funext E; rw [Polynomial.coe_evalRingHom]
-  rw [hfun, Gate.EndoMul.constraints_map]
-  -- The endo constant transports via `eval_C`; the witness cells via `eval_columnPoly`
-  -- (current row) and `eval_shift_columnPoly` (next row).
-  congr 1
-  · rw [Polynomial.coe_evalRingHom, eval_C]
-  · simp only [polyWitness, rowWitness, cellMap, Gate.EndoMul.Witness.map,
-      Polynomial.coe_evalRingHom, eval_columnPoly hω, eval_shift_columnPoly hω]
+/-- **EndoMul `Argument` instance.** Parametrized by the base-field endomorphism coefficient
+`endo : F`; over an `F`-algebra `R` the constant is transported as `algebraMap F R endo`
+(on `R = F[X]` this is `C endo`, cf. `Polynomial.algebraMap_eq`), which every `F`-algebra hom
+fixes (`AlgHom.commutes`) — that is what makes the gate's ring-hom naturality
+`Gate.EndoMul.constraints_map` land back on the same instance. The cell map reads the current
+and next rows (a two-row gate; the coefficient family is unused). -/
+def argument (endo : F) : Argument F where
+  constraints {R} _ _ env :=
+    Gate.EndoMul.constraints (algebraMap F R endo) (cellMap env.witnessCurr env.witnessNext)
+  constraints_map f env := by
+    have h := Gate.EndoMul.constraints_map f.toRingHom (algebraMap F _ endo)
+      (cellMap env.witnessCurr env.witnessNext)
+    rw [show f.toRingHom (algebraMap F _ endo) = algebraMap F _ endo from f.commutes endo] at h
+    exact h
 
 /-! ## Divisibility corollaries -/
 
 /-- **EndoMul rows hold iff divisible.** The full list of poly constraints is divisible by the
-vanishing polynomial `zH` iff every `EndoMul` row-witness satisfies `Holds`. Instance of the
-engine `rows_iff_dvd_of` with the bridge discharged by `bridge`. -/
+vanishing polynomial `zH` iff every `EndoMul` row-witness satisfies `Holds`. Specialization of
+`Argument.rows_iff_dvd` at the instance `argument endo` (bridging
+`algebraMap F F[X] endo = C endo` via `Polynomial.algebraMap_eq`). -/
 theorem rows_iff_dvd [NeZero n] (endo : F) (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
     (wTab : Fin n → Fin 15 → F) :
     (∀ E ∈ Gate.EndoMul.constraints (C endo) (polyWitness ω wTab), zH F n ∣ E)
       ↔ ∀ i, Gate.EndoMul.Holds endo (rowWitness wTab i) := by
-  -- Instantiate the ungated engine; `Holds endo w` is defeq to `∀ e ∈ constraints endo w, e = 0`.
-  exact Kimchi.Quotient.rows_iff_dvd_of hω hn _
-    (fun i => Gate.EndoMul.constraints endo (rowWitness wTab i)) (bridge endo hω wTab)
+  have h := (argument endo).rows_iff_dvd hω hn wTab wTab
+  simpa only [argument, polyEnv, rowEnv, Polynomial.algebraMap_eq,
+    Algebra.algebraMap_self_apply, Gate.EndoMul.Holds] using h
 
 /-- **EndoMul selector-gated rows iff divisible.** With a boolean selector `sel : Fin n → F`
 and `S = columnPoly ω sel`, divisibility of every `S · E` by `zH` is equivalent to the row
-constraints holding only on the selected rows. Instance of the engine `rowsSel_iff_dvd`. -/
+constraints holding only on the selected rows. Specialization of `Argument.rowsSel_iff_dvd` at
+the instance `argument endo`. -/
 theorem rowsSel_iff_dvd [NeZero n] (endo : F) (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
     (wTab : Fin n → Fin 15 → F) (sel : Fin n → F) (hsel : ∀ i, sel i = 0 ∨ sel i = 1) :
     (∀ E ∈ Gate.EndoMul.constraints (C endo) (polyWitness ω wTab),
         zH F n ∣ (columnPoly ω sel) * E)
       ↔ ∀ i, sel i = 1 → Gate.EndoMul.Holds endo (rowWitness wTab i) := by
-  -- Instantiate the selector-gated engine; `Holds endo w` is defeq to
-  -- `∀ e ∈ constraints endo w, e = 0`.
-  exact Kimchi.Quotient.rowsSel_iff_dvd hω hn _
-    (fun i => Gate.EndoMul.constraints endo (rowWitness wTab i)) sel hsel (bridge endo hω wTab)
+  have h := (argument endo).rowsSel_iff_dvd hω hn wTab wTab sel hsel
+  simpa only [argument, polyEnv, rowEnv, Polynomial.algebraMap_eq,
+    Algebra.algebraMap_self_apply, Gate.EndoMul.Holds] using h
 
 end Kimchi.Quotient.EndoMul

--- a/formal/Kimchi/Quotient/EndoMul.lean
+++ b/formal/Kimchi/Quotient/EndoMul.lean
@@ -45,8 +45,8 @@ Source: kimchi `endosclmul.rs`, module-doc layout table and `constraint_checks`.
 * `cellMap` — reads the two rows into a `Gate.EndoMul.Witness`.
 * `rowWitness` / `polyWitness` — the field-valued row witness and its polynomial lift.
 * `argument` — the EndoMul `Argument F` instance, parametrized by `endo : F` (two-row layout).
-* `rows_iff_dvd` / `rowsSel_iff_dvd` — the two divisibility corollaries, specializations of the
-  `Argument` engine theorems.
+* `rows_iff_dvd` — the divisibility corollary, a specialization of the `Argument` engine
+  theorems.
 
 Source of truth: `blueprint/src/chapters/Kimchi_Quotient_EndoMul.tex`.
 -/
@@ -113,31 +113,17 @@ def argument (endo : F) : Argument F where
     rw [show f.toRingHom (algebraMap F _ endo) = algebraMap F _ endo from f.commutes endo] at h
     exact h
 
-/-! ## Divisibility corollaries -/
+/-! ## Divisibility corollary -/
 
 /-- **EndoMul rows hold iff divisible.** The full list of poly constraints is divisible by the
-vanishing polynomial `zH` iff every `EndoMul` row-witness satisfies `Holds`. Specialization of
-`Argument.rows_iff_dvd` at the instance `argument endo` (bridging
-`algebraMap F F[X] endo = C endo` via `Polynomial.algebraMap_eq`). -/
-theorem rows_iff_dvd [NeZero n] (endo : F) (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
+vanishing polynomial `zH` iff every `EndoMul` row-witness satisfies `Holds`. Immediate
+specialization of `Argument.rows_iff_dvd` at the instance `argument endo`: the constant
+transports definitionally (`algebraMap F F[X] endo` is `C endo`, `algebraMap F F endo` is
+`endo`). -/
+theorem rows_iff_dvd [NeZero n] (endo : F) (hω : IsPrimitiveRoot ω n)
     (wTab : Fin n → Fin 15 → F) :
     (∀ E ∈ Gate.EndoMul.constraints (C endo) (polyWitness ω wTab), zH F n ∣ E)
-      ↔ ∀ i, Gate.EndoMul.Holds endo (rowWitness wTab i) := by
-  have h := (argument endo).rows_iff_dvd hω hn wTab wTab
-  simpa only [argument, polyEnv, rowEnv, Polynomial.algebraMap_eq,
-    Algebra.algebraMap_self_apply, Gate.EndoMul.Holds] using h
-
-/-- **EndoMul selector-gated rows iff divisible.** With a boolean selector `sel : Fin n → F`
-and `S = columnPoly ω sel`, divisibility of every `S · E` by `zH` is equivalent to the row
-constraints holding only on the selected rows. Specialization of `Argument.rowsSel_iff_dvd` at
-the instance `argument endo`. -/
-theorem rowsSel_iff_dvd [NeZero n] (endo : F) (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
-    (wTab : Fin n → Fin 15 → F) (sel : Fin n → F) (hsel : ∀ i, sel i = 0 ∨ sel i = 1) :
-    (∀ E ∈ Gate.EndoMul.constraints (C endo) (polyWitness ω wTab),
-        zH F n ∣ (columnPoly ω sel) * E)
-      ↔ ∀ i, sel i = 1 → Gate.EndoMul.Holds endo (rowWitness wTab i) := by
-  have h := (argument endo).rowsSel_iff_dvd hω hn wTab wTab sel hsel
-  simpa only [argument, polyEnv, rowEnv, Polynomial.algebraMap_eq,
-    Algebra.algebraMap_self_apply, Gate.EndoMul.Holds] using h
+      ↔ ∀ i, Gate.EndoMul.Holds endo (rowWitness wTab i) :=
+  (argument endo).rows_iff_dvd hω wTab wTab
 
 end Kimchi.Quotient.EndoMul

--- a/formal/Kimchi/Quotient/Generic.lean
+++ b/formal/Kimchi/Quotient/Generic.lean
@@ -1,4 +1,4 @@
-import Kimchi.Quotient.Domain
+import Kimchi.Quotient.Lift
 import Kimchi.Gate.Generic
 
 /-!
@@ -77,6 +77,25 @@ theorem eval_genericE2 (hω : IsPrimitiveRoot ω n)
         + qTab i 8 * (wTab i 3 * wTab i 4) + qTab i 9 := by
   simp only [genericE2, eval_add, eval_mul, eval_columnPoly hω]
 
+/-! ## The `Argument` instance
+
+The generic gate plugs into the `Argument` primitive of `Kimchi.Quotient.Lift` exactly like
+the other five gates: the gate row `Gate.Generic R` is assembled from the current-row cells
+(as `w`) and the coefficient cells (as `q`); the next-row family is unused (single-row). -/
+
+/-- **Generic cell map.** Assemble a `Gate.Generic R` from current-row cells `cur` (→ `w`) and
+coefficient cells `coeff` (→ `q`). -/
+def genericCellMap {R : Type*} (cur coeff : Fin 15 → R) : Gate.Generic R :=
+  ⟨coeff, cur⟩
+
+/-- **Generic `Argument` instance.** The gate's constraint list `Gate.Generic.constraints`
+read through `genericCellMap`; naturality is the gate module's `Generic.constraints_map` at
+the underlying ring hom. -/
+def genericArgument : Argument F where
+  constraints env := (genericCellMap env.witnessCurr env.coeff).constraints
+  constraints_map f env :=
+    Gate.Generic.constraints_map f.toRingHom (genericCellMap env.witnessCurr env.coeff)
+
 /-! ## The divisibility checkpoint
 
 The first end-to-end gate-to-divisibility theorem: the gate holds on every row
@@ -105,18 +124,16 @@ theorem genericRows_iff_dvd (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
         genericE2 (fun c => columnPoly ω (fun i => qTab i c))
           (fun c => columnPoly ω (fun i => wTab i c))) ↔
       ∀ i, (Gate.Generic.mk (qTab i) (wTab i)).Holds := by
-  simp only [Gate.Generic.Holds]
-  rw [zH_dvd_iff hω hn, zH_dvd_iff hω hn]
-  constructor
-  · rintro ⟨h1, h2⟩ i
-    refine ⟨?_, ?_⟩
-    · have := h1 i i.isLt; rwa [eval_genericE1 hω] at this
-    · have := h2 i i.isLt; rwa [eval_genericE2 hω] at this
-  · intro h
-    refine ⟨fun i hi => ?_, fun i hi => ?_⟩
-    · have := (h ⟨i, hi⟩).1
-      rw [← eval_genericE1 hω wTab qTab ⟨i, hi⟩] at this; exact this
-    · have := (h ⟨i, hi⟩).2
-      rw [← eval_genericE2 hω wTab qTab ⟨i, hi⟩] at this; exact this
+  haveI : NeZero n := ⟨Nat.pos_iff_ne_zero.mp hn⟩
+  -- Route through the abstract `Argument` engine at the instance `genericArgument`.
+  have key := (genericArgument (F := F)).rows_iff_dvd hω hn wTab qTab
+  -- Unfold the instance: the polynomial-environment constraint list is
+  -- `[genericE1 Q W, genericE2 Q W]` and the row-environment one is `[c₁ i, c₂ i]`, the two
+  -- entries of `Gate.Generic.Holds`.
+  simp only [genericArgument, polyEnv, rowEnv, genericCellMap,
+    Gate.Generic.constraints, List.forall_mem_cons, List.not_mem_nil, false_implies,
+    forall_const, and_true] at key
+  simp only [Gate.Generic.holds_iff]
+  exact key
 
 end Kimchi.Quotient

--- a/formal/Kimchi/Quotient/Generic.lean
+++ b/formal/Kimchi/Quotient/Generic.lean
@@ -51,32 +51,6 @@ noncomputable def genericE1 (Q W : Fin 15 → Polynomial F) : Polynomial F :=
 noncomputable def genericE2 (Q W : Fin 15 → Polynomial F) : Polynomial F :=
   Q 5 * W 3 + Q 6 * W 4 + Q 7 * W 5 + Q 8 * (W 3 * W 4) + Q 9
 
-/-- **Per-row bridge, first constraint.** For a circuit table `wTab, qTab` with
-column polynomials `W c = columnPoly (fun i => wTab i c)` and
-`Q c = columnPoly (fun i => qTab i c)`, evaluating `E₁` at the node `ω^i`
-recovers the left-hand side of the first constraint at row `i`.
-
-Evaluation at `ω^i` is a ring homomorphism, so it distributes over the sums and
-products of `genericE1`; then `eval_columnPoly` reduces each `W c` / `Q c` to
-the corresponding cell value. -/
-theorem eval_genericE1 (hω : IsPrimitiveRoot ω n)
-    (wTab qTab : Fin n → Fin 15 → F) (i : Fin n) :
-    (genericE1 (fun c => columnPoly ω (fun j => qTab j c))
-        (fun c => columnPoly ω (fun j => wTab j c))).eval (ω ^ (i : ℕ))
-      = qTab i 0 * wTab i 0 + qTab i 1 * wTab i 1 + qTab i 2 * wTab i 2
-        + qTab i 3 * (wTab i 0 * wTab i 1) + qTab i 4 := by
-  simp only [genericE1, eval_add, eval_mul, eval_columnPoly hω]
-
-/-- **Per-row bridge, second constraint.** Identical to `eval_genericE1`, using
-columns `3, 4, 5` and coefficients `5 … 9`. -/
-theorem eval_genericE2 (hω : IsPrimitiveRoot ω n)
-    (wTab qTab : Fin n → Fin 15 → F) (i : Fin n) :
-    (genericE2 (fun c => columnPoly ω (fun j => qTab j c))
-        (fun c => columnPoly ω (fun j => wTab j c))).eval (ω ^ (i : ℕ))
-      = qTab i 5 * wTab i 3 + qTab i 6 * wTab i 4 + qTab i 7 * wTab i 5
-        + qTab i 8 * (wTab i 3 * wTab i 4) + qTab i 9 := by
-  simp only [genericE2, eval_add, eval_mul, eval_columnPoly hω]
-
 /-! ## The `Argument` instance
 
 The generic gate plugs into the `Argument` primitive of `Kimchi.Quotient.Lift` exactly like
@@ -110,11 +84,11 @@ polynomials `W c = columnPoly (fun i => wTab i c)`,
 `Q c = columnPoly (fun i => qTab i c)`. Then both constraint polynomials are
 divisible by `Z_H` iff the double generic gate holds at every row.
 
-By `zH_dvd_iff`, `Z_H ∣ E ↔ ∀ i < n, E(ω^i) = 0`; by `eval_genericE1/2`,
-`E₁(ω^i) = 0` (resp. `E₂`) is exactly the first (resp. second) constraint of
-`Gate.Generic.Holds` at row `i`. Commuting `∧` past `∀` merges the two
-per-constraint statements. Pure polynomial algebra — no probabilistic content
-here. -/
+Specialization of `Argument.rows_iff_dvd` at the instance `genericArgument`:
+unfolding the instance identifies the polynomial-environment constraint list
+with `[E₁, E₂]` and the row-environment one with the two cell equations of
+`Gate.Generic.Holds` (via `holds_iff`). Pure polynomial algebra — no
+probabilistic content here. -/
 theorem genericRows_iff_dvd (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
     (wTab qTab : Fin n → Fin 15 → F) :
     (zH F n ∣
@@ -126,7 +100,7 @@ theorem genericRows_iff_dvd (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
       ∀ i, (Gate.Generic.mk (qTab i) (wTab i)).Holds := by
   haveI : NeZero n := ⟨Nat.pos_iff_ne_zero.mp hn⟩
   -- Route through the abstract `Argument` engine at the instance `genericArgument`.
-  have key := (genericArgument (F := F)).rows_iff_dvd hω hn wTab qTab
+  have key := genericArgument.rows_iff_dvd hω wTab qTab
   -- Unfold the instance: the polynomial-environment constraint list is
   -- `[genericE1 Q W, genericE2 Q W]` and the row-environment one is `[c₁ i, c₂ i]`, the two
   -- entries of `Gate.Generic.Holds`.

--- a/formal/Kimchi/Quotient/Lift.lean
+++ b/formal/Kimchi/Quotient/Lift.lean
@@ -50,6 +50,8 @@ proof in the library; every per-gate bridge is `constraints_map` pasted onto it.
 * `rowsSel_iff_dvd` — the selector-gated engine: divisibility of `S · E` (with
   `S = columnPoly ω sel` a boolean selector column) is equivalent to the row constraints
   holding only on the selected rows.
+* `dvd_of_evalCheck` — the composed pinning→separation engine, stated over an abstract family
+  of constraint polynomials with no gate content.
 * `ArgumentEnv`, `rowEnv`, `polyEnv`, `polyEnv_map_aeval` — the cell environment, its two
   carrier instantiations, and the evaluation bridge between them.
 * `Argument` with `bridge` / `rows_iff_dvd` / `rowsSel_iff_dvd` / `soundness` — the per-gate
@@ -120,6 +122,31 @@ theorem rowsSel_iff_dvd (hω : IsPrimitiveRoot ω n) (hn : 0 < n) (P : List (Pol
         rw [← hbridge ⟨i, hi⟩]
         exact List.mem_map.mpr ⟨E, hE, rfl⟩
       exact h ⟨i, hi⟩ h1 (E.eval (ω ^ i)) hmem
+
+/-! ## The composed pinning–separation engine -/
+
+/-- **Divisibility from the aggregated eval-check.** Fix a primitive `n`-th root `ω`, an
+injective node vector `ζ : Fin N → F`, an injective challenge vector `α : Fin k → F`, and two
+families `E, t : Fin k → F[X]`. Under the abstract degree bound `D < N` on the aggregate and
+on `t s · Z_H`, if the aggregated eval-check
+`(aggregate (α s) E)(ζ p) = (t s · Z_H)(ζ p)` holds for every challenge `s` and node `p`, then
+`Z_H ∣ E c` for every constraint index `c`.
+
+Proof: for each `s`, `zH_dvd_of_evals` pins `Z_H ∣ aggregate (α s) E`; feeding
+this to `dvd_separation` across the `k` distinct challenges yields `Z_H ∣ E c`. -/
+theorem dvd_of_evalCheck {k N : ℕ}
+    (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
+    (ζ : Fin N → F) (hζ : Function.Injective ζ)
+    (α : Fin k → F) (hα : Function.Injective α)
+    (E t : Fin k → Polynomial F) (D : ℕ) (hD : D < N)
+    (hCdeg : ∀ s, (aggregate (α s) E).natDegree ≤ D)
+    (htdeg : ∀ s, (t s * zH F n).natDegree ≤ D)
+    (hcheck : ∀ s : Fin k, ∀ p : Fin N,
+        (aggregate (α s) E).eval (ζ p) = (t s * zH F n).eval (ζ p)) :
+    ∀ c, zH F n ∣ E c :=
+  dvd_separation hω hn α hα E
+    (fun s => zH_dvd_of_evals hω hn ζ hζ (aggregate (α s) E) (t s) D
+      (hCdeg s) (htdeg s) hD (hcheck s))
 
 /-! ## The cell environment -/
 
@@ -204,11 +231,11 @@ theorem Argument.bridge [NeZero n] (G : Argument F) (hω : IsPrimitiveRoot ω n)
 the polynomial environment) are all divisible by `Z_H` iff its field-level constraints vanish
 at every row. Immediate instance of `rows_iff_dvd_of` at the `Argument` bridge. -/
 theorem Argument.rows_iff_dvd [NeZero n] (G : Argument F) (hω : IsPrimitiveRoot ω n)
-    (hn : 0 < n) (wTab qTab : Fin n → Fin 15 → F) :
+    (wTab qTab : Fin n → Fin 15 → F) :
     (∀ E ∈ G.constraints (polyEnv ω wTab qTab), zH F n ∣ E)
       ↔ ∀ i, ∀ e ∈ G.constraints (rowEnv wTab qTab i), e = 0 :=
-  rows_iff_dvd_of hω hn _ (fun i => G.constraints (rowEnv wTab qTab i))
-    (G.bridge hω wTab qTab)
+  rows_iff_dvd_of hω (Nat.pos_of_neZero n) _
+    (fun i => G.constraints (rowEnv wTab qTab i)) (G.bridge hω wTab qTab)
 
 /-- **`Argument` selector-gated rows iff divisible.** For a boolean selector column
 `S = columnPoly ω sel`, divisibility of every `S · E` by `Z_H` is equivalent to the gate's
@@ -216,12 +243,12 @@ field-level constraints vanishing on the selected rows only. Instance of `rowsSe
 the `Argument` bridge; the selector multiplication mirrors kimchi's
 `index(gate_type) * combined_constraints` gating (`argument.rs`). -/
 theorem Argument.rowsSel_iff_dvd [NeZero n] (G : Argument F) (hω : IsPrimitiveRoot ω n)
-    (hn : 0 < n) (wTab qTab : Fin n → Fin 15 → F) (sel : Fin n → F)
+    (wTab qTab : Fin n → Fin 15 → F) (sel : Fin n → F)
     (hsel : ∀ i, sel i = 0 ∨ sel i = 1) :
     (∀ E ∈ G.constraints (polyEnv ω wTab qTab), zH F n ∣ (columnPoly ω sel) * E)
       ↔ ∀ i, sel i = 1 → ∀ e ∈ G.constraints (rowEnv wTab qTab i), e = 0 :=
-  Kimchi.Quotient.rowsSel_iff_dvd hω hn _ (fun i => G.constraints (rowEnv wTab qTab i))
-    sel hsel (G.bridge hω wTab qTab)
+  Kimchi.Quotient.rowsSel_iff_dvd hω (Nat.pos_of_neZero n) _
+    (fun i => G.constraints (rowEnv wTab qTab i)) sel hsel (G.bridge hω wTab qTab)
 
 /-! ## Quotient-argument soundness -/
 
@@ -232,14 +259,12 @@ an injective node vector `ζ`, an injective challenge vector `α`, an abstract d
 selector-active row satisfies the gate's row constraints, i.e. every constraint expression of
 the row environment is zero.
 
-Proof: the composed pinning→separation engine (`zH_dvd_of_evals` per challenge, fed to
-`dvd_separation` across the distinct challenges — the inline body of `dvd_of_evalCheck`, which
-lives in the downstream `Quotient/Soundness.lean` and so cannot be imported here) yields
+Proof: apply `dvd_of_evalCheck` to the gated family to obtain
 `∀ c, zH ∣ (columnPoly ω sel) * (constraints …).get c`; converting the `Fin length` indexing to
 `∈ constraints …` membership and feeding the instance's selector-gated
 `Argument.rowsSel_iff_dvd` gives the row constraints on the selected rows. -/
 theorem Argument.soundness [DecidableEq F] {N : ℕ} [NeZero n] (G : Argument F)
-    (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
+    (hω : IsPrimitiveRoot ω n)
     (wTab qTab : Fin n → Fin 15 → F) (sel : Fin n → F) (hsel : ∀ i, sel i = 0 ∨ sel i = 1)
     (ζ : Fin N → F) (hζ : Function.Injective ζ)
     (α : Fin (G.constraints (polyEnv ω wTab qTab)).length → F)
@@ -253,15 +278,10 @@ theorem Argument.soundness [DecidableEq F] {N : ℕ} [NeZero n] (G : Argument F)
         (G.constraints (polyEnv ω wTab qTab)).get c)).eval (ζ p)
         = (t s * zH F n).eval (ζ p)) :
     ∀ i, sel i = 1 → ∀ e ∈ G.constraints (rowEnv wTab qTab i), e = 0 := by
-  have hdvd : ∀ c, zH F n ∣ columnPoly ω sel *
-      (G.constraints (polyEnv ω wTab qTab)).get c :=
-    dvd_separation hω hn α hα
-      (fun c => columnPoly ω sel * (G.constraints (polyEnv ω wTab qTab)).get c)
-      (fun s => zH_dvd_of_evals hω hn ζ hζ
-        (aggregate (α s) (fun c => columnPoly ω sel *
-          (G.constraints (polyEnv ω wTab qTab)).get c)) (t s) D
-        (hCdeg s) (htdeg s) hD (hcheck s))
-  apply (G.rowsSel_iff_dvd hω hn wTab qTab sel hsel).mp
+  have hdvd := dvd_of_evalCheck hω (Nat.pos_of_neZero n) ζ hζ α hα
+    (fun c => columnPoly ω sel * (G.constraints (polyEnv ω wTab qTab)).get c)
+    t D hD hCdeg htdeg hcheck
+  apply (G.rowsSel_iff_dvd hω wTab qTab sel hsel).mp
   intro E hE
   obtain ⟨c, rfl⟩ := List.mem_iff_get.mp hE
   exact hdvd c

--- a/formal/Kimchi/Quotient/Lift.lean
+++ b/formal/Kimchi/Quotient/Lift.lean
@@ -1,4 +1,7 @@
 import Kimchi.Quotient.Domain
+import Kimchi.Quotient.Shifted
+import Kimchi.Quotient.Aggregate
+import Kimchi.Quotient.Pinning
 
 /-!
 # The generic lift engine
@@ -10,17 +13,47 @@ an abstract field `[Field F]` with a primitive `n`-th root of unity supplied as 
 Every gate's "rows hold iff the constraint polynomials are divisible by `Z_H`" theorem is one
 instantiation of a single abstract lemma. The lemma takes the list `P` of constraint
 polynomials, the per-row list `rowCons i` of field-level constraint expressions, and a
-**bridge** hypothesis asserting that evaluating `P` at the node `ω^i` reproduces `rowCons i` —
-which for each gate is discharged by naturality of its `constraints` together with the
-evaluation lemmas for `columnPoly` and `shift ∘ columnPoly`. **No gate formula is ever restated
-at this layer.**
+**bridge** hypothesis asserting that evaluating `P` at the node `ω^i` reproduces `rowCons i`.
+**No gate formula is ever restated at this layer.**
+
+## The `ArgumentEnv` / `Argument` pair
+
+The per-gate interface mirrors kimchi's `argument.rs`:
+
+* `ArgumentEnv R` is the cell environment a gate's constraints may read, anchored at a row —
+  the current-row witness cells, the next-row witness cells (cyclic `i + 1`), and the
+  current row's coefficient cells. It is the Lean counterpart of kimchi's `ArgumentEnv`
+  restricted to the cell accessors (`witness_curr` / `witness_next` / `coeff`).
+* `Argument F` is one gate's constraint family: a list of constraint expressions defined over
+  every commutative `F`-algebra `R` from an `ArgumentEnv R`, together with its naturality
+  square along `F`-algebra homomorphisms. It is the Lean counterpart of kimchi's `Argument`
+  trait: `constraints` is `constraint_checks`, generic over the carrier the way
+  `constraint_checks` is generic over `T : ExprOps` — kimchi runs the same code at `T = F`
+  (direct row checks) and `T = E<F>` (the symbolic expressions compiled into the quotient),
+  and `constraints_map` is the corresponding agreement between the two instantiations, which
+  Rust gets for free by parametricity and Lean states as a proof obligation.
+
+Genericity over `F`-algebras (rather than plain rings) is what absorbs gate **parameters**
+(EndoMul's endomorphism constant, EndoScalar's interpolating-cubic coefficients): each becomes
+the image under `algebraMap F R` of a fixed element of `F`, and the evaluation morphism is the
+`F`-algebra hom `Polynomial.aeval (ω^i) : F[X] →ₐ[F] F`, which fixes those images.
+
+The two carrier instantiations are packaged once, gate-independently: `rowEnv` (the field-level
+cells of row `i`) and `polyEnv` (the column interpolants, with `shift` on the next-row side).
+`polyEnv_map_aeval` — evaluation at a node carries `polyEnv` to `rowEnv` — is the one bridge
+proof in the library; every per-gate bridge is `constraints_map` pasted onto it.
 
 ## Contents
 
-* `rows_iff_dvd_of` — the ungated engine: `(∀ E ∈ P, Z_H ∣ E) ↔ ∀ i, ∀ e ∈ rowCons i, e = 0`.
+* `rows_iff_dvd_of` — the ungated engine:
+  `(∀ E ∈ P, Z_H ∣ E) ↔ ∀ i, ∀ e ∈ rowCons i, e = 0`.
 * `rowsSel_iff_dvd` — the selector-gated engine: divisibility of `S · E` (with
   `S = columnPoly ω sel` a boolean selector column) is equivalent to the row constraints
   holding only on the selected rows.
+* `ArgumentEnv`, `rowEnv`, `polyEnv`, `polyEnv_map_aeval` — the cell environment, its two
+  carrier instantiations, and the evaluation bridge between them.
+* `Argument` with `bridge` / `rows_iff_dvd` / `rowsSel_iff_dvd` / `soundness` — the per-gate
+  interface and its four engine corollaries, each stated once.
 
 Source of truth: `blueprint/src/chapters/Kimchi_Quotient_Lift.tex`.
 -/
@@ -87,5 +120,150 @@ theorem rowsSel_iff_dvd (hω : IsPrimitiveRoot ω n) (hn : 0 < n) (P : List (Pol
         rw [← hbridge ⟨i, hi⟩]
         exact List.mem_map.mpr ⟨E, hE, rfl⟩
       exact h ⟨i, hi⟩ h1 (E.eval (ω ^ i)) hmem
+
+/-! ## The cell environment -/
+
+/-- **The cell environment of a gate row.** The three cell families a gate's constraints may
+read, anchored at a row: the current-row witness cells, the next-row witness cells (cyclic
+`i + 1`), and the current row's coefficient cells. Lean counterpart of kimchi's `ArgumentEnv`
+(`argument.rs`), restricted to the cell accessors (`witness_curr` / `witness_next` /
+`coeff`). -/
+structure ArgumentEnv (R : Type u) where
+  witnessCurr : Fin 15 → R
+  witnessNext : Fin 15 → R
+  coeff : Fin 15 → R
+
+/-- Push a carrier map `f : R → S` through an environment, cell by cell in each family. -/
+def ArgumentEnv.map {R S : Type u} (f : R → S) (env : ArgumentEnv R) : ArgumentEnv S :=
+  ⟨f ∘ env.witnessCurr, f ∘ env.witnessNext, f ∘ env.coeff⟩
+
+/-- **Row environment.** The field-level cells at row `i` of a witness table `wTab` and a
+coefficient table `qTab`: current row `wTab i`, next row `wTab (i + 1)` (cyclic), coefficients
+`qTab i`. -/
+def rowEnv [NeZero n] (wTab qTab : Fin n → Fin 15 → F) (i : Fin n) : ArgumentEnv F :=
+  ⟨wTab i, wTab (i + 1), qTab i⟩
+
+/-- **Polynomial environment.** The column interpolants of the tables: `columnPoly` of each
+witness column on the current side, its `shift` on the next side, and `columnPoly` of each
+coefficient column on the coefficient side. -/
+noncomputable def polyEnv (ω : F) (wTab qTab : Fin n → Fin 15 → F) :
+    ArgumentEnv (Polynomial F) :=
+  ⟨fun c => columnPoly ω (fun j => wTab j c),
+   fun c => shift ω (columnPoly ω (fun j => wTab j c)),
+   fun c => columnPoly ω (fun j => qTab j c)⟩
+
+/-- **Environment evaluation bridge.** Evaluating the polynomial environment at the node `ω^i`
+— i.e. mapping the `F`-algebra hom `aeval (ω^i)` through it — yields the row environment at
+`i`: `eval_columnPoly` on the current and coefficient sides, `eval_shift_columnPoly` on the
+next side. This is the one evaluation bridge in the library; every gate reaches its own bridge
+by pasting its naturality square onto this equation. -/
+theorem polyEnv_map_aeval [NeZero n] (hω : IsPrimitiveRoot ω n)
+    (wTab qTab : Fin n → Fin 15 → F) (i : Fin n) :
+    (polyEnv ω wTab qTab).map ⇑(aeval (ω ^ (i : ℕ)) : Polynomial F →ₐ[F] F)
+      = rowEnv wTab qTab i := by
+  simp only [polyEnv, ArgumentEnv.map, rowEnv]
+  congr 1
+  · funext c
+    simp only [Function.comp_apply, Polynomial.coe_aeval_eq_eval, eval_columnPoly hω]
+  · funext c
+    simp only [Function.comp_apply, Polynomial.coe_aeval_eq_eval, eval_shift_columnPoly hω]
+  · funext c
+    simp only [Function.comp_apply, Polynomial.coe_aeval_eq_eval, eval_columnPoly hω]
+
+/-! ## The `Argument` primitive over `F`-algebras -/
+
+/-- **The `Argument` primitive.** One gate's constraint family: the list of constraint
+expressions read from an `ArgumentEnv R`, defined for every commutative `F`-algebra `R`,
+together with its naturality square along `F`-algebra homomorphisms. Counterpart of kimchi's
+`Argument` trait (`argument.rs`): `constraints` is `constraint_checks`, and `constraints_map`
+is the agreement between its carrier instantiations that Rust obtains by parametricity.
+
+Gate parameters that are fixed field elements (an endomorphism coefficient, interpolating-cubic
+coefficients) enter through `algebraMap F R`, which every `f : R →ₐ[F] S` fixes
+(`AlgHom.commutes`) — this is what makes a uniform naturality square possible across gates with
+different parameters. -/
+structure Argument (F : Type u) [Field F] where
+  constraints : ∀ {R : Type u} [CommRing R] [Algebra F R], ArgumentEnv R → List R
+  constraints_map : ∀ {R S : Type u} [CommRing R] [CommRing S] [Algebra F R] [Algebra F S]
+      (f : R →ₐ[F] S) (env : ArgumentEnv R),
+    (constraints env).map f = constraints (env.map f)
+
+/-- **`Argument` eval bridge.** Evaluating the constraint polynomials of the polynomial
+environment at the node `ω^i` reproduces the field-level constraints of the row environment:
+the naturality square `constraints_map` at `aeval (ω^i)`, pasted onto `polyEnv_map_aeval`. -/
+theorem Argument.bridge [NeZero n] (G : Argument F) (hω : IsPrimitiveRoot ω n)
+    (wTab qTab : Fin n → Fin 15 → F) (i : Fin n) :
+    (G.constraints (polyEnv ω wTab qTab)).map (·.eval (ω ^ (i : ℕ)))
+      = G.constraints (rowEnv wTab qTab i) := by
+  have hfun : (fun E : Polynomial F => E.eval (ω ^ (i : ℕ)))
+      = ⇑(aeval (ω ^ (i : ℕ)) : Polynomial F →ₐ[F] F) := by
+    funext E; rw [Polynomial.coe_aeval_eq_eval]
+  rw [hfun, G.constraints_map, polyEnv_map_aeval hω]
+
+/-- **`Argument` rows iff divisible.** The gate's constraint polynomials (its constraints at
+the polynomial environment) are all divisible by `Z_H` iff its field-level constraints vanish
+at every row. Immediate instance of `rows_iff_dvd_of` at the `Argument` bridge. -/
+theorem Argument.rows_iff_dvd [NeZero n] (G : Argument F) (hω : IsPrimitiveRoot ω n)
+    (hn : 0 < n) (wTab qTab : Fin n → Fin 15 → F) :
+    (∀ E ∈ G.constraints (polyEnv ω wTab qTab), zH F n ∣ E)
+      ↔ ∀ i, ∀ e ∈ G.constraints (rowEnv wTab qTab i), e = 0 :=
+  rows_iff_dvd_of hω hn _ (fun i => G.constraints (rowEnv wTab qTab i))
+    (G.bridge hω wTab qTab)
+
+/-- **`Argument` selector-gated rows iff divisible.** For a boolean selector column
+`S = columnPoly ω sel`, divisibility of every `S · E` by `Z_H` is equivalent to the gate's
+field-level constraints vanishing on the selected rows only. Instance of `rowsSel_iff_dvd` at
+the `Argument` bridge; the selector multiplication mirrors kimchi's
+`index(gate_type) * combined_constraints` gating (`argument.rs`). -/
+theorem Argument.rowsSel_iff_dvd [NeZero n] (G : Argument F) (hω : IsPrimitiveRoot ω n)
+    (hn : 0 < n) (wTab qTab : Fin n → Fin 15 → F) (sel : Fin n → F)
+    (hsel : ∀ i, sel i = 0 ∨ sel i = 1) :
+    (∀ E ∈ G.constraints (polyEnv ω wTab qTab), zH F n ∣ (columnPoly ω sel) * E)
+      ↔ ∀ i, sel i = 1 → ∀ e ∈ G.constraints (rowEnv wTab qTab i), e = 0 :=
+  Kimchi.Quotient.rowsSel_iff_dvd hω hn _ (fun i => G.constraints (rowEnv wTab qTab i))
+    sel hsel (G.bridge hω wTab qTab)
+
+/-! ## Quotient-argument soundness -/
+
+/-- **`Argument` quotient soundness.** With the abstract quotient-argument hypotheses over the
+selector-gated family `c ↦ (columnPoly ω sel) * (constraints (polyEnv ω wTab qTab)).get c` —
+an injective node vector `ζ`, an injective challenge vector `α`, an abstract degree bound
+`D < N`, and the aggregated eval-check passing at every challenge and node — every
+selector-active row satisfies the gate's row constraints, i.e. every constraint expression of
+the row environment is zero.
+
+Proof: the composed pinning→separation engine (`zH_dvd_of_evals` per challenge, fed to
+`dvd_separation` across the distinct challenges — the inline body of `dvd_of_evalCheck`, which
+lives in the downstream `Quotient/Soundness.lean` and so cannot be imported here) yields
+`∀ c, zH ∣ (columnPoly ω sel) * (constraints …).get c`; converting the `Fin length` indexing to
+`∈ constraints …` membership and feeding the instance's selector-gated
+`Argument.rowsSel_iff_dvd` gives the row constraints on the selected rows. -/
+theorem Argument.soundness [DecidableEq F] {N : ℕ} [NeZero n] (G : Argument F)
+    (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
+    (wTab qTab : Fin n → Fin 15 → F) (sel : Fin n → F) (hsel : ∀ i, sel i = 0 ∨ sel i = 1)
+    (ζ : Fin N → F) (hζ : Function.Injective ζ)
+    (α : Fin (G.constraints (polyEnv ω wTab qTab)).length → F)
+    (hα : Function.Injective α)
+    (t : Fin (G.constraints (polyEnv ω wTab qTab)).length → Polynomial F)
+    (D : ℕ) (hD : D < N)
+    (hCdeg : ∀ s, (aggregate (α s) (fun c => columnPoly ω sel *
+        (G.constraints (polyEnv ω wTab qTab)).get c)).natDegree ≤ D)
+    (htdeg : ∀ s, (t s * zH F n).natDegree ≤ D)
+    (hcheck : ∀ s p, (aggregate (α s) (fun c => columnPoly ω sel *
+        (G.constraints (polyEnv ω wTab qTab)).get c)).eval (ζ p)
+        = (t s * zH F n).eval (ζ p)) :
+    ∀ i, sel i = 1 → ∀ e ∈ G.constraints (rowEnv wTab qTab i), e = 0 := by
+  have hdvd : ∀ c, zH F n ∣ columnPoly ω sel *
+      (G.constraints (polyEnv ω wTab qTab)).get c :=
+    dvd_separation hω hn α hα
+      (fun c => columnPoly ω sel * (G.constraints (polyEnv ω wTab qTab)).get c)
+      (fun s => zH_dvd_of_evals hω hn ζ hζ
+        (aggregate (α s) (fun c => columnPoly ω sel *
+          (G.constraints (polyEnv ω wTab qTab)).get c)) (t s) D
+        (hCdeg s) (htdeg s) hD (hcheck s))
+  apply (G.rowsSel_iff_dvd hω hn wTab qTab sel hsel).mp
+  intro E hE
+  obtain ⟨c, rfl⟩ := List.mem_iff_get.mp hE
+  exact hdvd c
 
 end Kimchi.Quotient

--- a/formal/Kimchi/Quotient/Soundness.lean
+++ b/formal/Kimchi/Quotient/Soundness.lean
@@ -79,7 +79,7 @@ selector-active row satisfies the CompleteAdd gate predicate.
 Proof: apply `dvd_of_evalCheck` to the gated family to obtain
 `∀ c, zH ∣ (columnPoly ω sel) * (constraints …).get c`; convert the `Fin length` indexing to
 `∈ constraints …` membership and feed the CompleteAdd `rowsSel_iff_dvd`. -/
-theorem soundness {F : Type*} [Field F] [DecidableEq F] {n N : ℕ} {ω : F}
+theorem soundness {F : Type*} [Field F] [DecidableEq F] {n N : ℕ} [NeZero n] {ω : F}
     (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
     (wTab : Fin n → Fin 15 → F) (sel : Fin n → F) (hsel : ∀ i, sel i = 0 ∨ sel i = 1)
     (ζ : Fin N → F) (hζ : Function.Injective ζ)
@@ -94,14 +94,8 @@ theorem soundness {F : Type*} [Field F] [DecidableEq F] {n N : ℕ} {ω : F}
         (Gate.AddComplete.constraints (polyWitness ω wTab)).get c)).eval (ζ p)
         = (t s * zH F n).eval (ζ p)) :
     ∀ i, sel i = 1 → Gate.AddComplete.Holds (rowWitness wTab i) := by
-  have hdvd := dvd_of_evalCheck hω hn ζ hζ α hα
-    (fun c => columnPoly ω sel * (Gate.AddComplete.constraints (polyWitness ω wTab)).get c)
-    t D hD hCdeg htdeg hcheck
-  apply (rowsSel_iff_dvd hω hn wTab sel hsel).mp
-  intro E hE
-  obtain ⟨c, rfl⟩ := List.mem_iff_get.mp hE
-  exact hdvd c
-
+  exact (argument (F := F)).soundness hω hn wTab wTab sel hsel ζ hζ α hα t D hD
+    hCdeg htdeg hcheck
 
 end Kimchi.Quotient.AddComplete
 
@@ -130,14 +124,8 @@ theorem soundness {F : Type*} [Field F] [DecidableEq F] {n N : ℕ} [NeZero n] {
         (Gate.VarBaseMul.constraints (polyWitness ω wTab)).get c)).eval (ζ p)
         = (t s * zH F n).eval (ζ p)) :
     ∀ i, sel i = 1 → Gate.VarBaseMul.Holds (rowWitness wTab i) := by
-  have hdvd := dvd_of_evalCheck hω hn ζ hζ α hα
-    (fun c => columnPoly ω sel * (Gate.VarBaseMul.constraints (polyWitness ω wTab)).get c)
-    t D hD hCdeg htdeg hcheck
-  apply (rowsSel_iff_dvd hω hn wTab sel hsel).mp
-  intro E hE
-  obtain ⟨c, rfl⟩ := List.mem_iff_get.mp hE
-  exact hdvd c
-
+  exact (argument (F := F)).soundness hω hn wTab wTab sel hsel ζ hζ α hα t D hD
+    hCdeg htdeg hcheck
 
 end Kimchi.Quotient.VarBaseMul
 
@@ -166,14 +154,9 @@ theorem soundness {F : Type*} [Field F] [DecidableEq F] {n N : ℕ} [NeZero n] {
         (Gate.EndoMul.constraints (C endo) (polyWitness ω wTab)).get c)).eval (ζ p)
         = (t s * zH F n).eval (ζ p)) :
     ∀ i, sel i = 1 → Gate.EndoMul.Holds endo (rowWitness wTab i) := by
-  have hdvd := dvd_of_evalCheck hω hn ζ hζ α hα
-    (fun c => columnPoly ω sel *
-      (Gate.EndoMul.constraints (C endo) (polyWitness ω wTab)).get c)
-    t D hD hCdeg htdeg hcheck
-  apply (rowsSel_iff_dvd endo hω hn wTab sel hsel).mp
-  intro E hE
-  obtain ⟨c, rfl⟩ := List.mem_iff_get.mp hE
-  exact hdvd c
-
+  have h := (argument endo).soundness hω hn wTab wTab sel hsel ζ hζ α hα t D hD
+    hCdeg htdeg hcheck
+  simpa only [argument, polyEnv, rowEnv, Polynomial.algebraMap_eq,
+    Algebra.algebraMap_self_apply, Gate.EndoMul.Holds] using h
 
 end Kimchi.Quotient.EndoMul

--- a/formal/Kimchi/Quotient/Soundness.lean
+++ b/formal/Kimchi/Quotient/Soundness.lean
@@ -1,4 +1,3 @@
-import Kimchi.Quotient.Pinning
 import Kimchi.Quotient.Aggregate
 import Kimchi.Quotient.AddComplete
 import Kimchi.Quotient.VarBaseMul
@@ -7,12 +6,11 @@ import Kimchi.Quotient.EndoMul
 /-!
 # The quotient-argument soundness
 
-The headline of the commitment-free quotient argument: it composes the
-ζ-pinning corollary (`Kimchi.Quotient.zH_dvd_of_evals`, `Kimchi/Quotient/Pinning.lean`), the
-α-separation lemma (`Kimchi.Quotient.dvd_separation`, `Kimchi/Quotient/Aggregate.lean`) and
-each gate's selector-gated lift (`Gate.<G>` `rowsSel_iff_dvd`) into a single statement per
-gate — "if the aggregated eval-check passes at enough distinct `ζ` over enough distinct `α`,
-then every selector-active row of the gate satisfies its `Gate.<G>.Holds`".
+The headline of the commitment-free quotient argument, one statement per gate: "if the
+aggregated eval-check passes at enough distinct `ζ` over enough distinct `α`, then every
+selector-active row of the gate satisfies its `Gate.<G>.Holds`". Each is an immediate
+specialization of the engine `Kimchi.Quotient.Argument.soundness`
+(`Kimchi/Quotient/Lift.lean`) at that gate's `argument` instance.
 
 It is entirely **commitment-free**: the "enough distinct challenges" premises are ordinary
 injectivity hypotheses on the evaluation nodes `ζ : Fin N → F` and the aggregation challenges
@@ -21,50 +19,17 @@ is no group, no SRS, no Fiat–Shamir.
 
 No gate formula is restated anywhere in this file — the per-gate soundness only reuses the
 read-only `Gate.<G>.constraints` applied to the gate's poly-witness together with that gate's
-`rowsSel_iff_dvd`. The EC meaning of the selected rows is obtained where it is consumed —
+`argument` instance. The EC meaning of the selected rows is obtained where it is consumed —
 by citing `Gate.<G>.sound` — not restated here.
 
 ## Contents
 
-* `dvd_of_evalCheck` — the composed pinning→separation engine, stated over an abstract family
-  of constraint polynomials with no gate content.
 * `AddComplete.soundness` / `VarBaseMul.soundness` / `EndoMul.soundness` — the per-gate
-  soundness statements, pure instantiations of the engine against each gate's selector-gated
-  lift.
+  soundness statements, pure specializations of `Argument.soundness` at each gate's
+  `argument` instance.
 
 Source of truth: `blueprint/src/chapters/Kimchi_Quotient_Soundness.tex`.
 -/
-
-namespace Kimchi.Quotient
-
-open Polynomial
-
-/-! ## The composed pinning–separation engine -/
-
-/-- **Divisibility from the aggregated eval-check.** Fix a primitive `n`-th root `ω`, an
-injective node vector `ζ : Fin N → F`, an injective challenge vector `α : Fin k → F`, and two
-families `E, t : Fin k → F[X]`. Under the abstract degree bound `D < N` on the aggregate and
-on `t s · Z_H`, if the aggregated eval-check
-`(aggregate (α s) E)(ζ p) = (t s · Z_H)(ζ p)` holds for every challenge `s` and node `p`, then
-`Z_H ∣ E c` for every constraint index `c`.
-
-Proof: for each `s`, `zH_dvd_of_evals` pins `Z_H ∣ aggregate (α s) E`; feeding
-this to `dvd_separation` across the `k` distinct challenges yields `Z_H ∣ E c`. -/
-theorem dvd_of_evalCheck {F : Type*} [Field F] {n k N : ℕ} {ω : F}
-    (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
-    (ζ : Fin N → F) (hζ : Function.Injective ζ)
-    (α : Fin k → F) (hα : Function.Injective α)
-    (E t : Fin k → Polynomial F) (D : ℕ) (hD : D < N)
-    (hCdeg : ∀ s, (aggregate (α s) E).natDegree ≤ D)
-    (htdeg : ∀ s, (t s * zH F n).natDegree ≤ D)
-    (hcheck : ∀ s : Fin k, ∀ p : Fin N,
-        (aggregate (α s) E).eval (ζ p) = (t s * zH F n).eval (ζ p)) :
-    ∀ c, zH F n ∣ E c :=
-  dvd_separation hω hn α hα E
-    (fun s => zH_dvd_of_evals hω hn ζ hζ (aggregate (α s) E) (t s) D
-      (hCdeg s) (htdeg s) hD (hcheck s))
-
-end Kimchi.Quotient
 
 /-! ## Per-gate soundness -/
 
@@ -76,10 +41,9 @@ open Polynomial Kimchi.Quotient WeierstrassCurve.Affine
 selector-gated family `c ↦ (columnPoly ω sel) * (constraints (polyWitness ω wTab)).get c`, every
 selector-active row satisfies the CompleteAdd gate predicate.
 
-Proof: apply `dvd_of_evalCheck` to the gated family to obtain
-`∀ c, zH ∣ (columnPoly ω sel) * (constraints …).get c`; convert the `Fin length` indexing to
-`∈ constraints …` membership and feed the CompleteAdd `rowsSel_iff_dvd`. -/
-theorem soundness {F : Type*} [Field F] [DecidableEq F] {n N : ℕ} [NeZero n] {ω : F}
+Proof: specialization of `Argument.soundness` at the instance `argument`; single-row, so
+`qTab := wTab` and the next-row / coefficient families are unused. -/
+theorem soundness {F : Type*} [Field F] [DecidableEq F] {n N : ℕ} {ω : F}
     (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
     (wTab : Fin n → Fin 15 → F) (sel : Fin n → F) (hsel : ∀ i, sel i = 0 ∨ sel i = 1)
     (ζ : Fin N → F) (hζ : Function.Injective ζ)
@@ -94,8 +58,8 @@ theorem soundness {F : Type*} [Field F] [DecidableEq F] {n N : ℕ} [NeZero n] {
         (Gate.AddComplete.constraints (polyWitness ω wTab)).get c)).eval (ζ p)
         = (t s * zH F n).eval (ζ p)) :
     ∀ i, sel i = 1 → Gate.AddComplete.Holds (rowWitness wTab i) := by
-  exact (argument (F := F)).soundness hω hn wTab wTab sel hsel ζ hζ α hα t D hD
-    hCdeg htdeg hcheck
+  haveI : NeZero n := ⟨Nat.pos_iff_ne_zero.mp hn⟩
+  exact argument.soundness hω wTab wTab sel hsel ζ hζ α hα t D hD hCdeg htdeg hcheck
 
 end Kimchi.Quotient.AddComplete
 
@@ -107,10 +71,9 @@ open Polynomial Kimchi.Quotient WeierstrassCurve.Affine
 VarBaseMul gate (`[NeZero n]` for the cyclic successor; the poly-witness next-row cells go
 through `shift`). Every selector-active row satisfies the VarBaseMul gate predicate.
 
-Proof: `dvd_of_evalCheck` on the gated family, then the VarBaseMul
-`rowsSel_iff_dvd`. -/
+Proof: specialization of `Argument.soundness` at the instance `argument`. -/
 theorem soundness {F : Type*} [Field F] [DecidableEq F] {n N : ℕ} [NeZero n] {ω : F}
-    (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
+    (hω : IsPrimitiveRoot ω n)
     (wTab : Fin n → Fin 15 → F) (sel : Fin n → F) (hsel : ∀ i, sel i = 0 ∨ sel i = 1)
     (ζ : Fin N → F) (hζ : Function.Injective ζ)
     (α : Fin (Gate.VarBaseMul.constraints (polyWitness ω wTab)).length → F)
@@ -123,9 +86,8 @@ theorem soundness {F : Type*} [Field F] [DecidableEq F] {n N : ℕ} [NeZero n] {
     (hcheck : ∀ s p, (aggregate (α s) (fun c => columnPoly ω sel *
         (Gate.VarBaseMul.constraints (polyWitness ω wTab)).get c)).eval (ζ p)
         = (t s * zH F n).eval (ζ p)) :
-    ∀ i, sel i = 1 → Gate.VarBaseMul.Holds (rowWitness wTab i) := by
-  exact (argument (F := F)).soundness hω hn wTab wTab sel hsel ζ hζ α hα t D hD
-    hCdeg htdeg hcheck
+    ∀ i, sel i = 1 → Gate.VarBaseMul.Holds (rowWitness wTab i) :=
+  argument.soundness hω wTab wTab sel hsel ζ hζ α hα t D hD hCdeg htdeg hcheck
 
 end Kimchi.Quotient.VarBaseMul
 
@@ -137,10 +99,10 @@ open Polynomial Kimchi.Quotient WeierstrassCurve.Affine
 EndoMul gate, with an extra endomorphism constant `endo : F` (the polynomial side uses
 `C endo`, the row side `endo`). Every selector-active row satisfies the EndoMul gate predicate.
 
-Proof: `dvd_of_evalCheck` on the gated family, then the EndoMul
-`rowsSel_iff_dvd`. -/
+Proof: specialization of `Argument.soundness` at the instance `argument endo`; the endo
+constant transports definitionally between the two carriers. -/
 theorem soundness {F : Type*} [Field F] [DecidableEq F] {n N : ℕ} [NeZero n] {ω : F}
-    (endo : F) (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
+    (endo : F) (hω : IsPrimitiveRoot ω n)
     (wTab : Fin n → Fin 15 → F) (sel : Fin n → F) (hsel : ∀ i, sel i = 0 ∨ sel i = 1)
     (ζ : Fin N → F) (hζ : Function.Injective ζ)
     (α : Fin (Gate.EndoMul.constraints (C endo) (polyWitness ω wTab)).length → F)
@@ -153,10 +115,7 @@ theorem soundness {F : Type*} [Field F] [DecidableEq F] {n N : ℕ} [NeZero n] {
     (hcheck : ∀ s p, (aggregate (α s) (fun c => columnPoly ω sel *
         (Gate.EndoMul.constraints (C endo) (polyWitness ω wTab)).get c)).eval (ζ p)
         = (t s * zH F n).eval (ζ p)) :
-    ∀ i, sel i = 1 → Gate.EndoMul.Holds endo (rowWitness wTab i) := by
-  have h := (argument endo).soundness hω hn wTab wTab sel hsel ζ hζ α hα t D hD
-    hCdeg htdeg hcheck
-  simpa only [argument, polyEnv, rowEnv, Polynomial.algebraMap_eq,
-    Algebra.algebraMap_self_apply, Gate.EndoMul.Holds] using h
+    ∀ i, sel i = 1 → Gate.EndoMul.Holds endo (rowWitness wTab i) :=
+  (argument endo).soundness hω wTab wTab sel hsel ζ hζ α hα t D hD hCdeg htdeg hcheck
 
 end Kimchi.Quotient.EndoMul

--- a/formal/Kimchi/Quotient/VarBaseMul.lean
+++ b/formal/Kimchi/Quotient/VarBaseMul.lean
@@ -23,8 +23,8 @@ on the last domain row, so this agrees with the intended semantics on every occu
 * `cellMap` — assemble a `Gate.VarBaseMul.Witness R` from a current and next row.
 * `rowWitness` / `polyWitness` — the field-valued row witness and its polynomial lift.
 * `argument` — the VarBaseMul `Argument F` instance (two-row layout).
-* `rows_iff_dvd` / `rowsSel_iff_dvd` — the two divisibility corollaries, immediate instances
-  of the `Argument` engine theorems.
+* `rows_iff_dvd` — the divisibility corollary, an immediate instance of the `Argument`
+  engine theorems.
 
 Source of truth: `blueprint/src/chapters/Kimchi_Quotient_VarBaseMul.tex`.
 -/
@@ -97,26 +97,15 @@ def argument : Argument F where
   constraints_map f env :=
     Gate.VarBaseMul.constraints_map f.toRingHom (cellMap env.witnessCurr env.witnessNext)
 
-/-! ## Divisibility corollaries -/
+/-! ## Divisibility corollary -/
 
 /-- **VarBaseMul rows hold iff divisible.** The gate's constraint polynomials are all divisible
 by the vanishing polynomial `Z_H` iff the gate holds on every row. Immediate specialization of
 `Argument.rows_iff_dvd` at the instance `argument`. -/
-theorem rows_iff_dvd [NeZero n] (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
+theorem rows_iff_dvd [NeZero n] (hω : IsPrimitiveRoot ω n)
     (wTab : Fin n → Fin 15 → F) :
     (∀ E ∈ Gate.VarBaseMul.constraints (polyWitness ω wTab), zH F n ∣ E)
       ↔ ∀ i, Gate.VarBaseMul.Holds (rowWitness wTab i) :=
-  (argument (F := F)).rows_iff_dvd hω hn wTab wTab
-
-/-- **VarBaseMul selector-gated rows iff divisible.** With a boolean selector column
-`S = columnPoly ω sel`, divisibility of `S · E` by `Z_H` is equivalent to the gate holding only
-on the selected rows. Immediate specialization of `Argument.rowsSel_iff_dvd` at the instance
-`argument`. -/
-theorem rowsSel_iff_dvd [NeZero n] (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
-    (wTab : Fin n → Fin 15 → F) (sel : Fin n → F) (hsel : ∀ i, sel i = 0 ∨ sel i = 1) :
-    (∀ E ∈ Gate.VarBaseMul.constraints (polyWitness ω wTab),
-        zH F n ∣ (columnPoly ω sel) * E)
-      ↔ ∀ i, sel i = 1 → Gate.VarBaseMul.Holds (rowWitness wTab i) :=
-  (argument (F := F)).rowsSel_iff_dvd hω hn wTab wTab sel hsel
+  argument.rows_iff_dvd hω wTab wTab
 
 end Kimchi.Quotient.VarBaseMul

--- a/formal/Kimchi/Quotient/VarBaseMul.lean
+++ b/formal/Kimchi/Quotient/VarBaseMul.lean
@@ -22,9 +22,9 @@ on the last domain row, so this agrees with the intended semantics on every occu
 
 * `cellMap` — assemble a `Gate.VarBaseMul.Witness R` from a current and next row.
 * `rowWitness` / `polyWitness` — the field-valued row witness and its polynomial lift.
-* `bridge` — naturality: evaluating the poly witness's constraints at `ω^i` reproduces the
-  row witness's constraints.
-* `rows_iff_dvd` / `rowsSel_iff_dvd` — the two engine-instance divisibility corollaries.
+* `argument` — the VarBaseMul `Argument F` instance (two-row layout).
+* `rows_iff_dvd` / `rowsSel_iff_dvd` — the two divisibility corollaries, immediate instances
+  of the `Argument` engine theorems.
 
 Source of truth: `blueprint/src/chapters/Kimchi_Quotient_VarBaseMul.tex`.
 -/
@@ -87,49 +87,36 @@ noncomputable def polyWitness (ω : F) (wTab : Fin n → Fin 15 → F) :
   cellMap (fun c => columnPoly ω (fun j => wTab j c))
     (fun c => shift ω (columnPoly ω (fun j => wTab j c)))
 
-/-! ## The naturality bridge -/
+/-! ## The `Argument` instance -/
 
-/-- **VarBaseMul per-row bridge.** Evaluating the poly witness's constraint polynomials at the
-node `ω^i` reproduces the row witness's field-level constraints. Discharged by naturality of
-`Gate.VarBaseMul.constraints_map` at `evalRingHom (ω^i)`, then `eval_columnPoly` (current side)
-and `eval_shift_columnPoly` (next side). -/
-theorem bridge [NeZero n] (hω : IsPrimitiveRoot ω n) (wTab : Fin n → Fin 15 → F) (i : Fin n) :
-    (Gate.VarBaseMul.constraints (polyWitness ω wTab)).map (·.eval (ω ^ (i : ℕ)))
-      = Gate.VarBaseMul.constraints (rowWitness wTab i) := by
-  -- Evaluation at `ω^i` is the ring hom `evalRingHom (ω^i)`; rewrite the plain map by it.
-  have hfun : (fun E : Polynomial F => E.eval (ω ^ (i : ℕ)))
-      = ⇑(evalRingHom (ω ^ (i : ℕ))) := by
-    funext E; rw [Polynomial.coe_evalRingHom]
-  rw [hfun, Gate.VarBaseMul.constraints_map]
-  -- Now identify the mapped poly-witness with the row witness, cell by cell: current-side cells
-  -- reduce by `eval_columnPoly`, next-side (shifted) cells by `eval_shift_columnPoly`.
-  congr 1
-  simp only [polyWitness, rowWitness, cellMap, Gate.VarBaseMul.Witness.map,
-    Polynomial.coe_evalRingHom, eval_columnPoly hω, eval_shift_columnPoly hω]
+/-- **VarBaseMul `Argument` instance.** The gate's constraints read through the two-row cell
+map (`cellMap env.witnessCurr env.witnessNext`; the coefficient family is unused); naturality
+is the gate's `Gate.VarBaseMul.constraints_map` at the underlying ring hom. -/
+def argument : Argument F where
+  constraints env := Gate.VarBaseMul.constraints (cellMap env.witnessCurr env.witnessNext)
+  constraints_map f env :=
+    Gate.VarBaseMul.constraints_map f.toRingHom (cellMap env.witnessCurr env.witnessNext)
 
 /-! ## Divisibility corollaries -/
 
 /-- **VarBaseMul rows hold iff divisible.** The gate's constraint polynomials are all divisible
-by the vanishing polynomial `Z_H` iff the gate holds on every row. Instance of the engine
-`rows_iff_dvd_of` with the bridge above. -/
+by the vanishing polynomial `Z_H` iff the gate holds on every row. Immediate specialization of
+`Argument.rows_iff_dvd` at the instance `argument`. -/
 theorem rows_iff_dvd [NeZero n] (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
     (wTab : Fin n → Fin 15 → F) :
     (∀ E ∈ Gate.VarBaseMul.constraints (polyWitness ω wTab), zH F n ∣ E)
-      ↔ ∀ i, Gate.VarBaseMul.Holds (rowWitness wTab i) := by
-  -- Instantiate the ungated engine; `Holds w` is defeq to `∀ e ∈ constraints w, e = 0`.
-  exact Kimchi.Quotient.rows_iff_dvd_of hω hn _
-    (fun i => Gate.VarBaseMul.constraints (rowWitness wTab i)) (bridge hω wTab)
+      ↔ ∀ i, Gate.VarBaseMul.Holds (rowWitness wTab i) :=
+  (argument (F := F)).rows_iff_dvd hω hn wTab wTab
 
 /-- **VarBaseMul selector-gated rows iff divisible.** With a boolean selector column
 `S = columnPoly ω sel`, divisibility of `S · E` by `Z_H` is equivalent to the gate holding only
-on the selected rows. Instance of the engine `rowsSel_iff_dvd` with the bridge above. -/
+on the selected rows. Immediate specialization of `Argument.rowsSel_iff_dvd` at the instance
+`argument`. -/
 theorem rowsSel_iff_dvd [NeZero n] (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
     (wTab : Fin n → Fin 15 → F) (sel : Fin n → F) (hsel : ∀ i, sel i = 0 ∨ sel i = 1) :
     (∀ E ∈ Gate.VarBaseMul.constraints (polyWitness ω wTab),
         zH F n ∣ (columnPoly ω sel) * E)
-      ↔ ∀ i, sel i = 1 → Gate.VarBaseMul.Holds (rowWitness wTab i) := by
-  -- Instantiate the selector-gated engine; `Holds w` is defeq to `∀ e ∈ constraints w, e = 0`.
-  exact Kimchi.Quotient.rowsSel_iff_dvd hω hn _
-    (fun i => Gate.VarBaseMul.constraints (rowWitness wTab i)) sel hsel (bridge hω wTab)
+      ↔ ∀ i, sel i = 1 → Gate.VarBaseMul.Holds (rowWitness wTab i) :=
+  (argument (F := F)).rowsSel_iff_dvd hω hn wTab wTab sel hsel
 
 end Kimchi.Quotient.VarBaseMul

--- a/formal/roots.txt
+++ b/formal/roots.txt
@@ -101,3 +101,9 @@ Kimchi.Quotient.EndoMul.rows_iff_dvd
 Kimchi.Quotient.AddComplete.soundness
 Kimchi.Quotient.VarBaseMul.soundness
 Kimchi.Quotient.EndoMul.soundness
+
+-- Argument: the single primitive every gate's quotient lift instantiates (kimchi argument.rs:
+-- an F-algebra-natural constraint family over the ArgumentEnv cell environment);
+-- rows/selector-gated/soundness stated once over it.
+Kimchi.Quotient.Argument.rows_iff_dvd
+Kimchi.Quotient.Argument.soundness

--- a/formal/scripts/check_axioms.lean
+++ b/formal/scripts/check_axioms.lean
@@ -56,7 +56,9 @@ def roots : List Name :=
     `Kimchi.Quotient.EndoMul.rows_iff_dvd,
     `Kimchi.Quotient.AddComplete.soundness,
     `Kimchi.Quotient.VarBaseMul.soundness,
-    `Kimchi.Quotient.EndoMul.soundness ]
+    `Kimchi.Quotient.EndoMul.soundness,
+    `Kimchi.Quotient.Argument.rows_iff_dvd,
+    `Kimchi.Quotient.Argument.soundness ]
 
 /-- The only axioms the roots may depend on: the standard logical axioms; the Pasta Hasse bounds
     (`{pallas,vesta}_hasse`); `Lean.ofReduceBool`; and the Pasta GLV endomorphism inputs (`β`, `λ`,


### PR DESCRIPTION
## Summary

Introduces `Kimchi.Quotient.Argument` — the single primitive every gate's quotient lift instantiates, mirroring kimchi's `Argument` trait (`argument.rs`). Two fields:

- `constraints : ∀ {R} [CommRing R] [Algebra F R], ArgumentEnv R → List R` — the gate's constraint family over any commutative F-algebra, read from a new `ArgumentEnv R` (`witnessCurr` / `witnessNext` / `coeff` — the Lean counterpart of kimchi's `ArgumentEnv` cell accessors);
- `constraints_map` — its naturality square along F-algebra homs (the agreement between carrier instantiations that Rust's `constraint_checks<T: ExprOps>` gets for free by parametricity, stated as a proof obligation in Lean).

The engine states everything once over it: the two carrier instantiations `rowEnv` / `polyEnv` and the evaluation bridge `polyEnv_map_aeval` are gate-independent, and `Argument.{bridge, rows_iff_dvd, rowsSel_iff_dvd, soundness}` are each a single proof. No gate restates a bespoke bridge. F-algebra genericity is what absorbs gate parameters: a fixed field element enters as its `algebraMap F R` image, which `aeval (ω^i) : F[X] →ₐ[F] F` fixes.

The existing gate lifts become instances (`constraints := Gate.X.constraints ∘ layout`, naturality by delegation — the layout equations hold definitionally):

- **AddComplete, VarBaseMul** — plain ring-hom naturality via `f.toRingHom`; hand-rolled bridges deleted.
- **EndoMul** — endo constant transported as `algebraMap F R endo` (`C endo` at `R = F[X]`), replacing the bespoke `eval_C` bridge.
- **Generic** — gains constraints-as-data (`constraints`, `Holds`/`ok` derived, `holds_iff`) + `constraints_map`, matching the #184 convention; its divisibility checkpoint routes through the engine.

Per-gate statements carry exactly the hypothesis their shape forces: single-row gates (AddComplete) keep the pre-PR `hn : 0 < n` signatures and derive `NeZero` inside the proof; two-row gates (VarBaseMul, EndoMul), whose statements force `[NeZero n]` through the cyclic `rowWitness`, drop the now-redundant `hn`. The per-gate `rowsSel_iff_dvd` wrappers are deleted — uncalled since soundness routes through `Argument.soundness`, and recoverable as one-line instantiations of `Argument.rowsSel_iff_dvd` when a consumer (the completeness direction) exists. The composed pinning→separation engine `dvd_of_evalCheck` moves from `Quotient/Soundness.lean` into `Lift.lean` so `Argument.soundness` calls it instead of inlining its body.

## Scope

This PR is the **machinery + migration of the three existing gate lifts** only. The EndoScalar and Poseidon quotient lifts (the two new instances that complete the six-gate story) follow as separate PRs stacked on this one.

## Roots / axiom gate

`roots.txt` / `check_axioms.lean` gain `Quotient.Argument.{rows_iff_dvd,soundness}` (50 roots total).

## Verification

- `lake build Kimchi` — success, no sorries
- `scripts/check-style.sh` — clean
- `scripts/check_axioms.sh` — all 50 roots reduce to the allowed axiom set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

