### PR TITLE
formal: EndoScalar quotient lift as an Argument instance

### DIFF
--- a/formal/Kimchi.lean
+++ b/formal/Kimchi.lean
@@ -16,4 +16,5 @@ import Kimchi.Circuit.EndoMul
 import Kimchi.Commitment.IPA.Soundness
 import Kimchi.Commitment.IPA.Soundness.Batch
 import Kimchi.Quotient.Generic
+import Kimchi.Quotient.EndoScalar
 import Kimchi.Quotient.Soundness

--- a/formal/Kimchi/Gate/EndoScalar.lean
+++ b/formal/Kimchi/Gate/EndoScalar.lean
@@ -45,18 +45,29 @@ The constraint model (`Witness` / `Holds` / `ok` / `ok_iff`) and the cubic↔tab
 
 namespace Kimchi.Gate.EndoScalar
 
-variable {F : Type*} [Field F]
+universe u
+
+variable {F : Type u} [Field F]
 
 /-- `c_func`'s interpolating cubic `⅔x³ − 5⁄2x² + 11⁄6x` (Lagrange over
     `(0,0),(1,0),(2,−1),(3,1)`). The gate enforces this polynomial; `cPoly_table`
-    shows it equals the intended `(0,0,−1,1)` table on crumbs. -/
-def cPoly (x : F) : F := 2 / 3 * x ^ 3 - 5 / 2 * x ^ 2 + 11 / 6 * x
+    shows it equals the intended `(0,0,−1,1)` table on crumbs.
 
-/-- `d_func = c_func + (−x² + 3x − 1)`; on crumbs it is the `(−1,1,0,0)` table. -/
-def dPoly (x : F) : F := cPoly x + (-x ^ 2 + 3 * x - 1)
+    Stated over an arbitrary commutative `F`-algebra `R`: the field constants become their
+    `algebraMap F R` images, so the quotient layer can read the gate over `R`. At `R = F` the
+    algebra map is the identity and this is the original field polynomial. -/
+def cPoly {R : Type u} [CommRing R] (x : R) (F : Type u := R) [Field F] [Algebra F R] : R :=
+  algebraMap F R (2 / 3) * x ^ 3 - algebraMap F R (5 / 2) * x ^ 2 + algebraMap F R (11 / 6) * x
 
-/-- The crumb-range polynomial `x(x−1)(x−2)(x−3)` — zero exactly on `{0,1,2,3}`. -/
-def crumbPoly (x : F) : F := x * (x - 1) * (x - 2) * (x - 3)
+/-- `d_func = c_func + (−x² + 3x − 1)`; on crumbs it is the `(−1,1,0,0)` table.
+    Read over an arbitrary commutative `F`-algebra `R` (see `cPoly`). -/
+def dPoly {R : Type u} [CommRing R] (x : R) (F : Type u := R) [Field F] [Algebra F R] : R :=
+  cPoly x (F := F) + (-x ^ 2 + 3 * x - 1)
+
+/-- The crumb-range polynomial `x(x−1)(x−2)(x−3)` — zero exactly on `{0,1,2,3}`.
+    Its coefficients are integers, so it needs no algebra map: it reads over any commutative
+    ring `R`. -/
+def crumbPoly {R : Type*} [CommRing R] (x : R) : R := x * (x - 1) * (x - 2) * (x - 3)
 
 /-- The range constraint vanishes iff the crumb is a genuine 2-bit value. Holds in
     any field (an integral domain): a product is zero iff a factor is. -/
@@ -71,7 +82,8 @@ theorem cPoly_table (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) :
       ∧ cPoly (2 : F) = -1 ∧ cPoly (3 : F) = 1 := by
   have h6 : (6 : F) ≠ 0 := by
     rw [show (6 : F) = 2 * 3 by norm_num]; exact mul_ne_zero h2 h3
-  refine ⟨?_, ?_, ?_, ?_⟩ <;> · simp only [cPoly]; field_simp; ring
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> ·
+    simp only [cPoly, Algebra.algebraMap_eq_smul_one, smul_eq_mul, mul_one]; field_simp; ring
 
 /-- `dPoly` reproduces the `d_func = (−1,1,0,0)` table on every crumb. -/
 theorem dPoly_table (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) :
@@ -102,14 +114,93 @@ deriving Repr
 /-- The gate constraint expressions (11 at the deployed 8-crumb width: `3 + #crumbs`) — the
     single transcription: the three accumulator folds (`n := 4n+x`, `a := 2a + cPoly x`,
     `b := 2b + dPoly x`) closing at `a8,b8,n8`, and the range polynomial per crumb. The
-    relational spec (`Holds`) and the checker (`ok`) are read from this list. (Stated over
-    the field `F` — `cPoly`/`dPoly` carry field-constant coefficients; the ring-generic
-    reading for the quotient layer goes through the algebra map, deferred to that layer.) -/
-def constraints (w : Witness F) : List F :=
+    relational spec (`Holds`) and the checker (`ok`) are read from this list. Stated over an
+    arbitrary commutative `F`-algebra `R` — `cPoly`/`dPoly` carry field-constant coefficients
+    mapped in through `algebraMap F R`; at `R = F` this is the original field reading, and the
+    `R`-generic form is what the quotient layer's `Argument` instance consumes. -/
+def constraints {R : Type u} [CommRing R] (w : Witness R) (F : Type u := R) [Field F]
+    [Algebra F R] : List R :=
   [ w.n8 - w.crumbs.foldl (fun acc x => 4 * acc + x) w.n0
-  , w.a8 - w.crumbs.foldl (fun acc x => 2 * acc + cPoly x) w.a0
-  , w.b8 - w.crumbs.foldl (fun acc x => 2 * acc + dPoly x) w.b0 ]
+  , w.a8 - w.crumbs.foldl (fun acc x => 2 * acc + cPoly x (F := F)) w.a0
+  , w.b8 - w.crumbs.foldl (fun acc x => 2 * acc + dPoly x (F := F)) w.b0 ]
   ++ w.crumbs.map crumbPoly
+
+/-- Push a carrier map `f : R → S` through a witness, cell by cell (the six accumulator cells
+    and every crumb). The vehicle for the `Argument` naturality: an `F`-algebra hom commutes
+    with the constraint list (see `constraints_map`). -/
+def Witness.map {R S : Type*} (f : R → S) (w : Witness R) : Witness S where
+  a0 := f w.a0
+  b0 := f w.b0
+  n0 := f w.n0
+  a8 := f w.a8
+  b8 := f w.b8
+  n8 := f w.n8
+  crumbs := w.crumbs.map f
+
+/-- `f` commutes with the interpolating cubic `cPoly`: an `F`-algebra hom fixes the
+    `algebraMap F _` coefficients (`AlgHom.commutes`) and preserves powers/products. -/
+theorem cPoly_map {R S : Type u} [CommRing R] [CommRing S] [Algebra F R] [Algebra F S]
+    (f : R →ₐ[F] S) (x : R) : f (cPoly x (F := F)) = cPoly (f x) (F := F) := by
+  simp only [cPoly, map_sub, map_add, map_mul, map_pow, AlgHom.commutes]
+
+/-- `f` commutes with `dPoly` (`cPoly` plus an integer-coefficient tail `−x²+3x−1`). -/
+theorem dPoly_map {R S : Type u} [CommRing R] [CommRing S] [Algebra F R] [Algebra F S]
+    (f : R →ₐ[F] S) (x : R) : f (dPoly x (F := F)) = dPoly (f x) (F := F) := by
+  simp only [dPoly, map_add, map_sub, map_neg, map_mul, map_pow, map_ofNat, map_one, cPoly_map f]
+
+/-- `f` commutes with the crumb-range polynomial `crumbPoly` (integer coefficients only). -/
+theorem crumbPoly_map {R S : Type u} [CommRing R] [CommRing S] [Algebra F R] [Algebra F S]
+    (f : R →ₐ[F] S) (x : R) : f (crumbPoly x) = crumbPoly (f x) := by
+  simp only [crumbPoly, map_mul, map_sub, map_ofNat, map_one]
+
+/-- `f` distributes through the `n`-accumulator fold `n := 4·n + x` (induction on the crumbs,
+    the shape of `foldl_table`; the base is `map f [] = []`, the step pushes `f` past one
+    update via `map_add`/`map_mul`/`map_ofNat`). -/
+theorem foldl_map_n {R S : Type u} [CommRing R] [CommRing S] [Algebra F R] [Algebra F S]
+    (f : R →ₐ[F] S) :
+    ∀ (xs : List R) (init : R),
+      f (xs.foldl (fun acc x => 4 * acc + x) init)
+        = (xs.map f).foldl (fun acc x => 4 * acc + x) (f init)
+  | [], _ => rfl
+  | y :: ys, init => by
+    simp only [List.foldl_cons, List.map_cons]
+    rw [foldl_map_n f ys (4 * init + y), map_add, map_mul, map_ofNat]
+
+/-- `f` distributes through the `a`-accumulator fold `a := 2·a + cPoly x`. -/
+theorem foldl_map_c {R S : Type u} [CommRing R] [CommRing S] [Algebra F R] [Algebra F S]
+    (f : R →ₐ[F] S) :
+    ∀ (xs : List R) (init : R),
+      f (xs.foldl (fun acc x => 2 * acc + cPoly x (F := F)) init)
+        = (xs.map f).foldl (fun acc x => 2 * acc + cPoly x (F := F)) (f init)
+  | [], _ => rfl
+  | y :: ys, init => by
+    simp only [List.foldl_cons, List.map_cons]
+    rw [foldl_map_c f ys (2 * init + cPoly y (F := F)), map_add, map_mul, map_ofNat, cPoly_map f]
+
+/-- `f` distributes through the `b`-accumulator fold `b := 2·b + dPoly x`. -/
+theorem foldl_map_d {R S : Type u} [CommRing R] [CommRing S] [Algebra F R] [Algebra F S]
+    (f : R →ₐ[F] S) :
+    ∀ (xs : List R) (init : R),
+      f (xs.foldl (fun acc x => 2 * acc + dPoly x (F := F)) init)
+        = (xs.map f).foldl (fun acc x => 2 * acc + dPoly x (F := F)) (f init)
+  | [], _ => rfl
+  | y :: ys, init => by
+    simp only [List.foldl_cons, List.map_cons]
+    rw [foldl_map_d f ys (2 * init + dPoly y (F := F)), map_add, map_mul, map_ofNat, dPoly_map f]
+
+/-- **Naturality.** An `F`-algebra hom `f : R →ₐ[F] S` commutes with the constraint list:
+    mapping `f` over `constraints w` is `constraints (Witness.map f w)`. `f` commutes with
+    `cPoly`/`dPoly` (it fixes the `algebraMap F _` coefficients and preserves powers/products)
+    and with `crumbPoly`, and distributes through the accumulator folds by induction on the
+    crumb list (the shape of `foldl_table`). This is what makes the gate an `Argument` instance. -/
+theorem constraints_map {R S : Type u} [CommRing R] [CommRing S] [Algebra F R] [Algebra F S]
+    (f : R →ₐ[F] S) (w : Witness R) :
+    (constraints (F := F) w).map f = constraints (F := F) (Witness.map f w) := by
+  simp only [constraints, Witness.map, List.map_append, List.map_cons, List.map_nil, map_sub]
+  rw [foldl_map_n f w.crumbs w.n0, foldl_map_c f w.crumbs w.a0, foldl_map_d f w.crumbs w.b0]
+  congr 1
+  rw [List.map_map, List.map_map]
+  exact List.map_congr_left fun x _ => crumbPoly_map f x
 
 /-- RELATIONAL spec: all constraint expressions vanish. -/
 def Holds (w : Witness F) : Prop :=

--- a/formal/Kimchi/Quotient/EndoScalar.lean
+++ b/formal/Kimchi/Quotient/EndoScalar.lean
@@ -1,0 +1,125 @@
+import Kimchi.Quotient.Lift
+import Kimchi.Quotient.Soundness
+import Kimchi.Gate.EndoScalar
+
+/-!
+# Quotient lift of the EndoScalar gate
+
+The polynomial-algebra lift of kimchi's `EndoScalar` gate (the endomorphism-scalar recoder —
+pure field arithmetic running Halo's Algorithm 2 over MSB-first 2-bit crumbs), packaged as a
+`Kimchi.Quotient.Argument` instance.
+
+The gate's constraint list `Gate.EndoScalar.constraints` is defined over any commutative
+`F`-algebra — its interpolating-cubic coefficients (`cPoly`/`dPoly`) enter through
+`algebraMap F R` — so the instance is a direct read-through of the cell map; naturality is the
+gate module's `Gate.EndoScalar.constraints_map`.
+
+`EndoScalar` is a **single-row** gate: both `n0` (input) and `n8` (output) live on the same
+row, so the cell map reads the current row only (the next-row and coefficient families are
+unused). The cross-row chaining of the scalar register (`n0 ↔ n8`) is a copy-constraint
+concern (the permutation layer), out of scope here.
+
+## Column layout
+
+Source: proof-systems kimchi `endomul_scalar.rs`, witness-layout comment l.116-122
+(`CONSTRAINTS = 11`):
+
+```
+|  0 |  1 |  2 |  3 |  4 |  5 |  6 |  7 |  8 |  9 | 10 | 11 | 12 | 13 | 14 | Type |
+| n0 | n8 | a0 | b0 | a8 | b8 | x0 | x1 | x2 | x3 | x4 | x5 | x6 | x7 |    | ENDO |
+```
+
+where each `xi` is a two-bit "crumb".
+
+## Contents
+
+* `cellMap` / `rowWitness` / `polyWitness` — the layout transcription and its two carrier
+  instantiations.
+* `argument` — the `Argument F` instance (`def:quotient_endoscalar_lift`).
+* `rows_iff_dvd` — rows hold iff the constraint polynomials are divisible by `zH`
+  (`thm:quotient_endoscalar_rows_iff_dvd`).
+* `soundness` — the abstract quotient-argument soundness statement
+  (`thm:quotient_endoscalar_soundness`).
+
+Source of truth: `blueprint/src/chapters/Kimchi_Quotient_EndoScalar.tex`.
+-/
+
+namespace Kimchi.Quotient.EndoScalar
+
+open Polynomial Kimchi.Quotient
+
+variable {F : Type*} [Field F] {n : ℕ} {ω : F}
+
+/-! ## Column layout and the cell map -/
+
+/-- **EndoScalar cell map.** Assemble a `Gate.EndoScalar.Witness R` by reading the circuit
+columns of a row `cur : Fin 15 → R`. The eight crumbs are the literal 8-element list, so the
+accumulator folds unfold directly on it (no witness reshape). -/
+def cellMap {R : Type*} (cur : Fin 15 → R) : Gate.EndoScalar.Witness R where
+  n0 := cur 0
+  n8 := cur 1
+  a0 := cur 2
+  b0 := cur 3
+  a8 := cur 4
+  b8 := cur 5
+  crumbs := [cur 6, cur 7, cur 8, cur 9, cur 10, cur 11, cur 12, cur 13]
+
+/-- **EndoScalar row witness.** The gate witness at row `i`, read off the circuit witness
+table `wTab : Fin n → Fin 15 → F`. -/
+def rowWitness (wTab : Fin n → Fin 15 → F) (i : Fin n) : Gate.EndoScalar.Witness F :=
+  cellMap (wTab i)
+
+/-- **EndoScalar poly witness.** The gate witness whose every cell is the interpolant
+`columnPoly ω` of the corresponding circuit column. -/
+noncomputable def polyWitness (ω : F) (wTab : Fin n → Fin 15 → F) :
+    Gate.EndoScalar.Witness (Polynomial F) :=
+  cellMap (fun c => columnPoly ω (fun j => wTab j c))
+
+/-! ## The `Argument` instance -/
+
+/-- **EndoScalar `Argument` instance.** The gate's algebra-generic constraints read through the
+single-row cell map (`cellMap env.witnessCurr`; the next-row and coefficient families are
+unused); naturality is the gate's `Gate.EndoScalar.constraints_map`. -/
+def argument : Argument F where
+  constraints env := Gate.EndoScalar.constraints (cellMap env.witnessCurr) (F := F)
+  constraints_map f env := Gate.EndoScalar.constraints_map (F := F) f (cellMap env.witnessCurr)
+
+/-! ## Divisibility corollary -/
+
+/-- **EndoScalar rows hold iff divisible.** The EndoScalar constraint polynomials of a witness
+table are all divisible by `zH` iff the gate holds on every row. Immediate specialization of
+`Argument.rows_iff_dvd` to the instance `argument`; single-row, so `qTab := wTab` and the
+next-row / coefficient families are unused. -/
+theorem rows_iff_dvd (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
+    (wTab : Fin n → Fin 15 → F) :
+    (∀ E ∈ Gate.EndoScalar.constraints (polyWitness ω wTab) (F := F), zH F n ∣ E)
+      ↔ ∀ i, Gate.EndoScalar.Holds (rowWitness wTab i) := by
+  haveI : NeZero n := ⟨Nat.pos_iff_ne_zero.mp hn⟩
+  exact argument.rows_iff_dvd hω wTab wTab
+
+/-! ## Quotient-argument soundness -/
+
+/-- **EndoScalar quotient soundness.** With the abstract quotient-argument hypotheses over the
+selector-gated EndoScalar family
+`c ↦ (columnPoly ω sel) * (constraints (polyWitness ω wTab)).get c`, every selector-active row
+satisfies the EndoScalar gate predicate `Gate.EndoScalar.Holds`. Specialization of
+`Argument.soundness` at the instance `argument`. -/
+theorem soundness [DecidableEq F] {N : ℕ}
+    (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
+    (wTab : Fin n → Fin 15 → F) (sel : Fin n → F) (hsel : ∀ i, sel i = 0 ∨ sel i = 1)
+    (ζ : Fin N → F) (hζ : Function.Injective ζ)
+    (α : Fin (Gate.EndoScalar.constraints (polyWitness ω wTab) (F := F)).length → F)
+    (hα : Function.Injective α)
+    (t : Fin (Gate.EndoScalar.constraints (polyWitness ω wTab) (F := F)).length → Polynomial F)
+    (D : ℕ) (hD : D < N)
+    (hCdeg : ∀ s, (aggregate (α s) (fun c => columnPoly ω sel *
+        (Gate.EndoScalar.constraints (polyWitness ω wTab) (F := F)).get c)).natDegree ≤ D)
+    (htdeg : ∀ s, (t s * zH F n).natDegree ≤ D)
+    (hcheck : ∀ s p, (aggregate (α s) (fun c => columnPoly ω sel *
+        (Gate.EndoScalar.constraints (polyWitness ω wTab) (F := F)).get c)).eval (ζ p)
+        = (t s * zH F n).eval (ζ p)) :
+    ∀ i, sel i = 1 → Gate.EndoScalar.Holds (rowWitness wTab i) := by
+  haveI : NeZero n := ⟨Nat.pos_iff_ne_zero.mp hn⟩
+  exact argument.soundness hω wTab wTab sel hsel ζ hζ α hα t D hD hCdeg htdeg hcheck
+
+end Kimchi.Quotient.EndoScalar

--- a/formal/roots.txt
+++ b/formal/roots.txt
@@ -107,3 +107,8 @@ Kimchi.Quotient.EndoMul.soundness
 -- rows/selector-gated/soundness stated once over it.
 Kimchi.Quotient.Argument.rows_iff_dvd
 Kimchi.Quotient.Argument.soundness
+
+-- EndoScalar quotient lift (the gate's constraints read over any commutative F-algebra —
+-- the cPoly/dPoly coefficients enter through algebraMap F R).
+Kimchi.Quotient.EndoScalar.rows_iff_dvd
+Kimchi.Quotient.EndoScalar.soundness

--- a/formal/scripts/check_axioms.lean
+++ b/formal/scripts/check_axioms.lean
@@ -58,7 +58,9 @@ def roots : List Name :=
     `Kimchi.Quotient.VarBaseMul.soundness,
     `Kimchi.Quotient.EndoMul.soundness,
     `Kimchi.Quotient.Argument.rows_iff_dvd,
-    `Kimchi.Quotient.Argument.soundness ]
+    `Kimchi.Quotient.Argument.soundness,
+    `Kimchi.Quotient.EndoScalar.rows_iff_dvd,
+    `Kimchi.Quotient.EndoScalar.soundness ]
 
 /-- The only axioms the roots may depend on: the standard logical axioms; the Pasta Hasse bounds
     (`{pallas,vesta}_hasse`); `Lean.ofReduceBool`; and the Pasta GLV endomorphism inputs (`β`, `λ`,


### PR DESCRIPTION
Stacked on #190 (the `Argument` machinery) — review only the top commit.

## Summary

- **Gate layer**: `Gate.EndoScalar.constraints` generalized over commutative F-algebras — the interpolating-cubic coefficients of `cPoly`/`dPoly` enter through `algebraMap F R` (at `R = F` the algebra map is the identity, so the field reading is unchanged; `crumbPoly` has integer coefficients and needs no algebra map). Naturality (`constraints_map`) is proved cellwise for the cubics via `AlgHom.commutes` and by induction on the crumb list for the three accumulator folds.
- **Quotient layer** (new `Kimchi/Quotient/EndoScalar.lean`): instantiates the `Argument` primitive with the single-row ENDO layout (`n0 n8 a0 b0 a8 b8 x0..x7`; `endomul_scalar.rs` l.116-122) and derives `rows_iff_dvd` and the quotient-argument soundness by specialization. The cross-row chaining of the scalar register (`n0 ↔ n8`) is a copy-constraint concern (permutation layer), out of scope here.

## Roots / axiom gate

`roots.txt` / `check_axioms.lean` gain `Quotient.EndoScalar.{rows_iff_dvd,soundness}` (52 roots).

## Verification

- `lake build Kimchi` — success, no sorries
- `scripts/check-style.sh` — clean
- `scripts/check_axioms.sh` — all 52 roots reduce to the allowed axiom set

🤖 Generated with [Claude Code](https://claude.com/claude-code)