### PR TITLE
formal: Poseidon quotient lift as an Argument instance

### DIFF
--- a/formal/Kimchi.lean
+++ b/formal/Kimchi.lean
@@ -17,4 +17,5 @@ import Kimchi.Commitment.IPA.Soundness
 import Kimchi.Commitment.IPA.Soundness.Batch
 import Kimchi.Quotient.Generic
 import Kimchi.Quotient.EndoScalar
+import Kimchi.Quotient.Poseidon
 import Kimchi.Quotient.Soundness

--- a/formal/Kimchi/Gate/Poseidon.lean
+++ b/formal/Kimchi/Gate/Poseidon.lean
@@ -69,6 +69,15 @@ structure Witness (F : Type*) where
   s4 : F × F × F
   s5 : F × F × F
 
+/-- Map `f` componentwise across all six state triples of a witness. -/
+def Witness.map {R S : Type*} (f : R → S) (w : Witness R) : Witness S where
+  s0 := (f w.s0.1, f w.s0.2.1, f w.s0.2.2)
+  s1 := (f w.s1.1, f w.s1.2.1, f w.s1.2.2)
+  s2 := (f w.s2.1, f w.s2.2.1, f w.s2.2.2)
+  s3 := (f w.s3.1, f w.s3.2.1, f w.s3.2.2)
+  s4 := (f w.s4.1, f w.s4.2.1, f w.s4.2.2)
+  s5 := (f w.s5.1, f w.s5.2.1, f w.s5.2.2)
+
 /-- The 15 constraint expressions: for each of the five rounds, the three components of
     `sᵢ₊₁ − round(sᵢ, rcᵢ)`. -/
 def constraints [CommRing F] (rc : Fin 5 → F × F × F) (w : Witness F) : List F :=
@@ -82,6 +91,16 @@ def constraints [CommRing F] (rc : Fin 5 → F × F × F) (w : Witness F) : List
     w.s4.2.2 - (round w.s3 (rc 3)).2.2,
     w.s5.1 - (round w.s4 (rc 4)).1, w.s5.2.1 - (round w.s4 (rc 4)).2.1,
     w.s5.2.2 - (round w.s4 (rc 4)).2.2 ]
+
+/-- Naturality of the constraint list: a ring hom `f` distributes over all 15 constraint
+    expressions, so mapping `f` over `constraints rc w` equals the constraints of the mapped
+    round constants and mapped witness. -/
+theorem constraints_map {R S : Type*} [CommRing R] [CommRing S] (f : R →+* S)
+    (rc : Fin 5 → R × R × R) (w : Witness R) :
+    (constraints rc w).map f
+      = constraints (fun j => (f (rc j).1, f (rc j).2.1, f (rc j).2.2)) (Witness.map f w) := by
+  simp [constraints, round, sbox, Witness.map, map_ofNat, m00, m01, m02, m10, m11, m12,
+    m20, m21, m22]
 
 /-- RELATIONAL spec: all 15 constraint expressions vanish. -/
 def Holds [CommRing F] (rc : Fin 5 → F × F × F) (w : Witness F) : Prop :=

--- a/formal/Kimchi/Quotient/Poseidon.lean
+++ b/formal/Kimchi/Quotient/Poseidon.lean
@@ -1,0 +1,138 @@
+import Kimchi.Quotient.Lift
+import Kimchi.Quotient.Shifted
+import Kimchi.Quotient.Soundness
+import Kimchi.Gate.Poseidon
+
+/-!
+# Quotient lift of the Poseidon gate
+
+The polynomial-algebra lift of kimchi's Poseidon gate, realized as a
+`Kimchi.Quotient.Argument` instance. Poseidon applies five permutation rounds per row
+(15 constraints = 5 rounds × 3 state elements). It is a **two-row** gate with a **permuted**
+register layout, and its round constants are its coefficient row: the next-row family supplies
+the output state `s5`, and the coefficient family supplies the round constants `rc`. The MDS
+entries are integer literals, so the gate's plain ring-hom naturality
+(`Gate.Poseidon.constraints_map`) already carries the `F`-algebra naturality the instance
+needs.
+
+## The register layout
+
+The layout (kimchi `poseidon.rs`, module-doc table l.9--13) is a genuine permutation:
+
+```
+|  0 |  1 |  2 |  3 |  4 |  5 |  6 |  7 |  8 |  9 | 10 | 11 | 12 | 13 | 14 |
+| s0 | s0 | s0 | s4 | s4 | s4 | s1 | s1 | s1 | s2 | s2 | s2 | s3 | s3 | s3 |
+| s5 | s5 | s5 |    |    |    |    |    |    |    |    |    |    |    |    |
+```
+
+Note that `s4` is stored **before** `s1, s2, s3` in the register order; the output state `s5`
+sits on the next row; the round constants `rc` come from the coefficient row (`rc()` l.212--217:
+`coeffs[SPONGE_WIDTH * round + col]`, `SPONGE_WIDTH = 3`).
+
+## Contents
+
+* `cellMap` / `rcMap` — the permuted layout transcription (state cells / round constants).
+* `rowWitness` / `rcRow` / `polyWitness` / `rcPoly` — their two carrier instantiations.
+* `argument` — the Poseidon `Argument F` instance.
+* `rows_iff_dvd` — the divisibility corollary, specialization of `Argument.rows_iff_dvd`.
+* `soundness` — the quotient-argument soundness, specialization of `Argument.soundness`.
+
+Source of truth: `blueprint/src/chapters/Kimchi_Quotient_Poseidon.tex`.
+-/
+
+namespace Kimchi.Quotient.Poseidon
+
+open Polynomial Kimchi.Quotient
+
+variable {F : Type*} [Field F] {n N : ℕ} {ω : F}
+
+/-! ## The layout transcription -/
+
+/-- **Poseidon cell map.** Assemble a `Gate.Poseidon.Witness R` from the permuted register
+layout: the current row supplies `s0, s4, s1, s2, s3` (in register order), the next row
+supplies the output state `s5`. -/
+def cellMap {R : Type*} (cur nxt : Fin 15 → R) : Gate.Poseidon.Witness R where
+  s0 := (cur 0, cur 1, cur 2)
+  s4 := (cur 3, cur 4, cur 5)
+  s1 := (cur 6, cur 7, cur 8)
+  s2 := (cur 9, cur 10, cur 11)
+  s3 := (cur 12, cur 13, cur 14)
+  s5 := (nxt 0, nxt 1, nxt 2)
+
+/-- **Poseidon round-constant map.** Read the round-constant triples off a coefficient row:
+`rc j = (coeff (3j), coeff (3j+1), coeff (3j+2))`. -/
+def rcMap {R : Type*} (coeff : Fin 15 → R) : Fin 5 → R × R × R := fun j =>
+  (coeff ⟨3 * (j : ℕ), by have := j.isLt; omega⟩,
+   coeff ⟨3 * (j : ℕ) + 1, by have := j.isLt; omega⟩,
+   coeff ⟨3 * (j : ℕ) + 2, by have := j.isLt; omega⟩)
+
+/-- **Poseidon row witness.** The state cells at rows `i` and `i + 1` (cyclic) of a witness
+table. -/
+def rowWitness [NeZero n] (wTab : Fin n → Fin 15 → F) (i : Fin n) : Gate.Poseidon.Witness F :=
+  cellMap (wTab i) (wTab (i + 1))
+
+/-- **Poseidon row round constants.** The round-constant triples at row `i` of a coefficient
+table. -/
+def rcRow (qTab : Fin n → Fin 15 → F) (i : Fin n) : Fin 5 → F × F × F :=
+  rcMap (qTab i)
+
+/-- **Poseidon poly witness.** The state cells as column interpolants: `columnPoly` on the
+current side, its `shift` on the next side. -/
+noncomputable def polyWitness (ω : F) (wTab : Fin n → Fin 15 → F) :
+    Gate.Poseidon.Witness (Polynomial F) :=
+  cellMap (fun c => columnPoly ω (fun j => wTab j c))
+    (fun c => shift ω (columnPoly ω (fun j => wTab j c)))
+
+/-- **Poseidon poly round constants.** The round-constant triples as coefficient-column
+interpolants. -/
+noncomputable def rcPoly (ω : F) (qTab : Fin n → Fin 15 → F) :
+    Fin 5 → Polynomial F × Polynomial F × Polynomial F :=
+  rcMap (fun c => columnPoly ω (fun j => qTab j c))
+
+/-! ## The `Argument` instance -/
+
+/-- **Poseidon `Argument` instance.** The gate's constraints
+`Gate.Poseidon.constraints (rcMap env.coeff) (cellMap env.witnessCurr env.witnessNext)`;
+naturality is the gate's ring-hom `Gate.Poseidon.constraints_map` (the MDS entries are integer
+literals, so no `algebraMap`-transported parameter is involved). -/
+def argument : Argument F where
+  constraints env :=
+    Gate.Poseidon.constraints (rcMap env.coeff) (cellMap env.witnessCurr env.witnessNext)
+  constraints_map f env :=
+    Gate.Poseidon.constraints_map f.toRingHom (rcMap env.coeff)
+      (cellMap env.witnessCurr env.witnessNext)
+
+/-! ## Divisibility corollary -/
+
+/-- **Poseidon rows hold iff divisible.** The Poseidon constraint polynomials of a
+witness/coefficient table are all divisible by `Z_H` iff the gate holds on every row.
+Specialization of `Argument.rows_iff_dvd` at `argument`. -/
+theorem rows_iff_dvd [NeZero n] (hω : IsPrimitiveRoot ω n)
+    (wTab qTab : Fin n → Fin 15 → F) :
+    (∀ E ∈ Gate.Poseidon.constraints (rcPoly ω qTab) (polyWitness ω wTab), zH F n ∣ E)
+      ↔ ∀ i, Gate.Poseidon.Holds (rcRow qTab i) (rowWitness wTab i) :=
+  argument.rows_iff_dvd hω wTab qTab
+
+/-! ## Quotient-argument soundness -/
+
+/-- **Poseidon quotient soundness.** With the abstract quotient-argument hypotheses over the
+selector-gated Poseidon family, every selector-active row satisfies `Gate.Poseidon.Holds`.
+Specialization of `Argument.soundness` at `argument`. -/
+theorem soundness [NeZero n] [DecidableEq F] (hω : IsPrimitiveRoot ω n)
+    (wTab qTab : Fin n → Fin 15 → F) (sel : Fin n → F) (hsel : ∀ i, sel i = 0 ∨ sel i = 1)
+    (ζ : Fin N → F) (hζ : Function.Injective ζ)
+    (α : Fin (Gate.Poseidon.constraints (rcPoly ω qTab) (polyWitness ω wTab)).length → F)
+    (hα : Function.Injective α)
+    (t : Fin (Gate.Poseidon.constraints (rcPoly ω qTab) (polyWitness ω wTab)).length
+        → Polynomial F)
+    (D : ℕ) (hD : D < N)
+    (hCdeg : ∀ s, (aggregate (α s) (fun c => columnPoly ω sel *
+        (Gate.Poseidon.constraints (rcPoly ω qTab) (polyWitness ω wTab)).get c)).natDegree ≤ D)
+    (htdeg : ∀ s, (t s * zH F n).natDegree ≤ D)
+    (hcheck : ∀ s p, (aggregate (α s) (fun c => columnPoly ω sel *
+        (Gate.Poseidon.constraints (rcPoly ω qTab) (polyWitness ω wTab)).get c)).eval (ζ p)
+        = (t s * zH F n).eval (ζ p)) :
+    ∀ i, sel i = 1 → Gate.Poseidon.Holds (rcRow qTab i) (rowWitness wTab i) :=
+  argument.soundness hω wTab qTab sel hsel ζ hζ α hα t D hD hCdeg htdeg hcheck
+
+end Kimchi.Quotient.Poseidon

--- a/formal/roots.txt
+++ b/formal/roots.txt
@@ -112,3 +112,10 @@ Kimchi.Quotient.Argument.soundness
 -- the cPoly/dPoly coefficients enter through algebraMap F R).
 Kimchi.Quotient.EndoScalar.rows_iff_dvd
 Kimchi.Quotient.EndoScalar.soundness
+
+-- Poseidon gate (sound = a satisfying row computes the 5-round permutation) and its quotient
+-- lift, completing the six-gate unification over the Argument primitive.
+Kimchi.Gate.Poseidon.sound
+Kimchi.Gate.Poseidon.complete
+Kimchi.Quotient.Poseidon.rows_iff_dvd
+Kimchi.Quotient.Poseidon.soundness

--- a/formal/scripts/check_axioms.lean
+++ b/formal/scripts/check_axioms.lean
@@ -60,7 +60,10 @@ def roots : List Name :=
     `Kimchi.Quotient.Argument.rows_iff_dvd,
     `Kimchi.Quotient.Argument.soundness,
     `Kimchi.Quotient.EndoScalar.rows_iff_dvd,
-    `Kimchi.Quotient.EndoScalar.soundness ]
+    `Kimchi.Quotient.EndoScalar.soundness,
+    `Kimchi.Gate.Poseidon.sound, `Kimchi.Gate.Poseidon.complete,
+    `Kimchi.Quotient.Poseidon.rows_iff_dvd,
+    `Kimchi.Quotient.Poseidon.soundness ]
 
 /-- The only axioms the roots may depend on: the standard logical axioms; the Pasta Hasse bounds
     (`{pallas,vesta}_hasse`); `Lean.ofReduceBool`; and the Pasta GLV endomorphism inputs (`β`, `λ`,


### PR DESCRIPTION
Stacked on the EndoScalar lift PR (itself on #190) — review only the top commit.

## Summary

- **Gate layer**: adds `Witness.map` and the ring-hom naturality `constraints_map` to the Poseidon gate. The MDS entries are integer literals, so a plain ring hom carries the whole square — no `algebraMap`-transported parameter is involved.
- **Quotient layer** (new `Kimchi/Quotient/Poseidon.lean`): instantiates the `Argument` primitive with the permuted two-row layout (`poseidon.rs` module-doc table: `s0 s4 s1 s2 s3` on the current row — note `s4` before `s1..s3` — and the output state `s5` on the next row) and the coefficient-row round constants (`rcMap`: `coeffs[3*round + col]`, `SPONGE_WIDTH = 3`). `rows_iff_dvd` and the quotient-argument soundness are derived by specialization and stated through named `rcRow`/`rcPoly` and `rowWitness`/`polyWitness` instantiations.

This completes the six-gate quotient unification: every modeled kimchi gate now has a rows-iff-divisible theorem and an abstract quotient-soundness theorem, each a two-line specialization of the shared engine.

## Roots / axiom gate

`roots.txt` / `check_axioms.lean` gain `Gate.Poseidon.{sound,complete}` and `Quotient.Poseidon.{rows_iff_dvd,soundness}` (56 roots).

## Verification

- `lake build Kimchi` — success, no sorries
- `scripts/check-style.sh` — clean
- `scripts/check_axioms.sh` — all 56 roots reduce to the allowed axiom set

🤖 Generated with [Claude Code](https://claude.com/claude-code)