### PR TITLE
formal: sponge layer follow-up — base/scalar naming, SWPoint absorption

### DIFF
--- a/formal/Kimchi/Sponge/FqSponge.lean
+++ b/formal/Kimchi/Sponge/FqSponge.lean
@@ -1,3 +1,4 @@
+import CompElliptic.Curves.Pasta
 import Kimchi.Sponge.Poseidon
 import Kimchi.Pasta.Constants
 
@@ -7,11 +8,11 @@ import Kimchi.Pasta.Constants
 The consumer-facing sponge of kimchi's Fiat-Shamir transform, transcribed from proof-systems
 `mina_poseidon` `sponge.rs` (`DefaultFqSponge`) on top of the duplex automaton of
 `Poseidon.lean`, generic over the curve's field pair: the sponge state lives in the base
-field `ZMod q`, challenges land in the scalar field `ZMod p`. A `Spec` supplies the two
-field-dependent data — the Poseidon parameters and the endomorphism eigenvalue `λ` — and
-everything else, including which `absorb_fr` encoding applies, is determined by the
-cardinalities: a scalar absorbs directly when `p < q`, and as (high bits, low bit) when the
-scalar field is the larger (`sponge.rs` `absorb_fr`, both branches).
+field `ZMod base`, challenges land in the scalar field `ZMod scalar`. A `Spec` supplies the
+two field-dependent data — the Poseidon parameters and the endomorphism eigenvalue `λ` —
+and everything else, including which `absorb_fr` encoding applies, is determined by the
+cardinalities: a scalar absorbs directly when `scalar < base`, and as (high bits, low bit)
+when the scalar field is the larger (`sponge.rs` `absorb_fr`, both branches).
 
 Alongside the Poseidon state, the sponge carries a buffer `lastSqueezed` of 64-bit limbs:
 each raw squeeze contributes its two low limbs (128 high-entropy bits), and a scalar
@@ -24,8 +25,8 @@ expansion (`sponge.rs` `to_field_with_length`, Halo §6.2): accumulators `a = b 
 for each 2-bit window from the top, `a, b := 2a, 2b`, the low bit selects `s = ±1`, the high
 bit routes `s` into `a` or `b`; the result is `a·λ + b`. This is the same recoding the
 `EndoScalar` gate constrains in-circuit (`Kimchi.Gate.EndoScalar`, accumulator init
-`(2, 2)`). Points absorb as their two affine coordinates; the point at infinity absorbs as a
-single `0` (`sponge.rs` `absorb_g`).
+`(2, 2)`). Points absorb as `SWPoint`s: the two affine coordinates, or a single `0` for the
+identity (`sponge.rs` `absorb_g`, both cases).
 
 `FqVesta` and `FqPallas` instantiate the two sides of the Pasta cycle
 (`DefaultFqSponge<VestaParameters>` / `DefaultFqSponge<PallasParameters>`); each is its
@@ -35,7 +36,7 @@ single `0` (`sponge.rs` `absorb_g`).
 ## Contents
 
 * `Spec`, `S`, `init` — the field-pair data and the sponge-plus-limb-buffer state.
-* `absorbFq`, `absorbG`, `absorbGInfinity`, `absorbFr` — the absorption encodings.
+* `absorbFq`, `absorbG`, `absorbFr` — the absorption encodings.
 * `challengeFq`, `challengeNat`, `challenge` — raw and 128-bit squeezes.
 * `endoExpand`, `squeezeChallenge` — the effective-scalar expansion.
 * `FqVesta`, `FqPallas` — the Pasta instantiations.
@@ -45,61 +46,60 @@ namespace Kimchi.Sponge.FqSponge
 
 /-- The field-pair data of a curve's Fq-sponge: the Poseidon parameters over the base field
 and the endomorphism eigenvalue `λ` of the scalar field's challenge expansion. Everything
-else is determined by the cardinalities `q` (base) and `p` (scalar). -/
-structure Spec (q p : ℕ) where
-  params : Params (ZMod q)
-  lam : ZMod p
+else is determined by the cardinalities. -/
+structure Spec (base scalar : ℕ) where
+  params : Params (ZMod base)
+  lam : ZMod scalar
 
-variable {q p : ℕ} [Field (ZMod q)] [Field (ZMod p)]
+open CompElliptic.CurveForms.ShortWeierstrass
+
+variable {base scalar : ℕ} [Field (ZMod base)] [Field (ZMod scalar)]
 
 /-- Sponge state: the Poseidon automaton over the base field plus the 64-bit limb buffer
 `lastSqueezed`. -/
-structure S (q : ℕ) where
-  sponge : State (ZMod q)
+structure S (base : ℕ) where
+  sponge : State (ZMod base)
   lastSqueezed : List ℕ
 
 /-- The fresh sponge: fresh automaton, empty buffer. -/
-def init : S q := ⟨Kimchi.Sponge.init, []⟩
+def init : S base := ⟨Kimchi.Sponge.init, []⟩
 
 
 
 /-- The two low 64-bit limbs of a squeezed element — its 128 high-entropy bits
 (`HIGH_ENTROPY_LIMBS = 2`). -/
-def lowLimbs (x : ZMod q) : List ℕ :=
+def lowLimbs (x : ZMod base) : List ℕ :=
   [x.val % 2 ^ 64, x.val / 2 ^ 64 % 2 ^ 64]
 
 /-- Absorb base-field elements (`absorb_fq`): clear the buffer, absorb each. -/
-def absorbFq (spec : Spec q p) (s : S q) (xs : List (ZMod q)) : S q :=
+def absorbFq (spec : Spec base scalar) (s : S base) (xs : List (ZMod base)) : S base :=
   ⟨absorb spec.params s.sponge xs, []⟩
 
-/-- Absorb an affine point (`absorb_g`, non-infinity case): its `x` then its `y`
-coordinate. -/
-def absorbG (spec : Spec q p) (s : S q) (pt : ZMod q × ZMod q) : S q :=
-  absorbFq spec s [pt.1, pt.2]
-
-/-- Absorb the point at infinity (`absorb_g`, infinity case): a single `0`. -/
-def absorbGInfinity (spec : Spec q p) (s : S q) : S q :=
-  absorbFq spec s [0]
+/-- Absorb a point (`absorb_g`): its `x` then its `y` coordinate, or a single `0` for the
+identity. -/
+def absorbG (spec : Spec base scalar) {E : SWCurve (ZMod base)} (s : S base)
+    (P : SWPoint E) : S base :=
+  if P = 0 then absorbFq spec s [0] else absorbFq spec s [P.x, P.y]
 
 /-- Absorb a scalar-field element (`absorb_fr`). The branch is determined by the
 cardinalities: a smaller scalar modulus embeds directly; a larger one absorbs as its high
 bits then its low bit. -/
-def absorbFr (spec : Spec q p) (s : S q) (x : ZMod p) : S q :=
-  if p < q then
-    absorbFq spec s [((x.val : ℕ) : ZMod q)]
+def absorbFr (spec : Spec base scalar) (s : S base) (x : ZMod scalar) : S base :=
+  if scalar < base then
+    absorbFq spec s [((x.val : ℕ) : ZMod base)]
   else
-    absorbFq spec s [((x.val / 2 : ℕ) : ZMod q), ((x.val % 2 : ℕ) : ZMod q)]
+    absorbFq spec s [((x.val / 2 : ℕ) : ZMod base), ((x.val % 2 : ℕ) : ZMod base)]
 
 /-- Squeeze a raw base-field element (`challenge_fq` / `squeeze_field`): bypass and clear
 the limb buffer. -/
-def challengeFq (spec : Spec q p) (s : S q) : ZMod q × S q :=
+def challengeFq (spec : Spec base scalar) (s : S base) : ZMod base × S base :=
   let (x, sp) := squeeze spec.params s.sponge
   (x, ⟨sp, []⟩)
 
 /-- Take two 64-bit limbs from the buffer, refilling it from the sponge as needed
 (`squeeze_limbs` at `CHALLENGE_LENGTH_IN_LIMBS = 2`); the packed 128-bit value. The fuel
 argument bounds the refills (each adds two limbs, so one suffices from empty). -/
-def squeezeLimbsPacked (spec : Spec q p) : ℕ → S q → ℕ × S q
+def squeezeLimbsPacked (spec : Spec base scalar) : ℕ → S base → ℕ × S base
   | 0, s => (0, s)
   | fuel + 1, s =>
     match s.lastSqueezed with
@@ -110,13 +110,13 @@ def squeezeLimbsPacked (spec : Spec q p) : ℕ → S q → ℕ × S q
 
 /-- Squeeze a 128-bit prechallenge, as a natural number (`challenge`, before the field
 cast). -/
-def challengeNat (spec : Spec q p) (s : S q) : ℕ × S q :=
+def challengeNat (spec : Spec base scalar) (s : S base) : ℕ × S base :=
   squeezeLimbsPacked spec 2 s
 
 /-- Squeeze a 128-bit prechallenge into the scalar field (`challenge`). -/
-def challenge (spec : Spec q p) (s : S q) : ZMod p × S q :=
+def challenge (spec : Spec base scalar) (s : S base) : ZMod scalar × S base :=
   let (n, s) := challengeNat spec s
-  ((n : ZMod p), s)
+  ((n : ZMod scalar), s)
 
 /-- The endomorphism expansion of a 128-bit prechallenge into an effective scalar
 (`to_field_with_length`, Halo §6.2): fold the 2-bit windows from the top into the
@@ -133,7 +133,7 @@ def endoExpand {F : Type*} [Field F] (lam : F) (chal : ℕ) : F :=
 /-- Squeeze an effective scalar challenge (`squeeze_challenge`,
 `poly-commitment/src/commitment.rs`): a 128-bit prechallenge, endo-expanded at the spec's
 eigenvalue. -/
-def squeezeChallenge (spec : Spec q p) (s : S q) : ZMod p × S q :=
+def squeezeChallenge (spec : Spec base scalar) (s : S base) : ZMod scalar × S base :=
   let (n, s) := challengeNat spec s
   (endoExpand spec.lam n, s)
 
@@ -145,7 +145,7 @@ namespace Kimchi.Sponge
 
 namespace FqVesta
 
-open CompElliptic.Fields.Pasta
+open CompElliptic.Fields.Pasta CompElliptic.Curves.Pasta
 
 /-- The sponge field: the Vesta base field. -/
 abbrev Fq := VestaBaseField
@@ -163,8 +163,8 @@ abbrev S := FqSponge.S PALLAS_SCALAR_CARD
 
 def init : S := FqSponge.init
 def absorbFq : S → List Fq → S := FqSponge.absorbFq spec
-def absorbG : S → Fq × Fq → S := FqSponge.absorbG spec
-def absorbGInfinity : S → S := FqSponge.absorbGInfinity spec
+def absorbG : S → CompElliptic.CurveForms.ShortWeierstrass.SWPoint Vesta.curve → S :=
+  FqSponge.absorbG spec
 def absorbFr : S → Fr → S := FqSponge.absorbFr spec
 def challengeFq : S → Fq × S := FqSponge.challengeFq spec
 def challengeNat : S → ℕ × S := FqSponge.challengeNat spec
@@ -175,7 +175,7 @@ end FqVesta
 
 namespace FqPallas
 
-open CompElliptic.Fields.Pasta
+open CompElliptic.Fields.Pasta CompElliptic.Curves.Pasta
 
 /-- The sponge field: the Pallas base field. -/
 abbrev Fq := PallasBaseField
@@ -194,8 +194,8 @@ abbrev S := FqSponge.S PALLAS_BASE_CARD
 
 def init : S := FqSponge.init
 def absorbFq : S → List Fq → S := FqSponge.absorbFq spec
-def absorbG : S → Fq × Fq → S := FqSponge.absorbG spec
-def absorbGInfinity : S → S := FqSponge.absorbGInfinity spec
+def absorbG : S → CompElliptic.CurveForms.ShortWeierstrass.SWPoint Pallas.curve → S :=
+  FqSponge.absorbG spec
 def absorbFr : S → Fr → S := FqSponge.absorbFr spec
 def challengeFq : S → Fq × S := FqSponge.challengeFq spec
 def challengeNat : S → ℕ × S := FqSponge.challengeNat spec

--- a/formal/Kimchi/Verifier/Ipa.lean
+++ b/formal/Kimchi/Verifier/Ipa.lean
@@ -134,18 +134,18 @@ def shiftScalar (x : C.Fr) : C.Fr :=
 
 /-- The verifier's Fiat-Shamir schedule (`SRS::verify`): absorb the shifted combined inner
 product; squeeze and map the `U` base; per round absorb `L`, `R` and squeeze a challenge;
-absorb `δ` and squeeze the Schnorr challenge. Points absorb as their coordinates. -/
+absorb `δ` and squeeze the Schnorr challenge. -/
 def transcript (inp : Input C) : C.Point × Array C.Fr × C.Fr :=
   let s := absorbFr C.sponge FqSponge.init (shiftScalar C (cipOf inp))
   let (t, s) := challengeFq C.sponge s
   let uBase := C.toGroup t
   let (chals, s) := inp.proof.lr.foldl
     (fun (acc : Array C.Fr × FqSponge.S C.base) LR =>
-      let s := absorbG C.sponge (absorbG C.sponge acc.2 (LR.1.x, LR.1.y)) (LR.2.x, LR.2.y)
+      let s := absorbG C.sponge (absorbG C.sponge acc.2 LR.1) LR.2
       let (u, s) := squeezeChallenge C.sponge s
       (acc.1.push u, s))
     (#[], s)
-  let s := absorbG C.sponge s (inp.proof.delta.x, inp.proof.delta.y)
+  let s := absorbG C.sponge s inp.proof.delta
   let (c, _) := squeezeChallenge C.sponge s
   (uBase, chals, c)
 

--- a/formal/scripts/check_fq_sponge.lean
+++ b/formal/scripts/check_fq_sponge.lean
@@ -20,43 +20,44 @@ Run (after `lake build Kimchi`): `scripts/check_fq_sponge.sh`.
 -/
 
 open Lean Kimchi.Fixture Kimchi.Sponge Kimchi.Sponge.FqSponge
+open CompElliptic.CurveForms.ShortWeierstrass CompElliptic.Curves.Pasta
 
 /-- One trace operation: an absorption input or an expected squeeze output. -/
-inductive VOp (Fq Fr : Type)
+inductive VOp {F : Type} [Field F] (E : SWCurve F) (Fr : Type)
   | absorbFr (x : Fr)
-  | absorbG (p : Fq × Fq)
-  | absorbGInfinity
-  | challengeFq (expect : Fq)
+  | absorbG (P : SWPoint E)
+  | challengeFq (expect : F)
   | challenge (expect : Fr)
   | squeezeChallenge (expect : Fr)
 
-def parseOp {Fq Fr : Type} (pFq : Json → Except String Fq) (pFr : Json → Except String Fr)
-    (j : Json) : Except String (VOp Fq Fr) := do
+def parseOp {F Fr : Type} [Field F] [DecidableEq F] (E : SWCurve F)
+    (pF : Json → Except String F) (pFr : Json → Except String Fr) (j : Json) :
+    Except String (VOp E Fr) := do
   match ← (← j.getObjVal? "op").getStr? with
   | "absorb_fr" => return .absorbFr (← pFr (← j.getObjVal? "value"))
-  | "absorb_g" => return .absorbG (← parsePoint pFq (← j.getObjVal? "point"))
-  | "absorb_g_inf" => return .absorbGInfinity
-  | "challenge_fq" => return .challengeFq (← pFq (← j.getObjVal? "expect"))
+  | "absorb_g" => return .absorbG (← parseSWPoint pF E (← j.getObjVal? "point"))
+  | "absorb_g_inf" => return .absorbG 0
+  | "challenge_fq" => return .challengeFq (← pF (← j.getObjVal? "expect"))
   | "challenge" => return .challenge (← pFr (← j.getObjVal? "expect"))
   | "squeeze_challenge" => return .squeezeChallenge (← pFr (← j.getObjVal? "expect"))
   | op => throw s!"unknown op: {op}"
 
 /-- One op's transition and verdict: absorptions are free, squeezes compare against the
 expectation. -/
-def step {q p : ℕ} [Field (ZMod q)] [Field (ZMod p)] (spec : Spec q p) (s : FqSponge.S q)
-    (op : VOp (ZMod q) (ZMod p)) : FqSponge.S q × Bool :=
+def step {base scalar : ℕ} [Field (ZMod base)] [Field (ZMod scalar)]
+    (spec : Spec base scalar) {E : SWCurve (ZMod base)} (s : FqSponge.S base)
+    (op : VOp E (ZMod scalar)) : FqSponge.S base × Bool :=
   match op with
   | .absorbFr x => (absorbFr spec s x, true)
-  | .absorbG pt => (absorbG spec s pt, true)
-  | .absorbGInfinity => (absorbGInfinity spec s, true)
+  | .absorbG P => (absorbG spec s P, true)
   | .challengeFq e => let (x, s) := challengeFq spec s; (s, decide (x = e))
   | .challenge e => let (x, s) := challenge spec s; (s, decide (x = e))
   | .squeezeChallenge e => let (x, s) := squeezeChallenge spec s; (s, decide (x = e))
 
-def checkSponge {q p : ℕ} [Field (ZMod q)] [Field (ZMod p)] (spec : Spec q p)
-    (path : String) : IO Bool :=
-  Trace.check (parseOp (parseZMod (n := q)) (parseZMod (n := p))) FqSponge.init (step spec)
-    path
+def checkSponge {base scalar : ℕ} [Field (ZMod base)] [Field (ZMod scalar)]
+    (spec : Spec base scalar) (E : SWCurve (ZMod base)) (path : String) : IO Bool :=
+  Trace.check (parseOp E (parseZMod (n := base)) (parseZMod (n := scalar))) FqSponge.init
+    (step spec) path
 
 def checkGroupMap {q : ℕ} [Field (ZMod q)] [DecidableEq (ZMod q)]
     (toGroup : ZMod q → ZMod q × ZMod q) (path : String) : IO Bool := do
@@ -74,8 +75,8 @@ def checkGroupMap {q : ℕ} [Field (ZMod q)] [DecidableEq (ZMod q)]
   return failed = 0
 
 def main : IO Unit := do
-  let okV ← checkSponge FqVesta.spec "fixtures/fq_sponge_vectors.json"
-  let okP ← checkSponge FqPallas.spec "fixtures/fq_sponge_pallas_vectors.json"
+  let okV ← checkSponge FqVesta.spec Vesta.curve "fixtures/fq_sponge_vectors.json"
+  let okP ← checkSponge FqPallas.spec Pallas.curve "fixtures/fq_sponge_pallas_vectors.json"
   let okGV ← checkGroupMap (fun t => let u := GroupMapVesta.toGroup t; (u.x, u.y))
     "fixtures/group_map_vectors.json"
   let okGP ← checkGroupMap (fun t => let u := GroupMapPallas.toGroup t; (u.x, u.y))


### PR DESCRIPTION
Follow-up to the #194 review, applying the same aesthetic to the (already merged) sponge layer, stacked on #194 because it simplifies the verifier's call sites:

- **`base`/`scalar` naming**: the generic sponge's cardinality parameters `q p` are renamed to match the verifier's `CommitmentCurve` bundle.
- **`absorbG` takes `SWPoint`**: the faithful `absorb_g` — coordinates for a point, a single `0` for the identity — as *one* function, subsuming and deleting `absorbGInfinity`. The `FqVesta`/`FqPallas` re-exports fix the curve (`SWPoint Vesta.curve` / `SWPoint Pallas.curve`), the verifier transcript absorbs points with no coordinate tupling anywhere, and the trace check parses trace points as `SWPoint`s (`absorb_g_inf` is `absorbG 0`).

All gates green: 4 IPA fixtures ACCEPT + 2 corruption REJECT, 39+39 sponge traces, 8+8 group-map vectors, 7+7 Poseidon traces, style, 59 axiom-clean roots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)