### PR TITLE
formal: coherent canonical typing + the Fiat-Shamir junction proved end to end

### DIFF
--- a/formal/Kimchi.lean
+++ b/formal/Kimchi.lean
@@ -26,3 +26,4 @@ import Kimchi.Sponge.Poseidon
 import Kimchi.Sponge.FqSponge
 import Kimchi.Sponge.GroupMap
 import Kimchi.Verifier.Ipa
+import Kimchi.Verifier.Reflection

--- a/formal/Kimchi/Circuit/EndoMul.lean
+++ b/formal/Kimchi/Circuit/EndoMul.lean
@@ -89,7 +89,7 @@ computes `[s]·T`. The per-row `hxne` is discharged internally from the GLV boun
     `off := pallas_combo_off_targets`), the eigenvalue from `pallas_eigen`, and the
     odd-prime-order conditions from `Kimchi.Pasta`. -/
 theorem pallas_endoMul (m : ℕ) (hbits : 4 * m ≤ 244)
-    (g : ℕ → Witness PallasBaseField)
+    (g : ℕ → Witness Fp)
     (hholds : ∀ i, i < m → Holds pallas_endo (g i))
     (T φT : Pallas.curve.toAffine.Point)
     (hTns : Pallas.curve.toAffine.Nonsingular (g 0).xT (g 0).yT) (hTeq : T = Point.some _ _ hTns)
@@ -101,14 +101,14 @@ theorem pallas_endoMul (m : ℕ) (hbits : 4 * m ≤ 244)
     (hP0 : Point.some _ _ hP0ns = (2 : ℤ) • T + (2 : ℤ) • φT) :
     ∃ (hfin : Pallas.curve.toAffine.Nonsingular (accX g m) (accY g m)) (s : ℤ),
       Point.some _ _ hfin = s • T
-        ∧ (s : PallasBaseField)
-            = Kimchi.Circuit.EndoScalar.toField (crumbList g m) (pallas_lam : PallasBaseField) := by
+        ∧ (s : Fp)
+            = Kimchi.Circuit.EndoScalar.toField (crumbList g m) (pallas_lam : Fp) := by
   have ha : Pallas.curve.toAffine.a₁ = 0 ∧ Pallas.curve.toAffine.a₂ = 0
       ∧ Pallas.curve.toAffine.a₃ = 0 := ⟨rfl, rfl, rfl⟩
   haveI : Fact (Pallas.curve.toAffine.a₁ = 0 ∧ Pallas.curve.toAffine.a₂ = 0
       ∧ Pallas.curve.toAffine.a₃ = 0) := ⟨ha⟩
-  have h2 : (2 : PallasBaseField) ≠ 0 := by decide
-  have h3 : (3 : PallasBaseField) ≠ 0 := by decide
+  have h2 : (2 : Fp) ≠ 0 := by decide
+  have h3 : (3 : Fp) ≠ 0 := by decide
   have hodd : Pallas.curve.toAffine.order ≠ 2 := by rw [pallas_card]; decide
   have hTne : T ≠ 0 := by rw [hTeq]; exact Point.some_ne_zero _
   have heig : φT = pallas_lam • T := by rw [hφTeq, hTeq]; exact pallas_eigen hTns hφTns
@@ -123,7 +123,7 @@ theorem pallas_endoMul (m : ℕ) (hbits : 4 * m ≤ 244)
 
 /-- **EndoMul at Vesta** — the other half of the 2-cycle, identical modulo `vesta_*`. -/
 theorem vesta_endoMul (m : ℕ) (hbits : 4 * m ≤ 244)
-    (g : ℕ → Witness VestaBaseField)
+    (g : ℕ → Witness Fq)
     (hholds : ∀ i, i < m → Holds vesta_endo (g i))
     (T φT : Vesta.curve.toAffine.Point)
     (hTns : Vesta.curve.toAffine.Nonsingular (g 0).xT (g 0).yT) (hTeq : T = Point.some _ _ hTns)
@@ -135,14 +135,14 @@ theorem vesta_endoMul (m : ℕ) (hbits : 4 * m ≤ 244)
     (hP0 : Point.some _ _ hP0ns = (2 : ℤ) • T + (2 : ℤ) • φT) :
     ∃ (hfin : Vesta.curve.toAffine.Nonsingular (accX g m) (accY g m)) (s : ℤ),
       Point.some _ _ hfin = s • T
-        ∧ (s : VestaBaseField)
-            = Kimchi.Circuit.EndoScalar.toField (crumbList g m) (vesta_lam : VestaBaseField) := by
+        ∧ (s : Fq)
+            = Kimchi.Circuit.EndoScalar.toField (crumbList g m) (vesta_lam : Fq) := by
   have ha : Vesta.curve.toAffine.a₁ = 0 ∧ Vesta.curve.toAffine.a₂ = 0
       ∧ Vesta.curve.toAffine.a₃ = 0 := ⟨rfl, rfl, rfl⟩
   haveI : Fact (Vesta.curve.toAffine.a₁ = 0 ∧ Vesta.curve.toAffine.a₂ = 0
       ∧ Vesta.curve.toAffine.a₃ = 0) := ⟨ha⟩
-  have h2 : (2 : VestaBaseField) ≠ 0 := by decide
-  have h3 : (3 : VestaBaseField) ≠ 0 := by decide
+  have h2 : (2 : Fq) ≠ 0 := by decide
+  have h3 : (3 : Fq) ≠ 0 := by decide
   have hodd : Vesta.curve.toAffine.order ≠ 2 := by rw [vesta_card]; decide
   have hTne : T ≠ 0 := by rw [hTeq]; exact Point.some_ne_zero _
   have heig : φT = vesta_lam • T := by rw [hφTeq, hTeq]; exact vesta_eigen hTns hφTns

--- a/formal/Kimchi/Circuit/VarBaseMul.lean
+++ b/formal/Kimchi/Circuit/VarBaseMul.lean
@@ -55,7 +55,7 @@ incomplete runtime guard; see `varBaseMul_forbidden_correct` for the faithfulnes
     (one-wrap, regime bounds + `order ≡ 1 mod 4` discharged from the cardinal). See
     `varBaseMul_forbidden_correct` for the band-vs-deployed-check faithfulness caveat. -/
 theorem varBaseMul_scaleFast1
-    (m : ℕ) (g : ℕ → Witness VestaBaseField)
+    (m : ℕ) (g : ℕ → Witness Fq)
     (T : Vesta.curve.toAffine.Point) (s : ℤ) (hTne : T ≠ 0)
     (hholds : ∀ i, i < m → Holds (g i))
     (hTns : Vesta.curve.toAffine.Nonsingular (g 0).xT (g 0).yT) (hTeq : T = Point.some _ _ hTns)
@@ -112,8 +112,8 @@ never a deployed entry point on its own. The split itself is modeled by `scalarM
     `gateStep_chain` for the derived `GateStep`s; `scalarMul_type2` then supplies the split +
     correction — matching the PureScript `scaleFast2` exactly. -/
 theorem varBaseMul_scaleFast2
-    (m : ℕ) (hm : 0 < m) (g : ℕ → Witness PallasBaseField)
-    (T : Pallas.curve.toAffine.Point) (N : ℕ → PallasBaseField) (hTne : T ≠ 0)
+    (m : ℕ) (hm : 0 < m) (g : ℕ → Witness Fp)
+    (T : Pallas.curve.toAffine.Point) (N : ℕ → Fp) (hTne : T ≠ 0)
     (hholds : ∀ i, i < m → Holds (g i))
     (hTns : Pallas.curve.toAffine.Nonsingular (g 0).xT (g 0).yT) (hTeq : T = Point.some _ _ hTns)
     (hbase : ∀ i, i < m → (g i).xT = (g 0).xT ∧ (g i).yT = (g 0).yT)
@@ -125,13 +125,13 @@ theorem varBaseMul_scaleFast2
     (hN0 : N 0 = 0)
     (hbits : 5 * m ≤ pastaFieldBits)
     (hsDiv2 : gateRegister g (5 * m) < 2 ^ (pastaFieldBits - 1))
-    (sOdd : PallasBaseField) (hsOdd : sOdd = 0 ∨ sOdd = 1) :
+    (sOdd : Fp) (hsOdd : sOdd = 0 ∨ sOdd = 1) :
     ∃ (hfin : Pallas.curve.toAffine.Nonsingular (accX g m) (accY g m)) (n : ℤ),
-      (n : PallasBaseField) = unshiftType2 (5 * m) (N m) sOdd
+      (n : Fp) = unshiftType2 (5 * m) (N m) sOdd
         ∧ ((sOdd = 1 ∧ Point.some _ _ hfin = n • T)
             ∨ (sOdd = 0 ∧ Point.some _ _ hfin - T = n • T)) := by
   obtain ⟨k, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : m ≠ 0)
-  have h2 : (2 : PallasBaseField) ≠ 0 := by decide
+  have h2 : (2 : Fp) ≠ 0 := by decide
   have hodd : Pallas.curve.toAffine.order ≠ 2 := by rw [Kimchi.Pasta.pallas_card]; decide
   have hq : Pallas.curve.toAffine.order = PALLAS_SCALAR_CARD := Kimchi.Pasta.pallas_card
   have hcanon : gateLadder g (5 * (k + 1)) < 2 * (PALLAS_BASE_CARD : ℤ) + 2 ^ (5 * (k + 1)) := by

--- a/formal/Kimchi/Commitment/IPA/Soundness/Batch.lean
+++ b/formal/Kimchi/Commitment/IPA/Soundness/Batch.lean
@@ -90,6 +90,20 @@ theorem ipa_soundnessB (σ : SRS G) (proof : OpeningProof F G σ.k) (P : G)
   rw [hP]
   abel
 
+/-- **Acceptance-generalized single-opening soundness.** `ipa_soundnessB` with the
+acceptance proposition fully abstract: the extraction consumes only the modus ponens of
+the Fiat-Shamir hypothesis against acceptance, never the shape of acceptance itself. This
+is the form the deployed verifier's acceptance (`Ipa.verify … = true`) plugs into. -/
+theorem ipa_soundnessA (σ : SRS G) (P : G) (b : Fin (2 ^ σ.k) → F) (v : F) {A : Prop}
+    (hFS : FiatShamirTreeB σ P b v A) (hacc : A) :
+    ∃ (a : Fin (2 ^ σ.k) → F) (ρ : F), openingRelationB σ P b v a ρ := by
+  obtain ⟨ρ, t, ht⟩ := hFS hacc
+  obtain ⟨a, hP, hv⟩ := ipaRelation_of_acceptV σ b (P - ρ • σ.h) v t ht
+  refine ⟨a, ρ, ?_, hv⟩
+  show commitGen σ.g a + ρ • σ.h = P
+  rw [hP]
+  abel
+
 /-- **Generator-commitment linearity over finite combinations.** Pushes a
 `•`-combination of witnesses through `commitGen`. Pure glue for `commit_sum_smul`. -/
 private theorem commitGen_sum_smul {n N : ℕ} (g : Fin N → G) (l : Fin n → F)
@@ -265,6 +279,96 @@ theorem batch_soundness (σ : SRS G) {n m : ℕ}
     rw [hvan t, mul_zero]
   rw [key3 (fun j => innerProduct (A2 i t₀) (evalVector (2 ^ σ.k) (x j)) - e i j)] at hzero
   simp only [hL, mul_ite, mul_one, mul_zero, Finset.sum_ite_eq', Finset.mem_univ, if_true] at hzero
+  exact (sub_eq_zero.mp hzero).symm
+
+
+/-- **Acceptance-generalized batched opening soundness.** `batch_soundness` with the
+grid acceptance abstracted to an arbitrary family `A`: the proof consumes acceptance only
+through the modus ponens of the Fiat-Shamir hypothesis (`ipa_soundnessA`), so no
+per-grid-point proof or challenge data appears. This is the form the deployed verifier's
+acceptance (`Ipa.verify … = true`, whose challenges are sponge-derived rather than
+carried) plugs into. -/
+theorem batch_soundnessA (σ : SRS G) {n m : ℕ}
+    (ξ : Fin n → F) (hξ : Function.Injective ξ)
+    (r : Fin m → F) (hr : Function.Injective r) (hm : 0 < m)
+    (C : Fin n → G) (x : Fin m → F) (e : Fin n → Fin m → F)
+    (A : Fin n → Fin m → Prop)
+    (hFS : ∀ s t, FiatShamirTreeB σ (combinedCommitment (ξ s) C)
+      (combinedEvalVector (2 ^ σ.k) (r t) x) (combinedInnerProduct (ξ s) (r t) e) (A s t))
+    (hbind : ∀ (w : Fin (2 ^ σ.k) → F) (w_h : F),
+      DLRelation σ w w_h → w = 0 ∧ w_h = 0)
+    (hacc : ∀ s t, A s t) :
+    ∃ (a : Fin n → Fin (2 ^ σ.k) → F) (ρ : Fin n → F), ∀ i,
+      commit σ (a i) (ρ i) = C i
+        ∧ ∀ j, e i j = innerProduct (a i) (evalVector (2 ^ σ.k) (x j)) := by
+  classical
+  -- **Step 1 (grid witnesses).** Extract a per-grid opening from acceptance alone.
+  have h1 : ∀ (s : Fin n) (t : Fin m), ∃ (aw : Fin (2 ^ σ.k) → F) (ρw : F),
+      commit σ aw ρw = combinedCommitment (ξ s) C
+        ∧ combinedInnerProduct (ξ s) (r t) e
+            = innerProduct aw (combinedEvalVector (2 ^ σ.k) (r t) x) := by
+    intro s t
+    exact ipa_soundnessA σ (combinedCommitment (ξ s) C)
+      (combinedEvalVector (2 ^ σ.k) (r t) x) (combinedInnerProduct (ξ s) (r t) e)
+      (hFS s t) (hacc s t)
+  choose a1 ρ1 hcommit1 hvalue1 using h1
+  -- **Step 2 (per commitment).** Vandermonde in `ξ` separates each `C i`.
+  have h2 : ∀ (i : Fin n) (t : Fin m), ∃ (A : Fin (2 ^ σ.k) → F) (P : F),
+      commit σ A P = C i
+        ∧ innerProduct A (combinedEvalVector (2 ^ σ.k) (r t) x)
+            = ∑ j, e i j * (r t) ^ (j : ℕ) := by
+    intro i t
+    exact perCommitment_separation σ ξ hξ (r t) x C e (fun s => a1 s t) (fun s => ρ1 s t)
+      (fun s => hcommit1 s t) (fun s => (hvalue1 s t).symm) i
+  choose A2 P2 hAcommit hAvalue using h2
+  -- Rewrite the combined-eval inner product into per-point evaluations (∗).
+  have hstar : ∀ (i : Fin n) (t : Fin m),
+      (∑ j : Fin m, (r t) ^ (j : ℕ) * innerProduct (A2 i t) (evalVector (2 ^ σ.k) (x j)))
+        = ∑ j, e i j * (r t) ^ (j : ℕ) := by
+    intro i t
+    rw [← innerProduct_combinedEvalVector]
+    exact hAvalue i t
+  -- **Step 3 (binding).** One witness per commitment, at the base evalscale `t₀`.
+  have hbd : CommitmentBinding (F := F) σ := (commitmentBinding_iff_no_relation σ).mpr hbind
+  set t₀ : Fin m := ⟨0, hm⟩ with ht₀
+  have hAeq : ∀ (i : Fin n) (t : Fin m), A2 i t = A2 i t₀ := by
+    intro i t
+    have hcol : commit σ (A2 i t) (P2 i t) = commit σ (A2 i t₀) (P2 i t₀) := by
+      rw [hAcommit i t, hAcommit i t₀]
+    have hpair := @hbd (A2 i t, P2 i t) (A2 i t₀, P2 i t₀) hcol
+    exact congrArg Prod.fst hpair
+  -- **Step 4 (per point).** Vandermonde in `r` pins every evaluation.
+  refine ⟨fun i => A2 i t₀, fun i => P2 i t₀, ?_⟩
+  intro i
+  refine ⟨hAcommit i t₀, ?_⟩
+  intro j0
+  have hvan : ∀ t : Fin m,
+      (∑ j : Fin m,
+        (innerProduct (A2 i t₀) (evalVector (2 ^ σ.k) (x j)) - e i j)
+          * (r t) ^ (j : ℕ)) = 0 := by
+    intro t
+    have h := hstar i t
+    rw [hAeq i t] at h
+    simp only [sub_mul]
+    rw [Finset.sum_sub_distrib, sub_eq_zero, ← h]
+    exact Finset.sum_congr rfl fun j _ => by ring
+  obtain ⟨L, hL⟩ := vandermondeN r hr j0
+  have key3 : ∀ g : Fin m → F,
+      (∑ t, L t * ∑ j : Fin m, g j * (r t) ^ (j : ℕ))
+        = ∑ j : Fin m, g j * ∑ t, L t * (r t) ^ (j : ℕ) := by
+    intro g
+    simp only [Finset.mul_sum]
+    rw [Finset.sum_comm]
+    exact Finset.sum_congr rfl fun j _ => Finset.sum_congr rfl fun t _ => by ring
+  have hzero : (∑ t, L t * ∑ j : Fin m,
+      (innerProduct (A2 i t₀) (evalVector (2 ^ σ.k) (x j)) - e i j)
+        * (r t) ^ (j : ℕ)) = 0 := by
+    apply Finset.sum_eq_zero
+    intro t _
+    rw [hvan t, mul_zero]
+  rw [key3 (fun j => innerProduct (A2 i t₀) (evalVector (2 ^ σ.k) (x j)) - e i j)] at hzero
+  simp only [hL, mul_ite, mul_one, mul_zero, Finset.sum_ite_eq', Finset.mem_univ,
+    if_true] at hzero
   exact (sub_eq_zero.mp hzero).symm
 
 end Kimchi.Commitment.IPA

--- a/formal/Kimchi/Pasta.lean
+++ b/formal/Kimchi/Pasta.lean
@@ -130,7 +130,7 @@ theorem glv_no_short_of_cert {n lam s t k2 u v : ℤ} (hn : 0 < n)
     `φ(P) = [λ]·P`. The defining property of the GLV endomorphism — not Mathlib-provable for the
     abstract curve, true by the Pasta construction (same trusted status as the point counts). It
     discharges `Kimchi.Circuit.EndoMul.endoMul`'s eigenvalue hypothesis `heig`. -/
-axiom pallas_eigen {x y : PallasBaseField}
+axiom pallas_eigen {x y : Fp}
     (h : Pallas.curve.toAffine.Nonsingular x y)
     (h' : Pallas.curve.toAffine.Nonsingular (pallas_endo * x) y) :
     Point.some _ _ h' = pallas_lam • Point.some _ _ h
@@ -155,7 +155,7 @@ theorem pallas_glv_no_short_relation {a b : ℤ} (hne : a ≠ 0 ∨ b ≠ 0)
 /-- **AXIOM (CM).** The Vesta endomorphism `φ(x, y) = (β·x, y)` acts as `[λ]` on the group:
     `φ(P) = [λ]·P` — the defining property of the GLV endomorphism (same trusted status as the
     point counts). It discharges `Kimchi.Circuit.EndoMul.endoMul`'s `heig` at Vesta. -/
-axiom vesta_eigen {x y : VestaBaseField}
+axiom vesta_eigen {x y : Fq}
     (h : Vesta.curve.toAffine.Nonsingular x y)
     (h' : Vesta.curve.toAffine.Nonsingular (vesta_endo * x) y) :
     Point.some _ _ h' = vesta_lam • Point.some _ _ h

--- a/formal/Kimchi/Pasta/Constants.lean
+++ b/formal/Kimchi/Pasta/Constants.lean
@@ -23,7 +23,7 @@ open CompElliptic.Fields.Pasta
 
 /-- The Pallas base-field endomorphism coefficient `β`: a primitive cube root of unity
     (proved below), so `φ(x, y) = (β·x, y)` maps `y² = x³ + 5` to itself. -/
-def pallas_endo : PallasBaseField :=
+def pallas_endo : Fp :=
   20444556541222657078399132219657928148671392403212669005631716460534733845831
 
 /-- `β³ = 1` on Pallas. -/
@@ -35,7 +35,7 @@ theorem pallas_endo_ne_one : pallas_endo ≠ 1 := by decide
 /-- The Vesta base-field endomorphism coefficient `β`: a primitive cube root of unity
     (proved below), so `φ(x, y) = (β·x, y)` maps `y² = x³ + 5` to itself. It is also the
     SvdW map-to-curve parameter `(√-3 − 1)/2` (`Kimchi.Sponge.GroupMapVesta`). -/
-def vesta_endo : VestaBaseField :=
+def vesta_endo : Fq :=
   2942865608506852014473558576493638302197734138389222805617480874486368177743
 
 /-- `β³ = 1` on Vesta. -/

--- a/formal/Kimchi/Sponge/FqSponge.lean
+++ b/formal/Kimchi/Sponge/FqSponge.lean
@@ -147,16 +147,10 @@ namespace FqVesta
 
 open CompElliptic.Fields.Pasta CompElliptic.Curves.Pasta
 
-/-- The sponge field: the Vesta base field. -/
-abbrev Fq := VestaBaseField
-
-/-- The challenge field: the Vesta scalar field. -/
-abbrev Fr := VestaScalarField
-
 /-- `DefaultFqSponge<VestaParameters>`: the `fq_kimchi` parameters and the Vesta
 eigenvalue. -/
 def spec : FqSponge.Spec PALLAS_SCALAR_CARD PALLAS_BASE_CARD :=
-  ⟨Fq.params, ((Kimchi.Pasta.vesta_lam : ℤ) : Fr)⟩
+  ⟨fqParams, ((Kimchi.Pasta.vesta_lam : ℤ) : Fp)⟩
 
 /-- The Vesta-side sponge state. -/
 abbrev S := FqSponge.S PALLAS_SCALAR_CARD
@@ -165,11 +159,11 @@ def init : S := FqSponge.init
 def absorbFq : S → List Fq → S := FqSponge.absorbFq spec
 def absorbG : S → CompElliptic.CurveForms.ShortWeierstrass.SWPoint Vesta.curve → S :=
   FqSponge.absorbG spec
-def absorbFr : S → Fr → S := FqSponge.absorbFr spec
+def absorbFr : S → Fp → S := FqSponge.absorbFr spec
 def challengeFq : S → Fq × S := FqSponge.challengeFq spec
 def challengeNat : S → ℕ × S := FqSponge.challengeNat spec
-def challenge : S → Fr × S := FqSponge.challenge spec
-def squeezeChallenge : S → Fr × S := FqSponge.squeezeChallenge spec
+def challenge : S → Fp × S := FqSponge.challenge spec
+def squeezeChallenge : S → Fp × S := FqSponge.squeezeChallenge spec
 
 end FqVesta
 
@@ -177,30 +171,24 @@ namespace FqPallas
 
 open CompElliptic.Fields.Pasta CompElliptic.Curves.Pasta
 
-/-- The sponge field: the Pallas base field. -/
-abbrev Fq := PallasBaseField
-
-/-- The challenge field: the Pallas scalar field. -/
-abbrev Fr := PallasScalarField
-
 /-- `DefaultFqSponge<PallasParameters>`: the `fp_kimchi` parameters and the Pallas
 eigenvalue. The scalar field is the larger of the pair, so `absorbFr` takes the
 high-bits/low-bit branch — selected by the cardinalities, not restated here. -/
 def spec : FqSponge.Spec PALLAS_BASE_CARD PALLAS_SCALAR_CARD :=
-  ⟨Fp.params, ((Kimchi.Pasta.pallas_lam : ℤ) : Fr)⟩
+  ⟨fpParams, ((Kimchi.Pasta.pallas_lam : ℤ) : Fq)⟩
 
 /-- The Pallas-side sponge state. -/
 abbrev S := FqSponge.S PALLAS_BASE_CARD
 
 def init : S := FqSponge.init
-def absorbFq : S → List Fq → S := FqSponge.absorbFq spec
+def absorbFq : S → List Fp → S := FqSponge.absorbFq spec
 def absorbG : S → CompElliptic.CurveForms.ShortWeierstrass.SWPoint Pallas.curve → S :=
   FqSponge.absorbG spec
-def absorbFr : S → Fr → S := FqSponge.absorbFr spec
-def challengeFq : S → Fq × S := FqSponge.challengeFq spec
+def absorbFr : S → Fq → S := FqSponge.absorbFr spec
+def challengeFq : S → Fp × S := FqSponge.challengeFq spec
 def challengeNat : S → ℕ × S := FqSponge.challengeNat spec
-def challenge : S → Fr × S := FqSponge.challenge spec
-def squeezeChallenge : S → Fr × S := FqSponge.squeezeChallenge spec
+def challenge : S → Fq × S := FqSponge.challenge spec
+def squeezeChallenge : S → Fq × S := FqSponge.squeezeChallenge spec
 
 end FqPallas
 

--- a/formal/Kimchi/Sponge/GroupMap.lean
+++ b/formal/Kimchi/Sponge/GroupMap.lean
@@ -96,7 +96,7 @@ end GroupMap
 
 namespace GroupMapVesta
 
-open CompElliptic.Fields.Pasta CompElliptic.Curves.Pasta Kimchi.Sponge.FqVesta
+open CompElliptic.Fields.Pasta CompElliptic.Curves.Pasta
 
 /-- The SvdW seed: the first abscissa with `f(u) ≠ 0`. -/
 def u : Fq := 1
@@ -145,16 +145,16 @@ end GroupMapVesta
 
 namespace GroupMapPallas
 
-open CompElliptic.Fields.Pasta CompElliptic.Curves.Pasta Kimchi.Sponge.FqPallas
+open CompElliptic.Fields.Pasta CompElliptic.Curves.Pasta
 
 /-- The SvdW seed: the first abscissa with `f(u) ≠ 0`. -/
-def u : Fq := 1
+def u : Fp := 1
 
 /-- `f(u)`. -/
-def fu : Fq := 6
+def fu : Fp := 6
 
 /-- `√(-3u²)` — the root `setup()` computes (the opposite sign choice to the Vesta side). -/
-def sqrtNegThreeUSquared : Fq :=
+def sqrtNegThreeUSquared : Fp :=
   17006931536212783554987228065028097629383328157457783420645920607630467569011
 
 example : sqrtNegThreeUSquared ^ 2 = -3 * u ^ 2 := by decide
@@ -162,7 +162,7 @@ example : sqrtNegThreeUSquared ^ 2 = -3 * u ^ 2 := by decide
 /-- `(√(-3u²) − u) / 2`. At `u = 1` this is `(√-3 − 1)/2` at `setup()`'s root choice — the
 *other* primitive cube root of unity from the Pallas endomorphism coefficient, i.e.
 `pallas_endo²`. -/
-def sqrtNegThreeUSquaredMinusUOver2 : Fq :=
+def sqrtNegThreeUSquaredMinusUOver2 : Fp :=
   8503465768106391777493614032514048814691664078728891710322960303815233784505
 
 example : sqrtNegThreeUSquaredMinusUOver2 = Kimchi.Pasta.pallas_endo ^ 2 := by decide
@@ -170,7 +170,7 @@ example : sqrtNegThreeUSquaredMinusUOver2 = Kimchi.Pasta.pallas_endo ^ 2 := by d
 example : 2 * sqrtNegThreeUSquaredMinusUOver2 = sqrtNegThreeUSquared - u := by decide
 
 /-- `(3u²)⁻¹`. -/
-def invThreeUSquared : Fq :=
+def invThreeUSquared : Fp :=
   19298681539552699237261830834781317975575370987961040477303117842899978420225
 
 example : invThreeUSquared * (3 * u ^ 2) = 1 := by decide
@@ -189,7 +189,7 @@ def spec : GroupMap.Spec PALLAS_BASE_CARD where
 example : fu = GroupMap.curveEqn spec u := by decide
 
 /-- The Pallas map-to-curve. -/
-def toGroup : Fq → SWPoint Pallas.curve :=
+def toGroup : Fp → SWPoint Pallas.curve :=
   GroupMap.toGroup spec
 
 end GroupMapPallas

--- a/formal/Kimchi/Sponge/Poseidon.lean
+++ b/formal/Kimchi/Sponge/Poseidon.lean
@@ -34,7 +34,7 @@ separate, explicitly flagged assumption where the instantiation meets the soundn
 
 * `Triple`, `Params`, `sbox`, `fullRound`, `blockCipher` — the permutation.
 * `Mode`, `State`, `init`, `absorb`, `squeeze`, `squeezeN` — the duplex automaton.
-* `Fq.params` / `Fp.params` — the concrete `fq_kimchi` / `fp_kimchi` instantiations.
+* `fqParams` / `fpParams` — the concrete `fq_kimchi` / `fp_kimchi` instantiations.
 -/
 
 namespace Kimchi.Sponge
@@ -136,50 +136,32 @@ def squeezeN (p : Params F) (sp : State F) : ℕ → List F × State F
     let (xs, sp) := squeezeN p sp n
     (x :: xs, sp)
 
-/-! ## The `fq_kimchi` instantiation -/
+/-! ## The Pasta instantiations -/
 
-namespace Fq
-
-open CompElliptic.Fields.Pasta
-
+open CompElliptic.Fields.Pasta in
 /-- The `fq_kimchi` parameters over the Vesta base field, from the generated constant
 tables. -/
-def params : Params VestaBaseField where
+def fqParams : Params Fq where
   roundConstants := FqKimchi.roundConstants.map fun row =>
-    (((row[0]! : ℕ) : VestaBaseField), ((row[1]! : ℕ) : VestaBaseField),
-     ((row[2]! : ℕ) : VestaBaseField))
+    (((row[0]! : ℕ) : Fq), ((row[1]! : ℕ) : Fq),
+     ((row[2]! : ℕ) : Fq))
   mds :=
     match FqKimchi.mds.map fun row =>
-        (((row[0]! : ℕ) : VestaBaseField), ((row[1]! : ℕ) : VestaBaseField),
-         ((row[2]! : ℕ) : VestaBaseField)) with
+        (((row[0]! : ℕ) : Fq), ((row[1]! : ℕ) : Fq),
+         ((row[2]! : ℕ) : Fq)) with
     | m => (m[0]!, m[1]!, m[2]!)
 
-/-- The fresh `fq_kimchi` sponge. -/
-def init : State VestaBaseField := Kimchi.Sponge.init
-
-end Fq
-
-/-! ## The `fp_kimchi` instantiation -/
-
-namespace Fp
-
-open CompElliptic.Fields.Pasta
-
+open CompElliptic.Fields.Pasta in
 /-- The `fp_kimchi` parameters over the Pallas base field, from the generated constant
 tables. -/
-def params : Params PallasBaseField where
+def fpParams : Params Fp where
   roundConstants := FpKimchi.roundConstants.map fun row =>
-    (((row[0]! : ℕ) : PallasBaseField), ((row[1]! : ℕ) : PallasBaseField),
-     ((row[2]! : ℕ) : PallasBaseField))
+    (((row[0]! : ℕ) : Fp), ((row[1]! : ℕ) : Fp),
+     ((row[2]! : ℕ) : Fp))
   mds :=
     match FpKimchi.mds.map fun row =>
-        (((row[0]! : ℕ) : PallasBaseField), ((row[1]! : ℕ) : PallasBaseField),
-         ((row[2]! : ℕ) : PallasBaseField)) with
+        (((row[0]! : ℕ) : Fp), ((row[1]! : ℕ) : Fp),
+         ((row[2]! : ℕ) : Fp)) with
     | m => (m[0]!, m[1]!, m[2]!)
-
-/-- The fresh `fp_kimchi` sponge. -/
-def init : State PallasBaseField := Kimchi.Sponge.init
-
-end Fp
 
 end Kimchi.Sponge

--- a/formal/Kimchi/Verifier/Ipa.lean
+++ b/formal/Kimchi/Verifier/Ipa.lean
@@ -54,6 +54,8 @@ production prover/verifier fixtures by `scripts/check_ipa_fixture.lean`.
 * `Proof`, `Input` — the wire data, indexed by the curve.
 * `shiftScalar` — the absorbed-scalar encoding, selected from the cardinalities.
 * `transcript` — the Fiat-Shamir schedule: `(U, chal, c)` from the wire data.
+* `Input.commitmentFn`/`pointFn`/`evalFn`, `transcriptChallenges`, `mkInput` — the named
+  wire→abstract views the reflection statements consume.
 * `verify` — the acceptance decision, against a library `SRS`.
 * `IpaVesta`, `IpaPallas` — the Pasta instantiations.
 -/
@@ -113,11 +115,27 @@ structure Input (C : CommitmentCurve) where
   evalscale : C.ScalarField
   proof : Proof C
 
+/-- The commitments as the `Fin`-indexed function of the abstract claim. -/
+def Input.commitmentFn {C : CommitmentCurve} (inp : Input C) :
+    Fin inp.commitments.size → C.Point :=
+  fun i => inp.commitments[i]
+
+/-- The evaluation points as the `Fin`-indexed function of the abstract claim. -/
+def Input.pointFn {C : CommitmentCurve} (inp : Input C) :
+    Fin inp.xs.size → C.ScalarField :=
+  fun j => inp.xs[j]
+
+/-- The claimed evaluation matrix as the indexed function of the abstract claim. The
+`evals` array is ragged, so this is where the unchecked indexing of the wire form lives —
+once, behind a name used identically on both sides of every statement. -/
+def Input.evalFn {C : CommitmentCurve} (inp : Input C) :
+    Fin inp.commitments.size → Fin inp.xs.size → C.ScalarField :=
+  fun i j => (inp.evals[i.val]!)[j.val]!
+
 /-- The combined inner product of the claimed evaluations
 (`Kimchi.Commitment.IPA.combinedInnerProduct` at the wire arrays). -/
 def cipOf {C : CommitmentCurve} (inp : Input C) : C.ScalarField :=
-  combinedInnerProduct inp.polyscale inp.evalscale
-    (fun (i : Fin inp.commitments.size) (j : Fin inp.xs.size) => (inp.evals[i.val]!)[j.val]!)
+  combinedInnerProduct inp.polyscale inp.evalscale inp.evalFn
 
 /-- The polyscale combination `∑ i, ξ^i • Cᵢ` of the commitments — the group-side mirror
 of `Kimchi.Commitment.IPA.combinedCommitment`, by a running power. -/
@@ -151,6 +169,41 @@ def transcript (inp : Input C) : C.Point × Array C.ScalarField × C.ScalarField
   let (c, _) := squeezeChallenge C.sponge s
   (uBase, chals, c)
 
+/-- A left fold that pushes exactly one element per step grows the array by the list
+length. -/
+private theorem foldl_fst_size {S γ α : Type*} (step : (Array γ × S) → α → (Array γ × S))
+    (hstep : ∀ acc a, (step acc a).1.size = acc.1.size + 1)
+    (l : List α) (init : Array γ × S) :
+    (l.foldl step init).1.size = init.1.size + l.length := by
+  induction l generalizing init with
+  | nil => simp
+  | cons a t ih =>
+    rw [List.foldl_cons, ih, hstep, List.length_cons]
+    omega
+
+/-- The transcript squeezes exactly one round challenge per `(L, R)` pair. -/
+theorem transcript_chals_size (inp : Input C) :
+    (transcript C inp).2.1.size = inp.proof.lr.size := by
+  simp only [transcript]
+  rw [← Array.foldl_toList, foldl_fst_size]
+  · simp
+  · intro acc a
+    simp [Array.size_push]
+
+/-- The derived round challenges as the `Fin`-indexed function the abstract layer
+consumes, under the shape fact. -/
+def transcriptChallenges (inp : Input C) {k : ℕ}
+    (hk : (transcript C inp).2.1.size = k) : Fin k → C.ScalarField :=
+  fun i => (transcript C inp).2.1[i.val]'(by omega)
+
+/-- A batched claim at given combination scalars — the wire input the grid rows of the
+soundness statements range over. -/
+def mkInput (commitments : Array C.Point) (xs : Array C.ScalarField)
+    (evals : Array (Array C.ScalarField)) (ξ r : C.ScalarField) (proof : Proof C) :
+    Input C :=
+  { commitments := commitments, xs := xs, evals := evals
+    polyscale := ξ, evalscale := r, proof := proof }
+
 /-- The acceptance decision, against a library SRS: derive the transcript, combine the
 claim, and check the Schnorr and `sg`-correctness equations. Shape guards (round count
 `σ.k`, evaluation matrix dimensions) reject malformed inputs. `σ.U` is never read — the
@@ -174,6 +227,22 @@ def verify (σ : SRS C.Point) (inp : Input C) : Bool :=
           + inp.proof.z2.val • σ.h)
     let sgOk := decide (inp.proof.sg = msm C σ.g (bPolyCoefficients chal))
     schnorr && sgOk
+
+/-- An accepting run has the announced round count. -/
+theorem verify_shape (σ : SRS C.Point) (inp : Input C)
+    (hv : verify C σ inp = true) : inp.proof.lr.size = σ.k := by
+  unfold verify at hv
+  split at hv
+  · simp at hv
+  · rename_i hguard
+    simp only [Bool.not_eq_true, Bool.or_eq_false_iff, bne_eq_false_iff_eq] at hguard
+    exact hguard.1.1
+
+/-- The round-challenge count of an accepting run, in the form `transcriptChallenges`
+consumes. -/
+theorem transcript_size_of_verify (σ : SRS C.Point) (inp : Input C)
+    (hv : verify C σ inp = true) : (transcript C inp).2.1.size = σ.k :=
+  (transcript_chals_size C inp).trans (verify_shape C σ inp hv)
 
 end Kimchi.Verifier.Ipa
 

--- a/formal/Kimchi/Verifier/Ipa.lean
+++ b/formal/Kimchi/Verifier/Ipa.lean
@@ -18,16 +18,18 @@ the wire protocol does not carry. In particular the abstract SRS's randomisation
 the derived base to the abstract one is exactly the Fiat-Shamir assumption's junction.
 
 Generic over a single `CommitmentCurve` bundle — the Lean analogue of the Rust
-`G: CommitmentCurve` associated types: the base and scalar cardinalities with their field
-instances (the fields recovered as the projections `Fq`/`Fr`), the sponge spec, the curve
-`E`, and the map-to-curve. Points are the library's `SWPoint E` (`Point`), so the group
+`G: CommitmentCurve` associated types: the base and scalar cardinalities with their
+primality facts, the sponge spec, the curve `E`, and the map-to-curve. The bundle carries
+*facts*, not structures: the field structures are the canonical `ZMod` instances
+synthesized from primality, so the executable and abstract layers cannot disagree on any
+field operation. Points are the library's `SWPoint E` (`Point`), so the group
 structure is inherited: `+`/`0` and the binary-nsmul scalar action from CompElliptic's
 `AddCommGroup` instance, point equality from its `DecidableEq`. `Proof`, `Input`, and
 `verify` are indexed by the bundle, so a proof's type names its curve.
 
 The scalar side reuses the `Kimchi.Commitment.IPA` definitions (`bPoly`,
 `bPolyCoefficients`, `combinedB`, `combinedInnerProduct`) at the concrete scalar field.
-Scalars act on points as `z.val • _` (the ℕ-action of the group): the `C.Fr`-module
+Scalars act on points as `z.val • _` (the ℕ-action of the group): the `C.ScalarField`-module
 structure on `Point` is the reflection concern relating this verifier to the `Prop`-level
 `BatchAccepts`, not stated here.
 
@@ -62,25 +64,25 @@ open CompElliptic.CurveForms.ShortWeierstrass
 open Kimchi.Sponge Kimchi.Sponge.FqSponge Kimchi.Commitment.IPA
 
 /-- The per-curve data of the verifier, bundled as a single index — base and scalar
-cardinalities with their field instances, the Fq-sponge spec, the curve, and the
-map-to-curve. The field types are recovered as the projections `Fq`/`Fr`, the point type
-as `Point`. -/
+cardinalities with their primality facts, the Fq-sponge spec, the curve, and the
+map-to-curve. Carrying facts rather than field structures makes every field operation
+resolve to the canonical `ZMod` instances on both the executable and abstract sides. -/
 structure CommitmentCurve where
   base : ℕ
   scalar : ℕ
-  [fieldBase : Field (ZMod base)]
-  [fieldScalar : Field (ZMod scalar)]
+  [primeBase : Fact (Nat.Prime base)]
+  [primeScalar : Fact (Nat.Prime scalar)]
   sponge : FqSponge.Spec base scalar
   E : SWCurve (ZMod base)
   toGroup : ZMod base → SWPoint E
 
-attribute [instance] CommitmentCurve.fieldBase CommitmentCurve.fieldScalar
+attribute [instance] CommitmentCurve.primeBase CommitmentCurve.primeScalar
 
-/-- The base field. -/
-abbrev CommitmentCurve.Fq (C : CommitmentCurve) := ZMod C.base
+/-- The base field — the canonical `ZMod` at the base cardinality. -/
+abbrev CommitmentCurve.BaseField (C : CommitmentCurve) := ZMod C.base
 
-/-- The scalar field. -/
-abbrev CommitmentCurve.Fr (C : CommitmentCurve) := ZMod C.scalar
+/-- The scalar field — the canonical `ZMod` at the scalar cardinality. -/
+abbrev CommitmentCurve.ScalarField (C : CommitmentCurve) := ZMod C.scalar
 
 /-- The point type — the library's proof-carrying `SWPoint`, with its group structure. -/
 abbrev CommitmentCurve.Point (C : CommitmentCurve) := SWPoint C.E
@@ -89,15 +91,15 @@ variable (C : CommitmentCurve)
 
 /-- Multi-scalar multiplication `∑ i, aᵢ • gᵢ` — the group-side mirror of
 `Kimchi.Commitment.IPA.commitGen`, with the scalars acting through `val`. -/
-def msm {n : ℕ} (g : Fin n → C.Point) (a : Fin n → C.Fr) : C.Point :=
+def msm {n : ℕ} (g : Fin n → C.Point) (a : Fin n → C.ScalarField) : C.Point :=
   ∑ i, (a i).val • g i
 
 /-- An IPA opening proof — the wire fields of `OpeningProof` (`ipa.rs`). -/
 structure Proof (C : CommitmentCurve) where
   lr : Array (C.Point × C.Point)
   delta : C.Point
-  z1 : C.Fr
-  z2 : C.Fr
+  z1 : C.ScalarField
+  z2 : C.ScalarField
   sg : C.Point
 
 /-- A batched opening claim, uncombined — the verifier's wire input: the per-polynomial
@@ -105,22 +107,22 @@ commitments (one chunk each), the evaluation points, the claimed evaluation matr
 (`evals[i][j]` = polynomial `i` at point `j`), the combination scalars, and the proof. -/
 structure Input (C : CommitmentCurve) where
   commitments : Array C.Point
-  xs : Array C.Fr
-  evals : Array (Array C.Fr)
-  polyscale : C.Fr
-  evalscale : C.Fr
+  xs : Array C.ScalarField
+  evals : Array (Array C.ScalarField)
+  polyscale : C.ScalarField
+  evalscale : C.ScalarField
   proof : Proof C
 
 /-- The combined inner product of the claimed evaluations
 (`Kimchi.Commitment.IPA.combinedInnerProduct` at the wire arrays). -/
-def cipOf {C : CommitmentCurve} (inp : Input C) : C.Fr :=
+def cipOf {C : CommitmentCurve} (inp : Input C) : C.ScalarField :=
   combinedInnerProduct inp.polyscale inp.evalscale
     (fun (i : Fin inp.commitments.size) (j : Fin inp.xs.size) => (inp.evals[i.val]!)[j.val]!)
 
 /-- The polyscale combination `∑ i, ξ^i • Cᵢ` of the commitments — the group-side mirror
 of `Kimchi.Commitment.IPA.combinedCommitment`, by a running power. -/
-def combineCommitments (ξ : C.Fr) (cs : Array C.Point) : C.Point :=
-  (cs.foldl (fun (acc : C.Point × C.Fr) P => (acc.1 + acc.2.val • P, acc.2 * ξ))
+def combineCommitments (ξ : C.ScalarField) (cs : Array C.Point) : C.Point :=
+  (cs.foldl (fun (acc : C.Point × C.ScalarField) P => (acc.1 + acc.2.val • P, acc.2 * ξ))
     (0, 1)).1
 
 /-- The transcript encoding of an absorbed scalar (`shift_scalar`,
@@ -128,19 +130,19 @@ def combineCommitments (ξ : C.Fr) (cs : Array C.Point) : C.Point :=
 scalar-modulus bit size `Nat.size scalar` (the Rust `MODULUS_BIT_SIZE`) — Type1
 (`(x − 2ᵇ − 1)/2`) when the scalar modulus is below the base modulus, the Type2 shift
 (`x − 2ᵇ`) otherwise. The branch is the Rust `n1 < n2`, decided from the cardinalities. -/
-def shiftScalar (x : C.Fr) : C.Fr :=
+def shiftScalar (x : C.ScalarField) : C.ScalarField :=
   if C.scalar < C.base then Kimchi.Shifted.shiftType1 (Nat.size C.scalar) x
   else Kimchi.Shifted.shiftType2 (Nat.size C.scalar) x
 
 /-- The verifier's Fiat-Shamir schedule (`SRS::verify`): absorb the shifted combined inner
 product; squeeze and map the `U` base; per round absorb `L`, `R` and squeeze a challenge;
 absorb `δ` and squeeze the Schnorr challenge. -/
-def transcript (inp : Input C) : C.Point × Array C.Fr × C.Fr :=
+def transcript (inp : Input C) : C.Point × Array C.ScalarField × C.ScalarField :=
   let s := absorbFr C.sponge FqSponge.init (shiftScalar C (cipOf inp))
   let (t, s) := challengeFq C.sponge s
   let uBase := C.toGroup t
   let (chals, s) := inp.proof.lr.foldl
-    (fun (acc : Array C.Fr × FqSponge.S C.base) LR =>
+    (fun (acc : Array C.ScalarField × FqSponge.S C.base) LR =>
       let s := absorbG C.sponge (absorbG C.sponge acc.2 LR.1) LR.2
       let (u, s) := squeezeChallenge C.sponge s
       (acc.1.push u, s))
@@ -159,12 +161,12 @@ def verify (σ : SRS C.Point) (inp : Input C) : Bool :=
     false
   else
     let (uBase, chals, c) := transcript C inp
-    let chal : Fin σ.k → C.Fr := fun i => chals[i.val]!
+    let chal : Fin σ.k → C.ScalarField := fun i => chals[i.val]!
     let b0 := combinedB chal inp.evalscale (fun j : Fin inp.xs.size => inp.xs[j.val]!)
     let v := cipOf inp
     let P := combineCommitments C inp.polyscale inp.commitments
     let Q := (inp.proof.lr.zip chals).foldl
-      (fun acc (LRu : (C.Point × C.Point) × C.Fr) =>
+      (fun acc (LRu : (C.Point × C.Point) × C.ScalarField) =>
         acc + (LRu.2⁻¹.val • LRu.1.1 + LRu.2.val • LRu.1.2))
       (P + v.val • uBase)
     let schnorr := decide (c.val • Q + inp.proof.delta
@@ -183,7 +185,7 @@ open CompElliptic.Fields.Pasta CompElliptic.Curves.Pasta Kimchi.Sponge Kimchi.Ve
 
 /-- The Vesta bundle. The scalar modulus is below the base modulus, so scalars absorb in
 Type1 form. -/
-def curve : Ipa.CommitmentCurve where
+abbrev curve : Ipa.CommitmentCurve where
   base := PALLAS_SCALAR_CARD
   scalar := PALLAS_BASE_CARD
   sponge := FqVesta.spec
@@ -204,7 +206,7 @@ open CompElliptic.Fields.Pasta CompElliptic.Curves.Pasta Kimchi.Sponge Kimchi.Ve
 
 /-- The Pallas bundle. The scalar modulus is above the base modulus, so scalars absorb in
 Type2 form — selected by the cardinalities, not restated here. -/
-def curve : Ipa.CommitmentCurve where
+abbrev curve : Ipa.CommitmentCurve where
   base := PALLAS_BASE_CARD
   scalar := PALLAS_SCALAR_CARD
   sponge := FqPallas.spec

--- a/formal/Kimchi/Verifier/Reflection.lean
+++ b/formal/Kimchi/Verifier/Reflection.lean
@@ -1,0 +1,324 @@
+import Kimchi.Verifier.Ipa
+import Kimchi.Commitment.IPA.Soundness.Batch
+import Kimchi.Pasta
+
+/-!
+# Reflection: the executable verifier meets the soundness layer
+
+The bridge between `Kimchi.Verifier.Ipa.verify` (executable, over wire data, challenges
+derived by the Poseidon sponge) and the `Prop`-level acceptance `BatchAccepts` of the IPA
+soundness development — and, through the Fiat-Shamir axiom, the batch knowledge-soundness
+theorem itself.
+
+Three strata:
+
+* **The scalar action.** The Pasta point groups are `p`-torsion for their group orders
+  (`CompElliptic.Curves.PastaOrder`, under the Hasse axioms), so each carries a
+  `Module (ZMod p)` structure by `AddCommGroup.zmodModule`; its action is definitionally
+  `z.val • _`, the ℕ-action the executable verifier computes with. This instantiates the
+  abstract `[Module F G]` of the soundness layer at the executable types.
+
+* **Reflection.** `verify` and `BatchAccepts` are the same equations in two spellings:
+  the executable combiners equal the library combiners (`msm_eq_commitGen`,
+  `combineCommitments_eq`), and an accepting run satisfies `BatchAccepts` at the
+  sponge-derived challenges, against the SRS whose randomisation base is the derived `U`
+  (`verify_reflects` — the `{σ with U := …}` substitution is the deployed protocol's
+  transcript-derived base standing in for the abstract one). The wire data enters through
+  the named views (`Input.commitmentFn`/`pointFn`/`evalFn`, `transcriptChallenges`), used
+  identically on both sides.
+
+* **The Fiat-Shamir axiom and the headline.** `poseidon_fiat_shamir_vesta` is the
+  project's declared assumption, stated at the junction: a run accepted by the
+  Poseidon-instantiated verifier admits a de-blinded accepting transcript tree over the
+  combined eval vector (`FiatShamirTreeB`, with the deployed acceptance
+  `verify … = true` as the antecedent). It packages the rewinding/forking extraction and
+  the random-oracle behaviour of the sponge; everything downstream of it is proved.
+  `ipaVesta_sound` composes the axiom and `batch_soundness`: a grid of accepting runs at
+  pairwise-distinct combination scalars, under the no-DL-relation binding *hypothesis*,
+  yields genuine openings for every commitment. Binding stays a hypothesis — it is
+  information-theoretically false at real parameters and meaningful only computationally
+  (see `Soundness/Batch.lean`).
+-/
+
+namespace Kimchi.Verifier
+
+open CompElliptic.CurveForms.ShortWeierstrass CompElliptic.Curves.Pasta
+open CompElliptic.Curves.Pasta.Vesta renaming curve → vestaCurve
+open CompElliptic.Curves.Pasta.Pallas renaming curve → pallasCurve
+open CompElliptic.Fields.Pasta Kimchi.Commitment.IPA Kimchi.Verifier.Ipa
+
+/-! ## The scalar action on the Pasta point groups -/
+
+/-- The Vesta point group is `PALLAS_BASE_CARD`-torsion (its group order, under the Hasse
+axiom), hence a module over its scalar field. The action is definitionally `z.val • _`. -/
+instance vestaPointModule : Module Fp (SWPoint vestaCurve) :=
+  AddCommGroup.zmodModule fun P => by
+    rw [← Vesta.card_eq Kimchi.Pasta.vesta_hasse]
+    exact card_nsmul_eq_zero'
+
+/-- The Pallas point group is `PALLAS_SCALAR_CARD`-torsion (its group order, under the
+Hasse axiom), hence a module over its scalar field. -/
+instance pallasPointModule : Module Fq (SWPoint pallasCurve) :=
+  AddCommGroup.zmodModule fun P => by
+    rw [← Pallas.card_eq Kimchi.Pasta.pallas_hasse]
+    exact card_nsmul_eq_zero'
+
+/-- The module action is the ℕ-action at the canonical representative — the form the
+executable verifier computes with. -/
+theorem vesta_smul_val (z : Fp) (P : SWPoint vestaCurve) : z • P = z.val • P :=
+  rfl
+
+theorem pallas_smul_val (z : Fq) (P : SWPoint pallasCurve) : z • P = z.val • P :=
+  rfl
+
+/-! ## The wire proof as an abstract opening proof -/
+
+/-- The wire proof, reindexed to the abstract `OpeningProof` at its round count. -/
+def Ipa.Proof.toOpening {C : CommitmentCurve} (p : Ipa.Proof C) {k : ℕ}
+    (hk : p.lr.size = k) : OpeningProof C.ScalarField C.Point k where
+  lr := fun j => p.lr[j.val]'(by omega)
+  delta := p.delta
+  z1 := p.z1
+  z2 := p.z2
+  sg := p.sg
+
+/-! ## Reflection: the executable combiners are the library combiners -/
+
+section Reflection
+
+variable {C : CommitmentCurve} [Module C.ScalarField C.Point]
+  (hsmul : ∀ (z : C.ScalarField) (P : C.Point), z • P = z.val • P)
+
+include hsmul in
+/-- The executable MSM is `commitGen`. -/
+theorem msm_eq_commitGen {n : ℕ} (g : Fin n → C.Point) (a : Fin n → C.ScalarField) :
+    msm C g a = commitGen g a := by
+  simp only [Ipa.msm, commitGen]
+  exact Finset.sum_congr rfl (fun i _ => (hsmul (a i) (g i)).symm)
+
+/-- Generalized-accumulator running-power fold over a list: from any starting
+accumulator `acc` and running power `p`, the first component is `acc` plus the
+`(p · ξ^i)`-scaled sum of the list entries. The engine behind `combineCommitments_eq`. -/
+private theorem combineFoldl_aux (ξ : C.ScalarField) (l : List C.Point) (acc : C.Point)
+    (p : C.ScalarField) :
+    (l.foldl (fun (a : C.Point × C.ScalarField) P => (a.1 + a.2.val • P, a.2 * ξ))
+        (acc, p)).1
+      = acc + ∑ i : Fin l.length, (p * ξ ^ (i : ℕ)).val • l[i] := by
+  induction l generalizing acc p with
+  | nil => simp
+  | cons P t ih =>
+    rw [List.foldl_cons, ih]
+    simp only [List.length_cons, Fin.sum_univ_succ, Fin.val_zero, pow_zero, mul_one,
+      Fin.val_succ]
+    rw [← _root_.add_assoc]
+    congr 1
+    refine Finset.sum_congr rfl fun i _ => ?_
+    congr 2
+    rw [pow_succ]; ring
+
+include hsmul in
+/-- The executable running-power combination is `combinedCommitment`. -/
+theorem combineCommitments_eq (ξ : C.ScalarField) (cs : Array C.Point) :
+    combineCommitments C ξ cs
+      = combinedCommitment ξ (fun i : Fin cs.size => cs[i]) := by
+  rw [combineCommitments, ← Array.foldl_toList, combineFoldl_aux]
+  simp only [one_mul, _root_.zero_add]
+  rw [combinedCommitment]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rw [hsmul]; congr 1
+
+/-- A left fold that adds `g x` for each list element equals the start plus the sum of
+`g` over the list. The engine behind the recombination bridge. -/
+private theorem foldl_add_eq_sum {D : Type*} (g : D → C.Point) (l : List D)
+    (init : C.Point) :
+    l.foldl (fun acc x => acc + g x) init = init + ∑ i : Fin l.length, g l[i] := by
+  induction l generalizing init with
+  | nil => simp
+  | cons a t ih =>
+    rw [List.foldl_cons, ih, _root_.add_assoc]
+    simp [Fin.sum_univ_succ]
+
+/-- The executable zip-fold recombination equals the abstract indexed sum: folding
+`(L, R, u)` triples matches `∑ j, (uⱼ⁻¹ • Lⱼ + uⱼ • Rⱼ)` scaled through `val`. -/
+private theorem zipFold_eq_recombine (init : C.Point)
+    (lr : Array (C.Point × C.Point)) (ch : Array C.ScalarField) (k : ℕ)
+    (hlr : lr.size = k) (hch : ch.size = k) :
+    (lr.zip ch).foldl
+        (fun (acc : C.Point) (LRu : (C.Point × C.Point) × C.ScalarField) =>
+          acc + (LRu.2⁻¹.val • LRu.1.1 + LRu.2.val • LRu.1.2)) init
+      = init + ∑ j : Fin k,
+          ((ch[(j : ℕ)]'(by omega))⁻¹.val • (lr[(j : ℕ)]'(by omega)).1
+            + (ch[(j : ℕ)]'(by omega)).val • (lr[(j : ℕ)]'(by omega)).2) := by
+  rw [← Array.foldl_toList, foldl_add_eq_sum]
+  congr 1
+  have hlen : (lr.zip ch).toList.length = k := by
+    rw [Array.length_toList, Array.size_zip, hlr, hch, min_self]
+  refine Fintype.sum_equiv (finCongr hlen) _ _ (fun i => ?_)
+  simp only [finCongr_apply, Fin.val_cast, Fin.getElem_fin, Array.getElem_toList,
+    Array.getElem_zip]
+
+include hsmul in
+/-- **Reflection.** An accepting executable run satisfies the `Prop`-level batched
+acceptance at the sponge-derived challenges, against the SRS whose randomisation base is
+the transcript-derived `U`. With `(U, chal, c) := transcript C inp`:
+`BatchAccepts {σ with U := U} proof ξ r c chal commitments xs evals`, the wire data
+entering through its named views. -/
+theorem verify_reflects (σ : SRS C.Point) (inp : Ipa.Input C)
+    (hv : Ipa.verify C σ inp = true) :
+    BatchAccepts { σ with U := (transcript C inp).1 }
+      (inp.proof.toOpening (verify_shape C σ inp hv))
+      inp.polyscale inp.evalscale
+      (transcript C inp).2.2
+      (transcriptChallenges C inp (transcript_size_of_verify C σ inp hv))
+      inp.commitmentFn inp.pointFn inp.evalFn := by
+  have hsize := verify_shape C σ inp hv
+  have hchsz := transcript_size_of_verify C σ inp hv
+  -- The two spelling bridges: the executable `getElem!` challenge and eval-point
+  -- functions are the named views.
+  have hchal : (fun i : Fin σ.k => (transcript C inp).2.1[i.val]!)
+      = transcriptChallenges C inp hchsz := by
+    funext i
+    exact getElem!_pos (transcript C inp).2.1 i.val (by rw [hchsz]; exact i.isLt)
+  have hpt : (fun j : Fin inp.xs.size => inp.xs[j.val]!) = inp.pointFn := by
+    funext j
+    exact getElem!_pos inp.xs j.val j.isLt
+  simp only [Ipa.verify] at hv
+  split at hv
+  · exact absurd hv (by simp)
+  · rw [Bool.and_eq_true] at hv
+    obtain ⟨hsch, hsg⟩ := hv
+    rw [decide_eq_true_eq] at hsch hsg
+    rw [hchal] at hsch hsg
+    rw [hpt] at hsch
+    refine ⟨?_, ?_⟩
+    · rw [zipFold_eq_recombine _ inp.proof.lr (transcript C inp).2.1 σ.k hsize hchsz]
+        at hsch
+      rw [combineCommitments_eq hsmul] at hsch
+      unfold Kimchi.Commitment.IPA.recombine Ipa.Proof.toOpening
+      simp only [hsmul, Ipa.transcriptChallenges, Ipa.Input.commitmentFn]
+      exact hsch
+    · exact hsg.trans (msm_eq_commitGen hsmul _ _)
+
+end Reflection
+
+/-! ## The Fiat-Shamir axiom -/
+
+/-- **AXIOM (Fiat-Shamir, Poseidon instantiation, Vesta).** A run accepted by the
+Poseidon-instantiated verifier admits a de-blinded accepting transcript tree over the
+combined eval vector: `FiatShamirTreeB` with the deployed acceptance
+`Ipa.verify … = true` as the antecedent. This is the project's declared assumption that
+the Poseidon sponge provides a valid Fiat-Shamir transform — it packages the
+rewinding/forking extraction and the random-oracle behaviour of the sponge. It is the
+sole non-standard axiom of the headline `ipaVesta_sound`. -/
+axiom poseidon_fiat_shamir_vesta (σ : SRS IpaVesta.Point) (inp : IpaVesta.Input) :
+  FiatShamirTreeB σ
+    (combinedCommitment inp.polyscale inp.commitmentFn)
+    (combinedEvalVector (2 ^ σ.k) inp.evalscale inp.pointFn)
+    (cipOf inp)
+    (Ipa.verify IpaVesta.curve σ inp = true)
+
+/-- **AXIOM (Fiat-Shamir, Poseidon instantiation, Pallas).** The Pallas-side twin of
+`poseidon_fiat_shamir_vesta`. -/
+axiom poseidon_fiat_shamir_pallas (σ : SRS IpaPallas.Point) (inp : IpaPallas.Input) :
+  FiatShamirTreeB σ
+    (combinedCommitment inp.polyscale inp.commitmentFn)
+    (combinedEvalVector (2 ^ σ.k) inp.evalscale inp.pointFn)
+    (cipOf inp)
+    (Ipa.verify IpaPallas.curve σ inp = true)
+
+/-! ## The headline -/
+
+/-- **Soundness of the deployed Vesta verifier.** A grid of Poseidon-accepted runs of the
+same claim — commitments `cs`, points `xs`, claimed evaluations `evals` — at
+pairwise-distinct polyscales `ξ` and evalscales `r`, under the no-DL-relation binding
+hypothesis, yields genuine openings: every commitment opens to a witness whose evaluation
+at every point is the claimed one. Composes `poseidon_fiat_shamir_vesta` and
+`batch_soundness`; binding remains a hypothesis (see the module docstring). -/
+theorem ipaVesta_sound (σ : SRS IpaVesta.Point)
+    (cs : Array IpaVesta.Point) (xs : Array Fp) (evals : Array (Array Fp))
+    (hm : 0 < xs.size)
+    (ξ : Fin cs.size → Fp) (hξ : Function.Injective ξ)
+    (r : Fin xs.size → Fp) (hr : Function.Injective r)
+    (proofs : Fin cs.size → Fin xs.size → IpaVesta.Proof)
+    (hacc : ∀ s t, Ipa.verify IpaVesta.curve σ
+      (mkInput IpaVesta.curve cs xs evals (ξ s) (r t) (proofs s t)) = true)
+    (hbind : ∀ (w : Fin (2 ^ σ.k) → Fp) (wh : Fp),
+      DLRelation σ w wh → w = 0 ∧ wh = 0) :
+    ∃ (a : Fin cs.size → Fin (2 ^ σ.k) → Fp) (ρ : Fin cs.size → Fp),
+      ∀ i, commit σ (a i) (ρ i) = cs[i]
+        ∧ ∀ j : Fin xs.size,
+            (evals[i.val]!)[j.val]! = innerProduct (a i) (evalVector (2 ^ σ.k) xs[j]) := by
+  -- The grid input at combination scalars `(ξ s, r t)`.
+  set inp : Fin cs.size → Fin xs.size → IpaVesta.Input := fun s t =>
+    mkInput IpaVesta.curve cs xs evals (ξ s) (r t) (proofs s t) with hinp
+  -- The Poseidon Fiat–Shamir axiom at every grid point: an accepting Poseidon run yields
+  -- a de-blinded accepting tree over the combined eval vector, with the deployed
+  -- acceptance `Ipa.verify … = true` as the antecedent.
+  have hFS : ∀ (s : Fin cs.size) (t : Fin xs.size),
+      FiatShamirTreeB σ
+        (combinedCommitment (ξ s) (fun i : Fin cs.size => cs[i]))
+        (combinedEvalVector (2 ^ σ.k) (r t) (fun j : Fin xs.size => xs[j]))
+        (cipOf (inp s t))
+        (Ipa.verify IpaVesta.curve σ (inp s t) = true) :=
+    fun s t => poseidon_fiat_shamir_vesta σ (inp s t)
+  -- `cipOf (inp s t)` is exactly the combined inner product of the claimed evaluations.
+  have hcip : ∀ (s : Fin cs.size) (t : Fin xs.size),
+      cipOf (inp s t)
+        = combinedInnerProduct (ξ s) (r t)
+            (fun (i : Fin cs.size) (j : Fin xs.size) => (evals[i.val]!)[j.val]!) :=
+    fun s t => rfl
+  simp only [hcip] at hFS
+  obtain ⟨a, ρ, h⟩ := batch_soundnessA σ ξ hξ r hr hm
+    (fun i : Fin cs.size => cs[i]) (fun j : Fin xs.size => xs[j])
+    (fun (i : Fin cs.size) (j : Fin xs.size) => (evals[i.val]!)[j.val]!)
+    (fun s t => Ipa.verify IpaVesta.curve σ (inp s t) = true)
+    hFS hbind hacc
+  exact ⟨a, ρ, fun i => ⟨(h i).1, fun j => (h i).2 j⟩⟩
+
+/-- **Soundness of the deployed Pallas verifier.** A grid of Poseidon-accepted runs of the
+same claim — commitments `cs`, points `xs`, claimed evaluations `evals` — at
+pairwise-distinct polyscales `ξ` and evalscales `r`, under the no-DL-relation binding
+hypothesis, yields genuine openings: every commitment opens to a witness whose evaluation
+at every point is the claimed one. The Pallas-side twin of `ipaPallas_sound`. -/
+theorem ipaPallas_sound (σ : SRS IpaPallas.Point)
+    (cs : Array IpaPallas.Point) (xs : Array Fq) (evals : Array (Array Fq))
+    (hm : 0 < xs.size)
+    (ξ : Fin cs.size → Fq) (hξ : Function.Injective ξ)
+    (r : Fin xs.size → Fq) (hr : Function.Injective r)
+    (proofs : Fin cs.size → Fin xs.size → IpaPallas.Proof)
+    (hacc : ∀ s t, Ipa.verify IpaPallas.curve σ
+      (mkInput IpaPallas.curve cs xs evals (ξ s) (r t) (proofs s t)) = true)
+    (hbind : ∀ (w : Fin (2 ^ σ.k) → Fq) (wh : Fq),
+      DLRelation σ w wh → w = 0 ∧ wh = 0) :
+    ∃ (a : Fin cs.size → Fin (2 ^ σ.k) → Fq) (ρ : Fin cs.size → Fq),
+      ∀ i, commit σ (a i) (ρ i) = cs[i]
+        ∧ ∀ j : Fin xs.size,
+            (evals[i.val]!)[j.val]! = innerProduct (a i) (evalVector (2 ^ σ.k) xs[j]) := by
+  -- The grid input at combination scalars `(ξ s, r t)`.
+  set inp : Fin cs.size → Fin xs.size → IpaPallas.Input := fun s t =>
+    mkInput IpaPallas.curve cs xs evals (ξ s) (r t) (proofs s t) with hinp
+  -- The Poseidon Fiat–Shamir axiom at every grid point: an accepting Poseidon run yields
+  -- a de-blinded accepting tree over the combined eval vector, with the deployed
+  -- acceptance `Ipa.verify … = true` as the antecedent.
+  have hFS : ∀ (s : Fin cs.size) (t : Fin xs.size),
+      FiatShamirTreeB σ
+        (combinedCommitment (ξ s) (fun i : Fin cs.size => cs[i]))
+        (combinedEvalVector (2 ^ σ.k) (r t) (fun j : Fin xs.size => xs[j]))
+        (cipOf (inp s t))
+        (Ipa.verify IpaPallas.curve σ (inp s t) = true) :=
+    fun s t => poseidon_fiat_shamir_pallas σ (inp s t)
+  -- `cipOf (inp s t)` is exactly the combined inner product of the claimed evaluations.
+  have hcip : ∀ (s : Fin cs.size) (t : Fin xs.size),
+      cipOf (inp s t)
+        = combinedInnerProduct (ξ s) (r t)
+            (fun (i : Fin cs.size) (j : Fin xs.size) => (evals[i.val]!)[j.val]!) :=
+    fun s t => rfl
+  simp only [hcip] at hFS
+  obtain ⟨a, ρ, h⟩ := batch_soundnessA σ ξ hξ r hr hm
+    (fun i : Fin cs.size => cs[i]) (fun j : Fin xs.size => xs[j])
+    (fun (i : Fin cs.size) (j : Fin xs.size) => (evals[i.val]!)[j.val]!)
+    (fun s t => Ipa.verify IpaPallas.curve σ (inp s t) = true)
+    hFS hbind hacc
+  exact ⟨a, ρ, fun i => ⟨(h i).1, fun j => (h i).2 j⟩⟩
+
+end Kimchi.Verifier

--- a/formal/roots.txt
+++ b/formal/roots.txt
@@ -126,3 +126,8 @@ Kimchi.Quotient.Poseidon.soundness
 Kimchi.Quotient.multiset_eq_of_pairFactor_prod_eq
 Kimchi.Quotient.identity_of_grid_evals
 Kimchi.Quotient.multiset_eq_of_grid_prod_evals
+
+-- The Fiat-Shamir junction: the executable verifier meets the soundness layer.
+Kimchi.Verifier.verify_reflects
+Kimchi.Verifier.ipaVesta_sound
+Kimchi.Verifier.ipaPallas_sound

--- a/formal/scripts/check_axioms.lean
+++ b/formal/scripts/check_axioms.lean
@@ -66,7 +66,9 @@ def roots : List Name :=
     `Kimchi.Quotient.Poseidon.soundness,
     `Kimchi.Quotient.multiset_eq_of_pairFactor_prod_eq,
     `Kimchi.Quotient.identity_of_grid_evals,
-    `Kimchi.Quotient.multiset_eq_of_grid_prod_evals ]
+    `Kimchi.Quotient.multiset_eq_of_grid_prod_evals,
+    `Kimchi.Verifier.verify_reflects, `Kimchi.Verifier.ipaVesta_sound,
+    `Kimchi.Verifier.ipaPallas_sound ]
 
 /-- The only axioms the roots may depend on: the standard logical axioms; the Pasta Hasse bounds
     (`{pallas,vesta}_hasse`); `Lean.ofReduceBool`; and the Pasta CM eigenvalue relations
@@ -76,6 +78,9 @@ def roots : List Name :=
 def allowed : List Name :=
   [ `propext, `Classical.choice, `Quot.sound, `Lean.ofReduceBool,
     `Kimchi.Pasta.pallas_hasse, `Kimchi.Pasta.vesta_hasse,
+    -- The declared Fiat-Shamir assumption: Poseidon-accepted runs admit de-blinded
+    -- accepting transcript trees (`Kimchi/Verifier/Reflection.lean`). One per Pasta curve.
+    `Kimchi.Verifier.poseidon_fiat_shamir_vesta, `Kimchi.Verifier.poseidon_fiat_shamir_pallas,
     `Kimchi.Pasta.pallas_eigen, `Kimchi.Pasta.vesta_eigen, ]
 
 /-- A CompElliptic `native_decide` witness: an axiom under the `CompElliptic` namespace carrying the

--- a/formal/scripts/check_ipa_fixture.lean
+++ b/formal/scripts/check_ipa_fixture.lean
@@ -34,7 +34,7 @@ def parseSRS (C : Ipa.CommitmentCurve) (j : Json) : Except String (SRS C.Point) 
 
 def parseInput (C : Ipa.CommitmentCurve) (curveName : String) (j : Json) :
     Except String (Ipa.Input C) := do
-  let parseS : Json → Except String C.Fr := parseZMod
+  let parseS : Json → Except String C.ScalarField := parseZMod
   let fld (k : String) : Except String Json := j.getObjVal? k
   let curve ← (← fld "curve").getStr?
   unless curve = curveName do throw s!"unexpected curve: {curve}"

--- a/formal/scripts/check_sponge_vectors.lean
+++ b/formal/scripts/check_sponge_vectors.lean
@@ -40,9 +40,9 @@ def checkFile {F : Type} [Field F] [DecidableEq F] (params : Params F)
   Trace.check (parseOp parseF) Kimchi.Sponge.init (step params) path
 
 def main : IO Unit := do
-  let okFq ← checkFile Fq.params (parseZMod (n := PALLAS_SCALAR_CARD))
+  let okFq ← checkFile fqParams (parseZMod (n := PALLAS_SCALAR_CARD))
     "fixtures/poseidon_fq_vectors.json"
-  let okFp ← checkFile Fp.params (parseZMod (n := PALLAS_BASE_CARD))
+  let okFp ← checkFile fpParams (parseZMod (n := PALLAS_BASE_CARD))
     "fixtures/poseidon_fp_vectors.json"
   unless okFq && okFp do
     throw (IO.userError "sponge vector case(s) FAILED")


### PR DESCRIPTION
Closes #196 (items 3–4) and #198. **Review commit-by-commit** — three slices:

1. `formal: coherent canonical typing` — the mechanical sweep (facts-not-structures, absolute `Fp`/`Fq` via a CompElliptic submodule bump ([l-adic/CompElliptic`@absolute-field-names`](https://github.com/l-adic/CompElliptic/tree/absolute-field-names), one commit), projections, transparent bundles). Big diff, zero semantic content.
2. `formal: named wire→abstract views` — the converter API on the verifier.
3. `formal: the Fiat-Shamir junction` — **the axioms**, the reflection theorem, `batch_soundnessA`, the headline, the gate. The commit to read line-by-line.
 Two things landed together because the second was forced by the first's absence:

## The type-coherence redesign (#198, pulled forward)

The Archon discharge run found a **genuine unprovability**: `CommitmentCurve` carried free `Field (ZMod _)` instance fields, so the executable verifier's operations (resolving to the canonical `ZMod` instances) and the abstract layer's (resolving to the bundle's field) could denote *different functions* — the reflection theorem's inverse obligation was generically false. Fix, on the principle that incoherence must be unrepresentable rather than reconciled by proof:

- **Facts, not structures**: the bundle carries `[Fact (Nat.Prime _)]`; the field structures are then *the* canonical `ZMod` instances on both sides. The diamond cannot exist.
- **Two absolute field names** (`Fp`/`Fq` in CompElliptic, replacing the four role aliases whose pun stated the Pasta cycle), **relative projections** `C.BaseField`/`C.ScalarField` (the Rust `G::BaseField`/`G::ScalarField`), **zero namespace-local field abbrevs**, and **transparent instantiation bundles** — after which the point-group `Module` instances resolve with *no bridge declarations at all*.
- **Named wire→abstract views** (`Input.commitmentFn`/`pointFn`/`evalFn`, `transcriptChallenges`, `mkInput`) replace inline mixed indexing in every statement; the one honest `getElem!` seam (the ragged `evals` array) lives behind one name used identically on both sides.

## The Fiat-Shamir junction, proved (no sorries)

- `Module Fp (SWPoint Vesta.curve)` / `Module Fq (SWPoint Pallas.curve)` — torsion at the `PastaOrder` group orders under the Hasse axioms; the action is definitionally the `z.val • _` the verifier computes with (`rfl`).
- **`verify_reflects`**: an accepting executable run satisfies `BatchAccepts` at the sponge-derived challenges, against the SRS whose randomisation base is the transcript-derived `U`. On the coherent base the Schnorr branch closes by `exact` after two spelling bridges — the previously-unprovable obligation needed nothing.
- **The declared assumption**, stated once per curve: `poseidon_fiat_shamir_{vesta,pallas}` — *a run accepted by the Poseidon-instantiated verifier admits a de-blinded accepting transcript tree* (`FiatShamirTreeB` with the deployed acceptance `verify … = true` as its antecedent).
- **`ipa_soundnessA` / `batch_soundnessA`** (additive, `Soundness/Batch.lean`): the extraction and batch theorems with acceptance abstracted to an arbitrary family — the proofs only ever consume acceptance by modus ponens, so the deployed acceptance plugs in directly.
- **`ipaVesta_sound` / `ipaPallas_sound`** (headlines, one per curve): a grid of Poseidon-accepted runs of one claim at pairwise-distinct combination scalars, under the no-DL-relation binding *hypothesis*, opens every commitment genuinely at every point. The Pallas twin is a verbatim clone of the Vesta proof — the genericity of the machinery, demonstrated.

## The receipt

`#print axioms ipaVesta_sound`:
```
propext, Classical.choice, Quot.sound,
Kimchi.Pasta.vesta_hasse,
Kimchi.Verifier.poseidon_fiat_shamir_vesta,
CompElliptic trusted native_decide certificates
```
No eigen axioms, no Pallas contamination; binding remains a hypothesis in the statement (it is information-theoretically false at real parameters — see `Soundness/Batch.lean`). Each headline depends only on ITS curve's Hasse bound and ITS FS axiom — no cross-curve contamination. Gate: 62 roots, allowlist grown by exactly the two named FS axioms.

Fold-lemma proofs credit: the Archon run (iterations 1–2), ported onto the restated file. All fixture suites (both curves), style, and the axiom gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)