### PR TITLE
formal: permutation milestone 2 — accumulator telescoping

### DIFF
--- a/formal/Kimchi.lean
+++ b/formal/Kimchi.lean
@@ -18,6 +18,7 @@ import Kimchi.Commitment.IPA.Soundness.Batch
 import Kimchi.Quotient.Generic
 import Kimchi.Quotient.EndoScalar
 import Kimchi.Quotient.Poseidon
+import Kimchi.Quotient.Accumulator
 import Kimchi.Quotient.GrandProduct
 import Kimchi.Quotient.Soundness
 import Kimchi.Fixture.Parse

--- a/formal/Kimchi/Quotient/Accumulator.lean
+++ b/formal/Kimchi/Quotient/Accumulator.lean
@@ -1,0 +1,54 @@
+import Mathlib
+
+/-!
+# The permutation accumulator telescopes into a grand-product equality
+
+The bridge between the row-level permutation constraint and the grand-product algebra of
+`Kimchi.Quotient.GrandProduct` (proof-systems `permutation.rs`): the accumulator column
+`z` satisfies `z(row 0) = 1`, the division-free per-row recurrence
+`z(k+1) · denₖ = z(k) · numₖ`, and the boundary pin `z(row m) = 1`; telescoping the
+recurrence forces `∏ num = ∏ den`. At the challenges `(β, γ)` the factors are the pair
+factors `wᵢ + β·posᵢ + γ`, so the conclusion is exactly the hypothesis of
+`multiset_eq_of_grid_prod_evals`.
+
+This is **pure finite induction**: no domain, no root of unity, no polynomials — indexed
+families over an abstract field. The kimchi-facing content (the `zkpm`-gated wire
+constraint producing the recurrence on the unmasked rows, the Lagrange-gated boundary
+pins, the two-row quotient engine) instantiates these hypotheses downstream.
+
+Because kimchi's recurrence is the multiplied-out form, no nonvanishing hypothesis on the
+denominators is needed for this direction: the invariant
+`z(k) · ∏_{j<k} den = ∏_{j<k} num` is maintained multiplicatively, and the boundary pins
+eliminate `z` at both ends.
+-/
+
+namespace Kimchi.Quotient
+
+variable {F : Type*} [Field F]
+
+/-- **Accumulator telescoping.** An accumulator pinned to `1` at both ends of a row range
+and satisfying the division-free recurrence `z(k+1) · denₖ = z(k) · numₖ` on it forces the
+grand products to agree: `∏ num = ∏ den`. -/
+theorem prod_eq_of_accumulator {m : ℕ} (num den z : ℕ → F)
+    (h0 : z 0 = 1) (hm : z m = 1)
+    (hstep : ∀ k < m, z (k + 1) * den k = z k * num k) :
+    ∏ k ∈ Finset.range m, num k = ∏ k ∈ Finset.range m, den k := by
+  have aux : ∀ k, k ≤ m →
+      z k * ∏ j ∈ Finset.range k, den j = ∏ j ∈ Finset.range k, num j := by
+    intro k
+    induction k with
+    | zero => simpa using h0
+    | succ k ih =>
+      intro hk
+      have hk' : k < m := Nat.lt_of_lt_of_le (Nat.lt_succ_self k) hk
+      rw [Finset.prod_range_succ, Finset.prod_range_succ]
+      calc z (k + 1) * ((∏ j ∈ Finset.range k, den j) * den k)
+          = (z (k + 1) * den k) * ∏ j ∈ Finset.range k, den j := by ring
+        _ = (z k * num k) * ∏ j ∈ Finset.range k, den j := by rw [hstep k hk']
+        _ = (z k * ∏ j ∈ Finset.range k, den j) * num k := by ring
+        _ = (∏ j ∈ Finset.range k, num j) * num k := by rw [ih hk'.le]
+  have h := aux m le_rfl
+  rw [hm, one_mul] at h
+  exact h.symm
+
+end Kimchi.Quotient

--- a/formal/roots.txt
+++ b/formal/roots.txt
@@ -123,6 +123,9 @@ Kimchi.Quotient.Poseidon.soundness
 -- Grand-product core (permutation argument, milestone 1): equal products of linear pair
 -- factors force equal pair multisets (UFD over F[β]); two-variable grid pinning; the
 -- composed headline turning field-level product checks at enough (β,γ) into multiset equality.
+-- Permutation milestone 2: the accumulator recurrence with both boundary pins telescopes
+-- into the grand-product equality the multiset core consumes.
+Kimchi.Quotient.prod_eq_of_accumulator
 Kimchi.Quotient.multiset_eq_of_pairFactor_prod_eq
 Kimchi.Quotient.identity_of_grid_evals
 Kimchi.Quotient.multiset_eq_of_grid_prod_evals

--- a/formal/scripts/check_axioms.lean
+++ b/formal/scripts/check_axioms.lean
@@ -64,6 +64,7 @@ def roots : List Name :=
     `Kimchi.Gate.Poseidon.sound, `Kimchi.Gate.Poseidon.complete,
     `Kimchi.Quotient.Poseidon.rows_iff_dvd,
     `Kimchi.Quotient.Poseidon.soundness,
+    `Kimchi.Quotient.prod_eq_of_accumulator,
     `Kimchi.Quotient.multiset_eq_of_pairFactor_prod_eq,
     `Kimchi.Quotient.identity_of_grid_evals,
     `Kimchi.Quotient.multiset_eq_of_grid_prod_evals,


### PR DESCRIPTION
Milestone 2 of the permutation argument: `Kimchi.Quotient.prod_eq_of_accumulator` — an accumulator pinned to `1` at both ends of a row range and satisfying kimchi's division-free per-row recurrence `z(k+1)·denₖ = z(k)·numₖ` forces `∏ num = ∏ den`.

- **Pure finite induction**, protocol-free (no domain, no ω, no polynomials): the invariant `z(k)·∏_{j<k} den = ∏_{j<k} num` is maintained multiplicatively, so — a small honesty dividend of the multiplied-out constraint form — **no denominator-nonvanishing hypothesis is needed** for this direction.
- Its conclusion at the challenges `(β, γ)` is verbatim the hypothesis of milestone 1's multiset core (`multiset_eq_of_grid_prod_evals`, #193).
- Root + axiom gate: 63 roots, standard set only.

*(Note: milestone 3 landed separately as `a9621669` on main.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)