### PR TITLE
optimize o1js benchmark

### DIFF
--- a/bench/o1js/src/programs.ts
+++ b/bench/o1js/src/programs.ts
@@ -51,8 +51,7 @@ export const Tree = ZkProgram({
 
         // Filler: mirror the PS `mul_ freshZero freshZero` loop.
         for (let i = 0; i < FILLER_ITERS; i++) {
-          const z1 = Provable.witness(Field, () => Field(0));
-          const z2 = Provable.witness(Field, () => Field(0));
+          const [z1, z2] = Provable.witnessFields(2, () => [0n, 0n]);
           z1.mul(z2);
         }
 


### PR DESCRIPTION
This replaces many repeated `Provable.witness` calls with batched `Provable.witnessFields`  calls in the benchmark loop.

The circuit shape is stays the exact same; we allocate the same private inputs and keep the same constraints, but avoid the generic per field witness path that o1js implements. this is faster in o1js because each generic witness call pays TypeScript/frontend overhead: callback executions, `Field(x)` constructions, type handling, variable allocation and JS/Snarky binding   calls. `witnessFields()` uses a more direct path and batches that work, so it reduces per-witness overhead. This is an o1js specific bottleneck because o1js builds circuits through TypeScript wrapper objects and JS/JSOO bindings, while lower level implementations operate closer to the internal field-variable representation. 

this frontend overhead is usually not a problem for normal applications or user circuits, because they typically do not call `Provable.witness` thousands of times in a loop. it becomes visible in this benchmark because the circuit intentionally creates a lot of witnesses 