### PR TITLE
ci: wire the Lean witness check + the unwired fixture scripts

### DIFF
--- a/.github/actions/setup-lean/action.yml
+++ b/.github/actions/setup-lean/action.yml
@@ -1,0 +1,54 @@
+name: Setup Lean (Kimchi formalization)
+description: >
+  elan (pinned toolchain) + Mathlib olean cloud cache + a build-directory cache for the
+  Kimchi library itself, then `lake build Kimchi`. Shared by the Lean workflow and the
+  witness-check job in the CI workflow so both build the library the same way.
+runs:
+  using: composite
+  steps:
+    - name: Install elan (reads the pinned toolchain from lean-toolchain)
+      shell: bash
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+          | sh -s -- -y --default-toolchain none
+        echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+    # Cache the project's own build directory (Mathlib oleans come from
+    # `lake exe cache get` below, not from here). `restore-keys` lets a run whose
+    # `formal/` sources changed start from the previous build and recompile
+    # incrementally instead of from scratch.
+    - name: Cache the Kimchi build directory
+      uses: actions/cache@v3
+      with:
+        path: formal/.lake/build
+        key: lean-${{ runner.os }}-${{ hashFiles('formal/lean-toolchain', 'formal/lakefile.toml') }}-${{ hashFiles('formal/**/*.lean') }}
+        restore-keys: |
+          lean-${{ runner.os }}-${{ hashFiles('formal/lean-toolchain', 'formal/lakefile.toml') }}-
+
+    - name: Fetch deps + build the library (= check every proof)
+      shell: bash
+      working-directory: formal
+      run: |
+        export PATH="$HOME/.elan/bin:$PATH"
+        # Ensure the manifest matches the Mathlib revision pinned in lakefile.toml
+        # so `lake exe cache get` does not fail on toolchain mismatch checks.
+        lake update mathlib
+        # Mathlib olean cache (does NOT include ProofWidgets' widget JS).
+        lake exe cache get
+        # Older ProofWidgets tags ship prebuilt widget JS in a GitHub release
+        # asset (`ProofWidgets4.tar.gz`) that `lake exe cache get` does not
+        # fetch. Newer tags vendor this differently and may not publish the
+        # tarball, so treat the download as best-effort.
+        pw=.lake/packages/proofwidgets
+        rev=$(jq -r '.packages[] | select(.name=="proofwidgets") | .inputRev' lake-manifest.json)
+        url="https://github.com/leanprover-community/ProofWidgets4/releases/download/${rev}/ProofWidgets4.tar.gz"
+        echo "Checking ProofWidgets cloud release $rev for prebuilt widget JS"
+        mkdir -p "$pw/.lake/build"
+        if curl -fsI "$url" >/dev/null; then
+          echo "Fetching ProofWidgets cloud release asset"
+          curl -fsSL "$url" | tar xz -C "$pw/.lake/build"
+        else
+          echo "No ProofWidgets release tarball for $rev; continuing"
+        fi
+        # Build only our library: typechecks every proof and runs the `#eval`s.
+        lake build Kimchi

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -11,11 +11,13 @@ on:
     paths:
       - 'formal/**'
       - '.github/workflows/lean.yml'
+      - '.github/actions/setup-lean/**'
   pull_request:
     branches: [ main ]
     paths:
       - 'formal/**'
       - '.github/workflows/lean.yml'
+      - '.github/actions/setup-lean/**'
   workflow_dispatch:
 
 permissions:
@@ -48,37 +50,10 @@ jobs:
       working-directory: .
       run: bash formal/scripts/check-style.sh
 
-    - name: Install elan (reads the pinned toolchain from lean-toolchain)
-      run: |
-        curl -sSfL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
-          | sh -s -- -y --default-toolchain none
-        echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-
-    - name: Fetch deps + build the library (= check every proof)
-      run: |
-        export PATH="$HOME/.elan/bin:$PATH"
-        # Ensure the manifest matches the Mathlib revision pinned in lakefile.toml
-        # so `lake exe cache get` does not fail on toolchain mismatch checks.
-        lake update mathlib
-        # Mathlib olean cache (does NOT include ProofWidgets' widget JS).
-        lake exe cache get
-        # Older ProofWidgets tags ship prebuilt widget JS in a GitHub release
-        # asset (`ProofWidgets4.tar.gz`) that `lake exe cache get` does not
-        # fetch. Newer tags vendor this differently and may not publish the
-        # tarball, so treat the download as best-effort.
-        pw=.lake/packages/proofwidgets
-        rev=$(jq -r '.packages[] | select(.name=="proofwidgets") | .inputRev' lake-manifest.json)
-        url="https://github.com/leanprover-community/ProofWidgets4/releases/download/${rev}/ProofWidgets4.tar.gz"
-        echo "Checking ProofWidgets cloud release $rev for prebuilt widget JS"
-        mkdir -p "$pw/.lake/build"
-        if curl -fsI "$url" >/dev/null; then
-          echo "Fetching ProofWidgets cloud release asset"
-          curl -fsSL "$url" | tar xz -C "$pw/.lake/build"
-        else
-          echo "No ProofWidgets release tarball for $rev; continuing"
-        fi
-        # Build only our library: typechecks every proof and runs the `#eval`s.
-        lake build Kimchi
+    # elan + Mathlib olean cache + the Kimchi build-directory cache + `lake build
+    # Kimchi` — shared with the `check-ps-witness` job in the CI workflow.
+    - name: Setup Lean + build the library (= check every proof)
+      uses: ./.github/actions/setup-lean
 
     # `lake build` succeeds even with `sorry` (it's only a warning), so gate
     # explicitly: every headline theorem must reduce to the allowed axiom set (the
@@ -111,4 +86,18 @@ jobs:
       run: |
         export PATH="$HOME/.elan/bin:$PATH"
         scripts/check_fq_sponge.sh
+
+    # The permutation-argument row semantics must hold on production kimchi data
+    # (fixtures/perm_vesta.json, from tools/fixture-dump's perm_dump).
+    - name: Check the permutation argument against kimchi row data
+      run: |
+        export PATH="$HOME/.elan/bin:$PATH"
+        scripts/check_perm_fixture.sh
+
+    # The index model must accept the mixed-gate production circuit: construction
+    # by decision, derived columns, satisfiability, and corruption rejections.
+    - name: Check the index model against the mixed-gate fixture
+      run: |
+        export PATH="$HOME/.elan/bin:$PATH"
+        scripts/check_index_fixture.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -244,6 +244,26 @@ jobs:
       run: make test-pickles-circuit-diffs
       env:
         NODE_OPTIONS: "--max-old-space-size=8192"
+        # Witness-carrying registrations also solve on a Gen-sampled input and
+        # embed the witness in their results JSON, for the Lean checker below.
+        CIRCUIT_DIFFS_WITNESS_EXPORT: "1"
+
+    # Run-scoped transport to the `check-ps-witness` job — the checker can only
+    # ever see the witness its own commit generated.
+    - name: Upload witness-carrying results for the Lean checker
+      uses: actions/upload-artifact@v4
+      with:
+        name: circuit-diff-witnesses
+        path: packages/pickles-circuit-diffs/circuits/results/*.json
+        retention-days: 1
+
+    # The visualizer bundles circuits/results/ into its dist (deployed to Pages);
+    # the witness columns are checker input, not visualizer content — strip them.
+    - name: Strip witnesses before the visualizer bundles results
+      run: |
+        for f in packages/pickles-circuit-diffs/circuits/results/*.json; do
+          jq 'del(.purescript.witness)' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+        done
 
     - name: Build circuit diff visualizer
       run: |
@@ -259,6 +279,42 @@ jobs:
         test -f packages/pickles-circuit-diffs/visualizer/dist/index.html
         test -f packages/pickles-circuit-diffs/visualizer/dist/results/manifest.jsonl
         echo "Visualizer build verified: $(ls packages/pickles-circuit-diffs/visualizer/dist/*.js | wc -l) JS bundle(s), $(ls packages/pickles-circuit-diffs/visualizer/dist/*.css | wc -l) CSS bundle(s), $(ls packages/pickles-circuit-diffs/visualizer/dist/results/*.json | wc -l) circuit result(s)"
+
+  # ---- verified witness check (Lean) ----------------------------------
+  # The harness's witness-carrying results are checked against the Lean index
+  # model (formal/scripts/check_ps_witness.sh): decide `Satisfies` on the dumped
+  # witness plus corruption rejections. Lives here (not lean.yml) because it
+  # consumes the artifact from test-circuit-diffs — `needs:`/artifacts only span
+  # a single workflow. On a Kimchi build-cache hit this is a few minutes; it
+  # only rebuilds the library when `formal/` changed (in parallel with lean.yml
+  # doing the same).
+  check-ps-witness:
+    if: github.event_name != 'workflow_dispatch'
+    needs: test-circuit-diffs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        # Skip the large `mina` submodule; only the Lean dependency submodules
+        # are needed.
+        submodules: false
+
+    - name: Check out the Lean dependency submodules (CompElliptic + ironwood)
+      run: git submodule update --init formal/vendor/CompElliptic formal/vendor/ironwood
+
+    - name: Setup Lean + build the library
+      uses: ./.github/actions/setup-lean
+
+    - name: Download the witness-carrying results
+      uses: actions/download-artifact@v4
+      with:
+        name: circuit-diff-witnesses
+        path: packages/pickles-circuit-diffs/circuits/results/
+
+    - name: Check witnesses against the index model
+      run: |
+        export PATH="$HOME/.elan/bin:$PATH"
+        bash formal/scripts/check_ps_witness.sh
 
   # ---- build the example app for GitHub Pages -------------------------
   # The in-browser block-pipeline app: wasm kimchi backend + vite bundle,


### PR DESCRIPTION
Stacked on #189 (retarget to main after it lands — the consumer job runs its `check_ps_witness.sh`).

## What this wires

1. **`check-ps-witness`** (new job in `test.yml`): `test-circuit-diffs` now runs with `CIRCUIT_DIFFS_WITNESS_EXPORT=1` and uploads the witness-carrying results JSONs as a run-scoped artifact; the new job (`needs: test-circuit-diffs`) restores the Lean build and runs `formal/scripts/check_ps_witness.sh` against them. Artifacts are scoped to the workflow run, so the checker can only ever see the witness its own commit generated — the PR's "no committed fixture, always fresh" property carries into CI.
2. **`check_perm_fixture` + `check_index_fixture`**: landed with the permutation milestone and A2 but were never added to `lean.yml` (its last step was `check_fq_sponge`). Now wired.

## Structure

- **`.github/actions/setup-lean`** — the Lean setup extracted verbatim from `lean.yml`, shared by both workflows, plus an `actions/cache` on `formal/.lake/build` (keyed on toolchain + lakefile + `formal/**/*.lean`, with a prefix `restore-key` for incremental rebuilds). On a cache hit the consumer job is a few minutes; it only rebuilds Kimchi when `formal/` changed — in parallel with `lean.yml` doing the same. Side effect: `lean.yml` itself stops re-checking every proof on unrelated reruns.
- The consumer lives in `test.yml` (not `lean.yml`) because `needs:`/artifacts only span one workflow file.
- The visualizer's copy of the results is stripped of witness columns before bundling (`jq del(.purescript.witness)`) — checker input, not Pages content.
- `deploy` is **not** gated on the new job; add it to `deploy.needs` if witness failures should block Pages.

## Known tuning risk

The `formal/.lake/build` cache across jobs is the one piece that may need a tweak: `lake update mathlib` regenerates the manifest each run, and lake's trace invalidation can occasionally rebuild more than expected. If it thrashes, the fix is committing/pinning the manifest restore order — a follow-up, not a design change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)