### PR TITLE
formal: phase C completeness — satisfiability characterized by the one quotient check

### DIFF
--- a/formal/Kimchi/Index/Aggregate.lean
+++ b/formal/Kimchi/Index/Aggregate.lean
@@ -69,10 +69,10 @@ noncomputable def gateConstraints (idx : Index F n) (wTab : Fin n → Fin 15 →
 /-- The shared gate alpha-pool size: kimchi registers the pool at the largest gate's
 count — VarBaseMul's 21 (`linearization.rs`: "Only the max number of constraints
 matters"). -/
-def gateAlphaCount : ℕ := 21
+@[reducible] def gateAlphaCount : ℕ := 21
 
 /-- The permutation's alpha count (`permutation.rs`: `CONSTRAINTS = 3`). -/
-def permAlphaCount : ℕ := 3
+@[reducible] def permAlphaCount : ℕ := 3
 
 /-- The lengths of the gate transcriptions match kimchi's `CONSTRAINTS` constants. -/
 theorem gateConstraints_length (idx : Index F n) (wTab : Fin n → Fin 15 → F) :
@@ -579,6 +579,103 @@ theorem gateMember_dvd_of_rowSatisfies (idx : Index F n) (pub : Fin idx.publicCo
   rw [zH_dvd_iff idx.omega_prim (Nat.pos_of_neZero n)]
   intro i hi
   exact idx.eval_gateMember_of_rowSatisfies pub wTab (hrow ⟨i, hi⟩) k
+
+
+/-! ## Completeness: the permutation members and the headline
+
+The converse assembly: a satisfied table admits honest quotient data at every
+nondegenerate challenge pair. The copy conjunct gives the grand-product identity by
+reindexing, the honest accumulator telescopes it through the three permutation
+constraints, and the gate members vanish row by row. Pointwise in `(β, γ)` — the
+completeness direction needs no challenge grid. -/
+
+open Kimchi.Quotient.Permutation in
+/-- **Permutation completeness at the index** (C2): under nondegenerate `(β, γ)`, a
+copy-invariant witness admits an accumulator whose three permutation constraints are
+`Z_H`-divisible. -/
+theorem permConstraints_dvd_of_copy (idx : Index F n) (wTab : Fin n → Fin 15 → F)
+    (β γ : F)
+    (hnd : Nondegenerate idx.omega idx.zkRows (idx.permWitnessPoly wTab) idx.shifts
+      idx.wiringPerm β γ)
+    (hcopy : ∀ c : Fin 7 × Fin n,
+      cellValue wTab (idx.wiringMap c) = cellValue wTab c) :
+    ∃ z : Polynomial F, ∀ s, zH F n ∣ Permutation.constraints idx.omega idx.zkRows z
+      (idx.permWitnessPoly wTab)
+      (Permutation.sigmaPoly idx.omega idx.shifts idx.wiringPerm) idx.shifts β γ
+      (⟨0, Nat.pos_of_neZero n⟩ : Fin n) idx.unmaskedEnd s := by
+  have hcopy' : ∀ c : Fin 7 × Fin (n - idx.zkRows),
+      ((idx.permWitnessPoly wTab) (idx.wiringPerm (embCell idx.zkRows c)).1).eval
+          (idx.omega ^ (((idx.wiringPerm (embCell idx.zkRows c)).2 : Fin n) : ℕ))
+        = ((idx.permWitnessPoly wTab) c.1).eval (idx.omega ^ ((c.2 : ℕ))) := by
+    intro c
+    rw [idx.eval_permWitnessPoly,
+      show (idx.omega ^ ((c.2 : ℕ)) : F)
+        = idx.omega ^ (((embCell idx.zkRows c).2 : Fin n) : ℕ) from rfl,
+      idx.eval_permWitnessPoly]
+    simpa using hcopy (embCell idx.zkRows c)
+  exact constraints_dvd_of_prods idx.omega_prim (Nat.pos_of_neZero n) idx.zk_pos
+    idx.zk_le _ _ idx.shifts β γ
+    (fun j hj => sigmaSide_eval_ne_zero idx.omega_prim hnd hj)
+    (prod_shiftSide_eq_prod_sigmaSide idx.omega_prim _ idx.shifts idx.wiringPerm
+      idx.wiringPerm_regionPreserving β γ hcopy')
+
+/-- The gate members of the full family: the entries below `gateAlphaCount`. -/
+theorem fullFamily_gate (idx : Index F n) (pub : Fin idx.publicCount → F)
+    (wTab : Fin n → Fin 15 → F) (z : Polynomial F) (β γ : F)
+    (k : Fin (gateAlphaCount + permAlphaCount)) (hk : (k : ℕ) < gateAlphaCount) :
+    idx.fullFamily pub wTab z β γ k = idx.gateMember pub wTab k := by
+  rw [fullFamily, dif_pos hk]
+
+open Kimchi.Quotient.Permutation in
+/-- **The completeness headline** (C3). A satisfied table admits honest quotient data
+at every nondegenerate challenge pair: an accumulator `z` making the whole `21 + 3`
+family `Z_H`-divisible — gate members from row satisfaction
+(`gateMember_dvd_of_rowSatisfies`), permutation members from the copy conjunct through
+the honest accumulator (`permConstraints_dvd_of_copy`). The converse of
+`satisfies_of_fullFamily_dvd`; with it, satisfiability at a wellformed index is
+*characterized* by the shape of kimchi's one quotient check. -/
+theorem fullFamily_dvd_of_satisfies (idx : Index F n) (pub : Fin idx.publicCount → F)
+    (wTab : Fin n → Fin 15 → F)
+    (hsat : Satisfies idx pub wTab) (β γ : F)
+    (hnd : Nondegenerate idx.omega idx.zkRows (idx.permWitnessPoly wTab) idx.shifts
+      idx.wiringPerm β γ) :
+    ∃ z : Polynomial F, ∀ s, zH F n ∣ idx.fullFamily pub wTab z β γ s := by
+  obtain ⟨hrow, hcopy, -⟩ := hsat
+  obtain ⟨z, hz⟩ := idx.permConstraints_dvd_of_copy wTab β γ hnd hcopy
+  refine ⟨z, fun s => ?_⟩
+  by_cases hk : (s : ℕ) < gateAlphaCount
+  · rw [idx.fullFamily_gate pub wTab z β γ s hk]
+    exact idx.gateMember_dvd_of_rowSatisfies pub wTab hrow s
+  · obtain ⟨j, rfl⟩ : ∃ j : Fin 3, s = Fin.natAdd gateAlphaCount j := by
+      refine ⟨⟨(s : ℕ) - gateAlphaCount, ?_⟩, Fin.ext ?_⟩
+      · have := s.isLt
+        simp only [gateAlphaCount, permAlphaCount] at *
+        omega
+      · simp only [Fin.natAdd]
+        omega
+    rw [idx.fullFamily_perm]
+    exact hz j
+
+open Kimchi.Quotient.Permutation in
+/-- **Exact-quotient completeness.** In the shape of the one production check: the
+honest accumulator and, for every fold challenge, a quotient `t` with
+`aggregate α (family) = t · Z_H` — a *polynomial identity*, so the eval-check passes at
+every node, not merely at sampled ones. -/
+theorem exists_quotient_of_satisfies (idx : Index F n) (pub : Fin idx.publicCount → F)
+    (wTab : Fin n → Fin 15 → F)
+    (hsat : Satisfies idx pub wTab) (β γ : F)
+    (hnd : Nondegenerate idx.omega idx.zkRows (idx.permWitnessPoly wTab) idx.shifts
+      idx.wiringPerm β γ) :
+    ∃ z : Polynomial F, ∀ a : F, ∃ t : Polynomial F,
+      aggregate a (idx.fullFamily pub wTab z β γ) = t * zH F n := by
+  obtain ⟨z, hz⟩ := idx.fullFamily_dvd_of_satisfies pub wTab hsat β γ hnd
+  refine ⟨z, fun a => ?_⟩
+  have hdvd : zH F n ∣ aggregate a (idx.fullFamily pub wTab z β γ) :=
+    Finset.dvd_sum fun c _ => by
+      rw [Polynomial.smul_eq_C_mul]
+      exact (hz c).mul_left _
+  obtain ⟨t, ht⟩ := hdvd
+  exact ⟨t, by rw [ht, mul_comm]⟩
 
 end Index
 

--- a/formal/Kimchi/Index/Aggregate.lean
+++ b/formal/Kimchi/Index/Aggregate.lean
@@ -677,6 +677,30 @@ theorem exists_quotient_of_satisfies (idx : Index F n) (pub : Fin idx.publicCoun
   obtain ⟨t, ht⟩ := hdvd
   exact ⟨t, by rw [ht, mul_comm]⟩
 
+
+open Kimchi.Quotient.Permutation in
+/-- **The characterization.** In a large enough field, a wellformed index is satisfied
+iff honest quotient data exists at every nondegenerate challenge pair — Phase B and
+Phase C fused into one statement. Forward is completeness, pointwise; backward
+manufactures a nondegenerate challenge grid (`exists_nondegenerate_grid` — the
+degenerate pairs are confined to `7·(n − zkRows)` affine lines) and runs the soundness
+headline over it. The field bound is vacuous at Pasta (`(K+1)² ≪ 2²⁵⁵`). -/
+theorem satisfies_iff_fullFamily_dvd [Fintype F] (idx : Index F n)
+    (pub : Fin idx.publicCount → F) (wTab : Fin n → Fin 15 → F)
+    (hF : (7 * (n - idx.zkRows) + 1) * (7 * (n - idx.zkRows) + 1) ≤ Fintype.card F) :
+    Satisfies idx pub wTab
+      ↔ ∀ β γ, Nondegenerate idx.omega idx.zkRows (idx.permWitnessPoly wTab)
+          idx.shifts idx.wiringPerm β γ →
+          ∃ z : Polynomial F, ∀ s, zH F n ∣ idx.fullFamily pub wTab z β γ s := by
+  constructor
+  · exact fun hsat β γ hnd => idx.fullFamily_dvd_of_satisfies pub wTab hsat β γ hnd
+  · intro h
+    obtain ⟨b, g, hb, hg, hnd⟩ := exists_nondegenerate_grid
+      (idx.permWitnessPoly wTab) idx.shifts idx.wiringPerm hF (ω := idx.omega)
+    choose zg hzg using fun a c => h (b a) (g c) (hnd a c)
+    exact idx.satisfies_of_fullFamily_dvd pub wTab b g hb hg (by omega) (by omega)
+      zg hzg
+
 end Index
 
 end Kimchi.Index

--- a/formal/Kimchi/Quotient/Accumulator.lean
+++ b/formal/Kimchi/Quotient/Accumulator.lean
@@ -51,4 +51,29 @@ theorem prod_eq_of_accumulator {m : ℕ} (num den z : ℕ → F)
   rw [hm, one_mul] at h
   exact h.symm
 
+/-- **Accumulator construction** — the converse of `prod_eq_of_accumulator`, and the
+completeness direction's witness. With nonzero denominators and agreeing grand
+products, the running-ratio column `z k = (∏_{j<k} num) / (∏_{j<k} den)` is an
+accumulator: pinned to `1` at both ends and satisfying the division-free recurrence.
+This is the one place the nonzero-denominator hypothesis is genuinely needed — the
+soundness direction (`prod_eq_of_accumulator`) is division-free. -/
+theorem accumulator_of_prod_eq {m : ℕ} (num den : ℕ → F)
+    (hden : ∀ k < m, den k ≠ 0)
+    (hprod : ∏ k ∈ Finset.range m, num k = ∏ k ∈ Finset.range m, den k) :
+    ∃ z : ℕ → F, z 0 = 1 ∧ z m = 1
+      ∧ ∀ k < m, z (k + 1) * den k = z k * num k := by
+  have hdprod : ∀ k, k ≤ m → (∏ j ∈ Finset.range k, den j) ≠ 0 := fun k hk =>
+    Finset.prod_ne_zero_iff.mpr fun j hj =>
+      hden j (lt_of_lt_of_le (Finset.mem_range.mp hj) hk)
+  refine ⟨fun k => (∏ j ∈ Finset.range k, num j) / (∏ j ∈ Finset.range k, den j),
+    by simp, ?_, ?_⟩
+  · dsimp only
+    rw [hprod, div_self (hdprod m le_rfl)]
+  · intro k hk
+    dsimp only
+    have hd := hdprod k hk.le
+    have hdk := hden k hk
+    rw [Finset.prod_range_succ, Finset.prod_range_succ]
+    field_simp
+
 end Kimchi.Quotient

--- a/formal/Kimchi/Quotient/Permutation.lean
+++ b/formal/Kimchi/Quotient/Permutation.lean
@@ -87,6 +87,15 @@ theorem zkpm_eval_ne_zero {ω : F} {n : ℕ} (hω : IsPrimitiveRoot ω n) (zkRow
   have : i = j := hω.pow_inj (by omega) hj₂ hEq
   omega
 
+/-- The mask vanishes on the masked rows: `zkpm(ωⁱ) = 0` for `n - zkRows ≤ i < n` —
+the completeness twin of `zkpm_eval_ne_zero`. -/
+theorem zkpm_eval_zero {ω : F} {n : ℕ} (zkRows : ℕ) {i : ℕ}
+    (hlo : n - zkRows ≤ i) (hhi : i < n) : (zkpm ω n zkRows).eval (ω ^ i) = 0 := by
+  unfold zkpm
+  rw [eval_prod]
+  refine Finset.prod_eq_zero (Finset.mem_Ico.mpr ⟨hlo, hhi⟩) ?_
+  simp
+
 /-- A Lagrange-gated pin: if `Z_H ∣ (z - 1) · L_r` then the accumulator is `1` at row
 `r`. -/
 theorem eval_eq_one_of_boundary {ω : F} {n : ℕ} (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
@@ -158,5 +167,70 @@ theorem soundness {ω : F} {n N : ℕ} (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
   soundness_of_dvd hω hn hzk0 hzkn z w σ shifts β γ
     (dvd_separation hω hn α hα _ fun s =>
       zH_dvd_of_evals hω hn ζ hζ _ (t s) D (hCdeg s) (htdeg s) hD (hcheck s))
+
+
+/-! ## Completeness: the honest accumulator -/
+
+/-- **Permutation completeness.** With nonvanishing σ-side row products (the
+nondegeneracy of `(β, γ)`) and agreeing grand products over the unmasked region, an
+accumulator exists whose three permutation constraints are all divisible by `Z_H`: the
+running-ratio column of `accumulator_of_prod_eq`, interpolated through the domain and
+held constant on the mask (where the zkpm gate erases the recurrence anyway). The
+converse of `soundness_of_dvd`, pointwise in `(β, γ)`. -/
+theorem constraints_dvd_of_prods {ω : F} {n : ℕ} (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
+    {zkRows : ℕ} (hzk0 : 0 < zkRows) (hzkn : zkRows ≤ n)
+    (w σ : Fin 7 → Polynomial F) (shifts : Fin 7 → F) (β γ : F)
+    (hden : ∀ j < n - zkRows, (sigmaSide w σ β γ).eval (ω ^ j) ≠ 0)
+    (hprod : ∏ j ∈ Finset.range (n - zkRows), (shiftSide w shifts β γ).eval (ω ^ j)
+      = ∏ j ∈ Finset.range (n - zkRows), (sigmaSide w σ β γ).eval (ω ^ j)) :
+    ∃ z : Polynomial F, ∀ s, zH F n ∣ constraints ω zkRows z w σ shifts β γ
+      (⟨0, hn⟩ : Fin n) ⟨n - zkRows, by omega⟩ s := by
+  obtain ⟨zc, hz0, hzm, hstep⟩ := accumulator_of_prod_eq
+    (fun j => (shiftSide w shifts β γ).eval (ω ^ j))
+    (fun j => (sigmaSide w σ β γ).eval (ω ^ j)) hden hprod
+  -- the accumulator column, held constant on the mask
+  set zrow : Fin n → F := fun i => zc (min (i : ℕ) (n - zkRows)) with hzrow
+  refine ⟨columnPoly ω zrow, ?_⟩
+  have hzeval : ∀ i : ℕ, ∀ hi : i < n,
+      (columnPoly ω zrow).eval (ω ^ i) = zc (min i (n - zkRows)) := fun i hi => by
+    rw [show (ω ^ i : F) = ω ^ (((⟨i, hi⟩ : Fin n)) : ℕ) from rfl,
+      eval_columnPoly hω]
+  intro s
+  rw [zH_dvd_iff hω hn]
+  intro i hi
+  match s with
+  | 0 =>
+    show ((zkpm ω n zkRows) * _).eval _ = 0
+    rw [eval_mul]
+    by_cases hmask : i < n - zkRows
+    · -- the recurrence, from the accumulator step
+      have hi1 : i + 1 < n := by omega
+      have hcomp : (shiftRow ω (columnPoly ω zrow)).eval (ω ^ i)
+          = (columnPoly ω zrow).eval (ω ^ (i + 1)) := by
+        rw [shiftRow, eval_comp, eval_mul, eval_C, eval_X, ← pow_succ']
+      rw [eval_sub, eval_mul, eval_mul, hcomp, hzeval i hi, hzeval (i + 1) hi1,
+        Nat.min_eq_left hmask.le, Nat.min_eq_left (by omega)]
+      rw [sub_eq_zero.mpr (hstep i hmask).symm, mul_zero]
+    · -- the mask kills the row
+      rw [zkpm_eval_zero zkRows (Nat.le_of_not_lt hmask) hi, zero_mul]
+  | 1 =>
+    show ((_ - 1) * columnPoly ω (rowIndicator (⟨0, hn⟩ : Fin n))).eval _ = 0
+    rw [eval_mul]
+    by_cases h0 : i = 0
+    · subst h0
+      rw [eval_sub, eval_one, hzeval 0 hn]
+      simp [hz0]
+    · rw [show (ω ^ i : F) = ω ^ (((⟨i, hi⟩ : Fin n)) : ℕ) from rfl,
+        eval_columnPoly hω, rowIndicator, if_neg (by simp [Fin.ext_iff, h0]), mul_zero]
+  | 2 =>
+    show ((_ - 1) * columnPoly ω (rowIndicator (⟨n - zkRows, by omega⟩ : Fin n))).eval _
+      = 0
+    rw [eval_mul]
+    by_cases hb : i = n - zkRows
+    · subst hb
+      rw [eval_sub, eval_one, hzeval (n - zkRows) (by omega)]
+      simp [hzm]
+    · rw [show (ω ^ i : F) = ω ^ (((⟨i, hi⟩ : Fin n)) : ℕ) from rfl,
+        eval_columnPoly hω, rowIndicator, if_neg (by simp [Fin.ext_iff, hb]), mul_zero]
 
 end Kimchi.Quotient.Permutation

--- a/formal/Kimchi/Quotient/Wiring.lean
+++ b/formal/Kimchi/Quotient/Wiring.lean
@@ -223,6 +223,59 @@ theorem prod_shiftSide_eq_prod_sigmaSide {ω : F} (hω : IsPrimitiveRoot ω n)
           ← Fin.prod_univ_eq_prod_range]
         exact Finset.prod_congr rfl fun j _ => (sigmaSide_eval _ _ _ _ _).symm
 
+/-- An injection avoiding a finite bad set: `Fin m` maps injectively into `F` outside
+`B` when `m + B.card ≤ |F|`. -/
+theorem exists_injective_avoiding {F : Type*} [Fintype F] [DecidableEq F]
+    (B : Finset F) (m : ℕ) (hcard : m + B.card ≤ Fintype.card F) :
+    ∃ f : Fin m → F, Function.Injective f ∧ ∀ i, f i ∉ B := by
+  have hle : m ≤ (Finset.univ \ B).card := by
+    rw [Finset.card_sdiff, Finset.card_univ, Finset.inter_univ]
+    omega
+  obtain ⟨t, ht, htcard⟩ := Finset.exists_subset_card_eq hle
+  let e := t.equivFinOfCardEq htcard
+  refine ⟨fun i => (e.symm i : F), fun a b hab => ?_, fun i => ?_⟩
+  · exact e.symm.injective (Subtype.ext hab)
+  · have hmem : ((e.symm i : t) : F) ∈ t := (e.symm i).2
+    exact (Finset.mem_sdiff.mp (ht hmem)).2
+
+/-- **A nondegenerate challenge grid exists** in a large enough field. Each unmasked
+cell forbids exactly one `γ` per `β` (the factor is affine-linear in `γ`), so with
+`K = 7·(n − zkRows)`: any `K + 1` distinct `β`'s, and `K + 1` distinct `γ`'s dodging
+the at most `(K+1)·K` bad values, give a fully nondegenerate grid — possible once
+`(K+1)² ≤ |F|`. -/
+theorem exists_nondegenerate_grid {F : Type*} [Field F] [Fintype F] [DecidableEq F]
+    {n zkRows : ℕ} {ω : F}
+    (w : Fin 7 → Polynomial F) (shifts : Fin 7 → F)
+    (σpFull : Equiv.Perm (Fin 7 × Fin n))
+    (hF : (7 * (n - zkRows) + 1) * (7 * (n - zkRows) + 1) ≤ Fintype.card F) :
+    ∃ b g : Fin (7 * (n - zkRows) + 1) → F,
+      Function.Injective b ∧ Function.Injective g
+        ∧ ∀ a c, Nondegenerate ω zkRows w shifts σpFull (b a) (g c) := by
+  set K := 7 * (n - zkRows) with hK
+  obtain ⟨b, hb, -⟩ := exists_injective_avoiding (∅ : Finset F) (K + 1)
+    (by simpa using le_trans (Nat.le_mul_of_pos_right _ (by omega)) hF)
+  set Bad : Finset F := (Finset.univ : Finset (Fin (K + 1))).biUnion fun a =>
+    (Finset.univ : Finset (Fin 7 × Fin (n - zkRows))).image fun c =>
+      -((w c.1).eval (ω ^ ((c.2 : ℕ)))
+        + b a * addr ω shifts (σpFull (embCell zkRows c))) with hBadDef
+  have hBad : Bad.card ≤ (K + 1) * K := by
+    refine le_trans Finset.card_biUnion_le ?_
+    refine le_trans (Finset.sum_le_card_nsmul _ _ K fun a _ => ?_) ?_
+    · refine le_trans Finset.card_image_le ?_
+      rw [Finset.card_univ]
+      simp [hK]
+    · simp [Finset.card_univ, mul_comm]
+  obtain ⟨g, hg, hgB⟩ := exists_injective_avoiding Bad (K + 1) (by
+    calc (K + 1) + Bad.card ≤ (K + 1) + (K + 1) * K := by omega
+      _ = (K + 1) * (K + 1) := by ring
+      _ ≤ Fintype.card F := hF)
+  refine ⟨b, g, hb, hg, fun a c cell h0 => ?_⟩
+  refine hgB c ?_
+  rw [hBadDef]
+  refine Finset.mem_biUnion.mpr ⟨a, Finset.mem_univ a, Finset.mem_image.mpr
+    ⟨cell, Finset.mem_univ cell, ?_⟩⟩
+  linear_combination -h0
+
 /-! ## Executable row forms and certificates
 
 The fixture check (`scripts/check_perm_fixture.lean`) replays the argument on production

--- a/formal/Kimchi/Quotient/Wiring.lean
+++ b/formal/Kimchi/Quotient/Wiring.lean
@@ -131,6 +131,98 @@ theorem eval_sigmaPoly {ω : F} (hω : IsPrimitiveRoot ω n) (shifts : Fin 7 →
     (sigmaPoly ω shifts σpFull i).eval (ω ^ (j : ℕ)) = addr ω shifts (σpFull (i, j)) :=
   eval_columnPoly hω _ j
 
+/-! ## Completeness: nondegenerate challenges and the grand-product identity -/
+
+/-- **Challenge nondegeneracy.** No σ-side factor vanishes on the unmasked region: at
+`(β, γ)`, every unmasked cell has `w(c) + γ + β·addr(σ c) ≠ 0`. The honest accumulator
+divides by exactly these factors, so this is the formal rendering of the protocol's
+division-by-zero edge case; each factor is affine-linear in `(β, γ)`, so the degenerate
+pairs lie on at most `7·(n − zkRows)` lines — the small bad locus a Fiat–Shamir sample
+misses. The shift side needs no such hypothesis: once the grand products agree, its
+nonvanishing follows from the σ side's. -/
+def Nondegenerate (ω : F) (zkRows : ℕ) (w : Fin 7 → Polynomial F) (shifts : Fin 7 → F)
+    (σpFull : Equiv.Perm (Fin 7 × Fin n)) (β γ : F) : Prop :=
+  ∀ c : Fin 7 × Fin (n - zkRows),
+    (w c.1).eval (ω ^ ((c.2 : ℕ))) + γ
+      + β * addr ω shifts (σpFull (embCell zkRows c)) ≠ 0
+
+/-- On the unmasked rows, nondegeneracy makes the σ-side row product nonzero. -/
+theorem sigmaSide_eval_ne_zero {ω : F} (hω : IsPrimitiveRoot ω n)
+    {w : Fin 7 → Polynomial F} {shifts : Fin 7 → F}
+    {σpFull : Equiv.Perm (Fin 7 × Fin n)} {β γ : F}
+    (hnd : Nondegenerate ω zkRows w shifts σpFull β γ)
+    {j : ℕ} (hj : j < n - zkRows) :
+    (sigmaSide w (sigmaPoly ω shifts σpFull) β γ).eval (ω ^ j) ≠ 0 := by
+  have hjn : j < n := lt_of_lt_of_le hj (Nat.sub_le n zkRows)
+  rw [sigmaSide_eval]
+  refine Finset.prod_ne_zero_iff.mpr fun i _ => ?_
+  have hs : (sigmaPoly ω shifts σpFull i).eval (ω ^ j)
+      = addr ω shifts (σpFull (embCell zkRows ((i, ⟨j, hj⟩) :
+          Fin 7 × Fin (n - zkRows)))) := by
+    rw [show (ω ^ j : F) = ω ^ (((⟨j, hjn⟩ : Fin n)) : ℕ) from rfl, eval_sigmaPoly hω]
+    rfl
+  rw [hs]
+  exact hnd (i, ⟨j, hj⟩)
+
+/-- **The grand products agree on a copy-invariant witness** — the completeness
+direction of the multiset argument, by pure reindexing: with `w(σ c) = w(c)` on the
+unmasked region, the σ-side factor at `c` *is* the shift-side factor at `σ c`, and the
+cell product transports along the wiring permutation (`Equiv.prod_comp`). No challenge
+grid and no Vandermonde content — pointwise in `(β, γ)`. -/
+theorem prod_shiftSide_eq_prod_sigmaSide {ω : F} (hω : IsPrimitiveRoot ω n)
+    (w : Fin 7 → Polynomial F) (shifts : Fin 7 → F)
+    (σpFull : Equiv.Perm (Fin 7 × Fin n)) (hp : RegionPreserving zkRows σpFull)
+    (β γ : F)
+    (hcopy : ∀ c : Fin 7 × Fin (n - zkRows),
+      (w (σpFull (embCell zkRows c)).1).eval
+          (ω ^ (((σpFull (embCell zkRows c)).2 : Fin n) : ℕ))
+        = (w c.1).eval (ω ^ ((c.2 : ℕ)))) :
+    ∏ j ∈ Finset.range (n - zkRows), (shiftSide w shifts β γ).eval (ω ^ j)
+      = ∏ j ∈ Finset.range (n - zkRows),
+          (sigmaSide w (sigmaPoly ω shifts σpFull) β γ).eval (ω ^ j) := by
+  set σp := restrictCells σpFull hp with hσp
+  calc ∏ j ∈ Finset.range (n - zkRows), (shiftSide w shifts β γ).eval (ω ^ j)
+      = ∏ x : Fin 7 × Fin (n - zkRows),
+          ((w x.1).eval (ω ^ ((x.2 : ℕ))) + γ
+            + β * (shifts x.1 * ω ^ ((x.2 : ℕ)))) := by
+        rw [← Finset.univ_product_univ, Finset.prod_product_right,
+          ← Fin.prod_univ_eq_prod_range]
+        refine Finset.prod_congr rfl fun j _ => ?_
+        rw [shiftSide_eval]
+        exact Finset.prod_congr rfl fun i _ => by ring
+    _ = ∏ x : Fin 7 × Fin (n - zkRows),
+          ((w (σp x).1).eval (ω ^ (((σp x).2 : ℕ))) + γ
+            + β * (shifts (σp x).1 * ω ^ (((σp x).2 : ℕ)))) :=
+        (Equiv.prod_comp σp fun y : Fin 7 × Fin (n - zkRows) =>
+          (w y.1).eval (ω ^ ((y.2 : ℕ))) + γ
+            + β * (shifts y.1 * ω ^ ((y.2 : ℕ)))).symm
+    _ = ∏ x : Fin 7 × Fin (n - zkRows),
+          ((w x.1).eval (ω ^ ((x.2 : ℕ))) + γ
+            + β * (sigmaPoly ω shifts σpFull x.1).eval (ω ^ ((x.2 : ℕ)))) := by
+        refine Finset.prod_congr rfl fun x _ => ?_
+        have hemb := embCell_restrictCells σpFull hp x
+        have hval : (w (σp x).1).eval (ω ^ (((σp x).2 : ℕ)))
+            = (w x.1).eval (ω ^ ((x.2 : ℕ))) := by
+          have hc := hcopy x
+          rw [← hemb] at hc
+          exact hc
+        have haddr : (sigmaPoly ω shifts σpFull x.1).eval (ω ^ ((x.2 : ℕ)))
+            = shifts (σp x).1 * ω ^ (((σp x).2 : ℕ)) := by
+          calc (sigmaPoly ω shifts σpFull x.1).eval (ω ^ ((x.2 : ℕ)))
+              = addr ω shifts (σpFull (embCell zkRows x)) := by
+                rw [show (ω ^ ((x.2 : ℕ)) : F)
+                    = ω ^ (((embCell zkRows x).2 : Fin n) : ℕ) from rfl,
+                  eval_sigmaPoly hω]
+                rfl
+            _ = addr ω shifts (embCell zkRows (σp x)) := by rw [hemb]
+            _ = shifts (σp x).1 * ω ^ (((σp x).2 : ℕ)) := rfl
+        rw [hval, haddr]
+    _ = ∏ j ∈ Finset.range (n - zkRows),
+          (sigmaSide w (sigmaPoly ω shifts σpFull) β γ).eval (ω ^ j) := by
+        rw [← Finset.univ_product_univ, Finset.prod_product_right,
+          ← Fin.prod_univ_eq_prod_range]
+        exact Finset.prod_congr rfl fun j _ => (sigmaSide_eval _ _ _ _ _).symm
+
 /-! ## Executable row forms and certificates
 
 The fixture check (`scripts/check_perm_fixture.lean`) replays the argument on production

--- a/formal/scripts/check_axioms.lean
+++ b/formal/scripts/check_axioms.lean
@@ -81,6 +81,7 @@ def roots : List Name :=
     `Kimchi.Index.Index.gateMember_dvd_of_rowSatisfies,
     `Kimchi.Index.Index.fullFamily_dvd_of_satisfies,
     `Kimchi.Index.Index.exists_quotient_of_satisfies,
+    `Kimchi.Index.Index.satisfies_iff_fullFamily_dvd,
     `Kimchi.Quotient.multiset_eq_of_pairFactor_prod_eq,
     `Kimchi.Quotient.identity_of_grid_evals,
     `Kimchi.Quotient.multiset_eq_of_grid_prod_evals,

--- a/formal/scripts/check_axioms.lean
+++ b/formal/scripts/check_axioms.lean
@@ -79,6 +79,8 @@ def roots : List Name :=
     `Kimchi.Index.Index.satisfies_of_fullFamily_dvd,
     `Kimchi.Index.Index.satisfies_of_evalCheck,
     `Kimchi.Index.Index.gateMember_dvd_of_rowSatisfies,
+    `Kimchi.Index.Index.fullFamily_dvd_of_satisfies,
+    `Kimchi.Index.Index.exists_quotient_of_satisfies,
     `Kimchi.Quotient.multiset_eq_of_pairFactor_prod_eq,
     `Kimchi.Quotient.identity_of_grid_evals,
     `Kimchi.Quotient.multiset_eq_of_grid_prod_evals,


### PR DESCRIPTION
The main completeness arc (C2 + C3), on top of #214's prep. **The headline**:

```
fullFamily_dvd_of_satisfies :
  Satisfies idx pub wTab → ∀ β γ, Nondegenerate … β γ →
    ∃ z, ∀ s, Z_H ∣ idx.fullFamily pub wTab z β γ s
```

With Phase B's `satisfies_of_fullFamily_dvd`, satisfiability at a wellformed index is now **characterized** by the shape of kimchi's one quotient check — the round-trip that also audits every transcription in the aggregate family (a wrong sign or slot anywhere would make one direction unprovable). Note the deliberate asymmetry: soundness needs a challenge *grid*; completeness is *pointwise* per (β, γ) — the honest prover works at whatever challenges it's given, outside the degenerate locus.

## The chain

1. **C2a** (`Accumulator.lean`): `accumulator_of_prod_eq` — the converse telescoping: nonzero denominators + agreeing grand products yield the running-ratio column, pinned to 1 at both ends. The one place the nonzero-denominator hypothesis is genuinely needed (soundness was division-free).
2. **C2b** (`Wiring.lean`): `Nondegenerate` — no σ-side factor vanishes on the unmasked region; the formal rendering of the prover's division-by-zero edge case, with the degenerate (β, γ) confined to ≤ `7·(n − zkRows)` affine lines (the small bad locus a Fiat–Shamir sample misses, same currency as the soundness grids). And `prod_shiftSide_eq_prod_sigmaSide` — the grand products agree on a copy-invariant witness by *pure reindexing* (`Equiv.prod_comp`): the σ-side factor at `c` is the shift-side factor at `σ c`. No grid, no Vandermonde.
3. **C2c** (`Permutation.lean`): `zkpm_eval_zero` (the completeness twin of `zkpm_eval_ne_zero`) and `constraints_dvd_of_prods` — the honest accumulator interpolated through the domain, held constant on the mask (where zkpm erases the recurrence anyway), makes all three permutation constraints divisible. Converse of `soundness_of_dvd`.
4. **C3** (`Index/Aggregate.lean`): `permConstraints_dvd_of_copy` (index-level C2), `fullFamily_gate` (naming the `dif_pos` projection), the headline, and `exists_quotient_of_satisfies` — completeness in the production shape: honest `z` and, per fold challenge, a quotient `t` with `aggregate = t·Z_H` as a **polynomial identity**, so the eval-check passes at every node, not merely sampled ones.

## Verification

Full `lake build`, style clean, **80 axiom roots** (both completeness headlines registered) reduce to the unchanged allowed set; the index fixture check stays green.

One Lean note baked into the diff: `gateAlphaCount`/`permAlphaCount` are now `@[reducible]` — `Fin.natAdd`'s implicit index otherwise elaborates as `permAlphaCount` or `3` depending on context, defeq but `rw`-opaque.

## Not in scope (tracked)

Mask-invariance (the honest prover's *randomized* zk region satisfies `Satisfies`) — needs the boundary law for two-row gates; and the single-theorem iff (deriving grids from pointwise needs a field-cardinality bound). Both documented for the protocol-completeness phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)