### PR TITLE
formal: the footprint theorem — Satisfies depends only on the unmasked rows

### DIFF
--- a/formal/Kimchi/Index/Basic.lean
+++ b/formal/Kimchi/Index/Basic.lean
@@ -54,6 +54,13 @@ inductive GateType where
   | endoScalar
   deriving DecidableEq, Repr, Inhabited, Fintype
 
+/-- The gate types whose constraints read the *next* row as well as their own
+(`witness_next` in kimchi's `ArgumentEnv`; the `cellMap cur nxt` transcriptions in the
+quotient layer). Everything else is single-row. -/
+def GateType.twoRow : GateType → Bool
+  | .poseidon | .varBaseMul | .endoMul => true
+  | _ => false
+
 /-- One row of the gate table: the gate type, the fifteen coefficient cells, and the
 seven wire pointers (each permuted cell names the next cell of its copy cycle —
 kimchi's cyclic-successor encoding of the wiring). The coefficients feed
@@ -105,11 +112,18 @@ structure Index (F : Type*) [Field F] (n : ℕ) where
   constraints, so `Satisfies`' whole-grid copy conjunct closes over them trivially… -/
   masked_identity : ∀ c : Fin 7 × Fin n, n - zkRows ≤ ((c.2 : ℕ)) →
     wiringMapOf gates c = c
-  /-- …and carry no gates either: kimchi's gate table stops at the circuit, and the
-  zero-knowledge rows hold the prover's randomness — the completeness direction needs
-  the gate members to vanish there *because the selectors do*, not because random
-  values satisfy anything. -/
+  /-- …and carry no gates either: kimchi's gate table stops at the circuit, so no
+  constraint *sits on* a masked row — the gate members vanish there because the
+  selectors do, whatever the cells hold… -/
   masked_zero : ∀ i : Fin n, n - zkRows ≤ (i : ℕ) → (gates i).typ = .zero
+  /-- …and no constraint *reads into* the mask from outside: a two-row gate at the
+  last unmasked row would have the first masked row in its footprint. With
+  `masked_identity`, `public_le`, and `masked_zero`, this closes the last read edge
+  into the mask — the constraint system's whole footprint is the unmasked region,
+  which is what makes `Satisfies` depend only on the unmasked rows
+  (`satisfies_congr_unmasked`). -/
+  masked_boundary : ∀ i : Fin n, (i : ℕ) + 1 = n - zkRows →
+    (gates i).typ.twoRow = false
 
 namespace Index
 
@@ -211,7 +225,8 @@ def build? [DecidableEq F] (gates : Fin n → GateRow F n) (publicCount zkRows :
       ∧ (∀ i : Fin n, (i : ℕ) < publicCount →
           ∀ c : Fin 15, (gates i).coeffs c = if c = 0 then 1 else 0)
       ∧ (∀ c : Fin 7 × Fin n, n - zkRows ≤ ((c.2 : ℕ)) → wiringMapOf gates c = c)
-      ∧ (∀ i : Fin n, n - zkRows ≤ (i : ℕ) → (gates i).typ = .zero) then
+      ∧ (∀ i : Fin n, n - zkRows ≤ (i : ℕ) → (gates i).typ = .zero)
+      ∧ (∀ i : Fin n, (i : ℕ) + 1 = n - zkRows → (gates i).typ.twoRow = false) then
     have homega : IsPrimitiveRoot omega n :=
       isPrimitiveRoot_of_certificate'
         (let ⟨k, _, hk⟩ := h.1; ⟨k, hk⟩) h.2.1
@@ -227,7 +242,8 @@ def build? [DecidableEq F] (gates : Fin n → GateRow F n) (publicCount zkRows :
            public_generic := h.2.2.2.2.2.2.2.2.1
            public_coeffs := h.2.2.2.2.2.2.2.2.2.1
            masked_identity := h.2.2.2.2.2.2.2.2.2.2.1
-           masked_zero := h.2.2.2.2.2.2.2.2.2.2.2 }
+           masked_zero := h.2.2.2.2.2.2.2.2.2.2.2.1
+           masked_boundary := h.2.2.2.2.2.2.2.2.2.2.2.2 }
   else none
 
 end Index

--- a/formal/Kimchi/Index/Satisfies.lean
+++ b/formal/Kimchi/Index/Satisfies.lean
@@ -79,4 +79,111 @@ instance (idx : Index F n) (pub : Fin idx.publicCount → F) (wTab : Fin n → F
   unfold Satisfies
   infer_instance
 
+
+/-! ## The footprint: `Satisfies` depends only on the unmasked rows
+
+The four mask laws close every read edge into the mask — `masked_zero` (no constraint
+sits on a masked row), `masked_boundary` (no two-row gate reads across the boundary),
+`masked_identity` with `wiring_region` (no copy edge crosses), `public_le` (the public
+pins are unmasked) — so satisfiability is a property of the unmasked restriction: the
+mask's contents are simply outside the constraint system's footprint. -/
+
+/-- `rowSatisfies` reads only unmasked cells. -/
+theorem rowSatisfies_congr_unmasked (idx : Index F n) (pub : Fin idx.publicCount → F)
+    {w w' : Fin n → Fin 15 → F}
+    (hagree : ∀ i : Fin n, (i : ℕ) < n - idx.zkRows → w i = w' i)
+    {i : Fin n} (h : rowSatisfies idx pub w i) : rowSatisfies idx pub w' i := by
+  by_cases hm : (i : ℕ) < n - idx.zkRows
+  · have hi : w i = w' i := hagree i hm
+    have hnext : (idx.gates i).typ.twoRow = true → w (i + 1) = w' (i + 1) := by
+      intro htwo
+      have hzk := idx.zk_pos
+      have hzn := idx.zk_le
+      have hlt1 : (i : ℕ) + 1 < n := by omega
+      have hval : ((i + 1 : Fin n) : ℕ) = (i : ℕ) + 1 := by
+        have h1 : ((1 : Fin n) : ℕ) = 1 := by
+          rw [Fin.val_one']
+          exact Nat.mod_eq_of_lt (by omega)
+        rw [Fin.add_def]
+        show ((i : ℕ) + ((1 : Fin n) : ℕ)) % n = (i : ℕ) + 1
+        rw [h1]
+        exact Nat.mod_eq_of_lt hlt1
+      by_cases hb : (i : ℕ) + 1 < n - idx.zkRows
+      · exact hagree (i + 1) (by rw [hval]; exact hb)
+      · have hbe : (i : ℕ) + 1 = n - idx.zkRows := by omega
+        have hlaw := idx.masked_boundary i hbe
+        rw [htwo] at hlaw
+        cases hlaw
+    unfold rowSatisfies at h ⊢
+    cases htyp : (idx.gates i).typ with
+    | zero => trivial
+    | generic =>
+      rw [htyp] at h
+      rwa [← hi]
+    | poseidon =>
+      rw [htyp] at h
+      have hn := hnext (by rw [htyp]; rfl)
+      show Gate.Poseidon.Holds (Poseidon.rcMap (idx.coeffTable i))
+        (Poseidon.cellMap (w' i) (w' (i + 1)))
+      rw [← hi, ← hn]
+      exact h
+    | completeAdd =>
+      rw [htyp] at h
+      show Gate.AddComplete.Holds (AddComplete.cellMap (w' i))
+      rw [← hi]
+      exact h
+    | varBaseMul =>
+      rw [htyp] at h
+      have hn := hnext (by rw [htyp]; rfl)
+      show Gate.VarBaseMul.Holds (VarBaseMul.cellMap (w' i) (w' (i + 1)))
+      rw [← hi, ← hn]
+      exact h
+    | endoMul =>
+      rw [htyp] at h
+      have hn := hnext (by rw [htyp]; rfl)
+      show Gate.EndoMul.Holds idx.endoBase (EndoMul.cellMap (w' i) (w' (i + 1)))
+      rw [← hi, ← hn]
+      exact h
+    | endoScalar =>
+      rw [htyp] at h
+      show Gate.EndoScalar.Holds (EndoScalar.cellMap (w' i))
+      rw [← hi]
+      exact h
+  · have hz := idx.masked_zero i (Nat.le_of_not_lt hm)
+    unfold rowSatisfies
+    simp only [hz]
+
+/-- **`Satisfies` depends only on the unmasked rows.** Tables agreeing off the mask are
+satisfiability-equivalent — the mask is outside the constraint system's read
+footprint. In particular the honest prover may put anything in the zero-knowledge
+rows without changing satisfiability. -/
+theorem satisfies_congr_unmasked (idx : Index F n) (pub : Fin idx.publicCount → F)
+    {w w' : Fin n → Fin 15 → F}
+    (hagree : ∀ i : Fin n, (i : ℕ) < n - idx.zkRows → w i = w' i) :
+    Satisfies idx pub w ↔ Satisfies idx pub w' := by
+  have key : ∀ {u u' : Fin n → Fin 15 → F},
+      (∀ i : Fin n, (i : ℕ) < n - idx.zkRows → u i = u' i) →
+      Satisfies idx pub u → Satisfies idx pub u' := by
+    intro u u' hag hsat
+    obtain ⟨hrow, hcopy, hpub⟩ := hsat
+    refine ⟨fun i => rowSatisfies_congr_unmasked idx pub hag (hrow i), ?_, ?_⟩
+    · intro c
+      by_cases hm : (c.2 : ℕ) < n - idx.zkRows
+      · have hc2 : cellValue u' c = cellValue u c := by
+          unfold cellValue
+          rw [hag c.2 hm]
+        have hw : cellValue u' (idx.wiringMap c) = cellValue u (idx.wiringMap c) := by
+          unfold cellValue
+          rw [hag (idx.wiringMap c).2 ((idx.wiring_region c).mp hm)]
+        rw [hc2, hw]
+        exact hcopy c
+      · rw [show idx.wiringMap c = c from idx.masked_identity c (Nat.le_of_not_lt hm)]
+    · intro i
+      have hrw := hag
+        ⟨(i : ℕ), by have h1 := idx.public_le; have h2 := idx.zk_le; omega⟩
+        (lt_of_lt_of_le i.isLt idx.public_le)
+      rw [← hrw]
+      exact hpub i
+  exact ⟨key hagree, key fun i hi => (hagree i hi).symm⟩
+
 end Kimchi.Index

--- a/formal/scripts/check_axioms.lean
+++ b/formal/scripts/check_axioms.lean
@@ -82,6 +82,7 @@ def roots : List Name :=
     `Kimchi.Index.Index.fullFamily_dvd_of_satisfies,
     `Kimchi.Index.Index.exists_quotient_of_satisfies,
     `Kimchi.Index.Index.satisfies_iff_fullFamily_dvd,
+    `Kimchi.Index.satisfies_congr_unmasked,
     `Kimchi.Quotient.multiset_eq_of_pairFactor_prod_eq,
     `Kimchi.Quotient.identity_of_grid_evals,
     `Kimchi.Quotient.multiset_eq_of_grid_prod_evals,


### PR DESCRIPTION
The last deferred item from the completeness arc (#215), reformulated randomness-free after discussion — "random" was protocol motivation, not formal content; the correct concept is the constraint system's **read footprint**.

## The theorem

```
satisfies_congr_unmasked :
  (∀ i, (i : ℕ) < n − zkRows → w i = w' i) →
    (Satisfies idx pub w ↔ Satisfies idx pub w')
```

Tables agreeing off the mask are satisfiability-equivalent — pure congruence, saying nothing about what the masked cells hold or why. The four mask laws each close one class of read edges into the mask:

- `masked_zero` — no constraint *sits on* a masked row (docstring reworded to footprint language here, retiring the "prover's randomness" phrasing);
- **`masked_boundary`** (new, the fifth law) — no constraint *reads into* the mask from outside: `GateType.twoRow` classifies the gates whose transcriptions use `witness_next` (poseidon, varBaseMul, endoMul), and the law forbids them at the last unmasked row;
- `masked_identity` + `wiring_region` — no copy edge crosses;
- `public_le` — the public pins are unmasked.

## The deliberate narrowing

`build?` now rejects a circuit whose last unmasked row is a two-row gate. That's the honest verdict: such a circuit's satisfiability genuinely depends on the mask's contents, so it has no well-defined witness satisfiability at all (and cannot be honestly proven with a nonempty mask). Both index-constructing fixture checks accept the extended `build?` on real data — production kimchi never emits such a circuit.

## Verification

Full `lake build`, style clean, **82 axiom roots** on the unchanged allowed set; `check_index_fixture` (production mixed-gate dump) and `check_ps_witness` (PS harness dump) both decide the new law true.

(Process note: this commit briefly landed on main directly by mistake and was reverted; this PR re-raises it unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)