### PR TITLE
formal: 3c — column extraction and the grid headline

### DIFF
--- a/formal/Kimchi/Quotient/Domain.lean
+++ b/formal/Kimchi/Quotient/Domain.lean
@@ -23,6 +23,8 @@ Source: kimchi `domains.rs` (`EvaluationDomains::d1`, the size-`n` radix-2 domai
 * `columnPoly` — the degree-`<n` Lagrange interpolant of a column `v : Fin n → F`.
 * `eval_columnPoly` — the interpolant reproduces its column on `H`.
 * `eq_of_eval_eq_on_domain` — uniqueness of degree-`<n` interpolants.
+* `columnPoly_eval_self` — a degree-`<n` polynomial is the interpolant of its own node
+  values (the commitment-world ↔ table-world seam).
 -/
 
 namespace Kimchi.Quotient
@@ -112,5 +114,20 @@ theorem eq_of_eval_eq_on_domain (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
       rw [zH, ← C_1, degree_X_pow_sub_C hn]
     rw [hdeg]
     exact lt_of_le_of_lt (degree_sub_le p q) (max_lt hp hq)
+
+/-- **A low-degree polynomial is the interpolant of its own node values.** The seam
+between the commitment world and the table world: a commitment binds a *polynomial*,
+satisfiability judges a *table*, and for degree `< n` the two determine each other —
+the column read off a bound polynomial interpolates back to that polynomial. The
+degree hypothesis is the protocol's own chunk/degree discipline: without it a bound
+polynomial could agree with a table on every node yet differ off the domain, where
+the verifier's equation constrains it. -/
+theorem columnPoly_eval_self (hω : IsPrimitiveRoot ω n) (hn : 0 < n)
+    (p : Polynomial F) (hdeg : p.natDegree < n) :
+    columnPoly ω (fun j : Fin n => p.eval (ω ^ (j : ℕ))) = p := by
+  refine eq_of_eval_eq_on_domain hω hn (degree_columnPoly_lt hω _)
+    (lt_of_le_of_lt degree_le_natDegree (by exact_mod_cast hdeg)) ?_
+  intro i hi
+  rw [show ((ω : F) ^ i) = ω ^ ((⟨i, hi⟩ : Fin n) : ℕ) from rfl, eval_columnPoly hω]
 
 end Kimchi.Quotient

--- a/formal/Kimchi/Verifier/Equation.lean
+++ b/formal/Kimchi/Verifier/Equation.lean
@@ -53,6 +53,40 @@ theorem evalEnv_evalsOf (idx : Index F n) (wTab : Fin n → Fin 15 → F)
   simp only [Function.comp_apply, Polynomial.coe_aeval_eq_eval, Kimchi.Quotient.shift,
     eval_comp, eval_mul, eval_C, eval_X]
 
+/-! ## Column extraction
+
+The soundness-direction junction: PCS binding (`chunked_batch_soundness`) delivers
+*polynomials* behind the witness commitments — each of degree `< n` from its chunk
+count — while `Satisfies` and the point-bridge's record speak *tables*. `extractTable`
+reads the table off the bound polynomials; by `columnPoly_eval_self` the honest record
+at that table evaluates the bound polynomials themselves, so the claimed evaluations
+that binding certifies are exactly the record's fields. -/
+
+/-- The witness table read off bound column polynomials: `wTab j c := W_c(ω^j)`. This
+is the table the headline exports in its `∃ wTab, Satisfies` conclusion. -/
+def extractTable (ω : F) (W : Fin 15 → Polynomial F) : Fin n → Fin 15 → F :=
+  fun j c => (W c).eval (ω ^ (j : ℕ))
+
+/-- The honest record at the extracted table evaluates the bound polynomials: the
+current-row field at column `c` is `W_c(ζ)` — binding's claimed evaluation. -/
+theorem evalsOf_extractTable_w [NeZero n] (idx : Index F n)
+    (W : Fin 15 → Polynomial F) (hW : ∀ c, (W c).natDegree < n)
+    (z : Polynomial F) (ζ : F) (c : Fin 15) :
+    (evalsOf idx (extractTable idx.omega W) z ζ).w c = (W c).eval ζ := by
+  show (columnPoly idx.omega fun j => (W c).eval (idx.omega ^ (j : ℕ))).eval ζ = _
+  rw [columnPoly_eval_self idx.omega_prim (Nat.pos_of_neZero n) (W c) (hW c)]
+
+/-- The next-row field at column `c` is `W_c(ωζ)` — binding's claimed evaluation at
+the shifted point. -/
+theorem evalsOf_extractTable_wOmega [NeZero n] (idx : Index F n)
+    (W : Fin 15 → Polynomial F) (hW : ∀ c, (W c).natDegree < n)
+    (z : Polynomial F) (ζ : F) (c : Fin 15) :
+    (evalsOf idx (extractTable idx.omega W) z ζ).wOmega c
+      = (W c).eval (idx.omega * ζ) := by
+  show (columnPoly idx.omega fun j => (W c).eval (idx.omega ^ (j : ℕ))).eval
+      (idx.omega * ζ) = _
+  rw [columnPoly_eval_self idx.omega_prim (Nat.pos_of_neZero n) (W c) (hW c)]
+
 /-! ## The gate side
 
 The α-power sum of the gate members, evaluated at `ζ`, is the closed-form

--- a/formal/Kimchi/Verifier/Equation.lean
+++ b/formal/Kimchi/Verifier/Equation.lean
@@ -1,5 +1,6 @@
 import Kimchi.Verifier.Linearization
 import Kimchi.Index.Aggregate
+import Kimchi.Index.Degree
 
 /-!
 # The verifier equation — the honest evaluation record
@@ -405,5 +406,98 @@ theorem verifierEquation_iff [DecidableEq F] [NeZero n] (idx : Index F n)
   constructor
   · intro h; linear_combination h - hperm
   · intro h; linear_combination h + hperm
+
+/-! ## The grid headline
+
+The Fiat–Shamir idealization surrogate: the deployed scalar-side acceptance equation,
+required at every node of injective challenge grids, implies `Satisfies` at the index.
+The grids over `(β, γ, α, ζ)` play the same role as the `(ξ, r)` grids of
+`batch_soundness` — milestone 5 discharges them from rewinding the transcript tree — and
+the dependence shape mirrors that tree: `zg` varies with `(β, γ)` only, `t` with
+`(β, γ, α)` only, "committed before `ζ` was sampled". The degree hypotheses `hz`/`ht`
+are what PCS binding (`chunked_batch_soundness`) supplies from the chunk counts; the
+per-point equation `heq` is the deployed verifier's acceptance check, adjudicated
+numerically against production in `scripts/check_linearization.lean`. The route is
+`verifierEquation_iff.mp` per grid point into `Index.satisfies_of_evalCheck` at
+`D := degreeBound n`, its degree side discharged by `aggregate_natDegree_le` and
+`t_zH_natDegree_le`. -/
+
+/-- **The grid headline.** A grid of deployed verifier-equation instances — the
+scalar-side acceptance check `heq` at every node of injective challenge grids — implies
+`Satisfies idx pub wTab`. Per point `(a, c, s, p)`, `heq` is syntactically the LHS of
+`verifierEquation_iff` at `z := zg a c`, `t := t a c s`, `ζ := ζ a c p`, `β := b a`,
+`γ := g c`, `α := α a c s`; the degree data `hz`/`ht` feeds the uniform bound
+`degreeBound n = 9·n` through `aggregate_natDegree_le` and `t_zH_natDegree_le`. -/
+theorem satisfies_of_verifierEquation [DecidableEq F] [NeZero n]
+    (idx : Index F n) (pub : Fin idx.publicCount → F) (wTab : Fin n → Fin 15 → F)
+    {M NN NNN : ℕ} (b : Fin M → F) (g : Fin NN → F)
+    (hb : Function.Injective b) (hg : Function.Injective g)
+    (hM : 7 * (n - idx.zkRows) < M) (hN : 7 * (n - idx.zkRows) < NN)
+    (zg : Fin M → Fin NN → Polynomial F) (hz : ∀ a c, (zg a c).natDegree < n)
+    (ζ : Fin M → Fin NN → Fin NNN → F) (hζ : ∀ a c, Function.Injective (ζ a c))
+    (hζ₁ : ∀ a c p, ζ a c p ≠ 1)
+    (hζb : ∀ a c p, ζ a c p ≠ idx.omega ^ (n - idx.zkRows))
+    (α : Fin M → Fin NN → Fin (Index.gateAlphaCount + Index.permAlphaCount) → F)
+    (hα : ∀ a c, Function.Injective (α a c))
+    (t : Fin M → Fin NN → Fin (Index.gateAlphaCount + Index.permAlphaCount)
+      → Polynomial F)
+    (ht : ∀ a c s, (t a c s).natDegree < 7 * n)
+    (hD : Index.degreeBound n < NNN)
+    (heq : ∀ a c s p,
+      permScalar (b a) (g c) (α a c s)
+          (zkpmEval n idx.zkRows idx.omega (ζ a c p))
+          (evalsOf idx wTab (zg a c) (ζ a c p))
+        * ((Permutation.sigmaPoly idx.omega idx.shifts idx.wiringPerm) 6).eval
+            (ζ a c p)
+        - ((ζ a c p) ^ n - 1) * (t a c s).eval (ζ a c p)
+      = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase (α a c s) (b a) (g c)
+          (ζ a c p) (-((idx.pubPoly pub).eval (ζ a c p)))
+          (evalsOf idx wTab (zg a c) (ζ a c p))) :
+    Satisfies idx pub wTab := by
+  refine idx.satisfies_of_evalCheck pub wTab b g hb hg hM hN zg ζ hζ α hα t
+    (Index.degreeBound n) hD (fun a c s => ?_) (fun a c s => ?_) (fun a c s p => ?_)
+  · exact idx.aggregate_natDegree_le pub wTab (zg a c) (hz a c) (b a) (g c) (α a c s)
+  · exact Index.Index.t_zH_natDegree_le _ (ht a c s)
+  · exact (verifierEquation_iff idx pub wTab (zg a c) (t a c s) (ζ a c p) (b a) (g c)
+      (α a c s) (hζ₁ a c p) (hζb a c p)).mp (heq a c s p)
+
+set_option linter.unusedVariables false in
+/-- **The grid headline at the extracted table.** The corollary at
+`wTab := extractTable idx.omega W` — the table read off the polynomials PCS binding
+delivers behind the witness commitments. The chunk-count degree fact `hW` is carried even
+though this instantiation does not consume it: it is what `chunked_batch_soundness`
+supplies, and milestone 4's claimed-evals conversion (`evalsOf_extractTable_w` /
+`evalsOf_extractTable_wOmega`) consumes it — the corollary fixes that interface. The
+unused-variable linter is silenced for this one theorem precisely because `hW` is
+interface-mandated dead weight here. -/
+theorem satisfies_extractTable_of_verifierEquation [DecidableEq F] [NeZero n]
+    (idx : Index F n) (pub : Fin idx.publicCount → F)
+    (W : Fin 15 → Polynomial F) (hW : ∀ c, (W c).natDegree < n)
+    {M NN NNN : ℕ} (b : Fin M → F) (g : Fin NN → F)
+    (hb : Function.Injective b) (hg : Function.Injective g)
+    (hM : 7 * (n - idx.zkRows) < M) (hN : 7 * (n - idx.zkRows) < NN)
+    (zg : Fin M → Fin NN → Polynomial F) (hz : ∀ a c, (zg a c).natDegree < n)
+    (ζ : Fin M → Fin NN → Fin NNN → F) (hζ : ∀ a c, Function.Injective (ζ a c))
+    (hζ₁ : ∀ a c p, ζ a c p ≠ 1)
+    (hζb : ∀ a c p, ζ a c p ≠ idx.omega ^ (n - idx.zkRows))
+    (α : Fin M → Fin NN → Fin (Index.gateAlphaCount + Index.permAlphaCount) → F)
+    (hα : ∀ a c, Function.Injective (α a c))
+    (t : Fin M → Fin NN → Fin (Index.gateAlphaCount + Index.permAlphaCount)
+      → Polynomial F)
+    (ht : ∀ a c s, (t a c s).natDegree < 7 * n)
+    (hD : Index.degreeBound n < NNN)
+    (heq : ∀ a c s p,
+      permScalar (b a) (g c) (α a c s)
+          (zkpmEval n idx.zkRows idx.omega (ζ a c p))
+          (evalsOf idx (extractTable idx.omega W) (zg a c) (ζ a c p))
+        * ((Permutation.sigmaPoly idx.omega idx.shifts idx.wiringPerm) 6).eval
+            (ζ a c p)
+        - ((ζ a c p) ^ n - 1) * (t a c s).eval (ζ a c p)
+      = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase (α a c s) (b a) (g c)
+          (ζ a c p) (-((idx.pubPoly pub).eval (ζ a c p)))
+          (evalsOf idx (extractTable idx.omega W) (zg a c) (ζ a c p))) :
+    Satisfies idx pub (extractTable idx.omega W) :=
+  satisfies_of_verifierEquation idx pub (extractTable idx.omega W) b g hb hg hM hN
+    zg hz ζ hζ hζ₁ hζb α hα t ht hD heq
 
 end Kimchi.Verifier.Equation

--- a/formal/scripts/check_axioms.lean
+++ b/formal/scripts/check_axioms.lean
@@ -90,7 +90,8 @@ def roots : List Name :=
     `Kimchi.Commitment.IPA.chunked_batch_soundness,
     `Kimchi.Verifier.verify_reflects, `Kimchi.Verifier.ipaVesta_sound,
     `Kimchi.Verifier.ipaPallas_sound,
-    `Kimchi.Verifier.Equation.verifierEquation_iff ]
+    `Kimchi.Verifier.Equation.verifierEquation_iff,
+    `Kimchi.Verifier.Equation.satisfies_of_verifierEquation ]
 
 /-- The only axioms the roots may depend on: the standard logical axioms; the Pasta Hasse bounds
     (`{pallas,vesta}_hasse`); `Lean.ofReduceBool`; and the Pasta CM eigenvalue relations


### PR DESCRIPTION
The remainder of 3c on top of the merged degree bounds (#222): deliverable 2 (this commit) and deliverable 3 (the grid headline, next).

**Deliverable 2 — column extraction.** The seam between what PCS binding produces (polynomials) and what `Satisfies` judges (tables): `columnPoly_eval_self` (a degree-`< n` polynomial is the interpolant of its own node values — the formal residue of "commitments determine wire values", with the degree hypothesis being exactly the chunk discipline `chunked_batch_soundness` supplies), `extractTable` (the table read off bound columns), and the two field identifications making the honest record's entries the bound polynomials' claimed evaluations. Deliberately thin: the σ/selector honest-index identification belongs to milestone 4, and no commitment statements appear here.

**Next — deliverable 3**: `satisfies_of_verifierEquation` (root #86): a grid of deployed-equation instances at bound data ⟹ `∃ wTab, Satisfies`, via `verifierEquation_iff` pointwise + `satisfies_of_evalCheck` with `degreeBound` from #222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)