### PR TITLE
formal: snarky DSL port, 1 — the deep-embedded circuit monad

### DIFF
--- a/formal/Snarky.lean
+++ b/formal/Snarky.lean
@@ -1,0 +1,14 @@
+import Snarky.CVar
+import Snarky.AsProver
+import Snarky.Monad
+
+/-!
+# Snarky — the circuit-building DSL, deep-embedded
+
+Root module of the `Snarky` library: a Lean port of the PureScript circuit DSL
+(`Snarky.Circuit.DSL.Monad`). This first slice is the monad itself — `CVar` expressions,
+the prover-side `AsProver` witness monad, and the deep-embedded `CircuitM` op tree with
+its `LawfulMonad` instance. The two interpreters (constraint builder and witness prover,
+mirroring `Snarky.Backend.Builder`/`Prover`) and the interpreter laws land in follow-up
+modules.
+-/

--- a/formal/Snarky/AsProver.lean
+++ b/formal/Snarky/AsProver.lean
@@ -1,0 +1,46 @@
+import Snarky.CVar
+
+/-!
+# The prover-side witness monad
+
+Port of the `AsProver` monad from `Snarky.Circuit.DSL.Monad`
+(packages/snarky/src/Snarky/Circuit/DSL/Monad.purs, lines 111–122). In PureScript an
+`AsProver f r a` is a function from a prover context to `Effect a`; here it is the pure
+reader-except stack over the current `Assignments` — witness computations read assigned
+values and may fail, nothing else.
+
+Deliberate deviation from PS: the advice row `r` (the `Run r` oracle layer and its
+`AdviceHandler`) is dropped in this port; it can be reintroduced later as an extra reader
+parameter without disturbing anything built on top.
+
+`AsProver` values are what the deep-embedded `CircuitM` (see `Snarky.Monad`) stores at its
+`existsOp`/`assignOp` nodes: the embedding is deep in the circuit structure but *shallow*
+in the witness functions, which stay semantic. The constraint builder (a follow-up module)
+never runs them — provably so, since continuations only ever see `Variable`s.
+-/
+
+namespace Snarky
+
+/-- A prover-only witness computation: read the current assignments, produce a value or
+fail (PS `AsProver f r a`, minus the advice row). `ReaderT`/`Except` supply the `Monad` and
+`LawfulMonad` instances. -/
+abbrev AsProver (F : Type u) : Type u → Type u :=
+  ReaderT (Assignments F) (Except EvalError)
+
+namespace AsProver
+
+/-- Read the value of an affine expression from the current assignments (PS `readCVar`). -/
+def readCVar [Add F] [Mul F] (x : CVar F) : AsProver F F :=
+  fun env => x.eval env
+
+/-- Fail with a message (PS `throwAsProver`). -/
+def throw (msg : String) : AsProver F α :=
+  fun _ => .error (.custom msg)
+
+/-- Run a witness computation against an assignment (PS `runAsProver`, minus `Effect`). -/
+def run (p : AsProver F α) (env : Assignments F) : Except EvalError α :=
+  p env
+
+end AsProver
+
+end Snarky

--- a/formal/Snarky/CVar.lean
+++ b/formal/Snarky/CVar.lean
@@ -1,0 +1,85 @@
+/-!
+# Circuit variables and affine expressions
+
+Port of `Snarky.Circuit.CVar` (packages/snarky/src/Snarky/Circuit/CVar.purs): the `CVar`
+type of affine expressions over allocated circuit variables, together with the prover-side
+partial assignment (`Assignments`) they are evaluated against.
+
+Everything here is core Lean (no Mathlib): evaluation only needs `Add`/`Mul` on the field,
+and the whole `Snarky` library stays executable and fast to build.
+-/
+
+namespace Snarky
+
+/-- A circuit variable: an index into the wire assignment, allocated sequentially by the
+interpreters (PS `Variable`). -/
+abbrev Variable := Nat
+
+/-- A partial assignment of field values to variables — the prover's witness table
+(PS `Assignments f`). -/
+abbrev Assignments (F : Type u) := Variable → Option F
+
+/-- Errors arising while running witness code or checking constraints during a prover run
+(PS `EvaluationError`, extended with the prover-side failure modes). -/
+inductive EvalError where
+  /-- A variable was read before being assigned. -/
+  | unassigned (v : Variable)
+  /-- A variable was assigned twice (assignments may only grow). -/
+  | conflict (v : Variable)
+  /-- A constraint added via `addConstraint` does not hold on the current assignment. -/
+  | unsatisfiedConstraint
+  /-- A witness computation failed with a message (PS `throwAsProver`). -/
+  | custom (msg : String)
+  deriving Repr, DecidableEq
+
+/-! ## Affine expressions -/
+
+/-- Affine expressions over circuit variables (PS `CVar`): variables, constants, sums and
+scalings. `sub x y` is expressible as `add x (scale (-1) y)` when `F` has negation, so it is
+not a separate constructor. -/
+inductive CVar (F : Type u) where
+  | var (v : Variable)
+  | const (c : F)
+  | add (a b : CVar F)
+  | scale (k : F) (x : CVar F)
+  deriving Repr, DecidableEq
+
+namespace CVar
+
+/-- Evaluate an affine expression against a partial assignment, failing on the first
+unassigned variable (PS `evalCVar`). Written with explicit `match` (not `do`) so proofs can
+`split` on the intermediate results. -/
+def eval [Add F] [Mul F] : CVar F → Assignments F → Except EvalError F
+  | .var v, env =>
+    match env v with
+    | some x => .ok x
+    | none => .error (.unassigned v)
+  | .const k, _ => .ok k
+  | .add a b, env =>
+    match a.eval env with
+    | .error e => .error e
+    | .ok x =>
+      match b.eval env with
+      | .error e => .error e
+      | .ok y => .ok (x + y)
+  | .scale k x, env =>
+    match x.eval env with
+    | .error e => .error e
+    | .ok y => .ok (k * y)
+
+end CVar
+
+/-! ## Assignments -/
+
+namespace Assignments
+
+/-- The empty assignment. -/
+def empty : Assignments F := fun _ => none
+
+/-- Assign `x` to `v`, leaving every other variable unchanged. -/
+def extend (a : Assignments F) (v : Variable) (x : F) : Assignments F :=
+  fun w => if w = v then some x else a w
+
+end Assignments
+
+end Snarky

--- a/formal/Snarky/Monad.lean
+++ b/formal/Snarky/Monad.lean
@@ -1,0 +1,125 @@
+import Snarky.AsProver
+
+/-!
+# The circuit-building monad, deep-embedded
+
+Port of the `Snarky` monad from `Snarky.Circuit.DSL.Monad`
+(packages/snarky/src/Snarky/Circuit/DSL/Monad.purs, lines 226–256). The PureScript
+original is final-tagless: `Snarky f c r a = CircuitOps f c r -> Effect a`, a bind is a
+closure, and the two interpreters (constraint builder, witness prover) are `CircuitOps`
+records over mutable refs. That shape is uninspectable, so this port reifies the op tree
+instead: one constructor per `CircuitOps` field, with continuations stored explicitly.
+
+The embedding is deep in the *circuit structure* only — the witness payloads at
+`existsOp`/`assignOp` are semantic `AsProver` functions, not syntax. Continuations receive
+only freshly allocated `Variable`s, never field values, so the shape of a circuit provably
+cannot depend on witness data.
+
+The interpreters land as pure recursive functions in follow-up modules: `Snarky.Builder`
+(constraint generation, PS `Snarky.Backend.Builder`) and `Snarky.Prover` (witness
+generation, PS `Snarky.Backend.Prover`), together with the interpreter laws
+(witness-independence, allocation agreement, completeness).
+
+Deviations from PS: `pushLabelOp`/`popLabelOp` collapse into one scoped `labelOp` node;
+`MonadRec` is unnecessary (Lean recursion over build-time data produces a fixed tree);
+the advice row `r` is dropped (see `Snarky.AsProver`).
+-/
+
+namespace Snarky
+
+/-- A circuit computation over field `F` and constraint type `c`, returning `α` — the
+deep-embedded counterpart of PS `Snarky f c r a`. Constructors mirror the `CircuitOps`
+record fields. -/
+inductive CircuitM (F c : Type u) (α : Type v) : Type (max u v) where
+  /-- Return a value (the monad's `pure`). -/
+  | pure (a : α)
+  /-- Allocate a fresh variable (PS `freshOp`). -/
+  | freshOp (k : Variable → CircuitM F c α)
+  /-- Emit a constraint (PS `addConstraintOp`). -/
+  | addConstraintOp (con : c) (k : CircuitM F c α)
+  /-- Allocate `n` fresh variables, to be assigned by the witness computation `wit` during
+  prover runs (PS `existsOp`). The builder ignores `wit`. -/
+  | existsOp (n : Nat) (wit : AsProver F (Vector F n)) (k : Vector Variable n → CircuitM F c α)
+  /-- Back-fill existing variables from a witness computation during prover runs
+  (PS `assignOp`). The builder ignores it entirely. -/
+  | assignOp {n : Nat} (vs : Vector Variable n) (wit : AsProver F (Vector F n))
+      (k : CircuitM F c α)
+  /-- A labelled scope, for error attribution (PS `pushLabelOp`/`popLabelOp`). -/
+  | labelOp (s : String) (k : CircuitM F c α)
+
+namespace CircuitM
+
+variable {F c : Type u}
+
+/-- Sequencing: graft `f` onto every leaf of the op tree. In PS a bind is a closure; here
+it is a structural recursion, which is what makes the interpreter proofs inductions. -/
+protected def bind : CircuitM F c α → (α → CircuitM F c β) → CircuitM F c β
+  | .pure a, f => f a
+  | .freshOp k, f => .freshOp fun v => (k v).bind f
+  | .addConstraintOp con k, f => .addConstraintOp con (k.bind f)
+  | .existsOp n wit k, f => .existsOp n wit fun vs => (k vs).bind f
+  | .assignOp vs wit k, f => .assignOp vs wit (k.bind f)
+  | .labelOp s k, f => .labelOp s (k.bind f)
+
+instance : Monad (CircuitM F c) where
+  pure := CircuitM.pure
+  bind := CircuitM.bind
+
+/-! ## Monad laws -/
+
+protected theorem bind_pure (m : CircuitM F c α) : m.bind CircuitM.pure = m := by
+  induction m with
+  | pure a => rfl
+  | freshOp k ih => simp only [CircuitM.bind]; exact congrArg _ (funext ih)
+  | addConstraintOp con k ih => simp only [CircuitM.bind]; exact congrArg _ ih
+  | existsOp n wit k ih => simp only [CircuitM.bind]; exact congrArg _ (funext ih)
+  | assignOp vs wit k ih => simp only [CircuitM.bind]; exact congrArg _ ih
+  | labelOp s k ih => simp only [CircuitM.bind]; exact congrArg _ ih
+
+protected theorem bind_assoc (m : CircuitM F c α) (f : α → CircuitM F c β)
+    (g : β → CircuitM F c γ) :
+    (m.bind f).bind g = m.bind fun a => (f a).bind g := by
+  induction m with
+  | pure a => rfl
+  | freshOp k ih => simp only [CircuitM.bind]; exact congrArg _ (funext ih)
+  | addConstraintOp con k ih => simp only [CircuitM.bind]; exact congrArg _ ih
+  | existsOp n wit k ih => simp only [CircuitM.bind]; exact congrArg _ (funext ih)
+  | assignOp vs wit k ih => simp only [CircuitM.bind]; exact congrArg _ ih
+  | labelOp s k ih => simp only [CircuitM.bind]; exact congrArg _ ih
+
+instance : LawfulMonad (CircuitM F c) :=
+  LawfulMonad.mk'
+    (id_map := fun m => CircuitM.bind_pure m)
+    (pure_bind := fun _ _ => rfl)
+    (bind_assoc := CircuitM.bind_assoc)
+
+end CircuitM
+
+/-! ## Smart constructors (the user-facing ops) -/
+
+variable {F c : Type u}
+
+/-- Allocate one fresh variable (PS `fresh`). -/
+def fresh : CircuitM F c Variable :=
+  .freshOp .pure
+
+/-- Emit one constraint (PS `addConstraint`). Returns `PUnit` rather than `Unit` so it can
+sit in `do`-blocks at any universe. -/
+def addConstraint (con : c) : CircuitM F c PUnit :=
+  .addConstraintOp con (.pure PUnit.unit)
+
+/-- Allocate `n` variables whose values the prover computes with `wit` (raw PS `existsOp`;
+the typed, `check`-inserting wrapper is `Snarky.witness` in `Snarky.DSL`). -/
+def existsVars (n : Nat) (wit : AsProver F (Vector F n)) : CircuitM F c (Vector Variable n) :=
+  .existsOp n wit .pure
+
+/-- Back-fill already-allocated variables from a witness computation (PS `assignVars`). -/
+def assignVars {n : Nat} (vs : Vector Variable n) (wit : AsProver F (Vector F n)) :
+    CircuitM F c PUnit :=
+  .assignOp vs wit (.pure PUnit.unit)
+
+/-- Run a computation under a label, for error attribution (PS `label`). -/
+def label (s : String) (m : CircuitM F c α) : CircuitM F c α :=
+  .labelOp s m
+
+end Snarky

--- a/formal/lakefile.toml
+++ b/formal/lakefile.toml
@@ -1,5 +1,5 @@
 name = "kimchi-formal"
-defaultTargets = ["Kimchi", "kimchi-demo"]
+defaultTargets = ["Kimchi", "Snarky", "kimchi-demo"]
 
 # CompElliptic: concrete short-Weierstrass `SWCurve` / `SWPoint` with a proven group law,
 # and the Pasta curve instances. Vendored as a git submodule at vendor/CompElliptic so the
@@ -30,6 +30,13 @@ rev = "v4.30.0"
 
 [[lean_lib]]
 name = "Kimchi"
+
+# Snarky: a deep-embedded port of the PureScript circuit-building DSL
+# (packages/snarky/src/Snarky/Circuit/DSL/Monad.purs). Lives beside Kimchi so the
+# "no circuit monad" stance of the Kimchi.* namespace stays true; Mathlib-free (core Lean
+# only) so it builds in seconds.
+[[lean_lib]]
+name = "Snarky"
 
 [[lean_exe]]
 name = "kimchi-demo"


### PR DESCRIPTION
First slice of a Lean port of the PureScript circuit DSL (`Snarky.Circuit.DSL.Monad`), as a new Lake library **`Snarky`** beside `Kimchi` (the `Kimchi.*` namespace keeps its no-circuit-monad stance; this lives next door).

## Why a deep embedding

The PS original is final-tagless — `Snarky f c r a = CircuitOps f c r -> Effect a`, state in mutable refs inside the interpreters — which is uninspectable: nothing can be *proved* about a computation you can only run. This port reifies the op tree instead:

- **`Snarky/CVar.lean`** — `CVar` affine expressions, `Assignments`, evaluation (explicit `match` so proofs can `split`).
- **`Snarky/AsProver.lean`** — the prover-side witness monad, now pure: `ReaderT (Assignments F) (Except EvalError)`. The PS advice row `r` is dropped for now.
- **`Snarky/Monad.lean`** — `CircuitM F c α`: one constructor per `CircuitOps` field (`freshOp`, `addConstraintOp`, `existsOp`, `assignOp`, `labelOp`), continuations reified, witness payloads kept *semantic* (`AsProver` functions, not syntax). `Monad` + `LawfulMonad` instances with the laws proved by induction on the tree.

Key structural property (by construction, made into theorems in the follow-up): continuations receive only freshly allocated `Variable`s, never field values — so a circuit's shape cannot depend on witness data.

The library is **Mathlib-free** (core Lean only) and builds in ~1s.

## Stacked follow-ups

1. *(this PR)* the monad
2. interpreters: pure `build`/`prove` mirroring `Snarky.Backend.Builder`/`Prover`, plus the assignment-extension order
3. the interpreter laws: witness-independence, builder/prover allocation agreement, completeness (a successful prover run satisfies every built constraint) + `check_axioms` wiring
4. the typed layer (`CircuitType`/`CheckedType`/`BasicSystem`, the `witness` combinator) and an executable R1CS end-to-end example, all `decide`-checked

## Design note: why Mathlib-free, and why not a library free monad

**Mathlib-free core.** This is the tree's own import discipline (`formal/CLAUDE.md`, "Import discipline for the executable trees") applied at the natural boundary. The core is a 9-job, ~2s build; the `Snarky.Kimchi.*` bridge modules that do import Mathlib (via `Kimchi.Gate.Generic`) sit atop an ~8,500-job closure. Three concrete payoffs:

- **Feedback loop** — interpreter-proof iteration happens against a 2-second build.
- **Axiom hygiene** — the core laws close over `[propext]` alone (`CVar.eval_le` uses *no* axioms); `Classical.choice` first enters with `ring`/`linear_combination` at the bridge, where it belongs.
- **Churn insulation** — even core renamed `List.enum` → `zipIdx` and `Option.bind_eq_some` → `bind_eq_some_iff` under this work; Mathlib churns faster. A Mathlib-free core means the DSL semantics can never be what breaks in a Mathlib pin bump.

Nothing in the core wants Mathlib: `CVar.eval` needs only `Add`/`Mul`, the interpreters are structural recursions, and `Assignments.Le` needs refl/trans (a `Preorder` instance would rename, not strengthen). Mathlib arrives exactly where it pays — `ZMod`/Pasta, `Generic.holds_iff`, `ring` — in the bridge layer.

**Why not Cslib's `FreeM` (freer monad)?** `CircuitM` *is* an instance of the freer pattern — `FreeM (CircuitOp F c)` over a response-indexed signature — and Cslib would supply the `Monad`/`LawfulMonad` instances and a canonical `liftM` interpreter. Declined, deliberately:

1. **The laws aren't free-monad theory.** `liftM`'s universal property gives uniqueness of monad morphisms; the follow-up theorems (witness-independence, allocation agreement, completeness) are relational properties of two *specific* handlers — still bespoke inductions, but one indirection deeper, with `prove` reformulated as a `StateT/Except` fold whose transformer unfoldings fight the `split at h` proof style used throughout.
2. **`labelOp` doesn't fit.** Freer monads handle *algebraic* operations; `labelOp (s : String) (body : CircuitM F c α)` is a **scoped** operation (a subtree, not a response-continuation) — it would force reverting to the PS push/pop pair or scoped-effects machinery `FreeM` doesn't have.
3. **Kernel reduction.** Everything downstream is validated by `decide`; first-order `match` interpreters reduce predictably, `liftM` through a transformer stack is the kind of term that wedges kernel evaluation (cf. the `Vector.map` WF-recursion trap already documented in `formal/CLAUDE.md`).
4. **Dependency economics.** The tree pins Mathlib + CompElliptic + Ironwood as deliberate, auditable trust surface; adding a young, fast-moving fourth dependency to save ~30 proved lines is a bad trade for a proof artifact. (Mathlib itself has no ergonomic free monad to offer — `FreeMonoid` is algebra; the `PFunctor`/QPF route is worse than the hand-rolled inductive.)

**Re-evaluation triggers**: if the PS advice row `r` is ported (it is literally an extensible-effects layer — the freer signature is then the right tool and Cslib a serious candidate), or if the DSL grows the PS numeric-tower instances (`Semiring` on `Snarky (FVar f)`), where Mathlib's algebra hierarchy in the core becomes tempting.

## Verification

- `lake build Snarky` clean (also full `lake build` including `Kimchi`)
- `scripts/check-style.sh` clean
- `#print axioms` on the `LawfulMonad` instance: `[propext, Quot.sound]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019r9D9Ds4BBjv97ZWPMEMQN
