### PR TITLE
formal: snarky DSL port, 2 — interpreters and the interpreter laws

### DIFF
--- a/formal/Snarky.lean
+++ b/formal/Snarky.lean
@@ -1,14 +1,15 @@
 import Snarky.CVar
 import Snarky.AsProver
 import Snarky.Monad
+import Snarky.Builder
+import Snarky.Prover
+import Snarky.Laws
 
 /-!
 # Snarky — the circuit-building DSL, deep-embedded
 
 Root module of the `Snarky` library: a Lean port of the PureScript circuit DSL
-(`Snarky.Circuit.DSL.Monad`). This first slice is the monad itself — `CVar` expressions,
-the prover-side `AsProver` witness monad, and the deep-embedded `CircuitM` op tree with
-its `LawfulMonad` instance. The two interpreters (constraint builder and witness prover,
-mirroring `Snarky.Backend.Builder`/`Prover`) and the interpreter laws land in follow-up
-modules.
+(`Snarky.Circuit.DSL.Monad` and its two backend interpreters). See each module's header
+for the correspondence with the `.purs` sources, and `Snarky/Laws.lean` for the theorems
+the embedding exists to state.
 -/

--- a/formal/Snarky/AsProver.lean
+++ b/formal/Snarky/AsProver.lean
@@ -15,8 +15,8 @@ parameter without disturbing anything built on top.
 
 `AsProver` values are what the deep-embedded `CircuitM` (see `Snarky.Monad`) stores at its
 `existsOp`/`assignOp` nodes: the embedding is deep in the circuit structure but *shallow*
-in the witness functions, which stay semantic. The constraint builder (a follow-up module)
-never runs them — provably so, since continuations only ever see `Variable`s.
+in the witness functions, which stay semantic. The constraint builder provably never runs
+them (`Snarky.Laws.build_eq_of_sameShape`).
 -/
 
 namespace Snarky

--- a/formal/Snarky/Builder.lean
+++ b/formal/Snarky/Builder.lean
@@ -1,0 +1,54 @@
+import Snarky.Monad
+
+/-!
+# The constraint builder
+
+Port of `Snarky.Backend.Builder` (packages/snarky/src/Snarky/Backend/Builder.purs,
+`runCircuitBuilder`/`builderOps`): interpret a `CircuitM` tree by allocating variables and
+collecting constraints, discarding every witness computation — exactly the PS builder,
+whose `existsOp` is `\n _ -> allocVars n` and whose `assignOp` is a no-op.
+
+Instead of threading a `CircuitBuilderState` record through `Effect` refs, `build` is a
+pure function from the next-variable counter to the result, the final counter, and the
+emitted constraints in order. (The PS builder also compiles DSL constraints to backend
+gates on the fly via `CompileCircuit`; that compilation step is deliberately out of scope
+here — `build` returns the DSL-level constraints, the natural first comparison point
+against a PS-side dump.)
+-/
+
+namespace Snarky
+
+variable {F c : Type u}
+
+/-- The `n` variables `start, start+1, …, start+n-1` — sequential allocation, shared
+verbatim by `build` and `prove` so the interpreters agree on numbering by construction. -/
+def allocRange (start n : Nat) : Vector Variable n :=
+  Vector.ofFn fun i => start + i.val
+
+/-- The builder's output: the computation's result, the final next-variable counter, and
+the emitted constraints in emission order (the pure image of PS `runCircuitBuilder`'s
+`Tuple a (CircuitBuilderState c aux)`). -/
+structure Built (c : Type u) (α : Type v) where
+  result : α
+  nextVar : Nat
+  constraints : List c
+
+/-- Interpret a circuit as its constraint system: from a next-variable counter, produce
+the result, the final counter, and the constraints in emission order. Witness payloads are
+never inspected — see `Snarky.Laws.build_eq_of_sameShape`. -/
+def build : CircuitM F c α → Nat → Built c α
+  | .pure a, n => ⟨a, n, []⟩
+  | .freshOp k, n => build (k n) (n + 1)
+  | .addConstraintOp con k, n =>
+    let r := build k n
+    ⟨r.result, r.nextVar, con :: r.constraints⟩
+  | .existsOp m _ k, n => build (k (allocRange n m)) (n + m)
+  | .assignOp _ _ k, n => build k n
+  | .labelOp _ k, n => build k n
+
+/-- The constraints of a circuit, counting variables from `0` (PS `compile`'s view of the
+finished `CircuitBuilderState`). -/
+def constraints (m : CircuitM F c α) : List c :=
+  (build m 0).constraints
+
+end Snarky

--- a/formal/Snarky/CVar.lean
+++ b/formal/Snarky/CVar.lean
@@ -7,6 +7,11 @@ partial assignment (`Assignments`) they are evaluated against.
 
 Everything here is core Lean (no Mathlib): evaluation only needs `Add`/`Mul` on the field,
 and the whole `Snarky` library stays executable and fast to build.
+
+The `Assignments.Le` order ("every assigned variable keeps its value") is the backbone of
+the completeness proof in `Snarky.Laws`: the prover only ever *extends* assignments (the
+guarded `extendPairs` errors on any re-assignment), so constraint checks performed early in a
+run remain valid against the final assignment.
 -/
 
 namespace Snarky
@@ -69,7 +74,7 @@ def eval [Add F] [Mul F] : CVar F → Assignments F → Except EvalError F
 
 end CVar
 
-/-! ## Assignments -/
+/-! ## The extension order on assignments -/
 
 namespace Assignments
 
@@ -80,6 +85,83 @@ def empty : Assignments F := fun _ => none
 def extend (a : Assignments F) (v : Variable) (x : F) : Assignments F :=
   fun w => if w = v then some x else a w
 
+/-- Guarded batch extension: assign each `(variable, value)` pair left to right, erroring
+on any variable that is already assigned — this is what makes prover runs monotone in
+`Assignments.Le`. Callers zip equal-length allocation and witness vectors, so pairing is
+total by construction and the only failure mode is a re-assignment. -/
+def extendPairs (a : Assignments F) : List (Variable × F) → Except EvalError (Assignments F)
+  | [] => .ok a
+  | (v, x) :: rest =>
+    match a v with
+    | some _ => .error (.conflict v)
+    | none => (a.extend v x).extendPairs rest
+
+/-- `a.Le a'` iff every variable assigned in `a` has the same value in `a'` — assignments
+only ever grow during a prover run. -/
+protected def Le (a a' : Assignments F) : Prop :=
+  ∀ v x, a v = some x → a' v = some x
+
+protected theorem Le.refl (a : Assignments F) : a.Le a := fun _ _ h => h
+
+protected theorem Le.trans {a b c : Assignments F} (h₁ : a.Le b) (h₂ : b.Le c) : a.Le c :=
+  fun v x h => h₂ v x (h₁ v x h)
+
+theorem le_extend {a : Assignments F} {v : Variable} (hv : a v = none) (x : F) :
+    a.Le (a.extend v x) := by
+  intro w y hw
+  simp only [extend]
+  split
+  · next hwv => rw [hwv, hv] at hw; cases hw
+  · exact hw
+
+theorem le_extendPairs {a a' : Assignments F} :
+    ∀ {l : List (Variable × F)}, a.extendPairs l = .ok a' → a.Le a' := by
+  intro l
+  induction l generalizing a with
+  | nil =>
+    intro h
+    simp only [extendPairs, Except.ok.injEq] at h
+    subst h
+    exact Assignments.Le.refl a
+  | cons vx rest ih =>
+    obtain ⟨v, x⟩ := vx
+    intro h
+    simp only [extendPairs] at h
+    split at h
+    · cases h
+    · next hnone => exact (le_extend hnone x).trans (ih h)
+
 end Assignments
+
+/-! ## Evaluation is monotone in the extension order -/
+
+namespace CVar
+
+/-- Successful evaluations are stable under assignment extension: the value of an affine
+expression cannot change once all its variables are assigned. -/
+theorem eval_le [Add F] [Mul F] {a a' : Assignments F} (hle : a.Le a') {x : CVar F} {v : F}
+    (h : x.eval a = .ok v) : x.eval a' = .ok v := by
+  induction x generalizing v with
+  | var w =>
+    simp only [eval] at h ⊢
+    split at h
+    · next y hy => rw [hle w y hy]; exact h
+    · cases h
+  | const k => exact h
+  | add p q ihp ihq =>
+    simp only [eval] at h ⊢
+    split at h
+    · cases h
+    · next xa hxa =>
+      split at h
+      · cases h
+      · next xb hxb => rw [ihp hxa, ihq hxb]; exact h
+  | scale k p ih =>
+    simp only [eval] at h ⊢
+    split at h
+    · cases h
+    · next y hy => rw [ih hy]; exact h
+
+end CVar
 
 end Snarky

--- a/formal/Snarky/Laws.lean
+++ b/formal/Snarky/Laws.lean
@@ -1,0 +1,201 @@
+import Snarky.Prover
+
+/-!
+# The interpreter laws
+
+The theorems the deep embedding exists to state — none of them is expressible against the
+final-tagless PureScript original:
+
+1. **Witness-independence** (`build_eraseWitness`): the constraint builder never
+   inspects a witness payload — `build` factors through `eraseWitness`, the function
+   stripping every `AsProver` computation from the tree. Two circuits differing only in
+   their witness payloads have equal erasures, hence identical constraint systems
+   (`build_eq_of_eraseWitness`). This is structural: continuations receive only fresh
+   `Variable`s, never field values.
+2. **Interpreter agreement** (`prove_build_agrees`): on a successful prover run, the
+   builder and the prover compute the same result and allocate variables identically —
+   the deep-embedding counterpart of PS's builder/prover running the *same* closure
+   against two `CircuitOps` records.
+3. **Completeness** (`prove_sound`): if the prover run succeeds, the final assignment
+   satisfies *every* constraint the builder emits. The prover checks each constraint
+   against the assignment current at emission time; the final assignment only extends it
+   (`prove_assignments_le`), so a monotone `holds` stays true. This is the DSL-level
+   bridge that, once `c` is instantiated at Kimchi gate rows, will feed
+   `Kimchi.Index.Satisfies`.
+-/
+
+namespace Snarky
+
+variable {F c : Type u}
+
+/-! ## Witness-independence -/
+
+/-- Strip every witness payload from the tree, leaving the circuit's shape: the
+`AsProver` computations at `existsOp`/`assignOp` nodes are replaced by the trivially
+failing one. Two circuits differ only in their witness code exactly when their erasures
+are equal — for literal circuit terms that equality is `rfl`. -/
+def eraseWitness : CircuitM F c α → CircuitM F c α
+  | .pure a => .pure a
+  | .freshOp k => .freshOp fun v => eraseWitness (k v)
+  | .addConstraintOp con k => .addConstraintOp con (eraseWitness k)
+  | .existsOp n _ k =>
+    .existsOp n (fun _ => .error (.custom "erased")) fun vs => eraseWitness (k vs)
+  | .assignOp vs _ k =>
+    .assignOp vs (fun _ => .error (.custom "erased")) (eraseWitness k)
+  | .labelOp s k => .labelOp s (eraseWitness k)
+
+/-- **Witness-independence of the builder**: `build` factors through `eraseWitness` —
+the constraint system (and the result, and the variable numbering) depends only on the
+shape of the circuit, never on the witness computations stored at `existsOp`/`assignOp`
+nodes. -/
+theorem build_eraseWitness (m : CircuitM F c α) : ∀ n, build (eraseWitness m) n = build m n := by
+  induction m with
+  | pure a => intro n; rfl
+  | freshOp k ih => intro n; simp only [eraseWitness, build]; exact ih n (n + 1)
+  | addConstraintOp con k ih => intro n; simp only [eraseWitness, build, ih n]
+  | existsOp k wit K ih => intro n; simp only [eraseWitness, build]; exact ih _ (n + k)
+  | assignOp vs wit k ih => intro n; simp only [eraseWitness, build]; exact ih n
+  | labelOp s k ih => intro n; simp only [eraseWitness, build]; exact ih n
+
+/-- Circuits with equal erasures build identically — the two-circuit corollary. -/
+theorem build_eq_of_eraseWitness {m m' : CircuitM F c α}
+    (h : eraseWitness m = eraseWitness m') (n : Nat) : build m n = build m' n := by
+  rw [← build_eraseWitness m, h, build_eraseWitness]
+
+/-! ## Prover runs only extend the assignment -/
+
+/-- A successful prover run never re-assigns a variable, so its final assignment extends
+its initial one. -/
+theorem prove_assignments_le {holds : c → Assignments F → Bool} {m : CircuitM F c α}
+    {nv nv' : Nat} {env env' : Assignments F} {x : α}
+    (h : prove holds m nv env = .ok ⟨x, nv', env'⟩) : env.Le env' := by
+  induction m generalizing nv nv' env env' x with
+  | pure a =>
+    simp only [prove, Except.ok.injEq, Proved.mk.injEq] at h
+    obtain ⟨-, -, rfl⟩ := h
+    exact Assignments.Le.refl _
+  | freshOp k ih =>
+    simp only [prove] at h
+    exact ih _ h
+  | addConstraintOp con k ih =>
+    simp only [prove] at h
+    split at h
+    · exact ih h
+    · cases h
+  | existsOp n wit k ih =>
+    simp only [prove] at h
+    split at h
+    · cases h
+    · split at h
+      · cases h
+      · next hext => exact (Assignments.le_extendPairs hext).trans (ih _ h)
+  | assignOp vs wit k ih =>
+    simp only [prove] at h
+    split at h
+    · cases h
+    · split at h
+      · cases h
+      · next hext => exact (Assignments.le_extendPairs hext).trans (ih h)
+  | labelOp str k ih =>
+    simp only [prove] at h
+    exact ih h
+
+/-! ## Interpreter agreement -/
+
+/-- **Builder/prover agreement**: on a successful prover run the two interpreters compute
+the same result and the same final variable counter — they allocate variables in lockstep
+(the PS builder and prover run the same closure against two `CircuitOps` records; here
+that is a theorem rather than an intention). -/
+theorem prove_build_agrees {holds : c → Assignments F → Bool} {m : CircuitM F c α}
+    {nv nv' : Nat} {env env' : Assignments F} {x : α}
+    (h : prove holds m nv env = .ok ⟨x, nv', env'⟩) :
+    (build m nv).result = x ∧ (build m nv).nextVar = nv' := by
+  induction m generalizing nv nv' env env' x with
+  | pure a =>
+    simp only [prove, Except.ok.injEq, Proved.mk.injEq] at h
+    obtain ⟨rfl, rfl, -⟩ := h
+    exact ⟨rfl, rfl⟩
+  | freshOp k ih =>
+    simp only [prove] at h
+    simp only [build]
+    exact ih _ h
+  | addConstraintOp con k ih =>
+    simp only [prove] at h
+    simp only [build]
+    split at h
+    · exact ih h
+    · cases h
+  | existsOp n wit k ih =>
+    simp only [prove] at h
+    simp only [build]
+    split at h
+    · cases h
+    · split at h
+      · cases h
+      · exact ih _ h
+  | assignOp vs wit k ih =>
+    simp only [prove] at h
+    simp only [build]
+    split at h
+    · cases h
+    · split at h
+      · cases h
+      · exact ih h
+  | labelOp str k ih =>
+    simp only [prove] at h
+    simp only [build]
+    exact ih h
+
+/-! ## Completeness -/
+
+/-- **Completeness**: if the prover run succeeds, the final assignment satisfies every
+constraint the builder emits — provided `holds` is monotone in the assignment-extension
+order (true of any constraint that evaluates its `CVar`s, by `CVar.eval_le`). The prover
+checked each constraint when it was added; monotonicity carries the check to the end of
+the run. -/
+theorem prove_sound {holds : c → Assignments F → Bool}
+    (hmono : ∀ (con : c) {a a' : Assignments F},
+      a.Le a' → holds con a = true → holds con a' = true)
+    {m : CircuitM F c α} {nv nv' : Nat} {env env' : Assignments F} {x : α}
+    (h : prove holds m nv env = .ok ⟨x, nv', env'⟩) :
+    ∀ con ∈ (build m nv).constraints, holds con env' = true := by
+  induction m generalizing nv nv' env env' x with
+  | pure a =>
+    intro con hcon
+    simp [build] at hcon
+  | freshOp k ih =>
+    simp only [prove] at h
+    simp only [build]
+    exact ih _ h
+  | addConstraintOp con' k ih =>
+    simp only [prove] at h
+    split at h
+    · next hh =>
+      intro con hcon
+      simp only [build, List.mem_cons] at hcon
+      rcases hcon with rfl | hcon
+      · exact hmono con (prove_assignments_le h) hh
+      · exact ih h con hcon
+    · cases h
+  | existsOp n wit k ih =>
+    simp only [prove] at h
+    simp only [build]
+    split at h
+    · cases h
+    · split at h
+      · cases h
+      · exact ih _ h
+  | assignOp vs wit k ih =>
+    simp only [prove] at h
+    simp only [build]
+    split at h
+    · cases h
+    · split at h
+      · cases h
+      · exact ih h
+  | labelOp str k ih =>
+    simp only [prove] at h
+    simp only [build]
+    exact ih h
+
+end Snarky

--- a/formal/Snarky/Monad.lean
+++ b/formal/Snarky/Monad.lean
@@ -13,12 +13,11 @@ instead: one constructor per `CircuitOps` field, with continuations stored expli
 The embedding is deep in the *circuit structure* only — the witness payloads at
 `existsOp`/`assignOp` are semantic `AsProver` functions, not syntax. Continuations receive
 only freshly allocated `Variable`s, never field values, so the shape of a circuit provably
-cannot depend on witness data.
+cannot depend on witness data (`Snarky.Laws.build_eq_of_sameShape`).
 
-The interpreters land as pure recursive functions in follow-up modules: `Snarky.Builder`
-(constraint generation, PS `Snarky.Backend.Builder`) and `Snarky.Prover` (witness
-generation, PS `Snarky.Backend.Prover`), together with the interpreter laws
-(witness-independence, allocation agreement, completeness).
+The interpreters are pure recursive functions in `Snarky.Builder` (constraint generation,
+PS `Snarky.Backend.Builder`) and `Snarky.Prover` (witness generation,
+PS `Snarky.Backend.Prover`).
 
 Deviations from PS: `pushLabelOp`/`popLabelOp` collapse into one scoped `labelOp` node;
 `MonadRec` is unnecessary (Lean recursion over build-time data produces a fixed tree);

--- a/formal/Snarky/Prover.lean
+++ b/formal/Snarky/Prover.lean
@@ -1,0 +1,68 @@
+import Snarky.Builder
+
+/-!
+# The witness prover
+
+Port of `Snarky.Backend.Prover` (packages/snarky/src/Snarky/Backend/Prover.purs,
+`runCircuitProver`/`proverOps`): interpret a `CircuitM` tree by *running* the witness
+computations against the accumulating assignment, checking each constraint as it is added
+(PS `proverConstraint`), and erroring out on the first failure.
+
+As with the builder, the PS interpreter state (`ProverState f`, mutable refs) becomes
+explicit arguments and results: `prove` takes the next-variable counter and the current
+assignment and returns the result with the final counter and assignment — the exact
+mirror of `build : CircuitM F c α → Nat → α × Nat × List c`, which is what makes the
+interpreter-agreement laws in `Snarky.Laws` read (and prove) symmetrically.
+
+Deviations from PS, both in the direction of stronger invariants:
+- assignment is guarded (`Assignments.extendPairs`): re-assigning a variable is an error,
+  so a prover run is monotone in `Assignments.Le` — the fact the completeness theorem
+  (`Snarky.Laws.prove_sound`) rests on;
+- the constraint check is a parameter `holds : c → Assignments F → Bool` rather than a
+  `SolveCircuit` class method, keeping `c` fully abstract.
+
+Written with explicit `match` (not `do`) so the `Snarky.Laws` proofs can `split` on every
+intermediate result.
+-/
+
+namespace Snarky
+
+variable {F c : Type u}
+
+/-- The prover's output: the computation's result, the final next-variable counter, and
+the final assignment — the mirror of `Built`, with the witness table where the builder
+has the constraints. -/
+structure Proved (F : Type u) (α : Type v) where
+  result : α
+  nextVar : Nat
+  assignments : Assignments F
+
+/-- Interpret a circuit as a prover run: allocate variables in lockstep with `build`, run
+witness computations to fill the assignment, and check every added constraint with
+`holds`. Succeeds with the result, the final counter, and the final assignment iff every
+witness computation succeeds, no variable is assigned twice, and every constraint holds
+when added. -/
+def prove (holds : c → Assignments F → Bool) :
+    CircuitM F c α → Nat → Assignments F → Except EvalError (Proved F α)
+  | .pure a, nv, env => .ok ⟨a, nv, env⟩
+  | .freshOp k, nv, env => prove holds (k nv) (nv + 1) env
+  | .addConstraintOp con k, nv, env =>
+    if holds con env then prove holds k nv env
+    else .error .unsatisfiedConstraint
+  | .existsOp n wit k, nv, env =>
+    match wit env with
+    | .error e => .error e
+    | .ok xs =>
+      match env.extendPairs ((allocRange nv n).toList.zip xs.toList) with
+      | .error e => .error e
+      | .ok env' => prove holds (k (allocRange nv n)) (nv + n) env'
+  | .assignOp vs wit k, nv, env =>
+    match wit env with
+    | .error e => .error e
+    | .ok xs =>
+      match env.extendPairs (vs.toList.zip xs.toList) with
+      | .error e => .error e
+      | .ok env' => prove holds k nv env'
+  | .labelOp _ k, nv, env => prove holds k nv env
+
+end Snarky

--- a/formal/scripts/check_axioms.lean
+++ b/formal/scripts/check_axioms.lean
@@ -12,6 +12,7 @@ and the Pasta GLV endomorphism inputs. This subsumes the old `sorryAx` grep: a `
 Run from `formal/`:  lake env lean scripts/check_axioms.lean   (or: scripts/check_axioms.sh)
 -/
 import Kimchi
+import Snarky
 
 open Lean Lean.Elab.Command
 
@@ -92,7 +93,13 @@ def roots : List Name :=
     `Kimchi.Verifier.ipaPallas_sound,
     `Kimchi.Verifier.Equation.verifierEquation_iff,
     `Kimchi.Verifier.Equation.satisfies_of_verifierEquation,
-    `Kimchi.Verifier.kimchiProof_sound ]
+    `Kimchi.Verifier.kimchiProof_sound,
+    -- The Snarky DSL library (see Snarky/Laws.lean): the interpreter laws.
+    `Snarky.build_eraseWitness,
+    `Snarky.prove_assignments_le,
+    `Snarky.prove_build_agrees,
+    `Snarky.prove_sound,
+    `Snarky.CVar.eval_le ]
 
 /-- The only axioms the roots may depend on: the standard logical axioms; the Pasta Hasse bounds
     (`{pallas,vesta}_hasse`); `Lean.ofReduceBool`; and the Pasta CM eigenvalue relations


### PR DESCRIPTION
Stacked on #225. The two pure interpreters over the reified `CircuitM` tree, and the theorems that justify the deep embedding.

## Interpreters

- **`Snarky/Builder.lean`** — `build : CircuitM F c α → Nat → Built c α`, the PS `runCircuitBuilder`/`builderOps` without `Effect`/`Ref`s: allocates variables sequentially, collects constraints in emission order, and (like PS) never touches a witness payload. `Built` is a named-field result (`result`/`nextVar`/`constraints`), so downstream statements read `(build m nv).constraints` rather than `.2.2`. The constraint list is the DSL-level view — the natural first comparison point against a PS-side dump.
- **`Snarky/Prover.lean`** — `prove : … → Nat → Assignments F → Except EvalError (Proved F α)`, the PS `runCircuitProver`/`proverOps`: runs witness computations against the accumulating `Assignments`, checks each constraint with a caller-supplied `holds : c → Assignments F → Bool` as it is added (PS `proverConstraint`), and errors on any re-assignment — a deliberately *stronger* invariant than PS, which is what makes runs monotone. `Proved` mirrors `Built` field-for-field (`result`/`nextVar`/`assignments`), making the agreement laws read symmetrically.
- `CVar.lean` grows the assignment-extension order `Assignments.Le`, the guarded `extendPairs` (consuming a zipped `(variable, value)` pair list, so pairing allocation with witness values is total by construction — per review, the only failure mode is a genuine re-assignment), and `CVar.eval_le` (evaluation is stable under extension).

## The laws (`Snarky/Laws.lean`)

1. **`build_eraseWitness`** — witness-independence: `build` factors through `eraseWitness`, the function stripping every `AsProver` payload from the tree, so circuits with equal erasures build identical constraint systems (`build_eq_of_eraseWitness`; for literal circuits differing only in witness code the erasure equality is `rfl`). In PS this is an intention; here it is a structural induction — and per review, stated with an erasure *function* rather than an auxiliary shape relation.
2. **`prove_build_agrees`** — on a successful prover run, builder and prover compute the same result and allocate variables in lockstep.
3. **`prove_sound`** — completeness: if the prover run succeeds, the *final* assignment satisfies *every* constraint the builder emits (each constraint was checked at emission time; `prove_assignments_le` + monotonicity of `holds` carry the check to the end). Once `c` is instantiated at Kimchi gate rows, this is the bridge toward `Kimchi.Index.Satisfies`.

## Verification

- `lake build` clean, `scripts/check-style.sh` clean
- All five theorems wired into `scripts/check_axioms.lean`; closure is `[propext]` (no `Classical.choice`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019r9D9Ds4BBjv97ZWPMEMQN

