### PR TITLE
formal: snarky DSL port, 5 — the soundness bridge to Kimchi's Generic gate

### DIFF
--- a/formal/Snarky/Kimchi/Example.lean
+++ b/formal/Snarky/Kimchi/Example.lean
@@ -1,4 +1,4 @@
-import Snarky.Kimchi.Backend
+import Snarky.Kimchi.Soundness
 import Snarky.DSL
 
 /-!
@@ -6,9 +6,10 @@ import Snarky.DSL
 
 The `Snarky.Example` multiply circuit, rebuilt against the `GateConstraint` backend and
 carried through to Kimchi's Generic gate: build the circuit, dump its constraints, run the
-prover, translate each emitted constraint to a `Gate.Generic` row against the prover's
-assignment, and `decide` that the whole gate list is satisfied (`Gate.satisfies`). Every
-check reduces, so the file is a regression test for the bridge's executable semantics.
+prover, translate the constraint list against the prover's assignment (`toCircuit`), and
+`decide` that the whole gate list is satisfied (`Gate.satisfies`). Every check reduces, so
+the file is a regression test for the executable semantics of both `Backend` and
+`Soundness`.
 -/
 
 namespace Snarky.Kimchi.Example
@@ -32,10 +33,10 @@ def solved : Assignments F17 :=
   | .ok ⟨_, _, env⟩ => env
   | .error _ => Assignments.empty
 
-/-- Translate every emitted constraint to a Generic gate row against the solved
-assignment (`none` would signal an unevaluable operand — does not happen here). -/
+/-- The circuit's constraints as Generic gate rows against the solved assignment
+(`none` would signal an unevaluable operand — does not happen here). -/
 def rows : Option (List (Generic F17)) :=
-  (constraints mulCircuit).mapM (·.toRow solved)
+  toCircuit (constraints mulCircuit) solved
 
 /-! ## Running it -/
 
@@ -46,7 +47,8 @@ example : (prove GateConstraint.holds mulCircuit 0 Assignments.empty).isOk = tru
 example : (constraints mulCircuit).length = 2 := by decide
 
 /-- Every constraint translates to a Generic row, and the resulting gate list is
-satisfied — the DSL circuit is a valid Kimchi Generic-gate circuit. -/
+satisfied — the DSL circuit is a valid Kimchi Generic-gate circuit, `decide`d end to
+end (the concrete instance of `satisfies_of_prove`). -/
 example : ∃ gs, rows = some gs ∧ Kimchi.Gate.satisfies gs = true := by decide
 
 end Snarky.Kimchi.Example

--- a/formal/Snarky/Kimchi/Soundness.lean
+++ b/formal/Snarky/Kimchi/Soundness.lean
@@ -1,0 +1,73 @@
+import Snarky.Kimchi.Backend
+import Snarky.Laws
+
+/-!
+# The soundness bridge: a successful prover run is a satisfied Kimchi gate list
+
+The headline of the port's Kimchi bridge. `Snarky.prove_sound` says a successful prover
+run's final assignment satisfies every constraint the builder emits; `holds_iff_row`
+(from `Snarky.Kimchi.Backend`) says each such constraint, evaluated, is a satisfying
+Generic gate row. Composing them: **a DSL circuit whose prover run succeeds translates to
+a list of `Kimchi.Gate.Generic` rows that all `Hold`** (`satisfies_of_prove`) — i.e. the
+DSL builds genuine, satisfiable Kimchi Generic-gate circuits, and the prover's witness is
+a satisfying assignment for them.
+
+`Gate.Generic.Holds` is the predicate `Kimchi.Index.rowSatisfies` uses for generic rows,
+so this lands on the same semantics the rest of the Kimchi stack (quotient, verifier)
+consumes. As in `Backend.lean`, the bridge is to the **un-wired** gate list; copy
+constraints (variable sharing as wiring) are the deferred `Index` step. The executable
+demos live in `Snarky.Kimchi.Example`.
+-/
+
+namespace Snarky.Kimchi
+
+open Snarky
+
+variable {F : Type*} [Field F] [DecidableEq F]
+
+/-- Translate a whole constraint list into a Generic gate circuit against an assignment:
+each constraint becomes one row (`GateConstraint.toRow`), `none` if any operand fails to
+evaluate. The failure case exists because `env` is arbitrary here — a constraint can
+mention a variable `env` never assigned; after a *successful prover run* it cannot fire,
+and that is a theorem (`toCircuit_sound` produces the `some`), not a default. Structural
+recursion (not `mapM`) so it reduces under `decide` and inducts cleanly. -/
+def toCircuit : List (GateConstraint F) → Assignments F → Option (List (Kimchi.Gate.Generic F))
+  | [], _ => some []
+  | con :: rest, env =>
+    match con.toRow env with
+    | some row => (toCircuit rest env).map (row :: ·)
+    | none => none
+
+/-- If every constraint in a list holds against `env`, the list translates to a Generic
+gate circuit that is satisfied — the list-level lift of `holds_iff_row`. -/
+theorem toCircuit_sound {L : List (GateConstraint F)} {env : Assignments F}
+    (hall : ∀ con ∈ L, con.holds env = true) :
+    ∃ rows, toCircuit L env = some rows ∧ Kimchi.Gate.Satisfies rows := by
+  induction L with
+  | nil => exact ⟨[], rfl, by intro g hg; cases hg⟩
+  | cons con rest ih =>
+    obtain ⟨row, hrow, hholds⟩ :=
+      (con.holds_iff_row env).mp (hall con (List.mem_cons_self ..))
+    obtain ⟨rows, hrows, hsat⟩ := ih fun c hc => hall c (List.mem_cons_of_mem _ hc)
+    refine ⟨row :: rows, ?_, ?_⟩
+    · simp only [toCircuit, hrow, hrows, Option.map_some]
+    · intro g hg
+      rcases List.mem_cons.mp hg with rfl | hg
+      · exact hholds
+      · exact hsat g hg
+
+/-- **The soundness bridge.** If the prover run of a DSL circuit (over the Kimchi
+Generic-gate backend) succeeds, then the constraints the builder emits translate — against
+the prover's final assignment — to a list of Generic gate rows that all `Hold`. The DSL
+produces satisfiable Kimchi Generic-gate circuits, and the prover's witness satisfies
+them. -/
+theorem satisfies_of_prove {α : Type*} {m : CircuitM F (GateConstraint F) α}
+    {nv nv' : Nat} {env env' : Assignments F} {x : α}
+    (h : prove GateConstraint.holds m nv env = .ok ⟨x, nv', env'⟩) :
+    ∃ rows, toCircuit (build m nv).constraints env' = some rows
+      ∧ Kimchi.Gate.Satisfies rows :=
+  toCircuit_sound
+    (prove_sound (holds := GateConstraint.holds)
+      (fun _con _ _ hle hh => GateConstraint.holds_mono hle hh) h)
+
+end Snarky.Kimchi

--- a/formal/scripts/check_axioms.lean
+++ b/formal/scripts/check_axioms.lean
@@ -13,6 +13,7 @@ Run from `formal/`:  lake env lean scripts/check_axioms.lean   (or: scripts/chec
 -/
 import Kimchi
 import Snarky
+import Snarky.Kimchi.Soundness
 
 open Lean Lean.Elab.Command
 
@@ -99,7 +100,11 @@ def roots : List Name :=
     `Snarky.prove_assignments_le,
     `Snarky.prove_build_agrees,
     `Snarky.prove_sound,
-    `Snarky.CVar.eval_le ]
+    `Snarky.CVar.eval_le,
+    -- The Kimchi Generic-gate bridge (Snarky/Kimchi/): a successful prover run is a
+    -- satisfied Generic gate list.
+    `Snarky.Kimchi.GateConstraint.holds_iff_row,
+    `Snarky.Kimchi.satisfies_of_prove ]
 
 /-- The only axioms the roots may depend on: the standard logical axioms; the Pasta Hasse bounds
     (`{pallas,vesta}_hasse`); `Lean.ofReduceBool`; and the Pasta CM eigenvalue relations


### PR DESCRIPTION
Stacked on #234. The headline of the Kimchi bridge — and the payoff the whole `Snarky` port was pointing at.

## What it proves

Composes two results already in the stack:
- **`Snarky.prove_sound`** (#226) — a successful prover run's final assignment satisfies every constraint the builder emits;
- **`GateConstraint.holds_iff_row`** (#234) — each such constraint, evaluated, is a satisfying `Gate.Generic` row.

into the headline:

> **`satisfies_of_prove`** — if the prover run of a DSL circuit (over the Generic-gate backend) succeeds, then the constraints the builder emits translate, against the prover's final assignment, to a list of `Kimchi.Gate.Generic` rows that all `Hold`.

So the DSL builds genuine, satisfiable Kimchi Generic-gate circuits, and the prover's witness is a satisfying assignment for them. `Gate.Generic.Holds` is exactly the predicate `Kimchi.Index.rowSatisfies` dispatches to for generic rows, so this lands on the same semantics the quotient and verifier layers consume.

## Pieces

- **`toCircuit`** — a structural (not `mapM`) translation of a constraint list to a Generic gate circuit against an assignment; structural so it reduces under `decide` and inducts cleanly.
- **`toCircuit_sound`** — the list-level lift of `holds_iff_row`.
- A concrete end-to-end `decide` example (the mul circuit's constraints → a satisfied gate list).

## Scope (unchanged from #234)

Bridges to the **un-wired** `Gate.Satisfies (List Generic)`. Variable sharing holds by construction but is not enforced as a copy constraint; the wired `Kimchi.Index` bridge (domain synthesis + placement) remains future work.

## Verification

- `lake build Snarky` clean, `scripts/check-style.sh` clean
- `scripts/check_axioms.sh` green: **92 roots**, `satisfies_of_prove` and `holds_iff_row` added; closure `[propext, Quot.sound]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019r9D9Ds4BBjv97ZWPMEMQN