### PR TITLE
formal: snarky DSL port, 7 — compilation is honest (satisfies_of_compile)

### DIFF
--- a/formal/CLAUDE.md
+++ b/formal/CLAUDE.md
@@ -16,11 +16,18 @@ tree `CircuitM` (constraint type kept abstract), pure `build`/`prove` interprete
 mirroring `Snarky.Backend.Builder`/`Prover`, and the interpreter laws in
 `Snarky/Laws.lean` (witness-independence of the builder, builder/prover allocation
 agreement, and completeness: a successful prover run satisfies every built constraint).
-It is **Mathlib-free by design** (core Lean only, builds in seconds) — keep it that way;
-concrete backends live in downstream files (see `Snarky/Constraint/R1CS.lean` for the
-plain R1CS model). Kernel-reducibility matters there: everything is validated by `decide`, so avoid
-core functions compiled by well-founded recursion in executable paths (e.g. `Vector.map`
-— use `Snarky.mapVec` from `Snarky/Vec.lean`).
+The core (`import Snarky`) is **Mathlib-free by design** (core Lean only, builds in
+seconds) — keep it that way; concrete backends live in downstream files (see
+`Snarky/Constraint/R1CS.lean` for the plain R1CS model). Kernel-reducibility matters
+there: everything is validated by `decide`, so avoid core functions compiled by
+well-founded recursion in executable paths (e.g. `Vector.map` — use `Snarky.mapVec`
+from `Snarky/Vec.lean`). The `Snarky/Kimchi/` bridge (which imports `Kimchi`, built via
+the lib's glob) instantiates the constraint type at a symbolic Generic gate and lands on
+the `Kimchi` stack twice: `Soundness.lean` on the un-wired gate list
+(`satisfies_of_prove`), and `Compile.lean`/`CompileSound.lean` on a wired `Kimchi.Index`
+— `compile` builds the gate table, copy-cycle wiring, and witness table, `Index.build?`
+decides the laws, and `satisfies_of_compile` proves the honest prover's table satisfies
+the compiled index (validated executably by `scripts/check_snarky_index.sh`).
 
 Build: `make lean-build` (from repo root) or `lake build` (from `formal/`). The toolchain
 is pinned in `lean-toolchain` (Lean `v4.30.0`, the official tag); deps in `lakefile.toml`

--- a/formal/Snarky/Kimchi/CompileSound.lean
+++ b/formal/Snarky/Kimchi/CompileSound.lean
@@ -1,0 +1,209 @@
+import Snarky.Kimchi.Compile
+import Snarky.Laws
+
+/-!
+# Compilation is honest: a successful prover run satisfies the compiled index
+
+The general theorem behind `Snarky.Kimchi.Compile.check`: whenever `compile` succeeds on
+a DSL circuit, the witness table it stores **satisfies the wired index it built** —
+`Kimchi.Index.Satisfies`, copy constraints included (`satisfies_of_compile`).
+
+The three conjuncts of `Satisfies` are proved separately:
+
+* **rows** (`rowSatisfies_gateTableOf`) — constraint rows are Generic gates whose cells
+  hold the operand evaluations, so `GateConstraint.holds` (delivered for every emitted
+  constraint by `Snarky.prove_sound`) is exactly the row's `Gate.Generic.Holds`; padding
+  rows are constraint-free `zero` gates.
+* **copy** (`cellValue_wireOf`) — *unconditional*: a wired-together pair of cells holds
+  the same variable (`cellVar_wireOf`, because a copy cycle `cellsOf` is closed under its
+  own cyclic successor `nextIn`), and `tabOf` reads a cell through its variable, so both
+  cells carry the same value whatever the assignment.
+* **public** — vacuous: `compile` builds indices with `publicCount = 0`.
+
+The provenance is definitional: `Index.build?` stores the constructed `gateTableOf`
+verbatim (`build?_gates`), so the index's rows, coefficients, and wiring are the
+compiler's own functions.
+-/
+
+namespace Snarky.Kimchi.Compile
+
+open Snarky Snarky.Kimchi Kimchi.Index CompElliptic.Fields.Pasta
+
+/-! ## `Index.build?` provenance -/
+
+/-- `Index.build?` stores its arguments verbatim: a built index's gate table and public
+count are the ones supplied. -/
+theorem build?_gates {F : Type*} [Field F] [DecidableEq F] {n : ℕ}
+    {gates : Fin n → GateRow F n} {pc zk : ℕ} {ω e : F} {sh : Fin 7 → F} {idx : Index F n}
+    (h : Index.build? gates pc zk ω e sh = some idx) :
+    idx.gates = gates ∧ idx.publicCount = pc := by
+  unfold Index.build? at h
+  split at h
+  · injection h with h'
+    subst h'
+    exact ⟨rfl, rfl⟩
+  · cases h
+
+/-! ## The copy conjunct -/
+
+/-- Every cell is enumerated. -/
+theorem mem_allCells {n : ℕ} (c : Fin 7 × Fin n) : c ∈ allCells n :=
+  List.mem_flatMap.mpr
+    ⟨c.2, List.mem_finRange c.2, List.mem_map.mpr ⟨c.1, List.mem_finRange c.1, rfl⟩⟩
+
+/-- A cell is in `v`'s copy cycle exactly when it holds `v`. -/
+theorem mem_cellsOf {cons : List (GateConstraint Fp)} {n : ℕ} {v : Variable}
+    {c : Fin 7 × Fin n} : c ∈ cellsOf cons n v ↔ cellVar cons c = some v := by
+  simp [cellsOf, List.mem_filter, mem_allCells]
+
+/-- The cyclic successor stays in the list. -/
+theorem nextIn_mem {β : Type*} [BEq β] [LawfulBEq β] {l : List β} {c : β} (hc : c ∈ l) :
+    nextIn l c ∈ l := by
+  have hlen : 0 < l.length := List.length_pos_of_mem hc
+  rw [nextIn, List.getD_eq_getElem _ _ (Nat.mod_lt _ hlen)]
+  exact List.getElem_mem _
+
+/-- The wiring successor of a cell holding `v` holds `v` too — a copy cycle is closed
+under its own successor map. -/
+theorem cellVar_wireOf {cons : List (GateConstraint Fp)} {n : ℕ} {c : Fin 7 × Fin n}
+    {v : Variable} (h : cellVar cons c = some v) :
+    cellVar cons (wireOf cons c) = some v := by
+  have hw : wireOf cons c = nextIn (cellsOf cons n v) c := by
+    unfold wireOf
+    rw [h]
+  rw [hw]
+  exact mem_cellsOf.mp (nextIn_mem (mem_cellsOf.mpr h))
+
+/-- `tabOf` reads a variable-holding cell through its variable: the cell's value is the
+variable's evaluation, whatever the assignment. -/
+theorem cellValue_tabOf {cons : List (GateConstraint Fp)} {env : Assignments Fp} {n : ℕ}
+    {c : Fin 7 × Fin n} {v : Variable} (h : cellVar cons c = some v) :
+    cellValue (tabOf cons env n) c = evalD env (some (.var v)) := by
+  have hval : cellValue (tabOf cons env n) c
+      = evalD env (cons[(c.2 : ℕ)]?.bind fun con => operandAt con (c.1 : ℕ)) := rfl
+  obtain ⟨x, hx, hxv⟩ := Option.bind_eq_some_iff.mp h
+  cases x with
+  | var v' =>
+    obtain rfl : v' = v := by simpa [varOf?] using hxv
+    rw [hval, hx]
+  | const k => simp [varOf?] at hxv
+  | add a b => simp [varOf?] at hxv
+  | scale k y => simp [varOf?] at hxv
+
+/-- **The copy conjunct, unconditionally**: wired-together cells of `tabOf` agree — both
+read the same variable's evaluation. -/
+theorem cellValue_wireOf (cons : List (GateConstraint Fp)) (env : Assignments Fp)
+    {n : ℕ} (c : Fin 7 × Fin n) :
+    cellValue (tabOf cons env n) (wireOf cons c) = cellValue (tabOf cons env n) c := by
+  cases h : cellVar cons c with
+  | none =>
+    have hw : wireOf cons c = c := by
+      unfold wireOf
+      rw [h]
+    rw [hw]
+  | some v =>
+    rw [cellValue_tabOf (cellVar_wireOf h), cellValue_tabOf h]
+
+/-! ## The row conjunct -/
+
+/-- A held constraint is a satisfied Generic row: the row whose coefficients are the
+constraint's and whose cells are `tabOf`'s reads at row `i`. -/
+theorem holds_row {cons : List (GateConstraint Fp)} {env : Assignments Fp} {n : ℕ}
+    {i : Fin n} {con : GateConstraint Fp} (hcon : cons[(i : ℕ)]? = some con)
+    (hh : con.holds env = true) :
+    Kimchi.Gate.Generic.Holds ⟨coeffsAt (some con), tabOf cons env n i⟩ := by
+  unfold GateConstraint.holds at hh
+  split at hh
+  next x y z hx hy hz =>
+    have w0 : tabOf cons env n i 0 = x := by
+      unfold tabOf
+      rw [hcon]
+      show evalD env (some con.a) = x
+      simp only [evalD, hx]
+    have w1 : tabOf cons env n i 1 = y := by
+      unfold tabOf
+      rw [hcon]
+      show evalD env (some con.b) = y
+      simp only [evalD, hy]
+    have w2 : tabOf cons env n i 2 = z := by
+      unfold tabOf
+      rw [hcon]
+      show evalD env (some con.o) = z
+      simp only [evalD, hz]
+    rw [Kimchi.Gate.Generic.holds_iff]
+    constructor
+    · show con.q0 * tabOf cons env n i 0 + con.q1 * tabOf cons env n i 1
+          + con.q2 * tabOf cons env n i 2
+          + con.q3 * (tabOf cons env n i 0 * tabOf cons env n i 1) + con.q4 = 0
+      rw [w0, w1, w2]
+      exact of_decide_eq_true hh
+    · show (0 : Fp) * tabOf cons env n i 3 + 0 * tabOf cons env n i 4
+          + 0 * tabOf cons env n i 5
+          + 0 * (tabOf cons env n i 3 * tabOf cons env n i 4) + 0 = 0
+      ring
+  next => exact absurd hh Bool.false_ne_true
+
+/-- Every row of the compiled table satisfies its gate: constraint rows through
+`holds_row`, padding rows vacuously (`zero` gates constrain nothing). -/
+theorem rowSatisfies_gateTableOf {cons : List (GateConstraint Fp)} {env : Assignments Fp}
+    {n : ℕ} [NeZero n] {idx : Index Fp n}
+    (hg : idx.gates = gateTableOf cons n) (hpc : idx.publicCount = 0)
+    (pub : Fin idx.publicCount → Fp)
+    (hall : ∀ con ∈ cons, con.holds env = true) (i : Fin n) :
+    rowSatisfies idx pub (tabOf cons env n) i := by
+  have htyp : (idx.gates i).typ = if (i : ℕ) < cons.length then .generic else .zero := by
+    rw [hg]; rfl
+  by_cases hi : (i : ℕ) < cons.length
+  · have hcon : cons[(i : ℕ)]? = some cons[(i : ℕ)] := List.getElem?_eq_getElem hi
+    have hpub : pubAt idx pub i = 0 := by
+      simp [pubAt, hpc]
+    have hq : idx.coeffTable i = coeffsAt (some cons[(i : ℕ)]) := by
+      show (idx.gates i).coeffs = _
+      rw [hg]
+      show coeffsAt cons[(i : ℕ)]? = _
+      rw [hcon]
+    unfold rowSatisfies
+    rw [htyp, if_pos hi]
+    show Kimchi.Gate.Generic.Holds
+      (Kimchi.Gate.Generic.withPublic ⟨idx.coeffTable i, tabOf cons env n i⟩
+        (pubAt idx pub i))
+    rw [hpub, Kimchi.Gate.Generic.withPublic_zero, hq]
+    exact holds_row hcon (hall cons[(i : ℕ)] (List.getElem_mem hi))
+  · unfold rowSatisfies
+    rw [htyp, if_neg hi]
+    exact trivial
+
+/-! ## The headline -/
+
+/-- **Compilation is honest.** Whenever `compile` succeeds, the witness table it stores
+satisfies the wired index it built — rows, copy constraints, and public pins. Composes
+`Snarky.prove_sound` (every emitted constraint holds on the prover's final assignment)
+with the row and copy conjuncts above; the provenance is `build?_gates`. -/
+theorem satisfies_of_compile {α : Type} {m : CircuitM Fp (GateConstraint Fp) α}
+    {out : Compiled} (h : compile m = .ok out) :
+    haveI : NeZero out.n := out.nz
+    Satisfies out.idx (fun _ => 0) out.tab := by
+  unfold compile at h
+  split at h
+  · cases h
+  next a nv env hp =>
+    split at h
+    · cases h
+    next idx hb =>
+      injection h with h'
+      subst h'
+      dsimp only
+      obtain ⟨hg, hpc⟩ := build?_gates hb
+      haveI : NeZero (paddedSize (constraints m).length) := ⟨(Nat.two_pow_pos _).ne'⟩
+      have hall : ∀ con ∈ constraints m, con.holds env = true :=
+        prove_sound (holds := GateConstraint.holds)
+          (fun _con _ _ hle hh => GateConstraint.holds_mono hle hh) hp
+      refine ⟨fun i => rowSatisfies_gateTableOf hg hpc _ hall i, fun c => ?_, fun i => ?_⟩
+      · have hw : idx.wiringMap c = wireOf (constraints m) c := by
+          show wiringMapOf idx.gates c = _
+          rw [hg]; rfl
+        rw [hw]
+        exact cellValue_wireOf (constraints m) env c
+      · exact absurd i.isLt (by omega)
+
+end Snarky.Kimchi.Compile

--- a/formal/scripts/check_axioms.lean
+++ b/formal/scripts/check_axioms.lean
@@ -14,6 +14,7 @@ Run from `formal/`:  lake env lean scripts/check_axioms.lean   (or: scripts/chec
 import Kimchi
 import Snarky
 import Snarky.Kimchi.Soundness
+import Snarky.Kimchi.CompileSound
 
 open Lean Lean.Elab.Command
 
@@ -104,7 +105,10 @@ def roots : List Name :=
     -- The Kimchi Generic-gate bridge (Snarky/Kimchi/): a successful prover run is a
     -- satisfied Generic gate list.
     `Snarky.Kimchi.GateConstraint.holds_iff_row,
-    `Snarky.Kimchi.satisfies_of_prove ]
+    `Snarky.Kimchi.satisfies_of_prove,
+    -- The wired bridge (Snarky/Kimchi/Compile*): a compiled index is satisfied by the
+    -- honest prover's witness table, copy constraints included.
+    `Snarky.Kimchi.Compile.satisfies_of_compile ]
 
 /-- The only axioms the roots may depend on: the standard logical axioms; the Pasta Hasse bounds
     (`{pallas,vesta}_hasse`); `Lean.ofReduceBool`; and the Pasta CM eigenvalue relations


### PR DESCRIPTION
Stacked on #236. The general theorem behind #236's executable `check`:

> **`satisfies_of_compile`** — whenever `compile` succeeds on a DSL circuit, the witness table it stores **satisfies the wired index it built**: `Kimchi.Index.Satisfies`, copy constraints included.

With #232's `kimchiVesta_sound` (`verify accepts + DL-binding + VKCorresponds ⟹ ∃ wTab, Satisfies idx …`), the two results now bracket `Index.Satisfies` from both sides: the DSL front-end *produces* satisfied wired indices, and the verifier *demands* satisfiable ones.

## Structure (`Snarky/Kimchi/CompileSound.lean`)

Provenance is definitional — `Index.build?` stores the constructed `gateTableOf` verbatim (`build?_gates`), so every conjunct is proved over the compiler's own functions:

- **rows** (`rowSatisfies_gateTableOf` / `holds_row`) — a constraint row's cells hold the operand evaluations, so `GateConstraint.holds` — delivered for every emitted constraint by `Snarky.prove_sound` (#226) — is exactly the row's `Gate.Generic.Holds`; padding rows are constraint-free `zero` gates.
- **copy** (`cellValue_wireOf`) — **unconditional**: a copy cycle (`cellsOf`) is closed under its own cyclic successor (`nextIn_mem`), so wired-together cells hold the same variable (`cellVar_wireOf`); and `tabOf` reads a cell *through* its variable (`cellValue_tabOf`), so both sides carry the same value whatever the assignment — the copy conjunct doesn't even need the prover to have succeeded.
- **public** — vacuous at `publicCount = 0`.

The headline composes these with `prove_sound` after inverting `compile`'s two matches.

## Verification

- full `lake build` clean, `scripts/check-style.sh` clean
- `scripts/check_axioms.sh` green: **95 roots**; `satisfies_of_compile`'s closure is exactly `[propext, Classical.choice, Quot.sound]` — no Pasta axioms, no `ofReduceBool`
- `scripts/check_snarky_index.sh` still green (the theorem's concrete instance)
- `formal/CLAUDE.md`'s Snarky paragraph now describes the full bridge

## What remains beyond this stack

Public inputs in the DSL (then `publicCount ≠ 0` and the public conjunct becomes real), a `seal` pass for affine operands, and the VK-commitment pass (`VKCorresponds` for a compiled index) that would connect a DSL-compiled circuit to #232's verifier statement end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019r9D9Ds4BBjv97ZWPMEMQN