### PR TITLE
formal: snarky DSL port, 8 — double-generic row packing

### DIFF
--- a/formal/Snarky/Kimchi/Compile.lean
+++ b/formal/Snarky/Kimchi/Compile.lean
@@ -15,40 +15,61 @@ the permutation — the object `Kimchi.Index.Satisfies` (and the verifier-soundn
 
 ## The compilation
 
-One `GateConstraint` → one Generic row: its coefficients into the row's `q₀…q₄`
-(`coeffsAt`), its operand values into witness cells `w₀ w₁ w₂` (`tabOf`). The **wiring**
-is read off variable occurrences: the cells holding a variable form its copy cycle
-(`cellsOf`, row-major), each cell pointing to the next (`nextIn`, kimchi's
-cyclic-successor encoding); cells holding constants, non-operand columns, and padding
-rows self-loop (`wireOf`). Domain synthesis follows `Kimchi.Fixture.PS.build` (rows pad
-to the smallest two-power holding the gates plus the zero-knowledge rows,
-`ω = g^((p−1)/n)`, generator-power coset shifts), and `Index.build?` *decides* every
-wellformedness law on the result — a wrong construction is a loud `.error`, never a
-trusted fact.
+Kimchi's generic gate is *double*: one physical row packs two constraint slots
+(`q₀…q₄` on cells `w₀w₁w₂` and `q₅…q₉` on `w₃w₄w₅`). So the constraint stream is first
+**packed** two-per-row (`pack`, the analogue of the PS reduction's pairing of pending
+generic constraints) and each `RowSlots` pair becomes one Generic row: the constraints'
+coefficients into the row's `q₀…q₉` (`coeffsAt`), their operand values into witness
+cells `w₀…w₅` (`tabOf`, through `slotOperand`). The **wiring** is read off variable
+occurrences: the cells holding a variable form its copy cycle (`cellsOf`, row-major),
+each cell pointing to the next (`nextIn`, kimchi's cyclic-successor encoding); cells
+holding constants, non-operand columns, and padding rows self-loop (`wireOf` — all six
+operand cells sit within the seven permutable columns, so slot-2 operands wire like
+slot-1's). Domain synthesis follows `Kimchi.Fixture.PS.build` (rows pad to the smallest
+two-power holding the gates plus the zero-knowledge rows, `ω = g^((p−1)/n)`,
+generator-power coset shifts), and `Index.build?` *decides* every wellformedness law on
+the result — a wrong construction is a loud `.error`, never a trusted fact.
 
 Unlike the fixture path (which decodes JSON through `PS.Raw`), the gate table is built
-directly as named functions of the constraint list — `gateTableOf`, `tabOf`, `wireOf` —
+directly as named functions of the packed stream — `gateTableOf`, `tabOf`, `wireOf` —
 and `Index.build?` stores `gates` verbatim, so `Snarky.Kimchi.CompileSound` can reason
 about the compiled index's rows and wiring definitionally.
 
 Scope of this first cut: `publicCount = 0` (the DSL has no public-input notion yet). The
 end-to-end `#eval` below is validated by `scripts/check_snarky_index.sh`; the general
-`Satisfies`-of-an-honest-run theorem is `Snarky.Kimchi.satisfies_of_compile`.
+`Satisfies`-of-an-honest-run theorem is `Snarky.Kimchi.Compile.satisfies_of_compile`.
 -/
 
 namespace Snarky.Kimchi.Compile
 
 open Snarky Snarky.Kimchi Kimchi.Index CompElliptic.Fields.Pasta
 
+/-! ## Packing: two constraints per physical row -/
+
+/-- One physical row's constraints: the slot-1 constraint and, when the stream had
+another pending, the slot-2 constraint (kimchi's double generic gate). -/
+abbrev RowSlots := GateConstraint Fp × Option (GateConstraint Fp)
+
+/-- Pack the constraint stream two-per-row — the analogue of the PS reduction's pairing
+of pending generic constraints. -/
+def pack : List (GateConstraint Fp) → List RowSlots
+  | c1 :: c2 :: rest => (c1, some c2) :: pack rest
+  | [c] => [(c, none)]
+  | [] => []
+
 /-! ## Cells: operands, variables, wiring -/
 
-/-- The operand expression a constraint places in witness cell `k`, if any: cells `0 1 2`
-hold `a b o`; the remaining cells hold nothing. Shared by the witness table (`Fin 15`
-cells) and the wiring (`Fin 7` cells) through the raw `ℕ` index. -/
-def operandAt (con : GateConstraint Fp) : ℕ → Option (CVar Fp)
-  | 0 => some con.a
-  | 1 => some con.b
-  | 2 => some con.o
+/-- The operand expression a packed row places in witness cell `k`, if any: cells `0 1 2`
+hold slot 1's `a b o`, cells `3 4 5` hold slot 2's; the remaining cells hold nothing.
+Shared by the witness table (`Fin 15` cells) and the wiring (`Fin 7` cells) through the
+raw `ℕ` index. -/
+def slotOperand (p : RowSlots) : ℕ → Option (CVar Fp)
+  | 0 => some p.1.a
+  | 1 => some p.1.b
+  | 2 => some p.1.o
+  | 3 => p.2.map (·.a)
+  | 4 => p.2.map (·.b)
+  | 5 => p.2.map (·.o)
   | _ => none
 
 /-- The bare variable of a `CVar`, if it is one. -/
@@ -57,19 +78,17 @@ def varOf? : CVar Fp → Option Variable
   | _ => none
 
 /-- The DSL variable a wiring cell holds: the bare-variable operand at column `c.1` of
-constraint row `c.2`, if any. -/
-def cellVar (cons : List (GateConstraint Fp)) {n : ℕ} (c : Fin 7 × Fin n) :
-    Option Variable :=
-  (cons[(c.2 : ℕ)]?.bind fun con => operandAt con (c.1 : ℕ)).bind varOf?
+packed row `c.2`, if any. -/
+def cellVar (rows : List RowSlots) {n : ℕ} (c : Fin 7 × Fin n) : Option Variable :=
+  (rows[(c.2 : ℕ)]?.bind fun p => slotOperand p (c.1 : ℕ)).bind varOf?
 
 /-- Every wiring cell, row-major — the enumeration fixing the copy-cycle order. -/
 def allCells (n : ℕ) : List (Fin 7 × Fin n) :=
   (List.finRange n).flatMap fun i => (List.finRange 7).map fun col => (col, i)
 
 /-- The copy cycle of variable `v`: every cell holding `v`, row-major. -/
-def cellsOf (cons : List (GateConstraint Fp)) (n : ℕ) (v : Variable) :
-    List (Fin 7 × Fin n) :=
-  (allCells n).filter fun c => cellVar cons c = some v
+def cellsOf (rows : List RowSlots) (n : ℕ) (v : Variable) : List (Fin 7 × Fin n) :=
+  (allCells n).filter fun c => cellVar rows c = some v
 
 /-- The cyclic successor in a list: the element after `c`, wrapping around; `c` itself
 when absent. -/
@@ -78,35 +97,40 @@ def nextIn [BEq β] (l : List β) (c : β) : β :=
 
 /-- The wiring successor of a cell: the next cell of its variable's copy cycle; the cell
 itself for constants, non-operand columns, and padding rows. -/
-def wireOf (cons : List (GateConstraint Fp)) {n : ℕ} (c : Fin 7 × Fin n) : Fin 7 × Fin n :=
-  match cellVar cons c with
-  | some v => nextIn (cellsOf cons n v) c
+def wireOf (rows : List RowSlots) {n : ℕ} (c : Fin 7 × Fin n) : Fin 7 × Fin n :=
+  match cellVar rows c with
+  | some v => nextIn (cellsOf rows n v) c
   | none => c
 
 /-! ## The gate table and the witness table -/
 
-/-- The coefficient cells of a row: the constraint's `q₀…q₄` over zeros; all-zero for
-padding rows. -/
-def coeffsAt (con? : Option (GateConstraint Fp)) : Fin 15 → Fp := fun cell =>
-  match con? with
+/-- The coefficient cells of a packed row: slot 1's `q₀…q₄` in cells `0…4`, slot 2's in
+cells `5…9`, zeros elsewhere; all-zero for padding rows. -/
+def coeffsAt (p? : Option RowSlots) : Fin 15 → Fp := fun cell =>
+  match p? with
   | none => 0
-  | some con =>
-    match (cell : ℕ) with
-    | 0 => con.q0
-    | 1 => con.q1
-    | 2 => con.q2
-    | 3 => con.q3
-    | 4 => con.q4
-    | _ => 0
+  | some p =>
+    match (cell : ℕ), p.2 with
+    | 0, _ => p.1.q0
+    | 1, _ => p.1.q1
+    | 2, _ => p.1.q2
+    | 3, _ => p.1.q3
+    | 4, _ => p.1.q4
+    | 5, some c2 => c2.q0
+    | 6, some c2 => c2.q1
+    | 7, some c2 => c2.q2
+    | 8, some c2 => c2.q3
+    | 9, some c2 => c2.q4
+    | _, _ => 0
 
-/-- The gate table at domain size `n`: one generic row per constraint, then
+/-- The gate table at domain size `n`: one generic row per packed pair, then
 constraint-free `zero` rows, all wired by `wireOf` (padding cells hold no variable, so
 they self-loop). -/
-def gateTableOf (cons : List (GateConstraint Fp)) (n : ℕ) : Fin n → GateRow Fp n :=
+def gateTableOf (rows : List RowSlots) (n : ℕ) : Fin n → GateRow Fp n :=
   fun i =>
-    { typ := if (i : ℕ) < cons.length then .generic else .zero
-      coeffs := coeffsAt cons[(i : ℕ)]?
-      wires := fun col => wireOf cons (col, i) }
+    { typ := if (i : ℕ) < rows.length then .generic else .zero
+      coeffs := coeffsAt rows[(i : ℕ)]?
+      wires := fun col => wireOf rows (col, i) }
 
 /-- Evaluate an optional operand, `0` for missing or unassigned — an honest prover run
 assigns every operand (`GateConstraint.holds` forces evaluation), so the default is never
@@ -118,15 +142,15 @@ def evalD (env : Assignments Fp) : Option (CVar Fp) → Fp
     | .error _ => 0
   | none => 0
 
-/-- The witness table: operand values in cells `0 1 2` of each constraint row, zeros
-everywhere else. -/
-def tabOf (cons : List (GateConstraint Fp)) (env : Assignments Fp) (n : ℕ) :
+/-- The witness table: operand values in cells `0…5` of each packed row, zeros everywhere
+else. -/
+def tabOf (rows : List RowSlots) (env : Assignments Fp) (n : ℕ) :
     Fin n → Fin 15 → Fp :=
-  fun i cell => evalD env (cons[(i : ℕ)]?.bind fun con => operandAt con (cell : ℕ))
+  fun i cell => evalD env (rows[(i : ℕ)]?.bind fun p => slotOperand p (cell : ℕ))
 
 /-! ## Domain synthesis and the compiler -/
 
-/-- The padded domain size: the smallest two-power holding the constraint rows plus the
+/-- The padded domain size: the smallest two-power holding the packed rows plus the
 zero-knowledge rows (as `Kimchi.Fixture.PS.build`). -/
 def paddedSize (rows : ℕ) : ℕ :=
   2 ^ Nat.clog 2 (rows + Kimchi.Fixture.PS.zkRows)
@@ -147,25 +171,27 @@ structure Compiled where
   idx : Index Fp n
   tab : Fin n → Fin 15 → Fp
 
-/-- Compile a DSL circuit to a wired index: run the prover for the assignment, build the
-gate table and wiring, and let `Index.build?` decide every wellformedness law. `.error`
-if the prover fails or a law is rejected. -/
+/-- Compile a DSL circuit to a wired index: run the prover for the assignment, pack the
+constraint stream, build the gate table and wiring, and let `Index.build?` decide every
+wellformedness law. `.error` if the prover fails or a law is rejected. -/
 def compile {α : Type} (m : CircuitM Fp (GateConstraint Fp) α) : Except String Compiled :=
   match prove GateConstraint.holds m 0 Assignments.empty with
   | .error _ => .error "compile: the prover failed"
   | .ok ⟨_, _, env⟩ =>
-    match Index.build? (gateTableOf (constraints m) (paddedSize (constraints m).length)) 0
-        Kimchi.Fixture.PS.zkRows (domainOmega (paddedSize (constraints m).length))
+    match Index.build?
+        (gateTableOf (pack (constraints m)) (paddedSize (pack (constraints m)).length)) 0
+        Kimchi.Fixture.PS.zkRows (domainOmega (paddedSize (pack (constraints m)).length))
         Kimchi.Pasta.pallas_endo domainShifts with
     | none => .error "compile: Index.build? rejected the construction"
     | some idx =>
-      .ok ⟨paddedSize (constraints m).length, ⟨(Nat.two_pow_pos _).ne'⟩, idx,
-        tabOf (constraints m) env (paddedSize (constraints m).length)⟩
+      .ok ⟨paddedSize (pack (constraints m)).length, ⟨(Nat.two_pow_pos _).ne'⟩, idx,
+        tabOf (pack (constraints m)) env (paddedSize (pack (constraints m)).length)⟩
 
 /-! ## End-to-end example (validated by `scripts/check_snarky_index.sh`) -/
 
 /-- Witness `x = 3`, `y = 5`, `z = x·y`, assert `z = 15` — over `Fp`, the field the index
-lives in. -/
+lives in. Its two constraints pack into one physical row, with `z` copy-wired between
+slot 1's output cell (`w₂`) and slot 2's left cell (`w₃`). -/
 def mulCircuit : CircuitM Fp (GateConstraint Fp) (FVar Fp) := do
   let x ← witness (val := Fp) (pure 3)
   let y ← witness (val := Fp) (pure 5)

--- a/formal/Snarky/Kimchi/CompileSound.lean
+++ b/formal/Snarky/Kimchi/CompileSound.lean
@@ -10,10 +10,12 @@ a DSL circuit, the witness table it stores **satisfies the wired index it built*
 
 The three conjuncts of `Satisfies` are proved separately:
 
-* **rows** (`rowSatisfies_gateTableOf`) — constraint rows are Generic gates whose cells
-  hold the operand evaluations, so `GateConstraint.holds` (delivered for every emitted
-  constraint by `Snarky.prove_sound`) is exactly the row's `Gate.Generic.Holds`; padding
-  rows are constraint-free `zero` gates.
+* **rows** (`rowSatisfies_gateTableOf`) — a packed row's cells hold its two slots'
+  operand evaluations, so `GateConstraint.holds` of both slot constraints (delivered for
+  every emitted constraint by `Snarky.prove_sound`, threaded through the packing by
+  `pack_mem`) is exactly the row's `Gate.Generic.Holds` — slot 1 in cells `w₀w₁w₂`
+  against `q₀…q₄`, slot 2 in `w₃w₄w₅` against `q₅…q₉` (trivial when the slot is empty);
+  padding rows are constraint-free `zero` gates.
 * **copy** (`cellValue_wireOf`) — *unconditional*: a wired-together pair of cells holds
   the same variable (`cellVar_wireOf`, because a copy cycle `cellsOf` is closed under its
   own cyclic successor `nextIn`), and `tabOf` reads a cell through its variable, so both
@@ -52,8 +54,8 @@ theorem mem_allCells {n : ℕ} (c : Fin 7 × Fin n) : c ∈ allCells n :=
     ⟨c.2, List.mem_finRange c.2, List.mem_map.mpr ⟨c.1, List.mem_finRange c.1, rfl⟩⟩
 
 /-- A cell is in `v`'s copy cycle exactly when it holds `v`. -/
-theorem mem_cellsOf {cons : List (GateConstraint Fp)} {n : ℕ} {v : Variable}
-    {c : Fin 7 × Fin n} : c ∈ cellsOf cons n v ↔ cellVar cons c = some v := by
+theorem mem_cellsOf {rows : List RowSlots} {n : ℕ} {v : Variable}
+    {c : Fin 7 × Fin n} : c ∈ cellsOf rows n v ↔ cellVar rows c = some v := by
   simp [cellsOf, List.mem_filter, mem_allCells]
 
 /-- The cyclic successor stays in the list. -/
@@ -65,10 +67,10 @@ theorem nextIn_mem {β : Type*} [BEq β] [LawfulBEq β] {l : List β} {c : β} (
 
 /-- The wiring successor of a cell holding `v` holds `v` too — a copy cycle is closed
 under its own successor map. -/
-theorem cellVar_wireOf {cons : List (GateConstraint Fp)} {n : ℕ} {c : Fin 7 × Fin n}
-    {v : Variable} (h : cellVar cons c = some v) :
-    cellVar cons (wireOf cons c) = some v := by
-  have hw : wireOf cons c = nextIn (cellsOf cons n v) c := by
+theorem cellVar_wireOf {rows : List RowSlots} {n : ℕ} {c : Fin 7 × Fin n}
+    {v : Variable} (h : cellVar rows c = some v) :
+    cellVar rows (wireOf rows c) = some v := by
+  have hw : wireOf rows c = nextIn (cellsOf rows n v) c := by
     unfold wireOf
     rw [h]
   rw [hw]
@@ -76,11 +78,11 @@ theorem cellVar_wireOf {cons : List (GateConstraint Fp)} {n : ℕ} {c : Fin 7 ×
 
 /-- `tabOf` reads a variable-holding cell through its variable: the cell's value is the
 variable's evaluation, whatever the assignment. -/
-theorem cellValue_tabOf {cons : List (GateConstraint Fp)} {env : Assignments Fp} {n : ℕ}
-    {c : Fin 7 × Fin n} {v : Variable} (h : cellVar cons c = some v) :
-    cellValue (tabOf cons env n) c = evalD env (some (.var v)) := by
-  have hval : cellValue (tabOf cons env n) c
-      = evalD env (cons[(c.2 : ℕ)]?.bind fun con => operandAt con (c.1 : ℕ)) := rfl
+theorem cellValue_tabOf {rows : List RowSlots} {env : Assignments Fp} {n : ℕ}
+    {c : Fin 7 × Fin n} {v : Variable} (h : cellVar rows c = some v) :
+    cellValue (tabOf rows env n) c = evalD env (some (.var v)) := by
+  have hval : cellValue (tabOf rows env n) c
+      = evalD env (rows[(c.2 : ℕ)]?.bind fun p => slotOperand p (c.1 : ℕ)) := rfl
   obtain ⟨x, hx, hxv⟩ := Option.bind_eq_some_iff.mp h
   cases x with
   | var v' =>
@@ -92,12 +94,12 @@ theorem cellValue_tabOf {cons : List (GateConstraint Fp)} {env : Assignments Fp}
 
 /-- **The copy conjunct, unconditionally**: wired-together cells of `tabOf` agree — both
 read the same variable's evaluation. -/
-theorem cellValue_wireOf (cons : List (GateConstraint Fp)) (env : Assignments Fp)
+theorem cellValue_wireOf (rows : List RowSlots) (env : Assignments Fp)
     {n : ℕ} (c : Fin 7 × Fin n) :
-    cellValue (tabOf cons env n) (wireOf cons c) = cellValue (tabOf cons env n) c := by
-  cases h : cellVar cons c with
+    cellValue (tabOf rows env n) (wireOf rows c) = cellValue (tabOf rows env n) c := by
+  cases h : cellVar rows c with
   | none =>
-    have hw : wireOf cons c = c := by
+    have hw : wireOf rows c = c := by
       unfold wireOf
       rw [h]
     rw [hw]
@@ -106,69 +108,118 @@ theorem cellValue_wireOf (cons : List (GateConstraint Fp)) (env : Assignments Fp
 
 /-! ## The row conjunct -/
 
-/-- A held constraint is a satisfied Generic row: the row whose coefficients are the
-constraint's and whose cells are `tabOf`'s reads at row `i`. -/
-theorem holds_row {cons : List (GateConstraint Fp)} {env : Assignments Fp} {n : ℕ}
-    {i : Fin n} {con : GateConstraint Fp} (hcon : cons[(i : ℕ)]? = some con)
-    (hh : con.holds env = true) :
-    Kimchi.Gate.Generic.Holds ⟨coeffsAt (some con), tabOf cons env n i⟩ := by
-  unfold GateConstraint.holds at hh
-  split at hh
-  next x y z hx hy hz =>
-    have w0 : tabOf cons env n i 0 = x := by
-      unfold tabOf
-      rw [hcon]
-      show evalD env (some con.a) = x
-      simp only [evalD, hx]
-    have w1 : tabOf cons env n i 1 = y := by
-      unfold tabOf
-      rw [hcon]
-      show evalD env (some con.b) = y
-      simp only [evalD, hy]
-    have w2 : tabOf cons env n i 2 = z := by
-      unfold tabOf
-      rw [hcon]
-      show evalD env (some con.o) = z
-      simp only [evalD, hz]
-    rw [Kimchi.Gate.Generic.holds_iff]
-    constructor
-    · show con.q0 * tabOf cons env n i 0 + con.q1 * tabOf cons env n i 1
-          + con.q2 * tabOf cons env n i 2
-          + con.q3 * (tabOf cons env n i 0 * tabOf cons env n i 1) + con.q4 = 0
-      rw [w0, w1, w2]
-      exact of_decide_eq_true hh
-    · show (0 : Fp) * tabOf cons env n i 3 + 0 * tabOf cons env n i 4
-          + 0 * tabOf cons env n i 5
-          + 0 * (tabOf cons env n i 3 * tabOf cons env n i 4) + 0 = 0
-      ring
-  next => exact absurd hh Bool.false_ne_true
+/-- Packing preserves membership: every slot constraint of a packed row came from the
+constraint stream. -/
+theorem pack_mem {cons : List (GateConstraint Fp)} {p : RowSlots} (hp : p ∈ pack cons) :
+    p.1 ∈ cons ∧ ∀ c ∈ p.2, c ∈ cons := by
+  induction cons using pack.induct with
+  | case1 c1 c2 rest ih =>
+    rcases List.mem_cons.mp hp with rfl | hp'
+    · refine ⟨List.mem_cons_self .., fun c hc => ?_⟩
+      obtain rfl : c2 = c := by simpa using hc
+      exact List.mem_cons_of_mem _ (List.mem_cons_self ..)
+    · obtain ⟨h1, h2⟩ := ih hp'
+      exact ⟨List.mem_cons_of_mem _ (List.mem_cons_of_mem _ h1),
+        fun c hc => List.mem_cons_of_mem _ (List.mem_cons_of_mem _ (h2 c hc))⟩
+  | case2 c =>
+    obtain rfl : p = (c, none) := by simpa [pack] using hp
+    exact ⟨List.mem_cons_self .., fun c' hc' => by simp at hc'⟩
+  | case3 => cases hp
 
-/-- Every row of the compiled table satisfies its gate: constraint rows through
-`holds_row`, padding rows vacuously (`zero` gates constrain nothing). -/
-theorem rowSatisfies_gateTableOf {cons : List (GateConstraint Fp)} {env : Assignments Fp}
+/-- A held pair of slot constraints is a satisfied Generic row: slot 1 in cells
+`w₀w₁w₂` against `q₀…q₄`, slot 2 in `w₃w₄w₅` against `q₅…q₉` (trivial when empty). -/
+theorem holds_row {rows : List RowSlots} {env : Assignments Fp} {n : ℕ}
+    {i : Fin n} {p : RowSlots} (hrow : rows[(i : ℕ)]? = some p)
+    (h1 : p.1.holds env = true) (h2 : ∀ c ∈ p.2, c.holds env = true) :
+    Kimchi.Gate.Generic.Holds ⟨coeffsAt (some p), tabOf rows env n i⟩ := by
+  obtain ⟨c1, oc2⟩ := p
+  rw [Kimchi.Gate.Generic.holds_iff]
+  refine ⟨?_, ?_⟩
+  · unfold GateConstraint.holds at h1
+    split at h1
+    next x y z hx hy hz =>
+      have w0 : tabOf rows env n i 0 = x := by
+        unfold tabOf
+        rw [hrow]
+        show evalD env (some c1.a) = x
+        simp only [evalD, hx]
+      have w1 : tabOf rows env n i 1 = y := by
+        unfold tabOf
+        rw [hrow]
+        show evalD env (some c1.b) = y
+        simp only [evalD, hy]
+      have w2 : tabOf rows env n i 2 = z := by
+        unfold tabOf
+        rw [hrow]
+        show evalD env (some c1.o) = z
+        simp only [evalD, hz]
+      show c1.q0 * tabOf rows env n i 0 + c1.q1 * tabOf rows env n i 1
+          + c1.q2 * tabOf rows env n i 2
+          + c1.q3 * (tabOf rows env n i 0 * tabOf rows env n i 1) + c1.q4 = 0
+      rw [w0, w1, w2]
+      exact of_decide_eq_true h1
+    next => exact absurd h1 Bool.false_ne_true
+  · cases oc2 with
+    | none =>
+      show (0 : Fp) * tabOf rows env n i 3 + 0 * tabOf rows env n i 4
+          + 0 * tabOf rows env n i 5
+          + 0 * (tabOf rows env n i 3 * tabOf rows env n i 4) + 0 = 0
+      ring
+    | some c2 =>
+      have hh2 := h2 c2 rfl
+      unfold GateConstraint.holds at hh2
+      split at hh2
+      next x y z hx hy hz =>
+        have w3 : tabOf rows env n i 3 = x := by
+          unfold tabOf
+          rw [hrow]
+          show evalD env (some c2.a) = x
+          simp only [evalD, hx]
+        have w4 : tabOf rows env n i 4 = y := by
+          unfold tabOf
+          rw [hrow]
+          show evalD env (some c2.b) = y
+          simp only [evalD, hy]
+        have w5 : tabOf rows env n i 5 = z := by
+          unfold tabOf
+          rw [hrow]
+          show evalD env (some c2.o) = z
+          simp only [evalD, hz]
+        show c2.q0 * tabOf rows env n i 3 + c2.q1 * tabOf rows env n i 4
+            + c2.q2 * tabOf rows env n i 5
+            + c2.q3 * (tabOf rows env n i 3 * tabOf rows env n i 4) + c2.q4 = 0
+        rw [w3, w4, w5]
+        exact of_decide_eq_true hh2
+      next => exact absurd hh2 Bool.false_ne_true
+
+/-- Every row of the compiled table satisfies its gate: packed rows through `holds_row`,
+padding rows vacuously (`zero` gates constrain nothing). -/
+theorem rowSatisfies_gateTableOf {rows : List RowSlots} {env : Assignments Fp}
     {n : ℕ} [NeZero n] {idx : Index Fp n}
-    (hg : idx.gates = gateTableOf cons n) (hpc : idx.publicCount = 0)
+    (hg : idx.gates = gateTableOf rows n) (hpc : idx.publicCount = 0)
     (pub : Fin idx.publicCount → Fp)
-    (hall : ∀ con ∈ cons, con.holds env = true) (i : Fin n) :
-    rowSatisfies idx pub (tabOf cons env n) i := by
-  have htyp : (idx.gates i).typ = if (i : ℕ) < cons.length then .generic else .zero := by
+    (hall : ∀ p ∈ rows, p.1.holds env = true ∧ ∀ c ∈ p.2, c.holds env = true)
+    (i : Fin n) :
+    rowSatisfies idx pub (tabOf rows env n) i := by
+  have htyp : (idx.gates i).typ = if (i : ℕ) < rows.length then .generic else .zero := by
     rw [hg]; rfl
-  by_cases hi : (i : ℕ) < cons.length
-  · have hcon : cons[(i : ℕ)]? = some cons[(i : ℕ)] := List.getElem?_eq_getElem hi
+  by_cases hi : (i : ℕ) < rows.length
+  · have hrow : rows[(i : ℕ)]? = some rows[(i : ℕ)] := List.getElem?_eq_getElem hi
     have hpub : pubAt idx pub i = 0 := by
       simp [pubAt, hpc]
-    have hq : idx.coeffTable i = coeffsAt (some cons[(i : ℕ)]) := by
+    have hq : idx.coeffTable i = coeffsAt (some rows[(i : ℕ)]) := by
       show (idx.gates i).coeffs = _
       rw [hg]
-      show coeffsAt cons[(i : ℕ)]? = _
-      rw [hcon]
+      show coeffsAt rows[(i : ℕ)]? = _
+      rw [hrow]
+    obtain ⟨hh1, hh2⟩ := hall rows[(i : ℕ)] (List.getElem_mem hi)
     unfold rowSatisfies
     rw [htyp, if_pos hi]
     show Kimchi.Gate.Generic.Holds
-      (Kimchi.Gate.Generic.withPublic ⟨idx.coeffTable i, tabOf cons env n i⟩
+      (Kimchi.Gate.Generic.withPublic ⟨idx.coeffTable i, tabOf rows env n i⟩
         (pubAt idx pub i))
     rw [hpub, Kimchi.Gate.Generic.withPublic_zero, hq]
-    exact holds_row hcon (hall cons[(i : ℕ)] (List.getElem_mem hi))
+    exact holds_row hrow hh1 hh2
   · unfold rowSatisfies
     rw [htyp, if_neg hi]
     exact trivial
@@ -178,7 +229,8 @@ theorem rowSatisfies_gateTableOf {cons : List (GateConstraint Fp)} {env : Assign
 /-- **Compilation is honest.** Whenever `compile` succeeds, the witness table it stores
 satisfies the wired index it built — rows, copy constraints, and public pins. Composes
 `Snarky.prove_sound` (every emitted constraint holds on the prover's final assignment)
-with the row and copy conjuncts above; the provenance is `build?_gates`. -/
+with the row and copy conjuncts above, threading the packing through `pack_mem`; the
+provenance is `build?_gates`. -/
 theorem satisfies_of_compile {α : Type} {m : CircuitM Fp (GateConstraint Fp) α}
     {out : Compiled} (h : compile m = .ok out) :
     haveI : NeZero out.n := out.nz
@@ -194,16 +246,20 @@ theorem satisfies_of_compile {α : Type} {m : CircuitM Fp (GateConstraint Fp) α
       subst h'
       dsimp only
       obtain ⟨hg, hpc⟩ := build?_gates hb
-      haveI : NeZero (paddedSize (constraints m).length) := ⟨(Nat.two_pow_pos _).ne'⟩
+      haveI : NeZero (paddedSize (pack (constraints m)).length) :=
+        ⟨(Nat.two_pow_pos _).ne'⟩
       have hall : ∀ con ∈ constraints m, con.holds env = true :=
         prove_sound (holds := GateConstraint.holds)
           (fun _con _ _ hle hh => GateConstraint.holds_mono hle hh) hp
-      refine ⟨fun i => rowSatisfies_gateTableOf hg hpc _ hall i, fun c => ?_, fun i => ?_⟩
-      · have hw : idx.wiringMap c = wireOf (constraints m) c := by
+      have hall' : ∀ p ∈ pack (constraints m),
+          p.1.holds env = true ∧ ∀ c ∈ p.2, c.holds env = true := fun p hp' =>
+        ⟨hall _ (pack_mem hp').1, fun c hc => hall _ ((pack_mem hp').2 c hc)⟩
+      refine ⟨fun i => rowSatisfies_gateTableOf hg hpc _ hall' i, fun c => ?_, fun i => ?_⟩
+      · have hw : idx.wiringMap c = wireOf (pack (constraints m)) c := by
           show wiringMapOf idx.gates c = _
           rw [hg]; rfl
         rw [hw]
-        exact cellValue_wireOf (constraints m) env c
+        exact cellValue_wireOf (pack (constraints m)) env c
       · exact absurd i.isLt (by omega)
 
 end Snarky.Kimchi.Compile


### PR DESCRIPTION
Stacked on #237. Closes the row-density gap with the PS compiler.

## What it does

Kimchi's generic gate is **double**: one physical row packs two constraint slots (`q₀…q₄` on cells `w₀w₁w₂`, `q₅…q₉` on `w₃w₄w₅`). The compiler now packs the constraint stream two-per-row (`pack` — the analogue of the PS reduction's pairing of pending generic constraints in `Reduction.purs`) before building the gate table, halving the row count.

**The constraint type is untouched.** A `GateConstraint` remains one 5+3 slot — the semantic unit matching PS's pre-reduction `Basic` stream (see the dictionary table in #234) — and packing is purely a compilation pass, per the design discussion: widening `c` to a row would bake geometry into semantics without buying the pairing, which is inherently a stream post-pass.

- `RowSlots := GateConstraint × Option GateConstraint`, `pack` pairs adjacent constraints (odd tail gets an empty slot 2).
- Geometry functions (`cellVar`/`cellsOf`/`wireOf`/`coeffsAt`/`gateTableOf`/`tabOf`) now read through `slotOperand` (cells `0…5`). All six operand cells sit within the seven permutable columns, so **slot-2 operands copy-wire like slot-1's** — in the mul example, `z` is wired between `w₂` (slot 1's output) and `w₃` (slot 2's input) *within a single row*, and the domain shrinks from 8 to 4.

## The proof carries over

`satisfies_of_compile` holds for the packed compiler:

- **`pack_mem`** threads `prove_sound`'s per-constraint `holds` through the packing (every slot constraint of a packed row came from the stream) — proved by `pack`'s functional induction.
- **`holds_row`** now proves both slots: slot 1 as before, slot 2 mirrored at cells `3 4 5` against `q₅…q₉` (trivially `0 = 0` when the slot is empty — the same shape the un-packed second half had).
- The **copy conjunct is unchanged in shape and still unconditional** — the shared-prefix design (`tabOf` and `cellVar` reading the same `rows[i]?.bind (slotOperand · cell)` prefix) survived the retargeting verbatim.

## Verification

- full `lake build` clean, `scripts/check-style.sh` clean
- `scripts/check_axioms.sh` green (95 roots); `satisfies_of_compile`'s closure still `[propext, Classical.choice, Quot.sound]`
- `scripts/check_snarky_index.sh` green — the mul circuit now compiles to a **one-row** (plus padding) wired index its witness satisfies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019r9D9Ds4BBjv97ZWPMEMQN