### PR TITLE
formal: snarky DSL port, 3 — the typed layer and an executable R1CS example

### DIFF
--- a/formal/CLAUDE.md
+++ b/formal/CLAUDE.md
@@ -2,11 +2,25 @@
 
 This directory is a **Lean 4 + Mathlib** formalization of the kimchi custom EC gates
 (AddComplete, VarBaseMul, EndoMul, EndoScalar, Generic) used by the Pasta-curve proof
-system. It is **not** a circuit-DSL embedding: there is no `Circuit` monad, no
-`FormalCircuit`/`ProvableType`/`ElaboratedCircuit`, no `circuit_proof_start`. Gates are
-modelled as **plain Lean predicates over witness structures**, and proved faithful to
-**Mathlib's elliptic-curve group law** (`WeierstrassCurve.Affine`). If you've seen the
-Clean framework, forget its vocabulary here — none of it applies.
+system. The `Kimchi.*` namespace is **not** a circuit-DSL embedding: there is no `Circuit`
+monad, no `FormalCircuit`/`ProvableType`/`ElaboratedCircuit`, no `circuit_proof_start`.
+Gates are modelled as **plain Lean predicates over witness structures**, and proved
+faithful to **Mathlib's elliptic-curve group law** (`WeierstrassCurve.Affine`). If you've
+seen the Clean framework, forget its vocabulary here — none of it applies.
+
+The package also hosts a second, independent library: **`Snarky/`** (namespace
+`Snarky.*`), a deep-embedded Lean port of the PureScript circuit-building DSL
+(`packages/snarky/src/Snarky/Circuit/DSL/Monad.purs`). It models how constraint systems
+are *constructed*, complementing `Kimchi`'s constraint-systems-as-data view: a reified op
+tree `CircuitM` (constraint type kept abstract), pure `build`/`prove` interpreters
+mirroring `Snarky.Backend.Builder`/`Prover`, and the interpreter laws in
+`Snarky/Laws.lean` (witness-independence of the builder, builder/prover allocation
+agreement, and completeness: a successful prover run satisfies every built constraint).
+It is **Mathlib-free by design** (core Lean only, builds in seconds) — keep it that way;
+concrete backends live in downstream files (see `Snarky/Constraint/R1CS.lean` for the
+plain R1CS model). Kernel-reducibility matters there: everything is validated by `decide`, so avoid
+core functions compiled by well-founded recursion in executable paths (e.g. `Vector.map`
+— use `Snarky.mapVec` from `Snarky/Vec.lean`).
 
 Build: `make lean-build` (from repo root) or `lake build` (from `formal/`). The toolchain
 is pinned in `lean-toolchain` (Lean `v4.30.0`, the official tag); deps in `lakefile.toml`

--- a/formal/Snarky.lean
+++ b/formal/Snarky.lean
@@ -3,7 +3,13 @@ import Snarky.AsProver
 import Snarky.Monad
 import Snarky.Builder
 import Snarky.Prover
+import Snarky.Vec
+import Snarky.Constraint.Basic
+import Snarky.Constraint.R1CS
+import Snarky.Types
+import Snarky.DSL
 import Snarky.Laws
+import Snarky.Example
 
 /-!
 # Snarky — the circuit-building DSL, deep-embedded

--- a/formal/Snarky/Constraint/Basic.lean
+++ b/formal/Snarky/Constraint/Basic.lean
@@ -1,0 +1,23 @@
+import Snarky.CVar
+
+/-!
+# The basic constraint interface
+
+Port of `Snarky.Constraint.Basic` (packages/snarky/src/Snarky/Constraint/Basic.purs): the
+two constraint constructors every backend supplies, and all the DSL's core combinators
+need — rank-1 products and booleanity. Backends instantiate the class at their concrete
+constraint type (`Snarky.Constraint.R1CS` for the plain R1CS model,
+`Snarky.Kimchi.GateConstraint` for the Kimchi Generic-gate bridge).
+-/
+
+namespace Snarky
+
+/-- The basic constraint constructors every backend supplies (PS
+`class BasicSystem f c`): rank-1 products and booleanity. -/
+class BasicSystem (F c : Type u) where
+  /-- The constraint `a * b = prod`. -/
+  r1cs : (a b prod : CVar F) → c
+  /-- The constraint `x * x = x`, pinning `x` to `{0, 1}`. -/
+  boolean : (x : CVar F) → c
+
+end Snarky

--- a/formal/Snarky/Constraint/R1CS.lean
+++ b/formal/Snarky/Constraint/R1CS.lean
@@ -1,0 +1,48 @@
+import Snarky.Constraint.Basic
+
+/-!
+# The plain R1CS constraint model
+
+A minimal concrete backend for the DSL: rank-1 constraints `a · b = prod` over affine
+expressions, with a decidable checker and its monotonicity in the assignment-extension
+order — everything `Snarky.prove` and `Snarky.prove_sound` need from a backend. Core
+Lean only, so the whole model stays `decide`-friendly; `Snarky.Example` exercises it end
+to end.
+-/
+
+namespace Snarky.Constraint
+
+open Snarky
+
+/-- A rank-1 constraint `a * b = prod` over affine expressions. -/
+structure R1CS (F : Type u) where
+  a : CVar F
+  b : CVar F
+  prod : CVar F
+  deriving Repr, DecidableEq
+
+instance {F : Type u} : BasicSystem F (R1CS F) where
+  r1cs a b prod := ⟨a, b, prod⟩
+  boolean x := ⟨x, x, x⟩
+
+/-- Decide a constraint against an assignment: all three expressions evaluate and the
+product identity holds. -/
+def R1CS.holds {F : Type u} [Add F] [Mul F] [DecidableEq F] (con : R1CS F)
+    (env : Assignments F) : Bool :=
+  match con.a.eval env, con.b.eval env, con.prod.eval env with
+  | .ok x, .ok y, .ok z => decide (x * y = z)
+  | _, _, _ => false
+
+/-- `R1CS.holds` is monotone in the assignment-extension order — the hypothesis
+`Snarky.prove_sound` needs, discharged once per backend via `CVar.eval_le`. -/
+theorem R1CS.holds_mono {F : Type u} [Add F] [Mul F] [DecidableEq F] {con : R1CS F}
+    {env env' : Assignments F} (hle : env.Le env') (h : con.holds env = true) :
+    con.holds env' = true := by
+  unfold R1CS.holds at h ⊢
+  split at h
+  · next hx hy hz =>
+    rw [CVar.eval_le hle hx, CVar.eval_le hle hy, CVar.eval_le hle hz]
+    exact h
+  · cases h
+
+end Snarky.Constraint

--- a/formal/Snarky/DSL.lean
+++ b/formal/Snarky/DSL.lean
@@ -1,0 +1,55 @@
+import Snarky.Types
+
+/-!
+# The user-facing combinators
+
+Port of the user-facing surface of `Snarky.Circuit.DSL`
+(packages/snarky/src/Snarky/Circuit/DSL.purs and its `Monad`/`Field`/`Assert`
+submodules): the typed `witness` combinator (PS `exists`, renamed — `exists` is a Lean
+keyword), the prover-side `readVar` (PS `read`), and the first field combinators
+(`mul` from PS `mul_`, `assertEq` from PS `assertEqual_`). Everything here is sugar over
+the `CircuitM` smart constructors and the `Snarky.Types`/`Snarky.BasicSystem` classes;
+the PS numeric-tower instances (`Semiring (Snarky f c r (FVar f))` …) are deliberately
+not ported — their underlying combinators live here as plain functions.
+-/
+
+namespace Snarky
+
+variable {F c val var : Type u}
+
+/-- Witness a typed value (PS `exists`, renamed — `exists` is a Lean keyword): allocate
+`size` fresh variables, record the witness computation for prover runs, assemble the
+variable bundle, and emit its `check` constraints under both interpreters. -/
+def witness [inst : CircuitType F val var] [CheckedType F c var]
+    (compute : AsProver F val) : CircuitM F c var :=
+  .existsOp inst.size (fun env => (compute env).map inst.valueToFields) fun vs => do
+    let v := inst.fieldsToVar (mapVec CVar.var vs)
+    CheckedType.check (c := c) v
+    pure v
+
+/-- Read a typed variable bundle back to its value during a prover run (PS `read`). The
+length check is dynamic (it always succeeds) to keep the definition kernel-reducible
+without a `mapM`-length lemma. -/
+def readVar [Add F] [Mul F] [inst : CircuitType F val var] (v : var) : AsProver F val :=
+  fun env => do
+    let fields ← (inst.varToFields v).toList.mapM (CVar.eval · env)
+    if h : fields.length = inst.size then
+      pure (inst.fieldsToValue ⟨⟨fields⟩, by simpa using h⟩)
+    else
+      .error (.custom "readVar: size mismatch")
+
+/-- Multiply two field variables: witness the product, constrain it with `r1cs`
+(PS `mul_`). -/
+def mul [Add F] [Mul F] [BasicSystem F c] (x y : FVar F) : CircuitM F c (FVar F) := do
+  let z ← witness (val := F) do
+    let xv ← AsProver.readCVar x
+    let yv ← AsProver.readCVar y
+    pure (xv * yv)
+  addConstraint (BasicSystem.r1cs x y z)
+  pure z
+
+/-- Assert that two field variables are equal, via `x * 1 = y` (PS `assertEqual_`). -/
+def assertEq [One F] [BasicSystem F c] (x y : FVar F) : CircuitM F c PUnit :=
+  addConstraint (BasicSystem.r1cs x (.const 1) y)
+
+end Snarky

--- a/formal/Snarky/Example.lean
+++ b/formal/Snarky/Example.lean
@@ -1,0 +1,59 @@
+import Snarky.DSL
+import Snarky.Constraint.R1CS
+import Snarky.Laws
+
+/-!
+# End-to-end example: an R1CS multiplication circuit
+
+The `Snarky.Constraint.R1CS` backend over `Fin 17`, exercising the whole stack: the typed
+`witness` combinator, both interpreters, and an instantiation of the completeness
+theorem. Everything here reduces by `rfl`/`decide`, so this file doubles as a regression
+test for the executable semantics.
+
+The circuit mirrors the smallest interesting PS example: witness two field elements,
+multiply them (one witnessed product + one `r1cs` constraint), and assert the result
+equals a constant.
+-/
+
+namespace Snarky.Example
+
+open Snarky Snarky.Constraint
+
+/-! ## The circuit -/
+
+abbrev F17 := Fin 17
+
+/-- Witness `x = 3` and `y = 5`, multiply, assert the product is `15`. -/
+def mulCircuit : CircuitM F17 (R1CS F17) (FVar F17) := do
+  let x ← witness (val := F17) (pure 3)
+  let y ← witness (val := F17) (pure 5)
+  let z ← mul x y
+  assertEq z (.const 15)
+  pure z
+
+/-! ## Running it -/
+
+/-- The builder allocates three variables (`x`, `y`, and the product). -/
+example : (build mulCircuit 0).nextVar = 3 := by decide
+
+/-- The builder emits two constraints (`x * y = z` and `z * 1 = 15`), in emission order. -/
+example : constraints mulCircuit =
+    [ ⟨.var 0, .var 1, .var 2⟩, ⟨.var 2, .const 1, .const 15⟩ ] := by decide
+
+/-- The prover succeeds: every witness computation runs and every constraint holds. -/
+example : (prove R1CS.holds mulCircuit 0 Assignments.empty).isOk = true := by decide
+
+/-- Changing the asserted constant makes the prover reject at the constraint check. -/
+example :
+    (prove R1CS.holds (do let z ← mulCircuit; assertEq z (.const 14))
+      0 Assignments.empty).isOk = false := by
+  decide
+
+/-- The completeness theorem, instantiated: any successful run of `mulCircuit` yields
+assignments satisfying every built constraint. -/
+example {x : FVar F17} {nv : Nat} {env : Assignments F17}
+    (h : prove R1CS.holds mulCircuit 0 Assignments.empty = .ok ⟨x, nv, env⟩) :
+    ∀ con ∈ constraints mulCircuit, con.holds env = true :=
+  prove_sound (holds := R1CS.holds) (fun _con _ _ hle hh => R1CS.holds_mono hle hh) h
+
+end Snarky.Example

--- a/formal/Snarky/Types.lean
+++ b/formal/Snarky/Types.lean
@@ -1,0 +1,73 @@
+import Snarky.Monad
+import Snarky.Vec
+import Snarky.Constraint.Basic
+
+/-!
+# Circuit types
+
+Port of the typed layer of the DSL: `CircuitType` (PS `class CircuitType f a var` from
+`Snarky.Circuit.Types`) and `CheckedType` (PS `class CheckedType f c var`,
+packages/snarky/src/Snarky/Circuit/DSL/Monad.purs lines 488–531), together with the
+`FVar`/`BoolVar` instances. The user-facing combinators built on these classes
+(`witness`, `readVar`, `mul`, `assertEq`) live in `Snarky.DSL`; the backend constraint
+interface lives in `Snarky.Constraint.Basic`.
+
+Improvement over PS: the field-vector size is type-level (`Vector F size` instead of
+`Array f` plus a runtime `sizeInFields` contract), so the length obligations disappear.
+
+Out of scope for this port (deliberately): the generic-deriving machinery
+(`GCheckedType`/`RCheckedType`) — Lean would grow `deriving` handlers or macros instead.
+-/
+
+namespace Snarky
+
+/-! ## The type classes -/
+
+/-- A bidirectional encoding of a value type `val` as `size` field elements, together with
+its variable-bundle counterpart `var` (PS `CircuitType f a var`). -/
+class CircuitType (F : Type u) (val : Type u) (var : outParam (Type u)) where
+  size : Nat
+  valueToFields : val → Vector F size
+  fieldsToValue : Vector F size → val
+  varToFields : var → Vector (CVar F) size
+  fieldsToVar : Vector (CVar F) size → var
+
+/-- Variable bundles whose well-formedness is enforced by constraints: `check` is emitted
+by `witness` under *both* interpreters, exactly like PS `CheckedType`'s `check`. -/
+class CheckedType (F c : Type u) (var : Type u) where
+  check : var → CircuitM F c PUnit
+
+/-! ## Field and boolean variables -/
+
+/-- A single field element as a circuit value (PS `FVar f` is a wrapped `CVar`). -/
+abbrev FVar (F : Type u) := CVar F
+
+instance : CircuitType F F (FVar F) where
+  size := 1
+  valueToFields x := #v[x]
+  fieldsToValue v := v[0]
+  varToFields x := #v[x]
+  fieldsToVar v := v[0]
+
+/-- A field element carries no well-formedness constraint (PS `CheckedType` instance for
+`FVar`: `check = const (pure unit)`). -/
+instance : CheckedType F c (FVar F) where
+  check _ := .pure PUnit.unit
+
+/-- A boolean as a circuit variable: a `CVar` constrained to `{0, 1}` (PS `BoolVar f`). -/
+structure BoolVar (F : Type u) where
+  toCVar : CVar F
+
+instance [Zero F] [One F] [DecidableEq F] : CircuitType F Bool (BoolVar F) where
+  size := 1
+  valueToFields b := #v[if b then 1 else 0]
+  fieldsToValue v := decide (v[0] ≠ 0)
+  varToFields b := #v[b.toCVar]
+  fieldsToVar v := ⟨v[0]⟩
+
+/-- A freshly witnessed boolean must be constrained to `{0, 1}` (PS `CheckedType`
+instance for `BoolVar`: `check = boolean`). -/
+instance [BasicSystem F c] : CheckedType F c (BoolVar F) where
+  check b := addConstraint (BasicSystem.boolean b.toCVar)
+
+end Snarky

--- a/formal/Snarky/Vec.lean
+++ b/formal/Snarky/Vec.lean
@@ -1,0 +1,20 @@
+/-!
+# Vector utilities
+
+Kernel-reduction-friendly replacements for core `Vector` operations. Everything in this
+library is validated by `decide`, which reduces terms in the kernel — and several core
+`Vector` functions go through `Array.mapM`, whose loop is compiled by *well-founded
+recursion* and is therefore opaque to kernel reduction: a single such call anywhere in an
+executable path silently wedges every downstream `decide`. The replacements here take the
+`List` route instead (structural recursion, reduces by iota), converting through
+`Vector.toList` with a `simp` length witness.
+-/
+
+namespace Snarky
+
+/-- A List-backed `Vector.map` (core's runs through `Array.mapM` — well-founded recursion,
+opaque to the kernel; `List.map` is structural, so this version reduces under `decide`). -/
+def mapVec (f : α → β) (v : Vector α n) : Vector β n :=
+  ⟨⟨v.toList.map f⟩, by simp⟩
+
+end Snarky


### PR DESCRIPTION
Relands #227 onto `main`. #227 was approved and merged, but its base was the stacked branch `lean-snarky/02-interpreters` rather than `main`; this PR carries the **identical commit** (d3b174b5) with main as the base. Review history and discussion live on #227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)