### PR TITLE
Fix CI headline-proofs: build the Snarky library root

### DIFF
--- a/.github/actions/setup-lean/action.yml
+++ b/.github/actions/setup-lean/action.yml
@@ -1,7 +1,7 @@
 name: Setup Lean (Kimchi formalization)
 description: >
   elan (pinned toolchain) + Mathlib olean cloud cache + a build-directory cache for the
-  Kimchi library itself, then `lake build Kimchi`. Shared by the Lean workflow and the
+  Kimchi + Snarky libraries, then `lake build Kimchi Snarky`. Shared by the Lean workflow and the
   witness-check job in the CI workflow so both build the library the same way.
 runs:
   using: composite
@@ -50,5 +50,6 @@ runs:
         else
           echo "No ProofWidgets release tarball for $rev; continuing"
         fi
-        # Build only our library: typechecks every proof and runs the `#eval`s.
-        lake build Kimchi
+        # Build our libraries: typechecks every proof and runs the `#eval`s. Both
+        # `Kimchi` and `Snarky` (the deep-embedded DSL port) — the axiom gate imports both.
+        lake build Kimchi Snarky

--- a/formal/lakefile.toml
+++ b/formal/lakefile.toml
@@ -38,7 +38,7 @@ name = "Kimchi"
 # Kimchi (and thus Mathlib), so the glob builds them without the root pulling them in.
 [[lean_lib]]
 name = "Snarky"
-globs = ["Snarky.+"]
+globs = ["Snarky", "Snarky.+"]
 
 [[lean_exe]]
 name = "kimchi-demo"

--- a/formal/scripts/check_axioms.sh
+++ b/formal/scripts/check_axioms.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Gate the headline theorems' axiom closure: fails unless every axiom is the standard logical
 # set plus the two trusted Pasta point-count axioms. Subsumes a `sorryAx` grep. Driver:
-# scripts/check_axioms.lean. Requires a prior `lake build Kimchi`.
+# scripts/check_axioms.lean. Requires a prior `lake build Kimchi Snarky` (the script imports both libraries).
 set -euo pipefail
 cd "$(dirname "$0")/.."
 lake env lean scripts/check_axioms.lean


### PR DESCRIPTION
The axiom gate (`formal/scripts/check_axioms.lean`) imports `Snarky` and lists five `Snarky.*` roots, but the **Verify headline proofs** CI job fails with `unknown module prefix 'Snarky'` / `Snarky.olean does not exist`. Two independent causes, both present on `main`:

1. **Lakefile glob excluded the root.** The `Snarky` lean_lib had `globs = ["Snarky.+"]`, which builds the submodules but **not** the root module `Snarky` (from `formal/Snarky.lean`) — so `import Snarky` never resolves and `Snarky.olean` is never produced. Fixed to `["Snarky", "Snarky.+"]`.
2. **The build step didn't build Snarky.** The shared `setup-lean` action ran `lake build Kimchi` only; `Snarky` is a separate target. Fixed to `lake build Kimchi Snarky`.

Both are required: without (1) the target has no root to build; without (2) CI never builds the target.

Verified locally — `scripts/check_axioms.sh` now passes: **all 117 roots (112 Kimchi + 5 Snarky) reduce to the allowed axiom set**, full library builds green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)