### PR TITLE
formal/poseidon: encapsulation pass (privatization + doc cleanup)

### DIFF
--- a/formal/poseidon/Poseidon/Basic.lean
+++ b/formal/poseidon/Poseidon/Basic.lean
@@ -29,12 +29,6 @@ respectively. Both validated against `mina_poseidon` absorb/squeeze traces by
 The sponge is the *definitional* layer of the Fiat-Shamir instantiation: the security of the
 transform (that these challenges behave as the abstract soundness hypotheses require) is a
 separate, explicitly flagged assumption where the instantiation meets the soundness theorems.
-
-## Contents
-
-* `Triple`, `Params`, `sbox`, `fullRound`, `blockCipher` — the permutation.
-* `Mode`, `State`, `init`, `absorb`, `squeeze`, `squeezeN` — the duplex automaton.
-* `fqParams` / `fpParams` — the concrete `fq_kimchi` / `fp_kimchi` instantiations.
 -/
 
 namespace Poseidon
@@ -44,7 +38,7 @@ variable {F : Type*} [Field F]
 /-! ## The permutation -/
 
 /-- A width-3 state: the components `(s₀, s₁, s₂)`. -/
-abbrev Triple (F : Type*) := F × F × F
+private abbrev Triple (F : Type*) := F × F × F
 
 /-- Poseidon parameters: one constant triple per round, and the MDS matrix as three rows. -/
 structure Params (F : Type*) where
@@ -52,11 +46,11 @@ structure Params (F : Type*) where
   mds : Triple (Triple F)
 
 /-- The S-box `x ↦ x^7`. -/
-def sbox (x : F) : F := x ^ 7
+private def sbox (x : F) : F := x ^ 7
 
 /-- One full round: S-box every state element, apply the MDS matrix, add the round
 constants (`permutation.rs` `full_round`). -/
-def fullRound (mds : Triple (Triple F)) (rc : Triple F) (s : Triple F) : Triple F :=
+private def fullRound (mds : Triple (Triple F)) (rc : Triple F) (s : Triple F) : Triple F :=
   let t0 := sbox s.1; let t1 := sbox s.2.1; let t2 := sbox s.2.2
   let m0 := mds.1; let m1 := mds.2.1; let m2 := mds.2.2
   (m0.1 * t0 + m0.2.1 * t1 + m0.2.2 * t2 + rc.1,
@@ -65,14 +59,14 @@ def fullRound (mds : Triple (Triple F)) (rc : Triple F) (s : Triple F) : Triple 
 
 /-- The Poseidon permutation: the full rounds folded over the round-constant table
 (`permutation.rs` `poseidon_block_cipher`, no initial ARK). -/
-def blockCipher (p : Params F) (s : Triple F) : Triple F :=
+private def blockCipher (p : Params F) (s : Triple F) : Triple F :=
   p.roundConstants.foldl (fun s rc => fullRound p.mds rc s) s
 
 /-! ## The duplex automaton -/
 
 /-- The sponge direction and intra-block position: `absorbed n` after `n` absorptions into
 the current block, `squeezed n` after `n` squeezes from the current block (`n ≤ 2`). -/
-inductive Mode
+private inductive Mode
   | absorbed (n : Fin 3)
   | squeezed (n : Fin 3)
 deriving Repr, DecidableEq
@@ -83,13 +77,13 @@ structure State (F : Type*) where
   mode : Mode
 
 /-- Read rate slot `n` (`n < 2`). -/
-def slot (s : Triple F) : Fin 3 → F
+private def slot (s : Triple F) : Fin 3 → F
   | 0 => s.1
   | 1 => s.2.1
   | _ => s.2.2
 
 /-- Add `x` into rate slot `n` (`n < 2`). -/
-def addSlot (s : Triple F) (n : Fin 3) (x : F) : Triple F :=
+private def addSlot (s : Triple F) (n : Fin 3) (x : F) : Triple F :=
   match n with
   | 0 => (s.1 + x, s.2.1, s.2.2)
   | 1 => (s.1, s.2.1 + x, s.2.2)
@@ -100,7 +94,7 @@ def init : State F := ⟨(0, 0, 0), .absorbed 0⟩
 
 /-- Absorb one field element (`poseidon.rs` `absorb`): add into the next rate slot,
 permuting first when the rate is full; absorbing after a squeeze restarts at slot 0. -/
-def absorb1 (p : Params F) (sp : State F) (x : F) : State F :=
+private def absorb1 (p : Params F) (sp : State F) (x : F) : State F :=
   match sp.mode with
   | .absorbed n =>
     if n.val = 2 then

--- a/formal/poseidon/Poseidon/FqSponge.lean
+++ b/formal/poseidon/Poseidon/FqSponge.lean
@@ -32,14 +32,6 @@ identity (`sponge.rs` `absorb_g`, both cases).
 (`DefaultFqSponge<VestaParameters>` / `DefaultFqSponge<PallasParameters>`); each is its
 `Spec` plus name re-exports. Both are validated against `DefaultFqSponge` op traces by
 `scripts/check_fq_sponge.lean`.
-
-## Contents
-
-* `Spec`, `S`, `init` — the field-pair data and the sponge-plus-limb-buffer state.
-* `absorbFq`, `absorbG`, `absorbFr` — the absorption encodings.
-* `challengeFq`, `challengeNat`, `challenge` — raw and 128-bit squeezes.
-* `endoExpand`, `squeezeChallenge` — the effective-scalar expansion.
-* `FqVesta`, `FqPallas` — the Pasta instantiations.
 -/
 
 namespace Poseidon.FqSponge
@@ -68,7 +60,7 @@ def init : S base := ⟨Poseidon.init, []⟩
 
 /-- The two low 64-bit limbs of a squeezed element — its 128 high-entropy bits
 (`HIGH_ENTROPY_LIMBS = 2`). -/
-def lowLimbs (x : ZMod base) : List ℕ :=
+private def lowLimbs (x : ZMod base) : List ℕ :=
   [x.val % 2 ^ 64, x.val / 2 ^ 64 % 2 ^ 64]
 
 /-- Absorb base-field elements (`absorb_fq`): clear the buffer, absorb each. -/
@@ -99,7 +91,7 @@ def challengeFq (spec : Spec base scalar) (s : S base) : ZMod base × S base :=
 /-- Take two 64-bit limbs from the buffer, refilling it from the sponge as needed
 (`squeeze_limbs` at `CHALLENGE_LENGTH_IN_LIMBS = 2`); the packed 128-bit value. The fuel
 argument bounds the refills (each adds two limbs, so one suffices from empty). -/
-def squeezeLimbsPacked (spec : Spec base scalar) : ℕ → S base → ℕ × S base
+private def squeezeLimbsPacked (spec : Spec base scalar) : ℕ → S base → ℕ × S base
   | 0, s => (0, s)
   | fuel + 1, s =>
     match s.lastSqueezed with

--- a/formal/poseidon/Poseidon/GroupMap.lean
+++ b/formal/poseidon/Poseidon/GroupMap.lean
@@ -52,14 +52,14 @@ structure Spec (q : ℕ) [Field (ZMod q)] [Fintype (ZMod q)] [DecidableEq (ZMod 
 variable {q : ℕ} [Field (ZMod q)] [Fintype (ZMod q)] [DecidableEq (ZMod q)]
 
 /-- The curve equation right-hand side `f(x) = x³ + B`. -/
-def curveEqn (spec : Spec q) (x : ZMod q) : ZMod q := x ^ 3 + spec.E.B
+private def curveEqn (spec : Spec q) (x : ZMod q) : ZMod q := x ^ 3 + spec.E.B
 
 /-- `√(f(x))`, when `x` is the abscissa of a curve point (`get_y`). -/
-def getY (spec : Spec q) (x : ZMod q) : Option (ZMod q) :=
+private def getY (spec : Spec q) (x : ZMod q) : Option (ZMod q) :=
   spec.sqrt.sqrt? (curveEqn spec x)
 
 /-- The three SvdW candidate abscissae for `t` (`potential_xs`). -/
-def potentialXs (spec : Spec q) (t : ZMod q) : ZMod q × ZMod q × ZMod q :=
+private def potentialXs (spec : Spec q) (t : ZMod q) : ZMod q × ZMod q × ZMod q :=
   let t2 := t ^ 2
   let alpha := (t2 * (t2 + spec.fu))⁻¹
   let x1 := spec.sqrtNegThreeUSquaredMinusUOver2 - t2 ^ 2 * alpha * spec.sqrtNegThreeUSquared
@@ -69,7 +69,7 @@ def potentialXs (spec : Spec q) (t : ZMod q) : ZMod q × ZMod q × ZMod q :=
 
 /-- A found candidate is on the curve: `sqrt?` is self-validating (`sqrt?_mul_self`), so
 `getY spec x = some y` means `y² = f(x)`. -/
-theorem onCurve_of_getY (spec : Spec q) {x y : ZMod q} (h : getY spec x = some y) :
+private theorem onCurve_of_getY (spec : Spec q) {x y : ZMod q} (h : getY spec x = some y) :
     OnCurve spec.E.A spec.E.B (x, y) := by
   have hy : y * y = curveEqn spec x := TonelliShanks.sqrt?_mul_self spec.sqrt h
   show y ^ 2 = x ^ 3 + spec.E.A * x + spec.E.B
@@ -102,22 +102,22 @@ open CompElliptic.Fields.Pasta CompElliptic.Curves.Pasta
 def u : Fq := 1
 
 /-- `f(u)`. -/
-def fu : Fq := 6
+private def fu : Fq := 6
 
 /-- `√(-3u²)` — the root `setup()` computes. -/
-def sqrtNegThreeUSquared : Fq :=
+private def sqrtNegThreeUSquared : Fq :=
   5885731217013704028947117152987276604395468276778445611234961748972736355487
 
 example : sqrtNegThreeUSquared ^ 2 = -3 * u ^ 2 := by decide
 
 /-- `(√(-3u²) − u) / 2`. At `u = 1` this is `(√-3 − 1)/2`, a primitive cube root of unity —
 the Vesta base-field endomorphism coefficient `β`, of which it is a reuse. -/
-def sqrtNegThreeUSquaredMinusUOver2 : Fq := Pasta.vesta_endo
+private def sqrtNegThreeUSquaredMinusUOver2 : Fq := Pasta.vesta_endo
 
 example : 2 * sqrtNegThreeUSquaredMinusUOver2 = sqrtNegThreeUSquared - u := by decide
 
 /-- `(3u²)⁻¹`. -/
-def invThreeUSquared : Fq :=
+private def invThreeUSquared : Fq :=
   19298681539552699237261830834781317975575370987961098253119828498928908632065
 
 example : invThreeUSquared * (3 * u ^ 2) = 1 := by decide
@@ -151,10 +151,10 @@ open CompElliptic.Fields.Pasta CompElliptic.Curves.Pasta
 def u : Fp := 1
 
 /-- `f(u)`. -/
-def fu : Fp := 6
+private def fu : Fp := 6
 
 /-- `√(-3u²)` — the root `setup()` computes (the opposite sign choice to the Vesta side). -/
-def sqrtNegThreeUSquared : Fp :=
+private def sqrtNegThreeUSquared : Fp :=
   17006931536212783554987228065028097629383328157457783420645920607630467569011
 
 example : sqrtNegThreeUSquared ^ 2 = -3 * u ^ 2 := by decide
@@ -162,7 +162,7 @@ example : sqrtNegThreeUSquared ^ 2 = -3 * u ^ 2 := by decide
 /-- `(√(-3u²) − u) / 2`. At `u = 1` this is `(√-3 − 1)/2` at `setup()`'s root choice — the
 *other* primitive cube root of unity from the Pallas endomorphism coefficient, i.e.
 `pallas_endo²`. -/
-def sqrtNegThreeUSquaredMinusUOver2 : Fp :=
+private def sqrtNegThreeUSquaredMinusUOver2 : Fp :=
   8503465768106391777493614032514048814691664078728891710322960303815233784505
 
 example : sqrtNegThreeUSquaredMinusUOver2 = Pasta.pallas_endo ^ 2 := by decide
@@ -170,7 +170,7 @@ example : sqrtNegThreeUSquaredMinusUOver2 = Pasta.pallas_endo ^ 2 := by decide
 example : 2 * sqrtNegThreeUSquaredMinusUOver2 = sqrtNegThreeUSquared - u := by decide
 
 /-- `(3u²)⁻¹`. -/
-def invThreeUSquared : Fp :=
+private def invThreeUSquared : Fp :=
   19298681539552699237261830834781317975575370987961040477303117842899978420225
 
 example : invThreeUSquared * (3 * u ^ 2) = 1 := by decide


### PR DESCRIPTION
Encapsulation pass over the **poseidon** package (the kimchi Poseidon sponge + FixtureKit), mirroring the bulletproof-pcs work.

## Privatization (0 → 22)

The package declared **no private helpers at all** — every internal was public. A scan for public decls with no consumer outside their own file (nor a manifest root, nor a check script) sealed the genuinely-internal machinery:

- **`Basic`** — the permutation/automaton internals (`sbox`, `slot`, `addSlot`, `absorb1`, `fullRound`, `blockCipher`) and the state-representation types `Mode`/`Triple`. `State` stays public as the opaque handle driven by `init`/`absorb`/`squeeze`.
- **`FqSponge`** — the limb-buffer plumbing (`lowLimbs`, `squeezeLimbsPacked`).
- **`GroupMap`** — the SvdW construction helpers (`curveEqn`, `fu`, `getY`, `potentialXs`, the sqrt/inv numerals, `onCurve_of_getY`), per curve.

The public surface is now **exactly the manifest roots**: the permutation parameters, `init`/`absorb`/`squeeze`/`squeezeN`, the `FqSponge` `Spec`/instantiations, and the map-to-curve.

`sbox`/`slot` were scan false-negatives — their apparent "external uses" are kimchi's own `Gate.Poseidon.sbox` and the English word "slot" in prose, not this package's decls.

## Doc pass

Dropped the `## Contents` decl-inventory blocks from `Basic` and `FqSponge` — they listed now-private decls and duplicate what the code shows (matching the `Wire.lean` treatment in #248). No evolution/changelog language was present.

## No conceptual reorg

Unlike bulletproof-pcs (14 construction-order files → 4), poseidon is already 6 coherent single-concept modules — permutation+automaton, the two generated parameter tables, the consumer Fq-sponge, the map-to-curve, plus the FixtureKit lib. Nothing to collapse.

## Verification

No declaration names change, so `roots.txt` and the axiom gates are untouched. Full build, all four gates, deadcode (129 roots / 0 missing), style (98 files), and both the `check_sponge_vectors` and `check_fq_sponge` drivers (sponges + Fq-sponges + map-to-curve vs proof-systems) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhavGeUhGukSRQTRH6JEaD
