### PR TITLE
formal/kimchi: per-curve Poseidon MDS as gate parameter

### DIFF
--- a/formal/kimchi/Kimchi/Gate/Poseidon.lean
+++ b/formal/kimchi/Kimchi/Gate/Poseidon.lean
@@ -5,8 +5,11 @@ import Mathlib
 Transcribed from proof-systems `.../polynomials/poseidon.rs` (15 constraints = 5 rounds × 3
 state elements). Each round maps the 3-element state through
 `state' = MDS · sbox(state) + roundConstants`, with the S-box `sbox(x) = x⁷` (Pasta
-`PERM_SBOX = 7`) and the 3×3 `MDS` matrix below (the Pasta `fp` kimchi constants). The five
-rounds chain `s0 → s1 → s2 → s3 → s4 → s5`, so one gate row applies five permutation rounds.
+`PERM_SBOX = 7`) and a 3×3 `MDS` matrix carried as a PARAMETER (`Mds F`): production
+evaluates the gate with `G::sponge_params().mds`, a DIFFERENT table per curve (`fp_kimchi`
+for Vesta proofs, `fq_kimchi` for Pallas proofs), so the matrix is gate data, not gate
+constants — exactly like `EndoMul`'s endomorphism coefficient. The five rounds chain
+`s0 → s1 → s2 → s3 → s4 → s5`, so one gate row applies five permutation rounds.
 
 Unlike the elliptic-curve gates there is no external Mathlib spec: the gate *defines* the
 permutation. Soundness (`sound`) is therefore that a satisfying witness's output state is the
@@ -22,26 +25,32 @@ namespace Kimchi.Gate.Poseidon
 
 variable {F : Type*}
 
-/-! ## The 3×3 MDS matrix (Pasta `fp` kimchi constants). -/
+/-! ## The 3×3 MDS matrix, as gate data. -/
 
-def m00 [CommRing F] : F :=
-  12035446894107573964500871153637039653510326950134440362813193268448863222019
-def m01 [CommRing F] : F :=
-  25461374787957152039031444204194007219326765802730624564074257060397341542093
-def m02 [CommRing F] : F :=
-  27667907157110496066452777015908813333407980290333709698851344970789663080149
-def m10 [CommRing F] : F :=
-  4491931056866994439025447213644536587424785196363427220456343191847333476930
-def m11 [CommRing F] : F :=
-  14743631939509747387607291926699970421064627808101543132147270746750887019919
-def m12 [CommRing F] : F :=
-  9448400033389617131295304336481030167723486090288313334230651810071857784477
-def m20 [CommRing F] : F :=
-  10525578725509990281643336361904863911009900817790387635342941550657754064843
-def m21 [CommRing F] : F :=
-  27437632000253211280915908546961303399777448677029255413769125486614773776695
-def m22 [CommRing F] : F :=
-  27566319851776897085443681456689352477426926500749993803132851225169606086988
+/-- The 3×3 MDS matrix of the round function — per-curve data
+(`G::sponge_params().mds`), one named field per entry. -/
+structure Mds (F : Type*) where
+  m00 : F
+  m01 : F
+  m02 : F
+  m10 : F
+  m11 : F
+  m12 : F
+  m20 : F
+  m21 : F
+  m22 : F
+
+/-- Map `f` over every matrix entry. -/
+def Mds.map {R S : Type*} (f : R → S) (M : Mds R) : Mds S where
+  m00 := f M.m00
+  m01 := f M.m01
+  m02 := f M.m02
+  m10 := f M.m10
+  m11 := f M.m11
+  m12 := f M.m12
+  m20 := f M.m20
+  m21 := f M.m21
+  m22 := f M.m22
 
 /-! ## The round function and the 5-round permutation. -/
 
@@ -49,14 +58,14 @@ def m22 [CommRing F] : F :=
 def sbox [CommRing F] (x : F) : F := x ^ 7
 
 /-- One full round: `state' = MDS · sbox(state) + roundConstants`. -/
-def round [CommRing F] (s r : F × F × F) : F × F × F :=
-  (r.1 + m00 * sbox s.1 + m01 * sbox s.2.1 + m02 * sbox s.2.2,
-   r.2.1 + m10 * sbox s.1 + m11 * sbox s.2.1 + m12 * sbox s.2.2,
-   r.2.2 + m20 * sbox s.1 + m21 * sbox s.2.1 + m22 * sbox s.2.2)
+def round [CommRing F] (M : Mds F) (s r : F × F × F) : F × F × F :=
+  (r.1 + M.m00 * sbox s.1 + M.m01 * sbox s.2.1 + M.m02 * sbox s.2.2,
+   r.2.1 + M.m10 * sbox s.1 + M.m11 * sbox s.2.1 + M.m12 * sbox s.2.2,
+   r.2.2 + M.m20 * sbox s.1 + M.m21 * sbox s.2.1 + M.m22 * sbox s.2.2)
 
 /-- The gate's 5-round permutation of the initial state. -/
-def perm [CommRing F] (s0 : F × F × F) (rc : Fin 5 → F × F × F) : F × F × F :=
-  round (round (round (round (round s0 (rc 0)) (rc 1)) (rc 2)) (rc 3)) (rc 4)
+def perm [CommRing F] (M : Mds F) (s0 : F × F × F) (rc : Fin 5 → F × F × F) : F × F × F :=
+  round M (round M (round M (round M (round M s0 (rc 0)) (rc 1)) (rc 2)) (rc 3)) (rc 4)
 
 /-! ## Witness and constraint model. -/
 
@@ -80,44 +89,46 @@ def Witness.map {R S : Type*} (f : R → S) (w : Witness R) : Witness S where
 
 /-- The 15 constraint expressions: for each of the five rounds, the three components of
     `sᵢ₊₁ − round(sᵢ, rcᵢ)`. -/
-def constraints [CommRing F] (rc : Fin 5 → F × F × F) (w : Witness F) : List F :=
-  [ w.s1.1 - (round w.s0 (rc 0)).1, w.s1.2.1 - (round w.s0 (rc 0)).2.1,
-    w.s1.2.2 - (round w.s0 (rc 0)).2.2,
-    w.s2.1 - (round w.s1 (rc 1)).1, w.s2.2.1 - (round w.s1 (rc 1)).2.1,
-    w.s2.2.2 - (round w.s1 (rc 1)).2.2,
-    w.s3.1 - (round w.s2 (rc 2)).1, w.s3.2.1 - (round w.s2 (rc 2)).2.1,
-    w.s3.2.2 - (round w.s2 (rc 2)).2.2,
-    w.s4.1 - (round w.s3 (rc 3)).1, w.s4.2.1 - (round w.s3 (rc 3)).2.1,
-    w.s4.2.2 - (round w.s3 (rc 3)).2.2,
-    w.s5.1 - (round w.s4 (rc 4)).1, w.s5.2.1 - (round w.s4 (rc 4)).2.1,
-    w.s5.2.2 - (round w.s4 (rc 4)).2.2 ]
+def constraints [CommRing F] (M : Mds F) (rc : Fin 5 → F × F × F) (w : Witness F) : List F :=
+  [ w.s1.1 - (round M w.s0 (rc 0)).1, w.s1.2.1 - (round M w.s0 (rc 0)).2.1,
+    w.s1.2.2 - (round M w.s0 (rc 0)).2.2,
+    w.s2.1 - (round M w.s1 (rc 1)).1, w.s2.2.1 - (round M w.s1 (rc 1)).2.1,
+    w.s2.2.2 - (round M w.s1 (rc 1)).2.2,
+    w.s3.1 - (round M w.s2 (rc 2)).1, w.s3.2.1 - (round M w.s2 (rc 2)).2.1,
+    w.s3.2.2 - (round M w.s2 (rc 2)).2.2,
+    w.s4.1 - (round M w.s3 (rc 3)).1, w.s4.2.1 - (round M w.s3 (rc 3)).2.1,
+    w.s4.2.2 - (round M w.s3 (rc 3)).2.2,
+    w.s5.1 - (round M w.s4 (rc 4)).1, w.s5.2.1 - (round M w.s4 (rc 4)).2.1,
+    w.s5.2.2 - (round M w.s4 (rc 4)).2.2 ]
 
 /-- Naturality of the constraint list: a ring hom `f` distributes over all 15 constraint
     expressions, so mapping `f` over `constraints rc w` equals the constraints of the mapped
     round constants and mapped witness. -/
 theorem constraints_map {R S : Type*} [CommRing R] [CommRing S] (f : R →+* S)
-    (rc : Fin 5 → R × R × R) (w : Witness R) :
-    (constraints rc w).map f
-      = constraints (fun j => (f (rc j).1, f (rc j).2.1, f (rc j).2.2)) (Witness.map f w) := by
-  simp [constraints, round, sbox, Witness.map, map_ofNat, m00, m01, m02, m10, m11, m12,
-    m20, m21, m22]
+    (M : Mds R) (rc : Fin 5 → R × R × R) (w : Witness R) :
+    (constraints M rc w).map f
+      = constraints (M.map f) (fun j => (f (rc j).1, f (rc j).2.1, f (rc j).2.2))
+          (Witness.map f w) := by
+  simp [constraints, round, sbox, Witness.map, Mds.map]
 
 /-- RELATIONAL spec: all 15 constraint expressions vanish. -/
-def Holds [CommRing F] (rc : Fin 5 → F × F × F) (w : Witness F) : Prop :=
-  ∀ e ∈ constraints rc w, e = 0
+def Holds [CommRing F] (M : Mds F) (rc : Fin 5 → F × F × F) (w : Witness F) : Prop :=
+  ∀ e ∈ constraints M rc w, e = 0
 
-instance [CommRing F] [DecidableEq F] (rc : Fin 5 → F × F × F) (w : Witness F) :
-    Decidable (Holds rc w) := by
+instance [CommRing F] [DecidableEq F] (M : Mds F) (rc : Fin 5 → F × F × F) (w : Witness F) :
+    Decidable (Holds M rc w) := by
   unfold Holds
   infer_instance
 
 /-- Executable checker: every constraint expression is zero. -/
-def ok [CommRing F] [DecidableEq F] (rc : Fin 5 → F × F × F) (w : Witness F) : Bool :=
-  (constraints rc w).all (· == 0)
+def ok [CommRing F] [DecidableEq F] (M : Mds F) (rc : Fin 5 → F × F × F) (w : Witness F) :
+    Bool :=
+  (constraints M rc w).all (· == 0)
 
 /-- Reflection: the `Bool` checker agrees with the relational spec. -/
-theorem ok_iff [CommRing F] [DecidableEq F] (rc : Fin 5 → F × F × F) (w : Witness F) :
-    ok rc w = true ↔ Holds rc w := by
+theorem ok_iff [CommRing F] [DecidableEq F] (M : Mds F) (rc : Fin 5 → F × F × F)
+    (w : Witness F) :
+    ok M rc w = true ↔ Holds M rc w := by
   simp only [ok, Holds, List.all_eq_true, beq_iff_eq]
 
 end Kimchi.Gate.Poseidon

--- a/formal/kimchi/Kimchi/Gate/Semantics/Poseidon.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/Poseidon.lean
@@ -16,41 +16,45 @@ private theorem step_eq [CommRing F] {a b : F × F × F}
 
 /-- **Soundness of the Poseidon gate.** A satisfying witness's output state `s5` is the 5-round
     permutation of its input state `s0`. -/
-theorem sound [CommRing F] (rc : Fin 5 → F × F × F) (w : Witness F) (h : Holds rc w) :
-    w.s5 = perm w.s0 rc := by
+theorem sound [CommRing F] (M : Mds F) (rc : Fin 5 → F × F × F) (w : Witness F)
+    (h : Holds M rc w) :
+    w.s5 = perm M w.s0 rc := by
   simp only [Holds, constraints, List.forall_mem_cons] at h
   obtain ⟨h1a, h1b, h1c, h2a, h2b, h2c, h3a, h3b, h3c,
     h4a, h4b, h4c, h5a, h5b, h5c, -⟩ := h
-  have hs1 : w.s1 = round w.s0 (rc 0) := step_eq h1a h1b h1c
-  have hs2 : w.s2 = round w.s1 (rc 1) := step_eq h2a h2b h2c
-  have hs3 : w.s3 = round w.s2 (rc 2) := step_eq h3a h3b h3c
-  have hs4 : w.s4 = round w.s3 (rc 3) := step_eq h4a h4b h4c
-  have hs5 : w.s5 = round w.s4 (rc 4) := step_eq h5a h5b h5c
+  have hs1 : w.s1 = round M w.s0 (rc 0) := step_eq h1a h1b h1c
+  have hs2 : w.s2 = round M w.s1 (rc 1) := step_eq h2a h2b h2c
+  have hs3 : w.s3 = round M w.s2 (rc 2) := step_eq h3a h3b h3c
+  have hs4 : w.s4 = round M w.s3 (rc 3) := step_eq h4a h4b h4c
+  have hs5 : w.s5 = round M w.s4 (rc 4) := step_eq h5a h5b h5c
   rw [perm, ← hs1, ← hs2, ← hs3, ← hs4, ← hs5]
 
 /-! ## Completeness: the honest witness satisfies the gate. -/
 
 /-- Build the canonical satisfying row by iterating `round` from the input state. -/
-def build [CommRing F] (s0 : F × F × F) (rc : Fin 5 → F × F × F) : Witness F :=
-  let s1 := round s0 (rc 0)
-  let s2 := round s1 (rc 1)
-  let s3 := round s2 (rc 2)
-  let s4 := round s3 (rc 3)
-  { s0, s1, s2, s3, s4, s5 := round s4 (rc 4) }
+def build [CommRing F] (M : Mds F) (s0 : F × F × F) (rc : Fin 5 → F × F × F) : Witness F :=
+  let s1 := round M s0 (rc 0)
+  let s2 := round M s1 (rc 1)
+  let s3 := round M s2 (rc 2)
+  let s4 := round M s3 (rc 3)
+  { s0, s1, s2, s3, s4, s5 := round M s4 (rc 4) }
 
 /-- **Completeness of the Poseidon gate.** The honest witness (`build`) satisfies all 15
     constraints — unconditionally (the permutation is total). -/
-theorem complete [CommRing F] (s0 : F × F × F) (rc : Fin 5 → F × F × F) :
-    Holds rc (build s0 rc) := by
+theorem complete [CommRing F] (M : Mds F) (s0 : F × F × F) (rc : Fin 5 → F × F × F) :
+    Holds M rc (build M s0 rc) := by
   intro e he
   fin_cases he <;> simp [build]
 
 /-! ## Runnable example. -/
 
+/-- A small-field MDS for the runnable example. -/
+private def egMds : Mds (ZMod 101) := ⟨2, 3, 5, 7, 11, 13, 17, 19, 23⟩
+
 /-- A concrete satisfying row over a small field: `build` always satisfies `ok`. -/
 private def egPoseidon : Witness (ZMod 101) :=
-  build (1, 2, 3) (fun _ => (1, 1, 1))
+  build egMds (1, 2, 3) (fun _ => (1, 1, 1))
 
-#eval ok (fun _ => (1, 1, 1)) egPoseidon   -- expect true
+#eval ok egMds (fun _ => (1, 1, 1)) egPoseidon   -- expect true
 
 end Kimchi.Gate.Poseidon

--- a/formal/kimchi/Kimchi/Index/Aggregate.lean
+++ b/formal/kimchi/Kimchi/Index/Aggregate.lean
@@ -66,8 +66,8 @@ noncomputable def gateConstraints (idx : Index F n) (wTab : Fin n → Fin 15 →
   | .zero => []
   | .generic => (Generic.argument (F := F)).constraints
       (polyEnv idx.omega wTab idx.coeffTable)
-  | .poseidon => Gate.Poseidon.constraints (Poseidon.rcPoly idx.omega idx.coeffTable)
-      (Poseidon.polyWitness idx.omega wTab)
+  | .poseidon => Gate.Poseidon.constraints (idx.mds.map C)
+      (Poseidon.rcPoly idx.omega idx.coeffTable) (Poseidon.polyWitness idx.omega wTab)
   | .completeAdd => Gate.AddComplete.constraints (AddComplete.polyWitness idx.omega wTab)
   | .varBaseMul => Gate.VarBaseMul.constraints (VarBaseMul.polyWitness idx.omega wTab)
   | .endoMul => Gate.EndoMul.constraints (C idx.endoBase)
@@ -252,7 +252,7 @@ private theorem rowSatisfies_of_gateMember_dvd (idx : Index F n) (pub : Fin idx.
     have hvan := idx.gateConstraints_vanish_of_dvd pub wTab hdvd (i := i) (by simp [htyp])
     rw [htyp] at hvan
     exact forall_mem_zero_of_bridge
-      ((Poseidon.argument (F := F)).bridge idx.omega_prim wTab idx.coeffTable i) hvan
+      ((Poseidon.argument idx.mds).bridge idx.omega_prim wTab idx.coeffTable i) hvan
   | completeAdd =>
     have hvan := idx.gateConstraints_vanish_of_dvd pub wTab hdvd (i := i) (by simp [htyp])
     rw [htyp] at hvan
@@ -565,7 +565,7 @@ private theorem gateConstraints_vanish_of_rowSatisfies (idx : Index F n)
   | poseidon =>
     rw [htyp] at hrow
     exact forall_mem_eval_of_bridge
-      ((Poseidon.argument (F := F)).bridge idx.omega_prim wTab idx.coeffTable i) hrow
+      ((Poseidon.argument idx.mds).bridge idx.omega_prim wTab idx.coeffTable i) hrow
   | completeAdd =>
     rw [htyp] at hrow
     exact forall_mem_eval_of_bridge

--- a/formal/kimchi/Kimchi/Index/Basic.lean
+++ b/formal/kimchi/Kimchi/Index/Basic.lean
@@ -1,4 +1,5 @@
 import Kimchi.Permutation.Wiring
+import Kimchi.Gate.Poseidon
 
 /-!
 # The kimchi index: the circuit as data
@@ -91,6 +92,11 @@ structure _root_.Kimchi.Index (F : Type*) [Field F] (n : ℕ) where
   gate. The scalar-field eigenvalue `λ` is challenge-expansion data (the sponge's
   `Spec.lam`), not index data. -/
   endoBase : F
+  /-- The Poseidon-round MDS matrix — per-curve data like `endoBase`: production
+  evaluates the gate expression with `G::sponge_params().mds`, the PROOF curve's
+  scalar-side table (`fp_kimchi` for Vesta proofs, `fq_kimchi` for Pallas proofs).
+  Data only, no law — the wire correspondence pins it to the deployed table. -/
+  mds : Gate.Poseidon.Mds F
   shifts : Fin 7 → F
   omega_prim : IsPrimitiveRoot omega n
   zk_pos : 0 < zkRows
@@ -193,7 +199,8 @@ theorem sigmaPoly_eq_wiring (idx : Index F n) (col : Fin 7) :
 boundary: the generator and shift laws through the `Wiring.lean` certificates, the rest
 by their `Fintype`/`Decidable` instances. `none` exactly when some law fails. -/
 def build? [DecidableEq F] (gates : Fin n → GateRow F n) (publicCount zkRows : ℕ)
-    (omega endoBase : F) (shifts : Fin 7 → F) : Option (Index F n) :=
+    (omega endoBase : F) (mds : Gate.Poseidon.Mds F) (shifts : Fin 7 → F) :
+    Option (Index F n) :=
   if h : (∃ k < n + 1, n = 2 ^ k)
       ∧ primitiveRootCertificate omega n = true
       ∧ cosetShiftsCertificate shifts n = true
@@ -211,7 +218,7 @@ def build? [DecidableEq F] (gates : Fin n → GateRow F n) (publicCount zkRows :
       isPrimitiveRoot_of_certificate'
         (let ⟨k, _, hk⟩ := h.1; ⟨k, hk⟩) h.2.1
     some { gates := gates, publicCount := publicCount, zkRows := zkRows
-           omega := omega, endoBase := endoBase, shifts := shifts
+           omega := omega, endoBase := endoBase, mds := mds, shifts := shifts
            omega_prim := homega
            zk_pos := h.2.2.2.1
            zk_le := h.2.2.2.2.1

--- a/formal/kimchi/Kimchi/Index/Degree.lean
+++ b/formal/kimchi/Kimchi/Index/Degree.lean
@@ -409,15 +409,15 @@ private theorem poseidon_entry_le [NeZero n] (idx : Index F n)
   have r41 : (Poseidon.rcPoly idx.omega idx.coeffTable 4).1.natDegree ≤ n - 1 := cell_le idx _
   have r42 : (Poseidon.rcPoly idx.omega idx.coeffTable 4).2.1.natDegree ≤ n - 1 := cell_le idx _
   have r43 : (Poseidon.rcPoly idx.omega idx.coeffTable 4).2.2.natDegree ≤ n - 1 := cell_le idx _
-  have hm00 : (Gate.Poseidon.m00 : Polynomial F).natDegree = 0 := by simp [Gate.Poseidon.m00]
-  have hm01 : (Gate.Poseidon.m01 : Polynomial F).natDegree = 0 := by simp [Gate.Poseidon.m01]
-  have hm02 : (Gate.Poseidon.m02 : Polynomial F).natDegree = 0 := by simp [Gate.Poseidon.m02]
-  have hm10 : (Gate.Poseidon.m10 : Polynomial F).natDegree = 0 := by simp [Gate.Poseidon.m10]
-  have hm11 : (Gate.Poseidon.m11 : Polynomial F).natDegree = 0 := by simp [Gate.Poseidon.m11]
-  have hm12 : (Gate.Poseidon.m12 : Polynomial F).natDegree = 0 := by simp [Gate.Poseidon.m12]
-  have hm20 : (Gate.Poseidon.m20 : Polynomial F).natDegree = 0 := by simp [Gate.Poseidon.m20]
-  have hm21 : (Gate.Poseidon.m21 : Polynomial F).natDegree = 0 := by simp [Gate.Poseidon.m21]
-  have hm22 : (Gate.Poseidon.m22 : Polynomial F).natDegree = 0 := by simp [Gate.Poseidon.m22]
+  have hm00 : ((idx.mds.map C).m00 : Polynomial F).natDegree = 0 := natDegree_C _
+  have hm01 : ((idx.mds.map C).m01 : Polynomial F).natDegree = 0 := natDegree_C _
+  have hm02 : ((idx.mds.map C).m02 : Polynomial F).natDegree = 0 := natDegree_C _
+  have hm10 : ((idx.mds.map C).m10 : Polynomial F).natDegree = 0 := natDegree_C _
+  have hm11 : ((idx.mds.map C).m11 : Polynomial F).natDegree = 0 := natDegree_C _
+  have hm12 : ((idx.mds.map C).m12 : Polynomial F).natDegree = 0 := natDegree_C _
+  have hm20 : ((idx.mds.map C).m20 : Polynomial F).natDegree = 0 := natDegree_C _
+  have hm21 : ((idx.mds.map C).m21 : Polynomial F).natDegree = 0 := natDegree_C _
+  have hm22 : ((idx.mds.map C).m22 : Polynomial F).natDegree = 0 := natDegree_C _
   have hd : 7 * (n - 1) ≤ 8 * n := by omega
   simp only [Index.gateConstraints, Gate.Poseidon.constraints, Gate.Poseidon.round,
     Gate.Poseidon.sbox, List.mem_cons, List.not_mem_nil, or_false] at hE

--- a/formal/kimchi/Kimchi/Index/Satisfies.lean
+++ b/formal/kimchi/Kimchi/Index/Satisfies.lean
@@ -45,7 +45,8 @@ def rowSatisfies (idx : Index F n) (pub : Fin idx.publicCount → F)
       Gate.Generic.Holds (Gate.Generic.withPublic ⟨idx.coeffTable i, wTab i⟩
         (pubAt idx pub i))
   | .poseidon =>
-      Gate.Poseidon.Holds (Poseidon.rcMap (idx.coeffTable i)) (Poseidon.rowWitness wTab i)
+      Gate.Poseidon.Holds idx.mds (Poseidon.rcMap (idx.coeffTable i))
+        (Poseidon.rowWitness wTab i)
   | .completeAdd => Gate.AddComplete.Holds (AddComplete.rowWitness wTab i)
   | .varBaseMul => Gate.VarBaseMul.Holds (VarBaseMul.rowWitness wTab i)
   | .endoMul => Gate.EndoMul.Holds idx.endoBase (EndoMul.rowWitness wTab i)

--- a/formal/kimchi/Kimchi/Lift.lean
+++ b/formal/kimchi/Kimchi/Lift.lean
@@ -572,16 +572,22 @@ noncomputable def rcPoly (ω : F) (qTab : Fin n → Fin 15 → F) :
 
 /-! ## The `Argument` instance -/
 
-/-- **Poseidon `Argument` instance.** The gate's constraints
-`Gate.Poseidon.constraints (rcMap env.coeff) (cellMap env.witnessCurr env.witnessNext)`;
-naturality is the gate's ring-hom `Gate.Poseidon.constraints_map` (the MDS entries are integer
-literals, so no `algebraMap`-transported parameter is involved). -/
-def argument : Argument F where
-  constraints env :=
-    Gate.Poseidon.constraints (rcMap env.coeff) (cellMap env.witnessCurr env.witnessNext)
-  constraints_map f env :=
-    Gate.Poseidon.constraints_map f.toRingHom (rcMap env.coeff)
+/-- **Poseidon `Argument` instance**, at an MDS matrix `M` (per-curve data —
+`G::sponge_params().mds`). The matrix enters every carrier through `algebraMap F R`,
+which each `f : R →ₐ[F] S` fixes (`AlgHom.commutes`) — the same transport as `EndoMul`'s
+endomorphism coefficient; naturality is the gate's ring-hom
+`Gate.Poseidon.constraints_map` with the transported matrix rewritten back. -/
+def argument (M : Gate.Poseidon.Mds F) : Argument F where
+  constraints {R} _ _ env :=
+    Gate.Poseidon.constraints (M.map (algebraMap F R)) (rcMap env.coeff)
       (cellMap env.witnessCurr env.witnessNext)
+  constraints_map {R S} _ _ _ _ f env := by
+    have hM : (M.map (algebraMap F R)).map f.toRingHom = M.map (algebraMap F S) := by
+      simp [Gate.Poseidon.Mds.map]
+    have h := Gate.Poseidon.constraints_map f.toRingHom (M.map (algebraMap F R))
+      (rcMap env.coeff) (cellMap env.witnessCurr env.witnessNext)
+    rw [hM] at h
+    exact h
 
 end Kimchi.Lift.Gate.Poseidon
 

--- a/formal/kimchi/Kimchi/Protocol/Accepts.lean
+++ b/formal/kimchi/Kimchi/Protocol/Accepts.lean
@@ -36,7 +36,7 @@ def Accepts (idx : Index F n) (pub : Fin idx.publicCount → F)
   permScalar β γ α (zkpmEval n idx.zkRows idx.omega ζ) E
       * ((Permutation.sigmaPoly idx.omega idx.shifts idx.wiringPerm) 6).eval ζ
     - (ζ ^ n - 1) * t.eval ζ
-  = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase α β γ ζ
+  = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase idx.mds α β γ ζ
       (-((idx.pubPoly pub).eval ζ)) E
 
 end Kimchi.Protocol

--- a/formal/kimchi/Kimchi/Protocol/Equation.lean
+++ b/formal/kimchi/Kimchi/Protocol/Equation.lean
@@ -131,7 +131,7 @@ private theorem gateMember_sum_eval [DecidableEq F] [NeZero n] (idx : Index F n)
     (pub : Fin idx.publicCount → F)
     (wTab : Fin n → Fin 15 → F) (z : Polynomial F) (ζ α : F) :
     ∑ k ∈ Finset.range Index.gateAlphaCount, α ^ k * (idx.gateMember pub wTab k).eval ζ
-      = gateLinearization idx.endoBase α (evalsOf idx wTab z ζ)
+      = gateLinearization idx.endoBase idx.mds α (evalsOf idx wTab z ζ)
           - (idx.pubPoly pub).eval ζ := by
   -- split each member into its selector-weighted pool term and the public correction
   have hmem : ∀ k, α ^ k * (idx.gateMember pub wTab k).eval ζ
@@ -168,9 +168,9 @@ private theorem gateMember_sum_eval [DecidableEq F] [NeZero n] (idx : Index F n)
   -- closed-form summands via the naturality square
   rw [gateLinearization]
   simp only [Index.gateConstraints]
-  rw [show Gate.Poseidon.constraints (Poseidon.rcPoly idx.omega idx.coeffTable)
-        (Poseidon.polyWitness idx.omega wTab)
-      = (Poseidon.argument (F := F)).constraints
+  rw [show Gate.Poseidon.constraints (idx.mds.map C)
+        (Poseidon.rcPoly idx.omega idx.coeffTable) (Poseidon.polyWitness idx.omega wTab)
+      = (Poseidon.argument idx.mds).constraints
           (polyEnv idx.omega wTab idx.coeffTable) from rfl,
     show Gate.AddComplete.constraints (AddComplete.polyWitness idx.omega wTab)
       = (AddComplete.argument (F := F)).constraints
@@ -185,7 +185,7 @@ private theorem gateMember_sum_eval [DecidableEq F] [NeZero n] (idx : Index F n)
       = (EndoScalar.argument (F := F)).constraints
           (polyEnv idx.omega wTab idx.coeffTable) from rfl]
   rw [constraints_map_evalsOf (Generic.argument (F := F)) idx wTab z ζ,
-    constraints_map_evalsOf (Poseidon.argument (F := F)) idx wTab z ζ,
+    constraints_map_evalsOf (Poseidon.argument idx.mds) idx wTab z ζ,
     constraints_map_evalsOf (AddComplete.argument (F := F)) idx wTab z ζ,
     constraints_map_evalsOf (VarBaseMul.argument (F := F)) idx wTab z ζ,
     constraints_map_evalsOf (EndoMul.argument idx.endoBase) idx wTab z ζ,
@@ -337,7 +337,7 @@ private theorem verifierEquation_iff [DecidableEq F] [NeZero n] (idx : Index F n
     permScalar β γ α (zkpmEval n idx.zkRows idx.omega ζ) (evalsOf idx wTab z ζ)
           * ((Permutation.sigmaPoly idx.omega idx.shifts idx.wiringPerm) 6).eval ζ
         - (ζ ^ n - 1) * t.eval ζ
-      = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase α β γ ζ
+      = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase idx.mds α β γ ζ
           (-((idx.pubPoly pub).eval ζ)) (evalsOf idx wTab z ζ)
       ↔ (aggregate α (idx.fullFamily pub wTab z β γ)).eval ζ = (t * zH F n).eval ζ := by
   -- the three permutation constraints at the index's wiring data
@@ -449,7 +449,7 @@ private theorem satisfies_of_verifierEquation [DecidableEq F] [NeZero n]
         * ((Permutation.sigmaPoly idx.omega idx.shifts idx.wiringPerm) 6).eval
             ζ
         - (ζ ^ n - 1) * t.eval ζ
-      = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase α β γ
+      = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase idx.mds α β γ
           ζ (-((idx.pubPoly pub).eval ζ))
           (evalsOf idx wTab zg ζ)) :
     Satisfies idx pub wTab := by

--- a/formal/kimchi/Kimchi/Protocol/Linearization.lean
+++ b/formal/kimchi/Kimchi/Protocol/Linearization.lean
@@ -65,10 +65,11 @@ theorem alphaCombo_eq_sum_getD (α : F) :
 /-- The gate linearization: each gate's α-weighted constraint list, evaluated at the
 cell environment and weighted by its evaluated selector. Gates share the alpha pool, so
 every list starts at `α⁰`. -/
-def gateLinearization (endo α : F) (e : Evals F) : F :=
+def gateLinearization (endo : F) (mds : Kimchi.Gate.Poseidon.Mds F) (α : F)
+    (e : Evals F) : F :=
   e.genericSelector * alphaCombo α ((Generic.argument (F := F)).constraints (evalEnv e))
     + e.poseidonSelector
-      * alphaCombo α ((Poseidon.argument (F := F)).constraints (evalEnv e))
+      * alphaCombo α ((Poseidon.argument mds).constraints (evalEnv e))
     + e.completeAddSelector
       * alphaCombo α ((AddComplete.argument (F := F)).constraints (evalEnv e))
     + e.mulSelector
@@ -92,7 +93,7 @@ def zkpmEval (n zkRows : ℕ) (ω ζ : F) : F :=
 evaluation, plus the accumulator boundary quotient pinning the two masked rows, minus the
 gate linearization. -/
 def ftEval0 (n zkRows : ℕ) (ω : F) (shifts : Fin 7 → F) (endo : F)
-    (α β γ ζ pubEval : F) (e : Evals F) : F :=
+    (mds : Kimchi.Gate.Poseidon.Mds F) (α β γ ζ pubEval : F) (e : Evals F) : F :=
   let zkpmZ := zkpmEval n zkRows ω ζ
   let zeta1m1 := ζ ^ n - 1
   let wBoundary := ω ^ (n - zkRows)
@@ -102,6 +103,6 @@ def ftEval0 (n zkRows : ℕ) (ω : F) (shifts : Fin 7 → F) (endo : F)
     * ∏ i : Fin 7, (γ + β * ζ * shifts i + e.w ⟨i, by omega⟩)
   let boundary := ((zeta1m1 * α ^ 22 * (ζ - wBoundary) + zeta1m1 * α ^ 23 * (ζ - 1))
     * (1 - e.z)) / ((ζ - wBoundary) * (ζ - 1))
-  sigmaSide - pubEval - shiftSide + boundary - gateLinearization endo α e
+  sigmaSide - pubEval - shiftSide + boundary - gateLinearization endo mds α e
 
 end Kimchi.Protocol.Linearization

--- a/formal/kimchi/Kimchi/Verifier/Capstone/Algebraic.lean
+++ b/formal/kimchi/Kimchi/Verifier/Capstone/Algebraic.lean
@@ -263,7 +263,7 @@ theorem kimchiProof_sound_algebraic {F G : Type*} [Field F] [AddCommGroup G]
           (permScalar β γ α (zkpmEval n idx.zkRows idx.omega ζ) (claimedEvals E)
               * (idx.sigmaPoly 6).eval ζ
             - (ζ ^ n - 1) * t.eval ζ
-            = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase α β γ
+            = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase idx.mds α β γ
                 ζ (-((idx.pubPoly pub).eval ζ)) (claimedEvals E)) →
           Satisfies idx pub
             (extractTable idx.omega fun col => rowPoly (aw₀ (wRow col))) := by
@@ -466,7 +466,7 @@ theorem kimchiProof_sound_algebraic_ft {F G : Type*} [Field F] [AddCommGroup G]
             = permScalar β γ α (zkpmEval n idx.zkRows idx.omega ζ) (claimedEvals E)
                 • Cσ6 - (ζ ^ n - 1) • ∑ j : Fin 7, (ζ ^ n) ^ (j : ℕ) • TC j) →
           (innerProduct aft (evalVector (2 ^ σ.k) ζ)
-            = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase α β γ
+            = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase idx.mds α β γ
                 ζ (-((idx.pubPoly pub).eval ζ)) (claimedEvals E)) →
           Satisfies idx pub
             (extractTable idx.omega fun col => rowPoly (aw₀ (wRow col))) := by
@@ -480,7 +480,7 @@ theorem kimchiProof_sound_algebraic_ft {F G : Type*} [Field F] [AddCommGroup G]
   obtain ⟨htdeg, hteq⟩ := ft_identity_of_chunks σ hbind (idx.sigmaPoly 6) hσ₆ Cσ6 hCσ6
     TC aT ρT hTC
     (permScalar β γ α (zkpmEval n idx.zkRows idx.omega ζ) (claimedEvals E)) ζ
-    (ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase α β γ ζ
+    (ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase idx.mds α β γ ζ
       (-((idx.pubPoly pub).eval ζ)) (claimedEvals E)) n hk aft ρft hftc hftv
   exact himp β γ α (ftChunkAssembly σ.k aT) ζ E ξ r A hβ hγ hα hζ hζ1 hζb htdeg
     hξ hr hFS hAcc hteq

--- a/formal/kimchi/Kimchi/Verifier/Capstone/Reflection.lean
+++ b/formal/kimchi/Kimchi/Verifier/Capstone/Reflection.lean
@@ -814,7 +814,7 @@ theorem kimchiVesta_run_sound_algebraic_ft (σ : SRS IpaVesta.Point)
             ≠ idx.omega ^ (n - idx.zkRows) →
           (runOracles IpaVesta.curve σ vk p pub).zeta ^ n ≠ 1 →
           Satisfies idx (pubView idx pub) wTab) := by
-  obtain ⟨hvk, homega, hzk, hshift, hendo⟩ := hvk
+  obtain ⟨hvk, homega, hzk, hshift, hendo, hmds⟩ := hvk
   -- (1) reflect the run; pin the batch width and the domain size
   have hrun := kimchiVerify_reflects IpaVesta.curve σ vk p pub hacc
   have hsize : (runInput IpaVesta.curve σ vk p pub).commitments.size = 45 := by
@@ -874,7 +874,7 @@ theorem kimchiVesta_run_sound_algebraic_ft (σ : SRS IpaVesta.Point)
   have hce := claimedEvals_runReindex_eq σ vk p pub hrun hsize
   unfold runPScalar runFtEval0 runFtEval0P at hteq0
   rw [runPubEvals_fst_eq σ vk p pub idx homega hn hpub hζn, hn, hzk, homega, hendo,
-    hshift, ← hce] at hteq0
+    hmds, hshift, ← hce] at hteq0
   -- (8) the per-row pins, at the consumer's two eval points
   have hpt : (runInput IpaVesta.curve σ vk p pub).pointFn
       = ![(runOracles IpaVesta.curve σ vk p pub).zeta,
@@ -952,7 +952,7 @@ theorem kimchiPallas_run_sound_algebraic_ft (σ : SRS IpaPallas.Point)
             ≠ idx.omega ^ (n - idx.zkRows) →
           (runOracles IpaPallas.curve σ vk p pub).zeta ^ n ≠ 1 →
           Satisfies idx (pubView idx pub) wTab) := by
-  obtain ⟨hvk, homega, hzk, hshift, hendo⟩ := hvk
+  obtain ⟨hvk, homega, hzk, hshift, hendo, hmds⟩ := hvk
   -- (1) reflect the run; pin the batch width and the domain size
   have hrun := kimchiVerify_reflects IpaPallas.curve σ vk p pub hacc
   have hsize : (runInput IpaPallas.curve σ vk p pub).commitments.size = 45 := by
@@ -1012,7 +1012,7 @@ theorem kimchiPallas_run_sound_algebraic_ft (σ : SRS IpaPallas.Point)
   have hce := claimedEvals_runReindex_eq σ vk p pub hrun hsize
   unfold runPScalar runFtEval0 runFtEval0P at hteq0
   rw [runPubEvals_fst_eq σ vk p pub idx homega hn hpub hζn, hn, hzk, homega, hendo,
-    hshift, ← hce] at hteq0
+    hmds, hshift, ← hce] at hteq0
   -- (8) the per-row pins, at the consumer's two eval points
   have hpt : (runInput IpaPallas.curve σ vk p pub).pointFn
       = ![(runOracles IpaPallas.curve σ vk p pub).zeta,

--- a/formal/kimchi/Kimchi/Verifier/Capstone/Standard.lean
+++ b/formal/kimchi/Kimchi/Verifier/Capstone/Standard.lean
@@ -262,7 +262,7 @@ private theorem kimchiVesta_sound (σ : SRS IpaVesta.Point) (vk : KimchiVesta.VK
           (permScalar β γ α (zkpmEval n idx.zkRows idx.omega ζ) (claimedEvals E)
               * (idx.sigmaPoly 6).eval ζ
             - (ζ ^ n - 1) * t.eval ζ
-            = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase α β γ
+            = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase idx.mds α β γ
                 ζ (-((idx.pubPoly (pubView idx pub)).eval ζ)) (claimedEvals E)) →
           Satisfies idx (pubView idx pub) wTab :=
   kimchiProof_sound σ idx hk hbind vk.comms hvk (pubView idx pub) wC
@@ -305,7 +305,7 @@ private theorem kimchiPallas_sound (σ : SRS IpaPallas.Point) (vk : KimchiPallas
           (permScalar β γ α (zkpmEval n idx.zkRows idx.omega ζ) (claimedEvals E)
               * (idx.sigmaPoly 6).eval ζ
             - (ζ ^ n - 1) * t.eval ζ
-            = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase α β γ
+            = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase idx.mds α β γ
                 ζ (-((idx.pubPoly (pubView idx pub)).eval ζ)) (claimedEvals E)) →
           Satisfies idx (pubView idx pub) wTab :=
   kimchiProof_sound σ idx hk hbind vk.comms hvk (pubView idx pub) wC
@@ -361,7 +361,7 @@ theorem kimchiVesta_run_sound (σ : SRS IpaVesta.Point) (vk : KimchiVesta.VK)
           * (idx.sigmaPoly 6).eval (runOracles IpaVesta.curve σ vk p pub).zeta
         - ((runOracles IpaVesta.curve σ vk p pub).zeta ^ n - 1)
             * t.eval (runOracles IpaVesta.curve σ vk p pub).zeta
-        = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase
+        = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase idx.mds
             (runOracles IpaVesta.curve σ vk p pub).alpha
             (runOracles IpaVesta.curve σ vk p pub).beta
             (runOracles IpaVesta.curve σ vk p pub).gamma
@@ -434,7 +434,7 @@ theorem kimchiPallas_run_sound (σ : SRS IpaPallas.Point) (vk : KimchiPallas.VK)
           * (idx.sigmaPoly 6).eval (runOracles IpaPallas.curve σ vk p pub).zeta
         - ((runOracles IpaPallas.curve σ vk p pub).zeta ^ n - 1)
             * t.eval (runOracles IpaPallas.curve σ vk p pub).zeta
-        = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase
+        = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase idx.mds
             (runOracles IpaPallas.curve σ vk p pub).alpha
             (runOracles IpaPallas.curve σ vk p pub).beta
             (runOracles IpaPallas.curve σ vk p pub).gamma

--- a/formal/kimchi/Kimchi/Verifier/Kimchi.lean
+++ b/formal/kimchi/Kimchi/Verifier/Kimchi.lean
@@ -143,6 +143,15 @@ structure KimchiVK (C : Ipa.CommitmentCurve) where
 /-- The domain size `n = 2 ^ domainLog2` (`domain.size`). -/
 def KimchiVK.n {C : Ipa.CommitmentCurve} (vk : KimchiVK C) : ℕ := 2 ^ vk.domainLog2
 
+/-- A Poseidon parameter table's MDS matrix as the gate's `Mds` record — the wire form
+of production's `Constants { mds: G::sponge_params().mds, .. }` (the scalar-side table,
+per curve). Consumed by the verifiers' `ftEval0` and pinned to `idx.mds` by the wire
+correspondence. -/
+def mdsOfParams {F : Type*} (p : Poseidon.Params F) : Gate.Poseidon.Mds F :=
+  ⟨p.mds.1.1, p.mds.1.2.1, p.mds.1.2.2,
+   p.mds.2.1.1, p.mds.2.1.2.1, p.mds.2.1.2.2,
+   p.mds.2.2.1, p.mds.2.2.2.1, p.mds.2.2.2.2⟩
+
 /-! ## The fr-sponge and the sponge digests -/
 
 /-- The fr-sponge (`DefaultFrSponge`, kimchi/src/plonk_sponge.rs): the generic `FqSponge`
@@ -376,7 +385,7 @@ def kimchiVerify (σ : SRS C.Point) (vk : KimchiVK C) (p : KimchiProof C)
     let e := p.linEvals
     let shifts : Fin 7 → C.ScalarField := fun i => vk.shifts[i.val]!
     let ftEval0 := Kimchi.Protocol.Linearization.ftEval0 n vk.zkRows vk.omega shifts vk.endo
-      o.alpha o.beta o.gamma o.zeta pubEval0 e
+      (mdsOfParams vk.frParams) o.alpha o.beta o.gamma o.zeta pubEval0 e
     let (v, u) := frOracles C vk p o.digest pubEval0 pubEval1
     let zkpmZ := Kimchi.Protocol.Linearization.zkpmEval n vk.zkRows vk.omega o.zeta
     let pScalar := Kimchi.Protocol.Linearization.permScalar o.beta o.gamma o.alpha zkpmZ e
@@ -427,10 +436,11 @@ def KimchiVK.comms {C : Ipa.CommitmentCurve} (vk : KimchiVK C) : IndexComms C.Po
 
 /-- The deployed key corresponds to the index: the committed columns are the circuit's
 own (`VKCorresponds`, through the `comms` view) AND the scalar-side parameters match —
-the domain generator, the zero-knowledge row count, the permutation shifts, and the
-`ft_eval0` endo coefficient. The scalar pins are separate conjuncts because they are
-not committed: no binding argument derives them from the column commitments, and the
-wire verifier computes its scalar side with the KEY's values. The wire-level
+the domain generator, the zero-knowledge row count, the permutation shifts, the
+`ft_eval0` endo coefficient, and the Poseidon MDS matrix (read off the fr-sponge
+table, `G::sponge_params().mds`). The scalar pins are separate conjuncts because they
+are not committed: no binding argument derives them from the column commitments, and
+the wire verifier computes its scalar side with the KEY's values. The wire-level
 correspondence the run-level roots consume. -/
 def KimchiVK.Corresponds {C : Ipa.CommitmentCurve} [Module C.ScalarField C.Point]
     {n : ℕ} (σ : SRS C.Point) (vk : KimchiVK C) (idx : Index C.ScalarField n) : Prop :=
@@ -439,6 +449,7 @@ def KimchiVK.Corresponds {C : Ipa.CommitmentCurve} [Module C.ScalarField C.Point
     ∧ vk.zkRows = idx.zkRows
     ∧ (fun i : Fin 7 => vk.shifts[(i : ℕ)]!) = idx.shifts
     ∧ vk.endo = idx.endoBase
+    ∧ mdsOfParams vk.frParams = idx.mds
 
 /-- The public-input array as the `Fin idx.publicCount`-indexed function the circuit
 model consumes (`getD`, total; the capstones pin `pub.size = idx.publicCount`, so the

--- a/formal/kimchi/Kimchi/Verifier/Reduction/Soundness.lean
+++ b/formal/kimchi/Kimchi/Verifier/Reduction/Soundness.lean
@@ -334,7 +334,7 @@ theorem kimchiProof_sound_of_openings [Field F] [AddCommGroup G] [Module F G]
           (permScalar β γ α (zkpmEval n idx.zkRows idx.omega ζ) (claimedEvals E)
               * (idx.sigmaPoly 6).eval ζ
             - (ζ ^ n - 1) * t.eval ζ
-            = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase α β γ
+            = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase idx.mds α β γ
                 ζ (-((idx.pubPoly pub).eval ζ)) (claimedEvals E)) →
           Satisfies idx pub
             (extractTable idx.omega fun col => rowPoly (aw₀ (wRow col))) := by
@@ -489,7 +489,7 @@ theorem kimchiProof_sound [Field F] [AddCommGroup G] [Module F G]
           (permScalar β γ α (zkpmEval n idx.zkRows idx.omega ζ) (claimedEvals E)
               * (idx.sigmaPoly 6).eval ζ
             - (ζ ^ n - 1) * t.eval ζ
-            = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase α β γ
+            = ftEval0 n idx.zkRows idx.omega idx.shifts idx.endoBase idx.mds α β γ
                 ζ (-((idx.pubPoly pub).eval ζ)) (claimedEvals E)) →
           Satisfies idx pub wTab := by
   obtain ⟨aw₀, ρw₀, hrow₀⟩ :=

--- a/formal/kimchi/Kimchi/Verifier/Reflect.lean
+++ b/formal/kimchi/Kimchi/Verifier/Reflect.lean
@@ -83,6 +83,7 @@ private def runVU (σ : SRS C.Point) (vk : KimchiVK C) (p : KimchiProof C)
 def runFtEval0P (σ : SRS C.Point) (vk : KimchiVK C) (p : KimchiProof C)
     (pub : Array C.ScalarField) (pubEval0 : C.ScalarField) : C.ScalarField :=
   ftEval0 vk.n vk.zkRows vk.omega (fun i => vk.shifts[i.val]!) vk.endo
+    (mdsOfParams vk.frParams)
     (runOracles C σ vk p pub).alpha (runOracles C σ vk p pub).beta
     (runOracles C σ vk p pub).gamma (runOracles C σ vk p pub).zeta pubEval0 p.linEvals
 

--- a/formal/kimchi/KimchiFixture/PS.lean
+++ b/formal/kimchi/KimchiFixture/PS.lean
@@ -1,5 +1,6 @@
 import CompElliptic.Fields.Pasta
 import Kimchi.Index.Satisfies
+import Kimchi.Verifier.Kimchi
 import FixtureKit.Parse
 import Pasta.Endo
 import Lean.Data.Json
@@ -193,7 +194,8 @@ def build (raw : Raw) : Except String Instance := do
   let shifts : Fin 7 → Fp := fun i => (powMod fpGenerator (i : ℕ) PALLAS_BASE_CARD : ℕ)
   let gates ← gateTable raw n
   match Index.build? gates raw.publicInputSize zkRows omega
-      Pasta.pallas_endo shifts with
+      Pasta.pallas_endo (Kimchi.Verifier.mdsOfParams Kimchi.Verifier.KimchiVesta.frParams)
+      shifts with
   | none => throw "Index.build? rejected the padded dump (a synthesized law failed)"
   | some idx =>
     return { n := n

--- a/formal/kimchi/scripts/check_index_fixture.lean
+++ b/formal/kimchi/scripts/check_index_fixture.lean
@@ -1,5 +1,6 @@
 import CompElliptic.Fields.Pasta
 import Kimchi.Index.Satisfies
+import Kimchi.Verifier.Kimchi
 import FixtureKit.Parse
 import Lean.Data.Json
 
@@ -142,6 +143,7 @@ def checks (fx : RawFixture) {n : ℕ} [NeZero n]
 def run {n : ℕ} [NeZero n] (fx : RawFixture) (hn : fx.n = n) : IO Unit := do
   let gates ← IO.ofExcept (buildGates fx hn)
   let some idx := Index.build? gates fx.publicCount fx.zkRows fx.omega fx.endoBase
+      (Kimchi.Verifier.mdsOfParams Kimchi.Verifier.KimchiVesta.frParams)
       (fun i => fx.shifts[(i : ℕ)]!)
     | throw (IO.userError "Index.build? rejected the production data")
   IO.println "  ✓ Index.build? accepts (all laws decided on production data)"

--- a/formal/kimchi/scripts/check_linearization.lean
+++ b/formal/kimchi/scripts/check_linearization.lean
@@ -1,5 +1,6 @@
 import Kimchi.Protocol.Linearization
 import Bulletproof.Wire
+import Kimchi.Verifier.Kimchi
 import FixtureKit.Parse
 import Lean.Data.Json
 
@@ -89,7 +90,9 @@ def main : IO Unit := do
           * alphaCombo α ((Kimchi.Lift.Gate.Generic.argument (F := F)).constraints gEnv),
           ← gateTarget "generic"),
         ("poseidon", e.poseidonSelector
-          * alphaCombo α ((Kimchi.Lift.Gate.Poseidon.argument (F := F)).constraints gEnv),
+          * alphaCombo α ((Kimchi.Lift.Gate.Poseidon.argument
+              (Kimchi.Verifier.mdsOfParams Kimchi.Verifier.KimchiVesta.frParams)).constraints
+            gEnv),
           ← gateTarget "poseidon"),
         ("completeAdd", e.completeAddSelector
           * alphaCombo α ((Kimchi.Lift.Gate.AddComplete.argument (F := F)).constraints gEnv),
@@ -108,8 +111,9 @@ def main : IO Unit := do
     let hGates := gates.all fun (_, mine, target) => mine = target
     let hZkpm := decide (zkpmEval n zkRows ω ζ = zkpmZ)
     let hPerm := decide (permScalar β γ α zkpmZ e = permTarget)
-    let hConst := decide (gateLinearization endo α e = constTarget)
-    let hFt := decide (ftEval0 n zkRows ω shifts endo α β γ ζ pubEval e = ftEval0Target)
+    let mds := Kimchi.Verifier.mdsOfParams Kimchi.Verifier.KimchiVesta.frParams
+    let hConst := decide (gateLinearization endo mds α e = constTarget)
+    let hFt := decide (ftEval0 n zkRows ω shifts endo mds α β γ ζ pubEval e = ftEval0Target)
     -- The assembled acceptance identity — the point-bridge (`verifierEquation_iff`)
     -- instantiated numerically on the real proof. The quotient evaluation t(ζ) cancels:
     -- permScalar·σ₆(ζ) − ft_eval0 must equal the aggregate Σ αᵏ·memberₖ(ζ), the left
@@ -123,7 +127,7 @@ def main : IO Unit := do
         - e.zOmega * (∏ i : Fin 7, (wF i + γ + β * sigmas i)))
       let m1 := (e.z - 1) * ((ζ ^ n - 1) / (ζ - 1))
       let m2 := (e.z - 1) * ((ζ ^ n - 1) / (ζ - ω ^ (n - zkRows)))
-      let rhs := gateLinearization endo α e + pubEval
+      let rhs := gateLinearization endo mds α e + pubEval
         + α ^ 21 * m0 + α ^ 22 * m1 + α ^ 23 * m2
       decide (permScalar β γ α zkpmZ e * sigma6Z - ftEval0Target = rhs)
     dbgTrace s!"{path}: zkpm: {if hZkpm then "✓" else "✗"}, \


### PR DESCRIPTION
`Gate.Poseidon` hard-coded the `fp_kimchi` MDS matrix as generic integer literals — garbage at `F = Fq`. Production evaluates the gate with `G::sponge_params().mds`, a **different table per curve** (`fp_kimchi` for Vesta proofs, `fq_kimchi` for Pallas proofs).

This PR makes the matrix gate data, following the `EndoMul` endo-coefficient pattern:

- `Gate.Poseidon.Mds F` record; `constraints`/`Holds`/`ok`/`sound`/`complete` take it as a parameter, `constraints_map` gets the transported-matrix naturality form.
- `Lift.Gate.Poseidon.argument` takes `mds`; the matrix enters each carrier through `algebraMap` (fixed by every `AlgHom`, so naturality holds).
- `Index` carries `mds` as data (docstringed: data only, no law — the wire correspondence pins it); `Index.build?` takes it at the deserialization boundary.
- `Protocol.Linearization.gateLinearization`/`ftEval0` thread it; `Protocol.Accepts` reads `idx.mds`.
- The wire verifier passes `mdsOfParams vk.frParams` (production's `Constants { mds: G::sponge_params().mds }`), and `KimchiVK.Corresponds` pins `mdsOfParams vk.frParams = idx.mds` as a sixth scalar conjunct.

**Why now**: exposed by the first-ever Pallas wire adjudication (the `nc = 2` fixtures on the chunking branch) — split out of #260 as a prerequisite. Without it the Pallas capstone terminals describe a verifier that diverges from deployed Pallas kimchi. Values are unchanged at Vesta (the deleted literals equal `mdsOfParams` of the Vesta fr-params), so every existing fixture adjudication is invariant.

**Gates** (all green): `lake build`, `check-style.sh`, 40-root axiom gate with unchanged allowed set, deadcode, and all six fixture drivers (kimchi verifier, vk-correspond, index, linearization, perm, ps-witness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhavGeUhGukSRQTRH6JEaD