### PR TITLE
formal: docstring exactness follow-ups from the #260 review

### DIFF
--- a/formal/bulletproof-pcs/Bulletproof/Soundness.lean
+++ b/formal/bulletproof-pcs/Bulletproof/Soundness.lean
@@ -399,7 +399,9 @@ point, every polynomial of the batch is bound: there is a genuine `q i` of degre
 evaluations are the `x^(2^k)`-power recombinations of the claimed chunk evaluations,
 and whose chunk windows REPRODUCE each per-chunk claim individually (the last clause —
 consumers that pin per-chunk claims against fixed chunk commitments, like the chunked
-kimchi reduction's verifier-key rows, read the claims off it directly). -/
+kimchi reduction's verifier-key rows, read the claims off it directly). The evaluation
+clause is the recombination corollary of the degree bound and the per-chunk clause
+(through `eval_eq_sum_chunkPoly` and `chunkPoly_eval`), kept for direct consumers. -/
 theorem chunked_batch_soundness (σ : SRS G) {n m : ℕ} {nc : Fin n → ℕ}
     (hnc : ∀ i, 0 < nc i)
     (ξ : Fin (∑ i, nc i) → F) (hξ : Function.Injective ξ)

--- a/formal/bulletproof-pcs/Bulletproof/Wire.lean
+++ b/formal/bulletproof-pcs/Bulletproof/Wire.lean
@@ -24,10 +24,12 @@ batch shape (`m` rows, `p` evaluation points, the claimed-evaluation matrix a
 `Vector` of `Vector`s). Every read of the verifier and of every statement over it is
 total; a checked input cannot hold a ragged claim. The raw serde records
 (`Wire.Proof`, `Wire.Input` — every payload a `Vec`) live in the `Wire` namespace
-below with their `check` parses, which are the verifier's own dimension guards
-(round count, `evals` square against the commitments and points) factored as a total
-parse — the parse IS the proof. Clients compose check-then-verify; rejecting ragged
-input is the same observable behavior as the guards' `false` returns.
+below with their `check` parses: THIS verifier's totality requirements (round count,
+`evals` square against the commitments and points), stated as a total parse — the
+parse IS the proof. Production's `SRS::verify` carries no such explicit guards — its
+`Vec` payloads feed the transcript and the batched MSM equations as-is, so a
+mis-shaped claim reaches the same rejection through the equations it then fails.
+Clients compose check-then-verify.
 
 Generic over a single `CommitmentCurve` bundle — the Lean analogue of the Rust
 `G: CommitmentCurve` associated types: the base and scalar cardinalities with their
@@ -296,16 +298,16 @@ structure Input (C : CommitmentCurve) where
   /-- The wire opening proof. -/
   proof : Proof C
 
-/-- Parse a wire proof at round count `k` — the verifier's `lr`-length guard as a
-total parse. -/
+/-- Parse a wire proof at round count `k` — the checked verifier's `lr`-length
+requirement as a total parse. -/
 def Proof.check (k : ℕ) (w : Proof C) : Option (Ipa.Proof C k) :=
   if h : w.lr.size = k then
     some { lr := ⟨w.lr, h⟩, delta := w.delta, z1 := w.z1, z2 := w.z2, sg := w.sg }
   else none
 
-/-- Parse a wire claim at its announced shape — the verifier's dimension guards
-(`evals` square against the commitments and points, the proof at round count `k`) as
-a total parse into the checked input. -/
+/-- Parse a wire claim at its announced shape — the checked verifier's dimension
+requirements (`evals` square against the commitments and points, the proof at round
+count `k`) as a total parse into the checked input. -/
 def Input.check (k : ℕ) (w : Input C) :
     Option (Ipa.Input C k w.commitments.size w.xs.size) := do
   let proof ← w.proof.check k

--- a/formal/kimchi/Kimchi/Protocol/Equation.lean
+++ b/formal/kimchi/Kimchi/Protocol/Equation.lean
@@ -12,16 +12,6 @@ objects the aggregate family is built on.
 -/
 namespace Kimchi.Protocol.Equation
 
-/-- The permutation members' alpha indices, kernel-checked against the shared pool:
-the recurrence member sits at `α ^ gateAlphaCount` (the literal `21` of `permScalar`)
-and the two boundary members at the next slots (the literals `22`/`23` of `ftEval0`).
-The scalar-side closed forms keep the literals — this lemma pins their origin. -/
-theorem perm_member_alpha_indices :
-    (21 : ℕ) = Index.gateAlphaCount
-      ∧ (22 : ℕ) = Index.gateAlphaCount + 1
-      ∧ (23 : ℕ) = Index.gateAlphaCount + 2 :=
-  ⟨rfl, rfl, rfl⟩
-
 open Polynomial Kimchi.Lift Kimchi.Index Kimchi.Protocol.Linearization
 open Kimchi.GrandProduct
 open Kimchi.Lift.Gate
@@ -236,6 +226,17 @@ private theorem eval_permWitnessPoly_eq_w [NeZero n] (idx : Index F n)
 At the first permutation alpha, the `permScalar · σ₆(ζ)` term and `ftEval0`'s σ-side and
 shift-side products recombine into that alpha times the quotient's first permutation
 constraint at the honest record. -/
+
+/-- The permutation members' alpha indices, kernel-checked against the shared pool:
+the recurrence member sits at `α ^ gateAlphaCount` (the literal `21` of `permScalar`,
+`Protocol/Linearization.lean`) and the two boundary members at the next slots (the
+literals `22`/`23` of `ftEval0`, same module). The scalar-side closed forms keep the
+literals — this lemma pins their origin. -/
+theorem perm_member_alpha_indices :
+    (21 : ℕ) = Index.gateAlphaCount
+      ∧ (22 : ℕ) = Index.gateAlphaCount + 1
+      ∧ (23 : ℕ) = Index.gateAlphaCount + 2 :=
+  ⟨rfl, rfl, rfl⟩
 
 /-- **σ-side of the verifier equation.** The permutation scalar against `σ₆(ζ)`, minus
 `ftEval0`'s σ-side product against `z(ζω)`, plus its shift-side product against `z(ζ)`,

--- a/formal/kimchi/Kimchi/Verifier/Capstone/Algebraic.lean
+++ b/formal/kimchi/Kimchi/Verifier/Capstone/Algebraic.lean
@@ -14,9 +14,10 @@ algebraic-group-model idiom), so a SINGLE accepted IPA opening suffices — no g
 density. The content delivered here: representations + ONE accepted opening ⟹ the per-row
 eval pins (`eval_pins_of_opening`), replacing the special-soundness grid; the pins land in
 `kimchiProof_sound_of_openings`' consumer verbatim. Two new bad axes appear — the
-combination challenges `(ξ, r)` — with proved-small bad sets (`badXiOf`/`badROf`, ≤ 84 and
-≤ 1, counting SZ via `SZ.badComb`), curried by the consumer data `(E, ζ)`/`(E, ζ, ξ)` so
-they are quantified BEFORE `(ξ, r)`. Honest scope note: this corollary KEEPS the
+combination challenges `(ξ, r)` — with proved-small bad sets (`badXiOf`/`badROf`,
+≤ `2·(44·nc − 1)` and ≤ 1, counting SZ via `SZ.badComb`), curried by the consumer data
+`(E, ζ)`/`(E, ζ, ξ)` so they are quantified BEFORE `(ξ, r)`. Honest scope note: this
+corollary KEEPS the
 ft/quotient identity `hteq` (and `t`, `t.natDegree`) as a hypothesis — the same residue as
 the run-level capstones.
 
@@ -56,16 +57,18 @@ opening's value equation leaves the single field identity
 `∑ i, ξ^i · (∑ j, D i j · r^j) = 0` in the discrepancies
 `D i j = E i j − ⟨aw₀ i, evalVector (x j)⟩`, and two counting-Schwartz–Zippel steps
 (`SZ.badComb`, first at `r`, then at `ξ`) kill every `D i j` — the eval pins. The bad
-`(ξ, r)` sets are COUNTED, never assumed: `badXiOf` (≤ 84 = 2·(43−1)) depends only on
-`(σ, aw₀, x, E)`, `badROf` (≤ 1 = 2−1) additionally on `ξ` — neither mentions the
-challenge it guards, which is what lets the capstones quantify them BEFORE `(ξ, r)`. -/
+`(ξ, r)` sets are COUNTED, never assumed: `badXiOf` (≤ `2·(m − 1)` at `m` flat segments)
+depends only on `(σ, aw₀, x, E)`, `badROf` (≤ 1 = 2−1) additionally on `ξ` — neither
+mentions the challenge it guards, which is what lets the capstones quantify them
+BEFORE `(ξ, r)`. -/
 
 /-- The bad row-combination challenges of one claimed-vs-represented evaluation matrix:
 the union over the two eval points of the counting-SZ bad sets of the discrepancy
 columns `i ↦ E i j − ⟨aw₀ i, evalVector (x j)⟩`. Depends only on `(σ, aw₀, x, E)` —
 never on `ξ` or `r` (anti-vacuity: the capstone quantifies it before both). Arity-generic
-(`Fin m` rows): the AGM capstones use it at the 43-row `batchC`, the FS-reflection layer
-at the reflected run's own 45-row batch. -/
+(`Fin m` rows): the AGM capstones use it at the flattened 44-row `batchC` (`44·nc`
+segments), the FS-reflection layer at the reflected run's own `44·nc + 1`-segment flat
+batch (45 at `nc = 1`). -/
 noncomputable def badXiOf {F G : Type*} [Field F] [DecidableEq F]
     (σ : SRS G) {m : ℕ} (aw₀ : Fin m → Fin (2 ^ σ.k) → F)
     (x : Fin evalPts → F) (E : Fin m → Fin evalPts → F) : Finset F :=
@@ -82,8 +85,8 @@ noncomputable def badROf {F G : Type*} [Field F] [DecidableEq F]
   Kimchi.SZ.badComb (fun j : Fin evalPts => ∑ i : Fin m,
     ξ ^ (i : ℕ) * (E i j - innerProduct (aw₀ i) (evalVector (2 ^ σ.k) (x j))))
 
-/-- `badXiOf` counts at most `2 · (m − 1)` challenges (at the 43-row batch: `84`): a
-union of two counting-SZ bad sets over `Fin m`. -/
+/-- `badXiOf` counts at most `2 · (m − 1)` challenges (at the flattened batch's `44·nc`
+segments: `2·(44·nc − 1)`): a union of two counting-SZ bad sets over `Fin m`. -/
 private theorem card_badXiOf_le {F G : Type*} [Field F] [DecidableEq F]
     (σ : SRS G) {m : ℕ} (aw₀ : Fin m → Fin (2 ^ σ.k) → F)
     (x : Fin evalPts → F) (E : Fin m → Fin evalPts → F) :
@@ -113,8 +116,9 @@ binding (`hbind`, through `commitmentBinding_iff_no_relation`) forces the opened
 to BE that combination; the opening's value equation then reduces to
 `∑ j, r^j · (∑ i, ξ^i · D i j) = 0` in the discrepancies `D`, and
 `SZ.eq_zero_of_comb_eq_zero` — first at `r`, then per point at `ξ` — kills every
-`D i j`. Arity-generic: the AGM capstones consume it at the 43-row `batchC`, the
-FS-reflection layer at the reflected run's own 45-row batch. -/
+`D i j`. Arity-generic: the AGM capstones consume it at the flattened 44-row `batchC`
+(`44·nc` segments), the FS-reflection layer at the reflected run's own
+`44·nc + 1`-segment flat batch (45 at `nc = 1`). -/
 theorem eval_pins_of_opening {F G : Type*} [Field F] [DecidableEq F]
     [AddCommGroup G] [Module F G] (σ : SRS G)
     (hbind : ∀ (w : Fin (2 ^ σ.k) → F) (wh : F), DLRelation σ w wh → w = 0 ∧ wh = 0)

--- a/formal/kimchi/Kimchi/Verifier/Capstone/Standard.lean
+++ b/formal/kimchi/Kimchi/Verifier/Capstone/Standard.lean
@@ -12,8 +12,10 @@ batch — the wire commitment array pinned SEGMENT-wise to the flat stream of th
 44-row chunked assembly (`flatten (batchC …)`, the order the deployed verifier's
 `combined_inner_product` walks), one grid node per flat segment × eval point. Each
 node's `FiatShamirTreeB` family is derived from the node's own deployed acceptance via
-the per-node `poseidon_fiat_shamir_*` axiom, transported to the chunk combiners
-through the `_eq_flat` flattening lemmas — the same `hcip` move as `ipaVesta_sound`.
+the per-node `poseidon_fiat_shamir_*` axiom, transported to the chunk combiners through
+the flattening lemmas `chunkedCombinedCommitment_eq_flat` /
+`chunkedCombinedInnerProduct_eq_flat` (`Bulletproof/Protocol.lean`) — the same reshaping
+`ipaVesta_sound` performs on the bulletproof side.
 
 Trust story: the grid is a HYPOTHESIS (the forking/rewinding idiom, posited outright),
 one FS axiom per node, everything else proved. The run-level corollaries live in the
@@ -263,9 +265,13 @@ capstone's consumer implication instantiated at a real chunked run's own sponge
 challenges — the literal `runOracles` fields — over the run's own commitment
 chunks. The consumer grid `T'` shares the accumulator and public commitments and sits
 at the run's own `ζ`; its Fiat–Shamir trees, acceptances, and challenge injectivity
-discharge the capstone's transcript antecedents. The quotient residue
-`(t, hdeg, heq)` stays the one undischarged antecedent, exactly as at `nc = 1` (its
-dissolution is the `_ft` terminal's job). -/
+discharge the capstone's transcript antecedents. `T` is not simply `T'`: the reference
+grid drives the witness extraction at its own `ζ₀`, which the statement never ties to
+the run's `ζ` (only `T'.ζ₀` is pinned, through `hζ'`) — the two grids share just the
+accumulator and public commitment chunks (`hzC`, `hpC`), so identifying them would
+needlessly pin the reference transcript at the run's evaluation point. The quotient
+residue `(t, hdeg, heq)` stays the one undischarged antecedent, exactly as at `nc = 1`
+(its dissolution is the `_ft` terminal's job). -/
 theorem kimchiVesta_run_sound (σ : SRS IpaVesta.Point) {nc : ℕ} (hnc : 0 < nc)
     (pub : Array Fp) {n : ℕ} [NeZero n]
     (idx : Index Fp n)

--- a/formal/kimchi/Kimchi/Verifier/Reduction/Soundness.lean
+++ b/formal/kimchi/Kimchi/Verifier/Reduction/Soundness.lean
@@ -31,8 +31,12 @@ Two structural consequences of chunking:
   combined public claim (`claimedPub`) in `ft_eval0`'s public slot.
 
 Trust boundary: challenge grids for Fiat–Shamir, no-DL-relation binding, the key–index
-correspondence as hypothesis. The assembled witness polynomials have degree `< n`, so
-`Kimchi.Protocol.sound` consumption never sees the SRS.
+correspondence as hypothesis. The quotient `t` also enters as hypothesis data in the
+consumer's shape (the acceptance equation `hteq` at each `ζ`): a quotient serving every
+consumed evaluation point is a transcript-prefix fact, not something this layer can
+produce — its dissolution into the committed `t_comm` chunks is the `_ft` capstone's job
+(`ft_identity_of_chunks`, `Capstone/Algebraic.lean`). The assembled witness polynomials
+have degree `< n`, so `Kimchi.Protocol.sound` consumption never sees the SRS.
 -/
 open Bulletproof
 
@@ -123,7 +127,10 @@ def VKCorresponds [Field F] [AddCommGroup G] [Module F G] (σ : SRS G) (nc : ℕ
 
 The abstract rows are the deployed `to_batch` order (verifier.rs) with the ft row
 omitted — the ft opening is consumed separately (the `_ft` terminals read it off the
-run):
+run). Production's `to_batch` also pushes the recursion (`polys`, prev-challenge) rows
+ahead of the public row (verifier.rs:972); those rows are absent here because recursion
+(`prev_challenges`) is a declared deferral (the scope list in `Verifier/Kimchi.lean`).
+The rows:
 
 | row     | column                | `to_batch` push (verifier.rs)       |
 | ------- | --------------------- | ----------------------------------- |
@@ -261,12 +268,14 @@ theorem segTotal_eq_sum (nc : ℕ) : segTotal nc = ∑ _ : Fin batchRows, nc := 
   simp [segTotal, Finset.sum_const, Finset.card_univ, mul_comm]
 
 /-- The flat (segment) view of a per-row-per-chunk family, along `finSigmaFinEquiv` —
-the order `chunkedCombinedCommitment`/`chunkedCombinedInnerProduct` combine in. -/
+the order `chunkedCombinedCommitment`/`chunkedCombinedInnerProduct` combine in. Consumed
+by the capstone layer (`Capstone/Standard.lean`, `Capstone/Algebraic.lean`). -/
 def flatten {α : Type*} {m nc : ℕ} (f : Fin m → Fin nc → α) :
     Fin (∑ _ : Fin m, nc) → α :=
   fun s => f (finSigmaFinEquiv.symm s).1 (finSigmaFinEquiv.symm s).2
 
-/-- `flatten` at the multiplied index form. -/
+/-- `flatten` at the multiplied index form. Consumed by the capstone layer
+(`KimchiBatchAcc`'s stream pins `hcs`/`hes`, `Capstone/Standard.lean`). -/
 def flatSeg {α : Type*} {nc : ℕ} (f : Fin batchRows → Fin nc → α) : Fin (segTotal nc) → α :=
   fun s => flatten f (finCongr (segTotal_eq_sum nc) s)
 


### PR DESCRIPTION
## Summary

Enacts the deferred LOW-severity documentation findings from the #260 review (group C of the follow-up ledger). Docstrings and one same-file declaration move only — zero statement changes, zero proof changes.

- **Reduction/Soundness**: the batch-row table now notes production's recursion rows (`to_batch` pushes them before the public row, verifier.rs:972) and their declared `prev_challenges` deferral; the module header again explains why the quotient acceptance equation (`hteq`) is hypothesis data — a transcript-prefix fact whose dissolution into the committed `t_comm` chunks is the `_ft` capstone's job; `flatten`/`flatSeg` name their actual capstone consumers (verified by grep — Standard/Algebraic, not Reflection).
- **Capstone/Standard**: the two-transcript (`T`/`T'`) corollaries state why the reference grid is not the consumer grid (only `T'.ζ₀` is pinned through `hζ'`; identifying them would needlessly pin the reference at the run's evaluation point); the cross-package proof-local `hcip` citation is replaced by the public flattening lemmas `chunkedCombined{Commitment,InnerProduct}_eq_flat`.
- **Capstone/Algebraic**: arity-generic batch phrasing (`44·nc + 1` segments, 45 at `nc = 1`), plus a stale-bound catch beyond the original finding: the prose still claimed a "43-row `batchC`" and a `≤ 84 = 2·(43−1)` bad-set bound, contradicting the proved `2·((∑ _ : Fin batchRows, nc) − 1)`; corrected to `2·(44·nc − 1)` at all three sites.
- **Protocol/Equation**: `perm_member_alpha_indices` sits beside the permutation-member material with the pinned literals named (`21` of `permScalar`, `22`/`23` of `ftEval0`, `Protocol/Linearization.lean`). The reviewer's suggested cross-file move is barred by the targeted-import discipline: `Linearization` sits on the executable path and the lemma's closure pulls wholesale Mathlib.
- **Bulletproof Wire/Soundness**: the parse guards are attributed honestly — they are *this* verifier's totality requirements stated as a total parse; production's `SRS::verify` carries no such guards (mis-shaped claims reach the same rejection through the batch equations they then fail). `chunked_batch_soundness`'s clause 3 is documented as the recombination corollary of clauses 1 and 4, kept for direct consumers.

The reviewer's item on `Index/Degree.lean`'s nine `unnecessarySeqFocus` warnings was already resolved on main by #262; verified zero warnings on forced re-elaboration.

## Validation

`lake build` green across the workspace with no new warnings; style check clean; `runLinter` on both touched roots with no baseline growth; both packages' axiom gates pass (48 + 7 roots, allowed sets unchanged). All Rust claims re-verified against the vendored proof-systems (verifier.rs:972/:311–312, ipa.rs:195–387/:1129–1137).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSVEv2RHLtK4WDc4g3zZz7