### PR TITLE
formal: structural follow-ups from the #260 review — typing, dedup, layering

### DIFF
--- a/formal/bulletproof-pcs/Bulletproof/Reflection.lean
+++ b/formal/bulletproof-pcs/Bulletproof/Reflection.lean
@@ -163,12 +163,14 @@ theorem verify_reflects (σ : SRS C.Point) {m p : ℕ} (inp : Ipa.Input C σ.k m
       (transcript C inp).2.2
       (fun i => (transcript C inp).2.1[i])
       inp.commitmentFn inp.pointFn inp.evalFn := by
-  simp only [Ipa.verify] at hv
+  simp only [Ipa.transcript]
+  simp only [Ipa.verify, Ipa.verifyFrom] at hv
   rw [Bool.and_eq_true] at hv
   obtain ⟨hsch, hsg⟩ := hv
   rw [decide_eq_true_eq] at hsch hsg
   refine ⟨?_, ?_⟩
-  · rw [zipFold_eq_recombine _ inp.proof.lr.toArray (transcript C inp).2.1.toArray σ.k
+  · rw [zipFold_eq_recombine _ inp.proof.lr.toArray
+        (transcriptFrom C Poseidon.FqSponge.init inp).2.1.toArray σ.k
         (by simp) (by simp)] at hsch
     rw [combineCommitments_toArray_eq hsmul] at hsch
     unfold Bulletproof.recombine Ipa.Proof.toOpening

--- a/formal/bulletproof-pcs/Bulletproof/Wire.lean
+++ b/formal/bulletproof-pcs/Bulletproof/Wire.lean
@@ -80,6 +80,12 @@ structure CommitmentCurve where
   [primeScalar : Fact (Nat.Prime scalar)]
   /-- The Fq-sponge spec driving the verifier's Fiat-Shamir transcript. -/
   sponge : FqSponge.Spec base scalar
+  /-- The scalar-side Poseidon parameters — production's `G::sponge_params()`,
+  curve-determined like the fq-sponge spec. Not read by the IPA opening verifier
+  itself; carried on the bundle for the consumers that run a scalar-side (fr-)sponge
+  over the same curve (kimchi's `frOracles`), the way production types the table on
+  the curve rather than on any wire record. -/
+  frParams : Params (ZMod scalar)
   /-- The curve, in short-Weierstrass form over the base field. -/
   E : SWCurve (ZMod base)
   /-- The map-to-curve deriving the transcript `U` base from a squeezed field element. -/
@@ -213,19 +219,28 @@ def roundChallenges (s : FqSponge.S C.base) {k : ℕ} (lr : Vector (C.Point × C
   let r := roundChallengesAux C s lr.toArray
   (⟨r.1, (roundChallengesAux_size C s lr.toArray).trans lr.size_toArray⟩, r.2)
 
-/-- The verifier's Fiat-Shamir schedule (`SRS::verify`): absorb the shifted combined inner
-product; squeeze and map the `U` base; per round absorb `L`, `R` and squeeze a challenge;
-absorb `δ` and squeeze the Schnorr challenge. The round challenges come back as a
-`Vector` at the checked round count, so every downstream read is total. -/
-def transcript (inp : Input C k m p) :
+/-- The verifier's Fiat-Shamir schedule from a given initial sponge state `s₀`
+(`SRS::verify`, with the sponge supplied by the caller — kimchi hands the warm post-`ζ`
+fq-sponge state here, `BatchEvaluationProof { sponge: fq_sponge, .. }`): absorb the
+shifted combined inner product; squeeze and map the `U` base; per round absorb `L`, `R`
+and squeeze a challenge; absorb `δ` and squeeze the Schnorr challenge. The round
+challenges come back as a `Vector` at the checked round count, so every downstream read
+is total. -/
+def transcriptFrom (s₀ : FqSponge.S C.base) (inp : Input C k m p) :
     C.Point × Vector C.ScalarField k × C.ScalarField :=
-  let s := absorbFr C.sponge FqSponge.init (shiftScalar C (cipOf inp))
+  let s := absorbFr C.sponge s₀ (shiftScalar C (cipOf inp))
   let (t, s) := challengeFq C.sponge s
   let uBase := C.toGroup t
   let (chals, s) := roundChallenges C s inp.proof.lr
   let s := absorbG C.sponge s inp.proof.delta
   let (c, _) := squeezeChallenge C.sponge s
   (uBase, chals, c)
+
+/-- The standalone verifier's Fiat-Shamir schedule: `transcriptFrom` at the fresh
+sponge `FqSponge.init` — the cold start. -/
+def transcript (inp : Input C k m p) :
+    C.Point × Vector C.ScalarField k × C.ScalarField :=
+  transcriptFrom C FqSponge.init inp
 
 /-- A batched claim at given combination scalars — the checked input the grid rows of
 the soundness statements range over. The curve is implicit (inferred from the
@@ -236,13 +251,15 @@ def mkInput {C : CommitmentCurve} {k m p : ℕ} (commitments : Vector C.Point m)
   { commitments := commitments, xs := xs, evals := evals
     polyscale := ξ, evalscale := r, proof := proof }
 
-/-- The acceptance decision, against a library SRS: derive the transcript, combine the
-claim, and check the Schnorr and `sg`-correctness equations. The claim's shape is
-carried by its type (round count `σ.k`), so there are no runtime guards — rejecting
-ragged input is the wire parse's job. `σ.U` is never read — the deployed `U` is
-transcript-derived. -/
-def verify (σ : SRS C.Point) (inp : Input C σ.k m p) : Bool :=
-  let (uBase, chals, c) := transcript C inp
+/-- The acceptance decision from a given initial sponge state `s₀`, against a library
+SRS: derive the transcript (from `s₀` — kimchi's warm start hands the post-`ζ`
+fq-sponge state, verifier.rs:1184–1193), combine the claim, and check the Schnorr and
+`sg`-correctness equations. The claim's shape is carried by its type (round count
+`σ.k`), so there are no runtime guards — rejecting ragged input is the wire parse's
+job. `σ.U` is never read — the deployed `U` is transcript-derived. -/
+def verifyFrom (σ : SRS C.Point) (s₀ : FqSponge.S C.base) (inp : Input C σ.k m p) :
+    Bool :=
+  let (uBase, chals, c) := transcriptFrom C s₀ inp
   let chal : Fin σ.k → C.ScalarField := fun i => chals[i]
   let b0 := combinedB chal inp.evalscale inp.pointFn
   let v := cipOf inp
@@ -256,6 +273,11 @@ def verify (σ : SRS C.Point) (inp : Input C σ.k m p) : Bool :=
         + inp.proof.z2.val • σ.h)
   let sgOk := decide (inp.proof.sg = msm C σ.g (bPolyCoefficients chal))
   schnorr && sgOk
+
+/-- The standalone acceptance decision: `verifyFrom` at the fresh sponge
+`FqSponge.init` — the cold start, validated against the production opening fixtures. -/
+def verify (σ : SRS C.Point) (inp : Input C σ.k m p) : Bool :=
+  verifyFrom C σ FqSponge.init inp
 
 end Bulletproof.Ipa
 
@@ -327,11 +349,13 @@ namespace Bulletproof.IpaVesta
 open CompElliptic.Fields.Pasta CompElliptic.Curves.Pasta Poseidon Bulletproof
 
 /-- The Vesta bundle. The scalar modulus is below the base modulus, so scalars absorb in
-Type1 form. -/
+Type1 form. The scalar field is `Fp`, so `G::sponge_params()` is the `fp_kimchi`
+table. -/
 abbrev curve : Ipa.CommitmentCurve where
   base := PALLAS_SCALAR_CARD
   scalar := PALLAS_BASE_CARD
   sponge := FqVesta.spec
+  frParams := fpParams
   E := Vesta.curve
   toGroup := GroupMapVesta.toGroup
 
@@ -361,11 +385,13 @@ namespace Bulletproof.IpaPallas
 open CompElliptic.Fields.Pasta CompElliptic.Curves.Pasta Poseidon Bulletproof
 
 /-- The Pallas bundle. The scalar modulus is above the base modulus, so scalars absorb in
-Type2 form (selected by the cardinalities). -/
+Type2 form (selected by the cardinalities). The scalar field is `Fq`, so
+`G::sponge_params()` is the `fq_kimchi` table. -/
 abbrev curve : Ipa.CommitmentCurve where
   base := PALLAS_BASE_CARD
   scalar := PALLAS_SCALAR_CARD
   sponge := FqPallas.spec
+  frParams := fqParams
   E := Pallas.curve
   toGroup := GroupMapPallas.toGroup
 

--- a/formal/kimchi/Kimchi/Index/Basic.lean
+++ b/formal/kimchi/Kimchi/Index/Basic.lean
@@ -232,23 +232,24 @@ def build? [DecidableEq F] (gates : Fin n → GateRow F n) (publicCount zkRows :
       ∧ (∀ c : Fin permCols × Fin n, n - zkRows ≤ ((c.2 : ℕ)) → wiringMapOf gates c = c)
       ∧ (∀ i : Fin n, n - zkRows ≤ (i : ℕ) → (gates i).typ = .zero)
       ∧ (∀ i : Fin n, (i : ℕ) + 1 = n - zkRows → (gates i).typ.twoRow = false) then
+    have ⟨hpow, hprim, hcoset, hzk_three, hzk_le, hpublic_le, hbij, hregion,
+      hgeneric, hcoeffs, hmask_id, hmask_zero, hmask_boundary⟩ := h
     have homega : IsPrimitiveRoot omega n :=
-      isPrimitiveRoot_of_certificate'
-        (let ⟨k, _, hk⟩ := h.1; ⟨k, hk⟩) h.2.1
+      isPrimitiveRoot_of_certificate' (let ⟨k, _, hk⟩ := hpow; ⟨k, hk⟩) hprim
     some { gates := gates, publicCount := publicCount, zkRows := zkRows
            omega := omega, endoBase := endoBase, mds := mds, shifts := shifts
            omega_prim := homega
-           zk_three := h.2.2.2.1
-           zk_le := h.2.2.2.2.1
-           public_le := h.2.2.2.2.2.1
-           shifts_coset := cosetShifts_of_certificate homega h.2.2.1
-           wiring_bijective := h.2.2.2.2.2.2.1
-           wiring_region := h.2.2.2.2.2.2.2.1
-           public_generic := h.2.2.2.2.2.2.2.2.1
-           public_coeffs := h.2.2.2.2.2.2.2.2.2.1
-           masked_identity := h.2.2.2.2.2.2.2.2.2.2.1
-           masked_zero := h.2.2.2.2.2.2.2.2.2.2.2.1
-           masked_boundary := h.2.2.2.2.2.2.2.2.2.2.2.2 }
+           zk_three := hzk_three
+           zk_le := hzk_le
+           public_le := hpublic_le
+           shifts_coset := cosetShifts_of_certificate homega hcoset
+           wiring_bijective := hbij
+           wiring_region := hregion
+           public_generic := hgeneric
+           public_coeffs := hcoeffs
+           masked_identity := hmask_id
+           masked_zero := hmask_zero
+           masked_boundary := hmask_boundary }
   else none
 
 

--- a/formal/kimchi/Kimchi/Index/Satisfies.lean
+++ b/formal/kimchi/Kimchi/Index/Satisfies.lean
@@ -54,7 +54,7 @@ def rowSatisfies (idx : Index F n) (pub : Fin idx.publicCount → F)
 
 /-- The value of a permuted cell: column `c.1` (of the seven) at row `c.2`. -/
 def cellValue (wTab : Fin n → Fin wCols → F) (c : Fin permCols × Fin n) : F :=
-  wTab c.2 (Fin.castLE (by omega) c.1)
+  wTab c.2 (permCol c.1)
 
 /-- A witness table satisfies an index at a public input: every row's gate holds, every
 permuted cell equals its wired-to cell, and the public rows pin the first column. -/

--- a/formal/kimchi/Kimchi/Lift.lean
+++ b/formal/kimchi/Kimchi/Lift.lean
@@ -53,6 +53,31 @@ in the library; every per-gate bridge is that gate's `constraints_map` pasted on
   carrying its polynomial-side constraints to the row-side ones.
 -/
 
+namespace Kimchi
+
+/-! ## The column embeddings
+
+The permuted (wired) columns are the FIRST SEVEN witness columns
+(`PERMUTS ≤ COLUMNS`, proof-systems `circuits/wires.rs`), and the batch carries the
+first six of the seven committed σ columns (`sigma_comm[PERMUTS − 1]` is linearized
+away). These three embeddings name every inclusion between the column index types;
+they are `abbrev`s (fully reducible), so each is definitionally the anonymous
+`⟨i, _⟩` it replaces. -/
+
+/-- Wired column `i` as a witness column: the wired columns are the first seven
+witness columns (`PERMUTS ≤ COLUMNS`, proof-systems `circuits/wires.rs`). -/
+abbrev permCol (i : Fin permCols) : Fin wCols := ⟨i, by omega⟩
+
+/-- Batched σ column `i` as a witness column: the first six of the seven wired
+columns, which are the first seven witness columns. -/
+abbrev sigmaCol (i : Fin sigmaRows) : Fin wCols := ⟨i, by omega⟩
+
+/-- Batched σ column `i` among the seven committed σ columns: the batch carries
+`sigma_comm[0..5]` (the seventh is consumed by the linearization instead). -/
+abbrev sigmaPermCol (i : Fin sigmaRows) : Fin permCols := ⟨i, by omega⟩
+
+end Kimchi
+
 namespace Kimchi.Lift
 
 open Polynomial

--- a/formal/kimchi/Kimchi/Protocol/Equation.lean
+++ b/formal/kimchi/Kimchi/Protocol/Equation.lean
@@ -38,7 +38,7 @@ noncomputable def evalsOf (idx : Index F n) (wTab : Fin n → Fin wCols → F)
     wOmega := fun c => (columnPoly idx.omega (fun j => wTab j c)).eval (idx.omega * ζ)
     z := z.eval ζ
     zOmega := z.eval (idx.omega * ζ)
-    s := fun i => (idx.sigmaPoly ⟨(i : ℕ), by omega⟩).eval ζ
+    s := fun i => (idx.sigmaPoly (sigmaPermCol i)).eval ζ
     coeffs := fun c => (columnPoly idx.omega (fun j => idx.coeffTable j c)).eval ζ
     genericSelector := (idx.selectorPoly .generic).eval ζ
     poseidonSelector := (idx.selectorPoly .poseidon).eval ζ
@@ -226,9 +226,8 @@ this is the tiny naturality square that lets the σ-side recurrence recombine. -
 /-- The `permWitnessPoly` interpolant of column `col`, evaluated at `ζ`, is the honest
 record's witness value in that column. -/
 private theorem eval_permWitnessPoly_eq_w [NeZero n] (idx : Index F n)
-    (wTab : Fin n → Fin wCols → F) (z : Polynomial F) (ζ : F) (col : Fin permCols)
-    (h : (col : ℕ) < 15) :
-    (idx.permWitnessPoly wTab col).eval ζ = (evalsOf idx wTab z ζ).w ⟨(col : ℕ), h⟩ := by
+    (wTab : Fin n → Fin wCols → F) (z : Polynomial F) (ζ : F) (col : Fin permCols) :
+    (idx.permWitnessPoly wTab col).eval ζ = (evalsOf idx wTab z ζ).w (permCol col) := by
   rfl
 
 /-! ## The σ-side recurrence recombination
@@ -243,17 +242,17 @@ all at `α²¹·zkpm(ζ)`, equals `α²¹` times the quotient's `0`-th permutati
 the honest record. -/
 private theorem permMember_eval [NeZero n] (idx : Index F n) (wTab : Fin n → Fin wCols → F)
     (z : Polynomial F) (ζ β γ α : F) (σ : Fin permCols → Polynomial F)
-    (hσ : ∀ i : Fin sigmaRows, (σ ⟨(i : ℕ), by omega⟩).eval ζ = (evalsOf idx wTab z ζ).s i)
+    (hσ : ∀ i : Fin sigmaRows, (σ (sigmaPermCol i)).eval ζ = (evalsOf idx wTab z ζ).s i)
     (r₀ r₁ : Fin n) :
     permScalar β γ α (zkpmEval n idx.zkRows idx.omega ζ) (evalsOf idx wTab z ζ)
         * (σ 6).eval ζ
       - ((evalsOf idx wTab z ζ).w 6 + γ) * (evalsOf idx wTab z ζ).zOmega
           * α ^ 21 * zkpmEval n idx.zkRows idx.omega ζ
           * ∏ i : Fin sigmaRows, (β * (evalsOf idx wTab z ζ).s i
-              + (evalsOf idx wTab z ζ).w ⟨(i : ℕ), by omega⟩ + γ)
+              + (evalsOf idx wTab z ζ).w (sigmaCol i) + γ)
       + (α ^ 21 * zkpmEval n idx.zkRows idx.omega ζ * (evalsOf idx wTab z ζ).z)
           * ∏ i : Fin permCols, (γ + β * ζ * idx.shifts i
-              + (evalsOf idx wTab z ζ).w ⟨(i : ℕ), by omega⟩)
+              + (evalsOf idx wTab z ζ).w (permCol i))
       = α ^ 21 * (Permutation.constraints idx.omega idx.zkRows z
           (idx.permWitnessPoly wTab) σ idx.shifts β γ r₀ r₁ 0).eval ζ := by
   rw [zkpmEval_eq]
@@ -264,26 +263,26 @@ private theorem permMember_eval [NeZero n] (idx : Index F n) (wTab : Fin n → F
   have hshift : (∏ x : Fin permCols,
         (eval ζ (idx.permWitnessPoly wTab x) + γ + β * idx.shifts x * ζ))
       = ∏ i : Fin permCols, (γ + β * ζ * idx.shifts i
-          + (evalsOf idx wTab z ζ).w ⟨(i : ℕ), by omega⟩) :=
+          + (evalsOf idx wTab z ζ).w (permCol i)) :=
     Finset.prod_congr rfl fun x _ => by
-      rw [eval_permWitnessPoly_eq_w idx wTab z ζ x (by omega)]; ring
+      rw [eval_permWitnessPoly_eq_w idx wTab z ζ x]; ring
   -- split the σ-side 7-product off its last factor
   have hsigma : (∏ x : Fin permCols,
         (eval ζ (idx.permWitnessPoly wTab x) + γ + β * eval ζ (σ x)))
       = (∏ i : Fin sigmaRows, (β * (evalsOf idx wTab z ζ).s i
-            + (evalsOf idx wTab z ζ).w ⟨(i : ℕ), by omega⟩ + γ))
+            + (evalsOf idx wTab z ζ).w (sigmaCol i) + γ))
           * ((evalsOf idx wTab z ζ).w 6 + γ + β * eval ζ (σ 6)) := by
     rw [Fin.prod_univ_castSucc]
     congr 1
     refine Finset.prod_congr rfl fun i _ => ?_
-    rw [show (i.castSucc : Fin permCols) = (⟨(i : ℕ), by omega⟩ : Fin permCols) from rfl,
-      eval_permWitnessPoly_eq_w idx wTab z ζ ⟨(i : ℕ), by omega⟩ (by omega), hσ i]
+    rw [show (i.castSucc : Fin permCols) = sigmaPermCol i from rfl,
+      eval_permWitnessPoly_eq_w idx wTab z ζ (sigmaPermCol i), hσ i]
     ring
   rw [hshift, hsigma,
     show (∏ i : Fin sigmaRows, (γ + β * (evalsOf idx wTab z ζ).s i
-            + (evalsOf idx wTab z ζ).w ⟨(i : ℕ), by omega⟩))
+            + (evalsOf idx wTab z ζ).w (sigmaCol i)))
         = ∏ i : Fin sigmaRows, (β * (evalsOf idx wTab z ζ).s i
-            + (evalsOf idx wTab z ζ).w ⟨(i : ℕ), by omega⟩ + γ) from
+            + (evalsOf idx wTab z ζ).w (sigmaCol i) + γ) from
       Finset.prod_congr rfl fun i _ => by ring]
   simp only [evalsOf, mul_comm idx.omega ζ]
   ring

--- a/formal/kimchi/Kimchi/Protocol/Linearization.lean
+++ b/formal/kimchi/Kimchi/Protocol/Linearization.lean
@@ -25,6 +25,7 @@ variable {F : Type*} [Field F]
 
 /-- The combined evaluations the scalar side reads: each column at `ζ`, with the witness
 and the accumulator also at `ζω`. -/
+@[ext]
 structure Evals (F : Type*) where
   /-- The witness columns (`wCols`) at `ζ`. -/
   w : Fin wCols → F
@@ -94,7 +95,7 @@ def gateLinearization (endo : F) (mds : Kimchi.Gate.Poseidon.Mds F) (α : F)
 row of the permutation recurrence, at the first permutation alpha. -/
 def permScalar (β γ α zkpmZ : F) (e : Evals F) : F :=
   -(e.zOmega * β * α ^ 21 * zkpmZ
-    * ∏ i : Fin sigmaRows, (γ + β * e.s i + e.w ⟨i, by omega⟩))
+    * ∏ i : Fin sigmaRows, (γ + β * e.s i + e.w (sigmaCol i)))
 
 /-- The permutation vanishing polynomial at a point:
 `zkpm(ζ) = (ζ − ω^{n−zkRows})(ζ − ω^{n−zkRows+1})(ζ − ω^{n−1})` — production's
@@ -112,9 +113,9 @@ def ftEval0 (n zkRows : ℕ) (ω : F) (shifts : Fin permCols → F) (endo : F)
   let zeta1m1 := ζ ^ n - 1
   let wBoundary := ω ^ (n - zkRows)
   let sigmaSide := ((e.w 6 + γ) * e.zOmega * α ^ 21 * zkpmZ)
-    * ∏ i : Fin sigmaRows, (β * e.s i + e.w ⟨i, by omega⟩ + γ)
+    * ∏ i : Fin sigmaRows, (β * e.s i + e.w (sigmaCol i) + γ)
   let shiftSide := (α ^ 21 * zkpmZ * e.z)
-    * ∏ i : Fin permCols, (γ + β * ζ * shifts i + e.w ⟨i, by omega⟩)
+    * ∏ i : Fin permCols, (γ + β * ζ * shifts i + e.w (permCol i))
   let boundary := ((zeta1m1 * α ^ 22 * (ζ - wBoundary) + zeta1m1 * α ^ 23 * (ζ - 1))
     * (1 - e.z)) / ((ζ - wBoundary) * (ζ - 1))
   sigmaSide - pubEval - shiftSide + boundary - gateLinearization endo mds α e

--- a/formal/kimchi/Kimchi/Verifier/Capstone/Reflection.lean
+++ b/formal/kimchi/Kimchi/Verifier/Capstone/Reflection.lean
@@ -136,94 +136,6 @@ private theorem stream_tail_read (q c : ℕ) (hq : q < tailRowCount) (hc : c < n
   simp only [show nc + 1 + q * nc + c - (nc + 1) = q * nc + c from by omega]
   exact flatten_read _ q c hq hc
 
-/-- Tail row `j < 7` is the `j`-th literal row (`z` + the six selectors). -/
-private theorem tailRows_read_lit (j : ℕ) (hj : j < litRowCount) :
-    (tailRowsOf C cvk cp)[j]'(by omega)
-      = ((⟨#[zipSeg C cp.zComm cp.evals.z,
-            zipSeg C cvk.genericComm cp.evals.genericSelector,
-            zipSeg C cvk.poseidonComm cp.evals.poseidonSelector,
-            zipSeg C cvk.completeAddComm cp.evals.completeAddSelector,
-            zipSeg C cvk.mulComm cp.evals.mulSelector,
-            zipSeg C cvk.emulComm cp.evals.emulSelector,
-            zipSeg C cvk.endomulScalarComm cp.evals.endomulScalarSelector], rfl⟩
-          : Vector (Vector (C.Point × C.ScalarField × C.ScalarField) nc) litRowCount)[j]'hj) := by
-  show ((⟨#[zipSeg C cp.zComm cp.evals.z,
-        zipSeg C cvk.genericComm cp.evals.genericSelector,
-        zipSeg C cvk.poseidonComm cp.evals.poseidonSelector,
-        zipSeg C cvk.completeAddComm cp.evals.completeAddSelector,
-        zipSeg C cvk.mulComm cp.evals.mulSelector,
-        zipSeg C cvk.emulComm cp.evals.emulSelector,
-        zipSeg C cvk.endomulScalarComm cp.evals.endomulScalarSelector], rfl⟩
-          : Vector (Vector (C.Point × C.ScalarField × C.ScalarField) nc) litRowCount)
-      ++ (cp.wComm.zip cp.evals.w).map (fun x => zipSeg C x.1 x.2)
-      ++ (cvk.coefficientsComm.zip cp.evals.coefficients).map (fun x => zipSeg C x.1 x.2)
-      ++ ((cvk.sigmaComm.take sigmaRows).zip cp.evals.s).map
-        (fun x => zipSeg C x.1 x.2))[j]'(by omega) = _
-  rw [Vector.getElem_append, dif_pos (by omega), Vector.getElem_append,
-    dif_pos (by omega), Vector.getElem_append, dif_pos hj]
-
-/-- Tail row `7 + q` is witness column `q`'s row. -/
-private theorem tailRows_read_w (q : ℕ) (hq : q < wCols) :
-    (tailRowsOf C cvk cp)[7 + q]'(by omega)
-      = zipSeg C (cp.wComm[q]'hq) (cp.evals.w[q]'hq) := by
-  show ((⟨#[zipSeg C cp.zComm cp.evals.z,
-        zipSeg C cvk.genericComm cp.evals.genericSelector,
-        zipSeg C cvk.poseidonComm cp.evals.poseidonSelector,
-        zipSeg C cvk.completeAddComm cp.evals.completeAddSelector,
-        zipSeg C cvk.mulComm cp.evals.mulSelector,
-        zipSeg C cvk.emulComm cp.evals.emulSelector,
-        zipSeg C cvk.endomulScalarComm cp.evals.endomulScalarSelector], rfl⟩
-          : Vector (Vector (C.Point × C.ScalarField × C.ScalarField) nc) litRowCount)
-      ++ (cp.wComm.zip cp.evals.w).map (fun x => zipSeg C x.1 x.2)
-      ++ (cvk.coefficientsComm.zip cp.evals.coefficients).map (fun x => zipSeg C x.1 x.2)
-      ++ ((cvk.sigmaComm.take sigmaRows).zip cp.evals.s).map
-        (fun x => zipSeg C x.1 x.2))[7 + q]'(by omega) = _
-  rw [Vector.getElem_append, dif_pos (by omega), Vector.getElem_append,
-    dif_pos (by omega), Vector.getElem_append, dif_neg (by omega)]
-  simp only [show 7 + q - 7 = q from by omega, Vector.getElem_map, Vector.getElem_zip]
-
-/-- Tail row `22 + q` is coefficient column `q`'s row. -/
-private theorem tailRows_read_c (q : ℕ) (hq : q < coeffCols) :
-    (tailRowsOf C cvk cp)[22 + q]'(by omega)
-      = zipSeg C (cvk.coefficientsComm[q]'hq) (cp.evals.coefficients[q]'hq) := by
-  show ((⟨#[zipSeg C cp.zComm cp.evals.z,
-        zipSeg C cvk.genericComm cp.evals.genericSelector,
-        zipSeg C cvk.poseidonComm cp.evals.poseidonSelector,
-        zipSeg C cvk.completeAddComm cp.evals.completeAddSelector,
-        zipSeg C cvk.mulComm cp.evals.mulSelector,
-        zipSeg C cvk.emulComm cp.evals.emulSelector,
-        zipSeg C cvk.endomulScalarComm cp.evals.endomulScalarSelector], rfl⟩
-          : Vector (Vector (C.Point × C.ScalarField × C.ScalarField) nc) litRowCount)
-      ++ (cp.wComm.zip cp.evals.w).map (fun x => zipSeg C x.1 x.2)
-      ++ (cvk.coefficientsComm.zip cp.evals.coefficients).map (fun x => zipSeg C x.1 x.2)
-      ++ ((cvk.sigmaComm.take sigmaRows).zip cp.evals.s).map
-        (fun x => zipSeg C x.1 x.2))[22 + q]'(by omega) = _
-  rw [Vector.getElem_append, dif_pos (by omega), Vector.getElem_append,
-    dif_neg (by omega)]
-  simp only [show 22 + q - (7 + 15) = q from by omega, Vector.getElem_map,
-    Vector.getElem_zip]
-
-/-- Tail row `37 + q` is the `q`-th σ row. -/
-private theorem tailRows_read_s (q : ℕ) (hq : q < sigmaRows) :
-    (tailRowsOf C cvk cp)[37 + q]'(by omega)
-      = zipSeg C (cvk.sigmaComm[q]'(by omega)) (cp.evals.s[q]'hq) := by
-  show ((⟨#[zipSeg C cp.zComm cp.evals.z,
-        zipSeg C cvk.genericComm cp.evals.genericSelector,
-        zipSeg C cvk.poseidonComm cp.evals.poseidonSelector,
-        zipSeg C cvk.completeAddComm cp.evals.completeAddSelector,
-        zipSeg C cvk.mulComm cp.evals.mulSelector,
-        zipSeg C cvk.emulComm cp.evals.emulSelector,
-        zipSeg C cvk.endomulScalarComm cp.evals.endomulScalarSelector], rfl⟩
-          : Vector (Vector (C.Point × C.ScalarField × C.ScalarField) nc) litRowCount)
-      ++ (cp.wComm.zip cp.evals.w).map (fun x => zipSeg C x.1 x.2)
-      ++ (cvk.coefficientsComm.zip cp.evals.coefficients).map (fun x => zipSeg C x.1 x.2)
-      ++ ((cvk.sigmaComm.take sigmaRows).zip cp.evals.s).map
-        (fun x => zipSeg C x.1 x.2))[37 + q]'(by omega) = _
-  rw [Vector.getElem_append, dif_neg (by omega)]
-  simp only [show 37 + q - (7 + 15 + 15) = q from by omega, Vector.getElem_map,
-    Vector.getElem_zip, Vector.getElem_take]
-  rfl
-
 end StreamReads
 
 /-! ## The stream positions
@@ -569,31 +481,6 @@ private theorem addFoldl_aux {α G : Type*} [AddCommMonoid G] (f : α → G) (l 
       Fin.getElem_fin, List.getElem_cons_zero, List.getElem_cons_succ]
     rw [add_assoc]
 
-/-- **The checked key–index correspondence**: the committed chunk columns are the
-circuit's own (`VKCorresponds`, through the total `comms` view), the scalar-side
-parameters match (the domain generator, the zero-knowledge row count, the shifts, the
-`ft_eval0` endo coefficient, and the Poseidon MDS — read off the fr-sponge table), AND
-the Lagrange-basis chunk commitments over the public region are the basis polynomials'
-own chunk commitments. The Lagrange pin is what binds the proof-carried public
-evaluations (the public batch row) to the circuit's public input: the verifier
-COMPUTES the public commitment from these key entries. Adjudicated numerically, per
-chunk, by `check_vk_correspond`. -/
-def KimchiVK.Corresponds {C : Ipa.CommitmentCurve}
-    [Module C.ScalarField C.Point] {nc : ℕ} {n : ℕ}
-    (σ : SRS C.Point) (cvk : KimchiVK C nc)
-    (idx : Index C.ScalarField n) : Prop :=
-  VKCorresponds σ nc cvk.comms idx
-    ∧ cvk.omega = idx.omega
-    ∧ cvk.zkRows = idx.zkRows
-    ∧ (fun i : Fin permCols => cvk.shifts[i]) = idx.shifts
-    ∧ cvk.endo = idx.endoBase
-    ∧ mdsOfParams cvk.frParams = idx.mds
-    ∧ ∀ (j : Fin n), (j : ℕ) < idx.publicCount →
-        ∀ (hj : (j : ℕ) < cvk.lagrangeBasis.size) (c : Fin nc),
-          (cvk.lagrangeBasis[(j : ℕ)]'hj)[c]
-            = commitPolyChunk σ
-                (columnPoly idx.omega (Kimchi.Permutation.rowIndicator j)) (c : ℕ)
-
 /-- **The public commitment corresponds**: under the Lagrange chunk pin, the deployed
 verifier's per-chunk public commitment is the per-chunk masked commitment of the
 NEGATED public interpolant — the `pubC` feed of the reduction. The `.val`-scalar
@@ -773,20 +660,6 @@ private theorem powPow2_eq {F : Type*} [Field F] (x : F) (k : ℕ) :
     rw [pow_succ]
     omega
 
-/-- Extensionality for the linearization's evaluation record. -/
-private theorem evals_ext {F : Type*} {e e' : Evals F} (h1 : e.w = e'.w)
-    (h2 : e.wOmega = e'.wOmega) (h3 : e.z = e'.z) (h4 : e.zOmega = e'.zOmega)
-    (h5 : e.s = e'.s) (h6 : e.coeffs = e'.coeffs)
-    (h7 : e.genericSelector = e'.genericSelector)
-    (h8 : e.poseidonSelector = e'.poseidonSelector)
-    (h9 : e.completeAddSelector = e'.completeAddSelector)
-    (h10 : e.mulSelector = e'.mulSelector) (h11 : e.emulSelector = e'.emulSelector)
-    (h12 : e.endoScalarSelector = e'.endoScalarSelector) : e = e' := by
-  cases e
-  cases e'
-  simp only [Evals.mk.injEq]
-  exact ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9, h10, h11, h12⟩
-
 /-- Reading the run input's evaluation matrix at a stream position: the flat row's
 claim pair. -/
 private theorem runEvals_read (i : Fin batchRows) (c : Fin nc) :
@@ -823,7 +696,7 @@ private theorem claimedEvals_run_eq :
           ((runInputP C σ cvk cp pub pe v u).evals[(streamPos nc i ch : ℕ)]'
               ((streamPos nc i ch).isLt))[(j : ℕ)]'j.isLt)
       = cp.linEvals (runZetaM C σ cvk cp pub) (runZetaOmegaM C σ cvk cp pub) := by
-  refine evals_ext ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_
+  refine Evals.ext ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_
   · funext col
     refine sum_readsTo C _ _ (by simp) _ fun ch => ?_
     beta_reduce

--- a/formal/kimchi/Kimchi/Verifier/Kimchi.lean
+++ b/formal/kimchi/Kimchi/Verifier/Kimchi.lean
@@ -1,6 +1,6 @@
 import Bulletproof.Wire
 import Kimchi.Protocol.Linearization
-import Kimchi.Verifier.Reduction.Correspond
+import Kimchi.Columns
 import Poseidon.FqSponge
 import Kimchi.Index.Basic
 
@@ -154,19 +154,22 @@ structure KimchiVK (C : Ipa.CommitmentCurve) (nc : ℕ) where
   endo : C.ScalarField
   /-- The precomputed `VerifierIndex::digest()` — an input here. -/
   digest : C.BaseField
-  /-- The Lagrange-basis commitments, chunk-validated in full. -/
+  /-- The Lagrange-basis commitments, chunk-validated in full — SRS-derived data
+  (`get_lagrange_basis` computes them from the SRS), a model input like `digest`. -/
   lagrangeBasis : Array (Vector C.Point nc)
-  /-- The scalar-side Poseidon parameters (`G::sponge_params()`), for the fr-sponge. -/
-  frParams : Params C.ScalarField
 
 /-- The domain size of a checked key. -/
 def KimchiVK.n {C : Ipa.CommitmentCurve} {nc : ℕ}
     (cvk : KimchiVK C nc) : ℕ := 2 ^ cvk.domainLog2
 
-/-- The fr-sponge spec of a checked key. -/
-private def KimchiVK.frSpec {C : Ipa.CommitmentCurve} {nc : ℕ}
-    (cvk : KimchiVK C nc) : FqSponge.Spec C.scalar C.scalar :=
-  ⟨cvk.frParams, 0⟩
+/-- The fr-sponge spec of a commitment curve: the curve's scalar-side Poseidon
+parameters (`C.frParams`, production's `G::sponge_params()`) with `lam := 0` —
+deliberately dead: the fr-sponge path never endo-expands through its own spec.
+`frOracles` expands its two squeezed prechallenges at `C.sponge.lam` (the eigenvalue
+lives on the fq-side spec), and `frDigest`'s `challengeFq`/`challengeNat` never read
+`lam`, so the slot is unused and zeroed. -/
+private def frSpec (C : Ipa.CommitmentCurve) : FqSponge.Spec C.scalar C.scalar :=
+  ⟨C.frParams, 0⟩
 
 /-- A Poseidon parameter table's MDS matrix as the gate's `Mds` record — the wire form
 of production's `Constants { mds: G::sponge_params().mds, .. }` (the scalar-side table,
@@ -236,39 +239,6 @@ def publicEvals {F : Type*} [Field F] (n : ℕ)
     (pubDot omega zeta pub * (zetaN - 1) * (n : F)⁻¹,
      pubDot omega zetaOmega pub * (n : F)⁻¹ * (zetaOmegaN - 1))
 
-/-! ## The warm-sponge opening finish -/
-
-/-- The IPA acceptance from a **warm** sponge state: production hands the post-`ζ`
-fq-sponge to the opening verifier (`BatchEvaluationProof { sponge: fq_sponge, .. }`,
-verifier.rs:1184–1193). The standalone `Bulletproof.Ipa.verify` (validated against the
-opening fixtures) hard-codes the fresh `FqSponge.init` start, so this is a copy: the
-verbatim body of `Ipa.transcript` + `Ipa.verify` with `FqSponge.init` replaced by
-`s₀`. That verbatim correspondence is the invariant that keeps the copy in sync with
-`Bulletproof.Ipa`, and the copy, like the rest of this module, is adjudicated against
-production by the fixture drivers. The claim's shape is carried by its type, so there
-are no runtime guards. -/
-def Ipa.verifyFrom {m p : ℕ} (σ : SRS C.Point) (s₀ : FqSponge.S C.base)
-    (inp : Ipa.Input C σ.k m p) : Bool :=
-  let s := absorbFr C.sponge s₀ (Ipa.shiftScalar C (Ipa.cipOf inp))
-  let (t, s) := challengeFq C.sponge s
-  let uBase := C.toGroup t
-  let (chals, s) := Ipa.roundChallenges C s inp.proof.lr
-  let s := absorbG C.sponge s inp.proof.delta
-  let (c, _) := squeezeChallenge C.sponge s
-  let chal : Fin σ.k → C.ScalarField := fun i => chals[i]
-  let b0 := combinedB chal inp.evalscale inp.pointFn
-  let v := Ipa.cipOf inp
-  let P := Ipa.combineCommitments C inp.polyscale inp.commitments.toArray
-  let Q := (inp.proof.lr.toArray.zip chals.toArray).foldl
-    (fun acc (LRu : (C.Point × C.Point) × C.ScalarField) =>
-      acc + (LRu.2⁻¹.val • LRu.1.1 + LRu.2.val • LRu.1.2))
-    (P + v.val • uBase)
-  let schnorr := decide (c.val • Q + inp.proof.delta
-    = inp.proof.z1.val • inp.proof.sg + (inp.proof.z1 * b0).val • uBase
-        + inp.proof.z2.val • σ.h)
-  let sgOk := decide (inp.proof.sg = Ipa.msm C σ.g (bPolyCoefficients chal))
-  schnorr && sgOk
-
 /-! ## The Fiat-Shamir schedules -/
 
 /-- The fq-sponge schedule of `oracles` (verifier.rs:156–283): `absorb_commitment` is
@@ -292,10 +262,10 @@ chunk vector — the two public chunk vectors via `absorb_multiple` (:391–392)
 column the `ζ`-chunk vector and the `ζω`-chunk vector (`absorb_evaluations`,
 plonk_sponge.rs: one `sponge.absorb` per point vector), in the `absorb_evaluations`
 order. -/
-def frOracles {nc k : ℕ} (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
+def frOracles {nc k : ℕ} (cp : KimchiProof C nc k)
     (fqDig : C.ScalarField) (pubEvals : PointEvaluations (Vector C.ScalarField nc)) :
     C.ScalarField × C.ScalarField :=
-  let sp := cvk.frSpec
+  let sp := frSpec C
   let ab := fun (s : FqSponge.S C.scalar)
       (e : PointEvaluations (Vector C.ScalarField nc)) =>
     absorbFq sp (absorbFq sp s e.zeta.toList) e.zetaOmega.toList
@@ -401,21 +371,92 @@ def zipSeg {nc : ℕ} (comm : Vector C.Point nc)
     Vector (C.Point × C.ScalarField × C.ScalarField) nc :=
   Vector.ofFn fun c => (comm[c], ev.zeta[c], ev.zetaOmega[c])
 
+/-- The literal single-column head block of the batch tail, in `to_batch` order: the
+accumulator `z` and the six selectors — the `litRowCount` rows whose commitments are
+single named record fields. The ONE place this vector literal is written; every read
+of the head region goes through `tailRows_read_lit` below. -/
+def litRowsOf {nc k : ℕ} (cvk : KimchiVK C nc) (cp : KimchiProof C nc k) :
+    Vector (Vector (C.Point × C.ScalarField × C.ScalarField) nc) litRowCount :=
+  ⟨#[zipSeg C cp.zComm cp.evals.z,
+     zipSeg C cvk.genericComm cp.evals.genericSelector,
+     zipSeg C cvk.poseidonComm cp.evals.poseidonSelector,
+     zipSeg C cvk.completeAddComm cp.evals.completeAddSelector,
+     zipSeg C cvk.mulComm cp.evals.mulSelector,
+     zipSeg C cvk.emulComm cp.evals.emulSelector,
+     zipSeg C cvk.endomulScalarComm cp.evals.endomulScalarSelector], rfl⟩
+
 /-- The 43 tail rows of the batch stream in `to_batch` order (`z`, the six selectors,
 witness `0–14`, coefficients `0–14`, σ `0–5`), each row its per-chunk segments. -/
 def tailRowsOf {nc k : ℕ} (cvk : KimchiVK C nc) (cp : KimchiProof C nc k) :
     Vector (Vector (C.Point × C.ScalarField × C.ScalarField) nc) tailRowCount :=
-  (⟨#[zipSeg C cp.zComm cp.evals.z,
-      zipSeg C cvk.genericComm cp.evals.genericSelector,
-      zipSeg C cvk.poseidonComm cp.evals.poseidonSelector,
-      zipSeg C cvk.completeAddComm cp.evals.completeAddSelector,
-      zipSeg C cvk.mulComm cp.evals.mulSelector,
-      zipSeg C cvk.emulComm cp.evals.emulSelector,
-      zipSeg C cvk.endomulScalarComm cp.evals.endomulScalarSelector], rfl⟩
-    : Vector _ litRowCount)
+  litRowsOf C cvk cp
   ++ (cp.wComm.zip cp.evals.w).map (fun x => zipSeg C x.1 x.2)
   ++ (cvk.coefficientsComm.zip cp.evals.coefficients).map (fun x => zipSeg C x.1 x.2)
   ++ ((cvk.sigmaComm.take sigmaRows).zip cp.evals.s).map (fun x => zipSeg C x.1 x.2)
+
+/-! ### The tail-region reads
+
+The four append regions of `tailRowsOf`, read off by `Vector.getElem_append` dispatch —
+stated here, next to the definition, so its region layout is written exactly once. The
+reflection layer (`Capstone/Reflection.lean`) consumes these for every stream read. -/
+
+section TailReads
+
+variable {nc k : ℕ} {cvk : KimchiVK C nc} {cp : KimchiProof C nc k}
+
+/-- Tail row `j < 7` is the `j`-th literal row (`z` + the six selectors). -/
+theorem tailRows_read_lit (j : ℕ) (hj : j < litRowCount) :
+    (tailRowsOf C cvk cp)[j]'(by omega) = (litRowsOf C cvk cp)[j]'hj := by
+  show (litRowsOf C cvk cp
+      ++ (cp.wComm.zip cp.evals.w).map (fun x => zipSeg C x.1 x.2)
+      ++ (cvk.coefficientsComm.zip cp.evals.coefficients).map (fun x => zipSeg C x.1 x.2)
+      ++ ((cvk.sigmaComm.take sigmaRows).zip cp.evals.s).map
+        (fun x => zipSeg C x.1 x.2))[j]'(by omega) = _
+  rw [Vector.getElem_append, dif_pos (by omega), Vector.getElem_append,
+    dif_pos (by omega), Vector.getElem_append, dif_pos hj]
+
+/-- Tail row `7 + q` is witness column `q`'s row. -/
+theorem tailRows_read_w (q : ℕ) (hq : q < wCols) :
+    (tailRowsOf C cvk cp)[7 + q]'(by omega)
+      = zipSeg C (cp.wComm[q]'hq) (cp.evals.w[q]'hq) := by
+  show (litRowsOf C cvk cp
+      ++ (cp.wComm.zip cp.evals.w).map (fun x => zipSeg C x.1 x.2)
+      ++ (cvk.coefficientsComm.zip cp.evals.coefficients).map (fun x => zipSeg C x.1 x.2)
+      ++ ((cvk.sigmaComm.take sigmaRows).zip cp.evals.s).map
+        (fun x => zipSeg C x.1 x.2))[7 + q]'(by omega) = _
+  rw [Vector.getElem_append, dif_pos (by omega), Vector.getElem_append,
+    dif_pos (by omega), Vector.getElem_append, dif_neg (by omega)]
+  simp only [show 7 + q - 7 = q from by omega, Vector.getElem_map, Vector.getElem_zip]
+
+/-- Tail row `22 + q` is coefficient column `q`'s row. -/
+theorem tailRows_read_c (q : ℕ) (hq : q < coeffCols) :
+    (tailRowsOf C cvk cp)[22 + q]'(by omega)
+      = zipSeg C (cvk.coefficientsComm[q]'hq) (cp.evals.coefficients[q]'hq) := by
+  show (litRowsOf C cvk cp
+      ++ (cp.wComm.zip cp.evals.w).map (fun x => zipSeg C x.1 x.2)
+      ++ (cvk.coefficientsComm.zip cp.evals.coefficients).map (fun x => zipSeg C x.1 x.2)
+      ++ ((cvk.sigmaComm.take sigmaRows).zip cp.evals.s).map
+        (fun x => zipSeg C x.1 x.2))[22 + q]'(by omega) = _
+  rw [Vector.getElem_append, dif_pos (by omega), Vector.getElem_append,
+    dif_neg (by omega)]
+  simp only [show 22 + q - (7 + 15) = q from by omega, Vector.getElem_map,
+    Vector.getElem_zip]
+
+/-- Tail row `37 + q` is the `q`-th σ row. -/
+theorem tailRows_read_s (q : ℕ) (hq : q < sigmaRows) :
+    (tailRowsOf C cvk cp)[37 + q]'(by omega)
+      = zipSeg C (cvk.sigmaComm[q]'(by omega)) (cp.evals.s[q]'hq) := by
+  show (litRowsOf C cvk cp
+      ++ (cp.wComm.zip cp.evals.w).map (fun x => zipSeg C x.1 x.2)
+      ++ (cvk.coefficientsComm.zip cp.evals.coefficients).map (fun x => zipSeg C x.1 x.2)
+      ++ ((cvk.sigmaComm.take sigmaRows).zip cp.evals.s).map
+        (fun x => zipSeg C x.1 x.2))[37 + q]'(by omega) = _
+  rw [Vector.getElem_append, dif_neg (by omega)]
+  simp only [show 37 + q - (7 + 15 + 15) = q from by omega, Vector.getElem_map,
+    Vector.getElem_zip, Vector.getElem_take]
+  rfl
+
+end TailReads
 
 /-! ## The verifier -/
 
@@ -448,8 +489,8 @@ def kimchiVerify {nc : ℕ} (σ : SRS C.Point) (cvk : KimchiVK C nc)
     let e := cp.linEvals zetaM zetaOmegaM
     let shifts : Fin permCols → C.ScalarField := fun i => cvk.shifts[i]
     let ftEval0 := Kimchi.Protocol.Linearization.ftEval0 n cvk.zkRows cvk.omega shifts
-      cvk.endo (mdsOfParams cvk.frParams) o.alpha o.beta o.gamma o.zeta pubEval0 e
-    let (v, u) := frOracles C cvk cp o.digest pubEvals
+      cvk.endo (mdsOfParams C.frParams) o.alpha o.beta o.gamma o.zeta pubEval0 e
+    let (v, u) := frOracles C cp o.digest pubEvals
     let zkpmZ := Kimchi.Protocol.Linearization.zkpmEval n cvk.zkRows cvk.omega o.zeta
     let pScalar := Kimchi.Protocol.Linearization.permScalar o.beta o.gamma o.alpha zkpmZ e
     let fComm := cvk.sigmaComm[6].map (fun P => pScalar.val • P)
@@ -470,21 +511,7 @@ def kimchiVerify {nc : ℕ} (σ : SRS C.Point) (cvk : KimchiVK C nc)
         proof := cp.opening }
     Ipa.verifyFrom C σ o.warm inp
 
-/-! ## The committed-column view -/
-
-/-- The committed-column view of a checked verifier key: the `IndexComms` over
-per-chunk carriers (`Fin nc → C.Point`) the reduction speaks about — every read
-total. The glue between the checked wire and the abstract capstones. -/
-def KimchiVK.comms {C : Ipa.CommitmentCurve} {nc : ℕ}
-    (cvk : KimchiVK C nc) : Kimchi.Verifier.IndexComms (Fin nc → C.Point) where
-  sigma i c := (cvk.sigmaComm[i])[c]
-  coefficients cc c := (cvk.coefficientsComm[cc])[c]
-  generic c := cvk.genericComm[c]
-  poseidon c := cvk.poseidonComm[c]
-  completeAdd c := cvk.completeAddComm[c]
-  varBaseMul c := cvk.mulComm[c]
-  endoMul c := cvk.emulComm[c]
-  endoScalar c := cvk.endomulScalarComm[c]
+/-! ## The public-input view -/
 
 /-- The public-input array as the `Fin idx.publicCount`-indexed function the circuit
 model consumes (`getD`, total; the capstones pin `pub.size = idx.publicCount`, so the

--- a/formal/kimchi/Kimchi/Verifier/Reduction/Correspond.lean
+++ b/formal/kimchi/Kimchi/Verifier/Reduction/Correspond.lean
@@ -1,6 +1,7 @@
 import Kimchi.Columns
 import Kimchi.Index.Aggregate
 import Bulletproof.Protocol
+import Kimchi.Verifier.Kimchi
 
 /-!
 # The verifier key–index correspondence
@@ -11,12 +12,17 @@ circuit — implicit in an implementation, where one pipeline produces both — 
 stated as a proposition.
 
 `indexerOf` is the honest indexer: the commitments a circuit's own interpolants
-determine. `VKCorresponds` says a key lies in its image. A key so produced satisfies it
-definitionally; an externally supplied key satisfies it exactly when its committed
-columns agree, which is a checkable condition.
+determine, per chunk. `VKCorresponds` says a key lies in its image. A key so produced
+satisfies it definitionally; an externally supplied key satisfies it exactly when its
+committed columns agree, which is a checkable condition.
 
-Everything is stated over an abstract module with an SRS, matching the commitment layer
-it composes with.
+The abstract layer (`IndexComms`, `indexerOf`, `VKCorresponds`) is stated over an
+abstract module with an SRS, matching the commitment layer it composes with. The
+checked layer (`KimchiVK.comms`, `KimchiVK.Corresponds`) reads a checked wire key onto
+it: `comms` is the total committed-column view, and `Corresponds` bundles the
+per-chunk `VKCorresponds` with the scalar-side pins and the Lagrange pin — the full
+key–index hypothesis the capstones consume, adjudicated numerically by
+`check_vk_correspond`.
 -/
 
 open Bulletproof
@@ -59,5 +65,78 @@ while the permutation and coefficient columns are unblinded — an asymmetry inh
 from the reference implementation. -/
 noncomputable def commitPolyMasked (σ : SRS G) (p : Polynomial F) : G :=
   commitPoly σ p + σ.h
+
+/-! ## The chunked indexer -/
+
+/-- Chunk `c` of the unblinded commitment of `p`: the commitment of its `c`-th
+width-`2^σ.k` coefficient window (`PolyComm.chunks`). -/
+noncomputable def commitPolyChunk (σ : SRS G) (p : Polynomial F) (c : ℕ) : G :=
+  commitPoly σ (chunkPoly (2 ^ σ.k) p c)
+
+/-- The fixed-unit-blinder chunk commitment: selectors (and the public commitment) are
+masked with the all-ones blinder, per chunk (`mask_custom`, ipa.rs:497–514). -/
+noncomputable def commitPolyMaskedChunk (σ : SRS G) (p : Polynomial F) (c : ℕ) : G :=
+  commitPolyChunk σ p c + σ.h
+
+/-- The honest chunked indexer: the verifier key a circuit determines at chunk count
+`nc` — the per-chunk commitments of its own interpolants (the parent `IndexComms` at
+the carrier `Fin nc → G`), selectors carrying the per-chunk fixed blinder. -/
+noncomputable def indexerOf (σ : SRS G) (nc : ℕ) (idx : Index F n) :
+    IndexComms (Fin nc → G) where
+  sigma i c := commitPolyChunk σ (idx.sigmaPoly i) (c : ℕ)
+  coefficients cc c := commitPolyChunk σ (idx.coeffPoly cc) (c : ℕ)
+  generic c := commitPolyMaskedChunk σ (idx.selectorPoly .generic) (c : ℕ)
+  poseidon c := commitPolyMaskedChunk σ (idx.selectorPoly .poseidon) (c : ℕ)
+  completeAdd c := commitPolyMaskedChunk σ (idx.selectorPoly .completeAdd) (c : ℕ)
+  varBaseMul c := commitPolyMaskedChunk σ (idx.selectorPoly .varBaseMul) (c : ℕ)
+  endoMul c := commitPolyMaskedChunk σ (idx.selectorPoly .endoMul) (c : ℕ)
+  endoScalar c := commitPolyMaskedChunk σ (idx.selectorPoly .endoScalar) (c : ℕ)
+
+/-- The chunked key–index correspondence: the committed chunk columns are the circuit's
+own. -/
+def VKCorresponds (σ : SRS G) (nc : ℕ) (comms : IndexComms (Fin nc → G))
+    (idx : Index F n) : Prop :=
+  comms = indexerOf σ nc idx
+
+/-! ## The checked key's view and correspondence -/
+
+/-- The committed-column view of a checked verifier key: the `IndexComms` over
+per-chunk carriers (`Fin nc → C.Point`) the reduction speaks about — every read
+total. The glue between the checked wire and the abstract capstones. -/
+def KimchiVK.comms {C : Ipa.CommitmentCurve} {nc : ℕ}
+    (cvk : KimchiVK C nc) : IndexComms (Fin nc → C.Point) where
+  sigma i c := (cvk.sigmaComm[i])[c]
+  coefficients cc c := (cvk.coefficientsComm[cc])[c]
+  generic c := cvk.genericComm[c]
+  poseidon c := cvk.poseidonComm[c]
+  completeAdd c := cvk.completeAddComm[c]
+  varBaseMul c := cvk.mulComm[c]
+  endoMul c := cvk.emulComm[c]
+  endoScalar c := cvk.endomulScalarComm[c]
+
+/-- **The checked key–index correspondence**: the committed chunk columns are the
+circuit's own (`VKCorresponds`, through the total `comms` view), the scalar-side
+parameters match (the domain generator, the zero-knowledge row count, the shifts, the
+`ft_eval0` endo coefficient, and the Poseidon MDS — read off the curve's fr-sponge
+table), AND the Lagrange-basis chunk commitments over the public region are the basis
+polynomials' own chunk commitments. The Lagrange pin is what binds the proof-carried
+public evaluations (the public batch row) to the circuit's public input: the verifier
+COMPUTES the public commitment from these key entries. Adjudicated numerically, per
+chunk, by `check_vk_correspond`. -/
+def KimchiVK.Corresponds {C : Ipa.CommitmentCurve}
+    [Module C.ScalarField C.Point] {nc : ℕ} {n : ℕ}
+    (σ : SRS C.Point) (cvk : KimchiVK C nc)
+    (idx : Index C.ScalarField n) : Prop :=
+  VKCorresponds σ nc cvk.comms idx
+    ∧ cvk.omega = idx.omega
+    ∧ cvk.zkRows = idx.zkRows
+    ∧ (fun i : Fin permCols => cvk.shifts[i]) = idx.shifts
+    ∧ cvk.endo = idx.endoBase
+    ∧ mdsOfParams C.frParams = idx.mds
+    ∧ ∀ (j : Fin n), (j : ℕ) < idx.publicCount →
+        ∀ (hj : (j : ℕ) < cvk.lagrangeBasis.size) (c : Fin nc),
+          (cvk.lagrangeBasis[(j : ℕ)]'hj)[c]
+            = commitPolyChunk σ
+                (columnPoly idx.omega (Kimchi.Permutation.rowIndicator j)) (c : ℕ)
 
 end Kimchi.Verifier

--- a/formal/kimchi/Kimchi/Verifier/Reduction/Soundness.lean
+++ b/formal/kimchi/Kimchi/Verifier/Reduction/Soundness.lean
@@ -73,52 +73,6 @@ private def selComm (comms : IndexComms G) : Fin selCount → G :=
 private def selGate : Fin selCount → GateType :=
   ![.generic, .poseidon, .completeAdd, .varBaseMul, .endoMul, .endoScalar]
 
-private theorem evalsExt {e e' : Evals F} (h1 : e.w = e'.w) (h2 : e.wOmega = e'.wOmega)
-    (h3 : e.z = e'.z) (h4 : e.zOmega = e'.zOmega) (h5 : e.s = e'.s)
-    (h6 : e.coeffs = e'.coeffs) (h7 : e.genericSelector = e'.genericSelector)
-    (h8 : e.poseidonSelector = e'.poseidonSelector)
-    (h9 : e.completeAddSelector = e'.completeAddSelector)
-    (h10 : e.mulSelector = e'.mulSelector) (h11 : e.emulSelector = e'.emulSelector)
-    (h12 : e.endoScalarSelector = e'.endoScalarSelector) : e = e' := by
-  cases e
-  cases e'
-  simp only [Evals.mk.injEq]
-  exact ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9, h10, h11, h12⟩
-
-/-! ## The chunked indexer -/
-
-/-- Chunk `c` of the unblinded commitment of `p`: the commitment of its `c`-th
-width-`2^σ.k` coefficient window (`PolyComm.chunks`). -/
-noncomputable def commitPolyChunk [Field F] [AddCommGroup G] [Module F G]
-    (σ : SRS G) (p : Polynomial F) (c : ℕ) : G :=
-  commitPoly σ (chunkPoly (2 ^ σ.k) p c)
-
-/-- The fixed-unit-blinder chunk commitment: selectors (and the public commitment) are
-masked with the all-ones blinder, per chunk (`mask_custom`, ipa.rs:497–514). -/
-noncomputable def commitPolyMaskedChunk [Field F] [AddCommGroup G] [Module F G]
-    (σ : SRS G) (p : Polynomial F) (c : ℕ) : G :=
-  commitPolyChunk σ p c + σ.h
-
-/-- The honest chunked indexer: the verifier key a circuit determines at chunk count
-`nc` — the per-chunk commitments of its own interpolants (the parent `IndexComms` at
-the carrier `Fin nc → G`), selectors carrying the per-chunk fixed blinder. -/
-noncomputable def indexerOf [Field F] [AddCommGroup G] [Module F G]
-    (σ : SRS G) (nc : ℕ) {n : ℕ} (idx : Index F n) : IndexComms (Fin nc → G) where
-  sigma i c := commitPolyChunk σ (idx.sigmaPoly i) (c : ℕ)
-  coefficients cc c := commitPolyChunk σ (idx.coeffPoly cc) (c : ℕ)
-  generic c := commitPolyMaskedChunk σ (idx.selectorPoly .generic) (c : ℕ)
-  poseidon c := commitPolyMaskedChunk σ (idx.selectorPoly .poseidon) (c : ℕ)
-  completeAdd c := commitPolyMaskedChunk σ (idx.selectorPoly .completeAdd) (c : ℕ)
-  varBaseMul c := commitPolyMaskedChunk σ (idx.selectorPoly .varBaseMul) (c : ℕ)
-  endoMul c := commitPolyMaskedChunk σ (idx.selectorPoly .endoMul) (c : ℕ)
-  endoScalar c := commitPolyMaskedChunk σ (idx.selectorPoly .endoScalar) (c : ℕ)
-
-/-- The chunked key–index correspondence: the committed chunk columns are the circuit's
-own. -/
-def VKCorresponds [Field F] [AddCommGroup G] [Module F G] (σ : SRS G) (nc : ℕ)
-    {n : ℕ} (comms : IndexComms (Fin nc → G)) (idx : Index F n) : Prop :=
-  comms = indexerOf σ nc idx
-
 /-! ## The batch assembly (44 logical rows)
 
 The abstract rows are the deployed `to_batch` order (verifier.rs) with the ft row
@@ -229,7 +183,7 @@ private theorem batchC_cRow {nc : ℕ} (wC : Fin wCols → Fin nc → G) (zC pub
 
 private theorem batchC_sRow {nc : ℕ} (wC : Fin wCols → Fin nc → G) (zC pubC : Fin nc → G)
     (comms : IndexComms (Fin nc → G)) (i : Fin sigmaRows) :
-    batchC wC zC pubC comms (sRow i) = comms.sigma ⟨(i : ℕ), by omega⟩ := by
+    batchC wC zC pubC comms (sRow i) = comms.sigma (sigmaPermCol i) := by
   have h1 : ¬ 38 + (i : ℕ) < 1 := by omega
   have h2 : ¬ 38 + (i : ℕ) < 2 := by omega
   have h3 : ¬ 38 + (i : ℕ) < 8 := by omega
@@ -484,7 +438,7 @@ theorem kimchiProof_sound_of_openings [Field F] [AddCommGroup G] [Module F G]
   -- VK-row pinning: the combined σ / coefficient / selector claims are the Index's own
   have hcombS : ∀ i : Fin sigmaRows,
       (∑ ch : Fin nc, (ζ ^ 2 ^ σ.k) ^ (ch : ℕ) * E (sRow i) ch 0)
-        = (idx.sigmaPoly ⟨(i : ℕ), by omega⟩).eval ζ :=
+        = (idx.sigmaPoly (sigmaPermCol i)).eval ζ :=
     fun i => combined_eval_of_chunks σ hbind (hdσ _)
       (fun c => (hrow (sRow i) c).1.trans
         (congrFun (batchC_sRow wC zC pubC (indexerOf σ nc idx) i) c))
@@ -516,7 +470,7 @@ theorem kimchiProof_sound_of_openings [Field F] [AddCommGroup G] [Module F G]
   -- the combined record IS the honest record at the assembled table
   have hrec : claimedEvals (ζ ^ 2 ^ σ.k) ((idx.omega * ζ) ^ 2 ^ σ.k) E
       = evalsOf idx (extractTable idx.omega W) zg ζ := by
-    refine evalsExt ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_
+    refine Evals.ext ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_
     · funext col
       rw [show (claimedEvals (ζ ^ 2 ^ σ.k) ((idx.omega * ζ) ^ 2 ^ σ.k) E).w col
           = ∑ ch : Fin nc, (ζ ^ 2 ^ σ.k) ^ (ch : ℕ) * E (wRow col) ch 0 from rfl,

--- a/formal/kimchi/Kimchi/Verifier/Reflect.lean
+++ b/formal/kimchi/Kimchi/Verifier/Reflect.lean
@@ -86,14 +86,14 @@ def runLinEvals (σ : SRS C.Point) (cvk : KimchiVK C nc)
 def runVU (σ : SRS C.Point) (cvk : KimchiVK C nc)
     (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) :
     C.ScalarField × C.ScalarField :=
-  frOracles C cvk cp (runOracles C σ cvk cp pub).digest (runPubEvals C σ cvk cp pub)
+  frOracles C cp (runOracles C σ cvk cp pub).digest (runPubEvals C σ cvk cp pub)
 
 /-- The run's computed `ft(ζ)` claim at a given combined public evaluation. -/
 def runFtEval0P (σ : SRS C.Point) (cvk : KimchiVK C nc)
     (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
     (pubEval0 : C.ScalarField) : C.ScalarField :=
   ftEval0 cvk.n cvk.zkRows cvk.omega (fun i => cvk.shifts[i]) cvk.endo
-    (mdsOfParams cvk.frParams)
+    (mdsOfParams C.frParams)
     (runOracles C σ cvk cp pub).alpha (runOracles C σ cvk cp pub).beta
     (runOracles C σ cvk cp pub).gamma (runOracles C σ cvk cp pub).zeta pubEval0
     (runLinEvals C σ cvk cp pub)

--- a/formal/kimchi/Kimchi/Verifier/Wire.lean
+++ b/formal/kimchi/Kimchi/Verifier/Wire.lean
@@ -29,7 +29,7 @@ open Bulletproof
 namespace Kimchi.Verifier.Wire
 
 open CompElliptic.CurveForms.ShortWeierstrass
-open Poseidon Poseidon.FqSponge Bulletproof
+open Bulletproof
 open Kimchi.Verifier (PointEvaluations ProofEvaluations PubEvalSrc)
 
 variable (C : Ipa.CommitmentCurve)
@@ -39,7 +39,7 @@ variable (C : Ipa.CommitmentCurve)
 /-- A wire polynomial commitment: the per-chunk commitment vector (`PolyComm.elems`,
 `Vec<G>`). serde imposes NO length here — the chunk count is a verify-time check
 (`checkChunks` against the run's `chunk_size`). -/
-private abbrev PolyComm (C : Ipa.CommitmentCurve) := Array C.Point
+abbrev PolyComm (C : Ipa.CommitmentCurve) := Array C.Point
 
 /-- The kimchi proof wire record (`ProverProof` + `ProofEvaluations`, proof.rs:50–170),
 basic gate set: fixed dimensions serde-typed, chunk payloads unchecked arrays. Lookup
@@ -80,32 +80,40 @@ structure KimchiVK (C : Ipa.CommitmentCurve) where
   sigmaComm : Vector (PolyComm C) permCols
   /-- The 15 coefficient commitments (`coefficients_comm`). -/
   coefficientsComm : Vector (PolyComm C) coeffCols
-  /-- The generic selector's commitment. -/
+  -- The six selector commitments of the transcribed basic gate set — production's
+  -- `{generic, psm, complete_add, mul, emul, endomul_scalar}_comm`
+  -- (`VerifierIndex`, verifier_index.rs). The field names here follow production's,
+  -- EXCEPT the poseidon selector: production calls it `psm_comm`, and the fixture
+  -- decoder handles that naming mismatch (`parseVK` reads the `psm_comm` key into
+  -- `poseidonComm`).
+  /-- The generic selector's commitment (`generic_comm`). -/
   genericComm : PolyComm C
-  /-- The poseidon selector's commitment. -/
+  /-- The poseidon selector's commitment — production's `psm_comm` (the one selector
+  whose wire name differs; the decoder maps it). -/
   poseidonComm : PolyComm C
-  /-- The completeAdd selector's commitment. -/
+  /-- The completeAdd selector's commitment (`complete_add_comm`). -/
   completeAddComm : PolyComm C
-  /-- The varBaseMul selector's commitment. -/
+  /-- The varBaseMul selector's commitment (`mul_comm`). -/
   mulComm : PolyComm C
-  /-- The endoMul selector's commitment. -/
+  /-- The endoMul selector's commitment (`emul_comm`). -/
   emulComm : PolyComm C
-  /-- The endoScalar selector's commitment. -/
+  /-- The endoScalar selector's commitment (`endomul_scalar_comm`). -/
   endomulScalarComm : PolyComm C
   /-- The 7 permutation shifts (`shift`). -/
   shifts : Vector C.ScalarField permCols
   /-- The number of zero-knowledge rows (`zk_rows`) — nc-dependent in production
   (constraints.rs:774–784), carried as data here. -/
   zkRows : ℕ
-  /-- `verifier_index.endo`, the `ft_eval0` endo coefficient. -/
+  /-- `verifier_index.endo`, the `ft_eval0` endo coefficient — NOT serialized data
+  (production marks it `#[serde(skip)]` and recomputes it as `endos::<G>()`,
+  verifier_index.rs:140); a model input like `digest`. -/
   endo : C.ScalarField
   /-- The precomputed `VerifierIndex::digest()` — an input here. -/
   digest : C.BaseField
-  /-- The Lagrange-basis commitments (`get_lagrange_basis` over a sub-domain SRS
-  chunks every basis polynomial). -/
+  /-- The Lagrange-basis commitments — SRS-derived data (`get_lagrange_basis`
+  computes them from the SRS, chunking every basis polynomial over a sub-domain
+  SRS); a model input like `digest`. -/
   lagrangeBasis : Array (PolyComm C)
-  /-- The scalar-side Poseidon parameters (`G::sponge_params()`), for the fr-sponge. -/
-  frParams : Params C.ScalarField
 
 /-- A chunk vector validated to the run's chunk count. -/
 private def checkChunks {α : Type*} (nc : ℕ) (a : Array α) : Option (Vector α nc) :=
@@ -172,8 +180,7 @@ def KimchiVK.check {C : Ipa.CommitmentCurve} (nc : ℕ) (vk : KimchiVK C) :
            endomulScalarComm := ← checkChunks nc vk.endomulScalarComm
            shifts := vk.shifts, zkRows := vk.zkRows, endo := vk.endo
            digest := vk.digest
-           lagrangeBasis := ← vk.lagrangeBasis.mapM (checkChunks nc)
-           frParams := vk.frParams }
+           lagrangeBasis := ← vk.lagrangeBasis.mapM (checkChunks nc) }
 
 /-- The run's chunk count, from the domain and SRS widths (production
 `chunk_size = d1 / max_poly_size`, verifier.rs:145–152): the count clients `check`
@@ -188,7 +195,7 @@ end Kimchi.Verifier.Wire
 
 namespace Kimchi.Verifier.Wire.KimchiVesta
 
-open CompElliptic.Fields.Pasta Poseidon Kimchi.Verifier Bulletproof
+open Kimchi.Verifier Bulletproof
 
 /-- The kimchi proof wire record over the Vesta commitment curve. -/
 abbrev Proof := KimchiProof IpaVesta.curve
@@ -196,28 +203,16 @@ abbrev Proof := KimchiProof IpaVesta.curve
 /-- The kimchi verifier key wire record over the Vesta commitment curve. -/
 abbrev VK := KimchiVK IpaVesta.curve
 
-/-- The Vesta-side fr-sponge Poseidon parameters: the scalar field is `Fp`, so the
-production `G::sponge_params()` is the `fp_kimchi` table. The fixture decoder pins
-`KimchiVK.frParams` to this value. -/
-def frParams : Params Fp := fpParams
-
-
 end Kimchi.Verifier.Wire.KimchiVesta
 
 namespace Kimchi.Verifier.Wire.KimchiPallas
 
-open CompElliptic.Fields.Pasta Poseidon Kimchi.Verifier Bulletproof
+open Kimchi.Verifier Bulletproof
 
 /-- The kimchi proof wire record over the Pallas commitment curve. -/
 abbrev Proof := KimchiProof IpaPallas.curve
 
 /-- The kimchi verifier key wire record over the Pallas commitment curve. -/
 abbrev VK := KimchiVK IpaPallas.curve
-
-/-- The Pallas-side fr-sponge Poseidon parameters: the scalar field is `Fq`, so the
-production `G::sponge_params()` is the `fq_kimchi` table. The fixture decoder pins
-`KimchiVK.frParams` to this value. -/
-def frParams : Params Fq := fqParams
-
 
 end Kimchi.Verifier.Wire.KimchiPallas

--- a/formal/kimchi/KimchiFixture/Kimchi.lean
+++ b/formal/kimchi/KimchiFixture/Kimchi.lean
@@ -91,9 +91,9 @@ def parseKimchiProof (C : Ipa.CommitmentCurve) (j : Json) :
            opening := ← parseProof C j }
 
 /-- The chunked verifier key (SRS excluded — parse it with `parseSRSAt` at
-`Nat.log2 max_poly_size`), with the fr-sponge parameters pinned by the caller. -/
-def parseVK (C : Ipa.CommitmentCurve)
-    (frParams : Poseidon.Params C.ScalarField) (j : Json) :
+`Nat.log2 max_poly_size`). The fr-sponge parameters are not wire data: they live on
+the commitment curve (`C.frParams`). -/
+def parseVK (C : Ipa.CommitmentCurve) (j : Json) :
     Except String (KimchiVK C) := do
   let fld (k : String) : Except String Json := j.getObjVal? k
   let nat (k : String) : Except String ℕ := do
@@ -118,7 +118,6 @@ def parseVK (C : Ipa.CommitmentCurve)
            zkRows := ← nat "zk_rows"
            endo := ← parseZMod (← fld "endo")
            digest := ← parseZMod (← fld "digest")
-           lagrangeBasis := ← parseArrOf (parseComm C) (← fld "lagrange_basis")
-           frParams := frParams }
+           lagrangeBasis := ← parseArrOf (parseComm C) (← fld "lagrange_basis") }
 
 end Kimchi.Fixture

--- a/formal/kimchi/KimchiFixture/PS.lean
+++ b/formal/kimchi/KimchiFixture/PS.lean
@@ -208,7 +208,7 @@ def build (raw : Raw) : Except String Instance := do
   let shifts : Fin permCols → Fp := fun i => (powMod fpGenerator (i : ℕ) PALLAS_BASE_CARD : ℕ)
   let gates ← gateTable raw n
   match Index.build? gates raw.publicInputSize zkRows omega
-      Pasta.pallasEndo (Kimchi.Verifier.mdsOfParams Kimchi.Verifier.Wire.KimchiVesta.frParams)
+      Pasta.pallasEndo (Kimchi.Verifier.mdsOfParams Bulletproof.IpaVesta.curve.frParams)
       shifts with
   | none => throw "Index.build? rejected the padded dump (a synthesized law failed)"
   | some idx =>

--- a/formal/kimchi/scripts/check_index_fixture.lean
+++ b/formal/kimchi/scripts/check_index_fixture.lean
@@ -144,7 +144,7 @@ def checks (fx : RawFixture) {n : ℕ} [NeZero n]
 def run {n : ℕ} [NeZero n] (fx : RawFixture) (hn : fx.n = n) : IO Unit := do
   let gates ← IO.ofExcept (buildGates fx hn)
   let some idx := Index.build? gates fx.publicCount fx.zkRows fx.omega fx.endoBase
-      (Kimchi.Verifier.mdsOfParams Kimchi.Verifier.Wire.KimchiVesta.frParams)
+      (Kimchi.Verifier.mdsOfParams Bulletproof.IpaVesta.curve.frParams)
       (fun i => fx.shifts[(i : ℕ)]!)
     | throw (IO.userError "Index.build? rejected the production data")
   IO.println "  ✓ Index.build? accepts (all laws decided on production data)"

--- a/formal/kimchi/scripts/check_kimchi_verifier.lean
+++ b/formal/kimchi/scripts/check_kimchi_verifier.lean
@@ -49,13 +49,13 @@ def verifyWire (C : Ipa.CommitmentCurve) (σ : Bulletproof.SRS C.Point)
 
 /-- One chunked-verifier fixture run: decode (both formats), verify, and check the
 corruption and parse-rejection matrices. Throws on any unexpected verdict. -/
-def runChunked (C : Ipa.CommitmentCurve) (frParams : Poseidon.Params C.ScalarField)
+def runChunked (C : Ipa.CommitmentCurve)
     (path : String) (expectPublic : Bool) : IO Unit := do
   let raw ← IO.FS.readFile path
   let r : Except String
       (_ × Wire.KimchiVK C × Wire.KimchiProof C × Array C.ScalarField) := do
     let j ← Json.parse raw
-    let vk ← Kimchi.Fixture.parseVK C frParams j
+    let vk ← Kimchi.Fixture.parseVK C j
     let mps ← match (← (← j.getObjVal? "max_poly_size").getStr?).toNat? with
       | some v => pure v
       | none => throw "field max_poly_size is not a numeral"
@@ -140,9 +140,9 @@ def main : IO Unit := do
   let dir := (← IO.getEnv "KIMCHI_FIXTURES_DIR").getD "fixtures"
   -- The chunked verifier: the one-chunk fixture (no regression), then nc = 2 on both
   -- curves.
-  runChunked CV Wire.KimchiVesta.frParams s!"{dir}/kimchi_proof_vesta.json" false
-  runChunked CV Wire.KimchiVesta.frParams s!"{dir}/kimchi_proof_vesta_nc2.json" true
-  runChunked CP Wire.KimchiPallas.frParams s!"{dir}/kimchi_proof_pallas_nc2.json" true
+  runChunked CV s!"{dir}/kimchi_proof_vesta.json" false
+  runChunked CV s!"{dir}/kimchi_proof_vesta_nc2.json" true
+  runChunked CP s!"{dir}/kimchi_proof_pallas_nc2.json" true
   IO.println "✓ the executable kimchi verifiers accept the production proofs (nc = 1 \
     and nc = 2, both curves), reject corruptions, and refuse to parse ragged wire data"
 

--- a/formal/kimchi/scripts/check_linearization.lean
+++ b/formal/kimchi/scripts/check_linearization.lean
@@ -95,7 +95,7 @@ def main : IO Unit := do
         ("poseidon", e.poseidonSelector
           * alphaCombo α ((Kimchi.Lift.Gate.Poseidon.argument
               (Kimchi.Verifier.mdsOfParams
-                Kimchi.Verifier.Wire.KimchiVesta.frParams)).constraints
+                Bulletproof.IpaVesta.curve.frParams)).constraints
             gEnv),
           ← gateTarget "poseidon"),
         ("completeAdd", e.completeAddSelector
@@ -115,7 +115,7 @@ def main : IO Unit := do
     let hGates := gates.all fun (_, mine, target) => mine = target
     let hZkpm := decide (zkpmEval n zkRows ω ζ = zkpmZ)
     let hPerm := decide (permScalar β γ α zkpmZ e = permTarget)
-    let mds := Kimchi.Verifier.mdsOfParams Kimchi.Verifier.Wire.KimchiVesta.frParams
+    let mds := Kimchi.Verifier.mdsOfParams Bulletproof.IpaVesta.curve.frParams
     let hConst := decide (gateLinearization endo mds α e = constTarget)
     let hFt := decide (ftEval0 n zkRows ω shifts endo mds α β γ ζ pubEval e = ftEval0Target)
     -- The assembled acceptance identity — the point-bridge (`verifierEquation_iff`)

--- a/formal/kimchi/scripts/check_vk_correspond.lean
+++ b/formal/kimchi/scripts/check_vk_correspond.lean
@@ -118,7 +118,7 @@ def sigmaColsOf (d : IdxData) (zkRows : ℕ) : Except String (Array (Array F)) :
     do
       let gates ← buildGates d rfl
       let some idx := Index.build? gates d.publicCount zkRows d.omega d.endoBase
-          (Kimchi.Verifier.mdsOfParams Kimchi.Verifier.Wire.KimchiVesta.frParams)
+          (Kimchi.Verifier.mdsOfParams Bulletproof.IpaVesta.curve.frParams)
           (fun i => d.shifts[(i : ℕ)]!)
         | throw s!"Index.build? rejected the index data at zk_rows = {zkRows}"
       return (List.finRange permCols).toArray.map fun c =>


### PR DESCRIPTION
## Summary

Enacts the structural-refactor findings from the #260 review (group B of the follow-up ledger): tighter static typing, de-duplication, and cleaner module layering. No tracked root renamed; every fully-qualified name preserved; net −19 lines across 19 files.

**Static typing & destructuring**
- `Evals` gains `@[ext]`; the two hand-rolled 12-field ext lemmas (`evalsExt`, `evals_ext`) are deleted in favor of the generated `Evals.ext`.
- `Index.build?` consumes a single named `obtain ⟨…⟩` destructure instead of a 12-deep positional `h.2.2.2…` chain, so inserting an index law no longer reshuffles every projection.
- The ~15 anonymous `⟨i, by omega⟩` / `Fin.castLE (by omega)` column coercions collapse to three documented embeddings — `permCol`, `sigmaCol`, `sigmaPermCol` — stating once that the wired columns are the first seven witness columns.

**Correspondence layer consolidated**
- `commitPolyChunk`, `commitPolyMaskedChunk`, `indexerOf`, `VKCorresponds`, `KimchiVK.comms`, and `KimchiVK.Corresponds` now live together in `Reduction/Correspond.lean` beside `IndexComms` (they were scattered across `Reduction/Soundness`, `Verifier/Kimchi`, and `Capstone/Reflection`). Fully-qualified names unchanged. `Verifier/Kimchi` drops its `Correspond` import — so the executable drivers' closure no longer transitively pulls `Index.Aggregate`.

**Wire boundary honesty**
- The non-wire VK fields are demarcated: `endo` (production `#[serde(skip)]`) and `lagrangeBasis` (SRS-derived) marked as model inputs the way `digest` already was.
- `frParams` (curve-determined via `G::sponge_params()`, not adversarial wire data — the fixture decoder took it as a caller argument) moves **out** of the wire and checked records into `Ipa.CommitmentCurve`, threaded through a curve-level `frSpec` / `mdsOfParams`. Ripples through `kimchiVerify`, `frOracles` (drops its now-unused param), `KimchiVK.check`, `Reflect`, and the fixture decoders.
- The six selector-commitment fields get a grouping docstring naming production's `{generic,psm,complete_add,mul,emul,endomul_scalar}_comm`, recording the `psm_comm`→`poseidonComm` decoder mismatch. `private abbrev PolyComm` is made public with a docstring; the zeroed-unused `lam` in `frSpec` is documented.

**De-duplication**
- The 7-row tail-row vector literal is single-sourced (`litRowsOf` + `tailRows_read_*` lemmas stated beside `tailRowsOf`); the five verbatim restatements in `Capstone/Reflection` are gone.
- The IPA verifier is parameterized on its initial sponge state (`Bulletproof.Ipa.transcriptFrom` / `verifyFrom`, with `transcript` / `verify` as `FqSponge.init` instantiations). Kimchi's verbatim-body `Ipa.verifyFrom` fork is deleted and every call site resolves to the Bulletproof warm verifier — ending both the copy and the `Kimchi.Verifier.Ipa` vs `Bulletproof.Ipa` pseudo-namespace collision. `verify`'s name and fixture-adjudicated behavior are unchanged.

**Declined, with assessment**
- The `batchC` row-classifier refactor was read in full and left as-is: a `rowRegion` inverse would replace the six per-row lemmas with an equal mass of round-trip lemmas plus a new datatype, and `batchC_eq_flat`'s `by_cases` scaffolds serve the flat-stream `streamPos` offset arithmetic rather than the row dispatch — neither file ends net simpler, which was the bar.

## Validation

Independently re-run from `formal/` after the branch was assembled: `lake build` green across the workspace with no new warnings; style clean; `runLinter` on all 8 touched roots (docBlame included — every new/moved field and def documented) with no baseline growth; `shake` (absolute `--cfg`) no findings; deadcode 83/83 resolved; both axiom gates pass (48 + 7 roots, allowed sets unchanged); all fixture drivers green (IPA both curves, kimchi-verifier accept+corruption+parse matrices at nc=1 and nc=2, VK-correspondence both regimes, index, linearization, permutation). All Rust claims re-checked against the vendored proof-systems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSVEv2RHLtK4WDc4g3zZz7