### PR TITLE
formal/poseidon: absorbG folds (0,0) for the identity point (audit M1)

### DIFF
--- a/formal/poseidon/Poseidon/FqSponge.lean
+++ b/formal/poseidon/Poseidon/FqSponge.lean
@@ -25,8 +25,8 @@ expansion (`sponge.rs` `to_field_with_length`, Halo §6.2): accumulators `a = b 
 for each 2-bit window from the top, `a, b := 2a, 2b`, the low bit selects `s = ±1`, the high
 bit routes `s` into `a` or `b`; the result is `a·λ + b`. This is the same recoding the
 `EndoScalar` gate constrains in-circuit (`Kimchi.Gate.EndoScalar`, accumulator init
-`(2, 2)`). Points absorb as `SWPoint`s: the two affine coordinates, or a single `0` for the
-identity (`sponge.rs` `absorb_g`, both cases).
+`(2, 2)`). Points absorb as `SWPoint`s: the two affine coordinates, or `(0, 0)` for the
+identity (`sponge.rs` `absorb_g`).
 
 `FqVesta` and `FqPallas` instantiate the two sides of the Pasta cycle
 (`DefaultFqSponge<VestaParameters>` / `DefaultFqSponge<PallasParameters>`); each is its
@@ -71,11 +71,12 @@ private def lowLimbs (x : ZMod base) : List ℕ :=
 def absorbFq (spec : Spec base scalar) (s : S base) (xs : List (ZMod base)) : S base :=
   ⟨absorb spec.params s.sponge xs, []⟩
 
-/-- Absorb a point (`absorb_g`): its `x` then its `y` coordinate, or a single `0` for the
-identity. -/
+/-- Absorb a point (`absorb_g`): its `x` then its `y` coordinate, or `(0, 0)` for the
+identity — matching `DefaultFqSponge::absorb_g` (`sponge.rs:337-339`), which absorbs two
+zeros for the identity point. -/
 def absorbG (spec : Spec base scalar) {E : SWCurve (ZMod base)} (s : S base)
     (P : SWPoint E) : S base :=
-  if P = 0 then absorbFq spec s [0] else absorbFq spec s [P.x, P.y]
+  if P = 0 then absorbFq spec s [0, 0] else absorbFq spec s [P.x, P.y]
 
 /-- Absorb a scalar-field element (`absorb_fr`). The branch is determined by the
 cardinalities: a smaller scalar modulus embeds directly; a larger one absorbs as its high


### PR DESCRIPTION
## Summary

Fixes audit finding **M1** (definition drift, verified author-direct): the Lean Fq-sponge absorbed the identity point differently from production.

`DefaultFqSponge::absorb_g` absorbs **two** zeros for the identity point (`sponge.rs:337-339`; trait comment: "the values `(0, 0)` are absorbed"). `Poseidon.FqSponge.absorbG` folded a **single** `0`. Because `absorb` is a per-element duplex fold, one element vs two shifts the rate position for everything absorbed afterward — so every subsequent Fiat–Shamir challenge would diverge from production whenever an absorbed point (a `w/z/t_comm` chunk, or an IPA `L/R/δ`) is the identity. That made `Ipa.verify`/`kimchiVerify` compute a different transcript than production on identity-carrying inputs, so the soundness headlines' antecedent neither implied nor was implied by deployed acceptance there.

The fix folds `[0, 0]` — the same one-call shape the on-curve branch already uses as `[P.x, P.y]`, which the `check_fq_sponge` fixtures validate against `mina_poseidon`. The two docstrings claiming "a single `0` for the identity" (`:28`, `:74`) were false against the cited source and are corrected.

## Why nothing else moves

No fixture exercises the identity branch — an honestly-produced proof never carries an identity in an absorbed position (the audit's "adversarially reachable input class the fixtures never exercise"). The change touches only the `P = 0` branch, leaving the non-identity path — the one the fixtures actually cover — untouched.

## Validation

All green from `formal/`:
- **full workspace build** — no proof breaks (`absorbG` sits under both the IPA and kimchi verifier trust surfaces);
- **sponge fixtures** still match production: `poseidon_{fq,fp}` 7/7, `fq_sponge` 39/39 on both curves, `group_map` 8/8 on both curves;
- **bulletproof** and **kimchi** axiom gates (allowed sets unchanged);
- **IPA** and **kimchi verifier** fixture drivers.

Scope note: this closes the *model* half of M1. It does not add a fixture that carries an identity in an absorbed position — that class is not honestly producible, so it cannot be recorded from production; the audit frames M1 as adversarial-only, and the fix is what brings the model into line with `verifier.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSVEv2RHLtK4WDc4g3zZz7