### PR TITLE
formal/kimchi: de-vacuate the terminal run-level AGM roots (statement-audit C1)

### DIFF
--- a/formal/kimchi/Kimchi/Protocol/Equation.lean
+++ b/formal/kimchi/Kimchi/Protocol/Equation.lean
@@ -480,38 +480,92 @@ open Polynomial Kimchi.Index Kimchi.Protocol.Equation
 
 variable {F : Type*} [Field F] {n : ℕ}
 
+/-! ## The Schwartz–Zippel exclusion sets
+
+`Protocol.sound`'s four exclusion sets as explicit named functions of the extracted witness
+table `extractTable idx.omega W`, so that soundness can be stated over these sets directly:
+`soundBadB`/`soundBadG` are the grand-product collapse β/γ sets of the two permutation
+multisets `soundM1`/`soundM2`, `soundBadA` the aggregate-family bad α's, and `soundBadZ` the
+bad ζ's that fail to pin the claimed quotient. -/
+
+/-- The left grand-product multiset of `sound`: the pairs `(W_c(ω^j), shift_c · ω^j)`
+ranging over every permutation column `c` and masked row `j`. -/
+noncomputable def soundM1 (idx : Index F n) (W : Fin wCols → Polynomial F) :
+    Multiset (F × F) :=
+  Finset.univ.val.map fun c : Fin permCols × Fin (n - idx.zkRows) =>
+    ((idx.permWitnessPoly (extractTable idx.omega W) c.1).eval (idx.omega ^ (c.2 : ℕ)),
+      idx.shifts c.1 * idx.omega ^ (c.2 : ℕ))
+
+/-- The right grand-product multiset of `sound`: the same witness values paired against
+the wiring-permuted `shift · node`. -/
+noncomputable def soundM2 (idx : Index F n) (W : Fin wCols → Polynomial F) :
+    Multiset (F × F) :=
+  Finset.univ.val.map fun c : Fin permCols × Fin (n - idx.zkRows) =>
+    ((idx.permWitnessPoly (extractTable idx.omega W) c.1).eval (idx.omega ^ (c.2 : ℕ)),
+      idx.shifts (Kimchi.Permutation.restrictCells idx.wiringPerm
+            idx.wiringPerm_regionPreserving c).1
+        * idx.omega ^ ((Kimchi.Permutation.restrictCells idx.wiringPerm
+            idx.wiringPerm_regionPreserving c).2 : ℕ))
+
+/-- The bad β-set of `sound`: the grand-product collapse β's for `soundM1`/`soundM2`. -/
+noncomputable def soundBadB [DecidableEq F] (idx : Index F n)
+    (W : Fin wCols → Polynomial F) : Finset F :=
+  Kimchi.GrandProduct.badBetas (soundM1 idx W) (soundM2 idx W)
+
+/-- The bad γ-set of `sound` at a good β: the grand-product collapse γ's, specialised at β. -/
+noncomputable def soundBadG [DecidableEq F] (idx : Index F n)
+    (W : Fin wCols → Polynomial F) (β : F) : Finset F :=
+  Kimchi.GrandProduct.badGammas (soundM1 idx W) (soundM2 idx W) β
+
+/-- The bad α-set of `sound`: the aggregate-family bad α's at the extracted table. -/
+noncomputable def soundBadA [DecidableEq F] [NeZero n] (idx : Index F n)
+    (pub : Fin idx.publicCount → F) (W : Fin wCols → Polynomial F)
+    (z : Polynomial F) (β γ : F) : Finset F :=
+  Kimchi.badAlphas (idx.fullFamily pub (extractTable idx.omega W) z β γ) idx.omega n
+
+/-- The bad ζ-set of `sound`: the roots pinning the claimed quotient `t` against the
+α-aggregate at the extracted table. -/
+noncomputable def soundBadZ [DecidableEq F] [NeZero n] (idx : Index F n)
+    (pub : Fin idx.publicCount → F) (W : Fin wCols → Polynomial F)
+    (z : Polynomial F) (β γ α : F) (t : Polynomial F) : Finset F :=
+  Kimchi.badZetas
+    (Kimchi.aggregate α (idx.fullFamily pub (extractTable idx.omega W) z β γ)) t n
+
 /-- **Soundness of the polynomial protocol, over the prover's oracles.** The prover's
 oracles are the witness-column polynomials `W` and the permutation-accumulator polynomial
 `z` (degree `< n`), with a quotient oracle `t` presented per challenge; the verifier has
-oracle access, reading them at the challenge point. The four Schwartz–Zippel bad challenge
-sets are small (β/γ bounded by `7·(n − zkRows)`, α by `n·(K − 1)`, ζ by
-`Index.degreeBound n`) and quantified BEFORE the challenges; and for every tuple avoiding
-them at which `Accepts` holds on the oracle evaluations, the assignment read off the
-witness oracles satisfies the circuit — the satisfying table is named EXPLICITLY in the
-conclusion (`extractTable idx.omega W`): the witness IS the oracles' own data, extracted,
-never supplied. Nothing here mentions commitments, an SRS,
-or a group: this is the idealized protocol. The commitment layer instantiates it by
-binding the oracles to commitments and certifying the claimed evaluations are the true
-oracle evaluations (`kimchiProof_sound_of_openings`). Packaged in the same `∃ bad sets,
-card bounds ∧ guarded implication` shape as the compiled roots, so the interface is a
-direct hand-off. -/
+oracle access, reading them at the challenge point. The conclusion pairs the
+Schwartz–Zippel cardinality bounds — the exclusion sets are small (β/γ bounded by
+`7·(n − zkRows)`, α by `n·(K − 1)`, ζ by `Index.degreeBound n`) — with the guarded
+implication: for every challenge tuple lying outside the exclusion sets at which `Accepts`
+holds on the oracle evaluations, the assignment read off the witness oracles satisfies the
+circuit. Both the exclusion sets (`soundBadB`/`soundBadG`/`soundBadA`/`soundBadZ`) and the
+satisfying table (`extractTable idx.omega W`) are explicit named terms of the oracles' own
+data — the witness is extracted, never supplied — so the statement is a claim about the
+protocol's specific challenges and assignment. Nothing here mentions commitments, an SRS, or
+a group: this is the idealized protocol. The commitment layer instantiates it by binding the
+oracles to commitments and certifying the claimed evaluations are the true oracle evaluations
+(`kimchiProof_sound_of_openings`). -/
 theorem sound [DecidableEq F] [NeZero n] (idx : Index F n)
     (pub : Fin idx.publicCount → F) (W : Fin wCols → Polynomial F)
     (z : Polynomial F) (hz : z.natDegree < n) :
-    ∃ (badB : Finset F) (badG : F → Finset F) (badA : F → F → Finset F)
-        (badZ : F → F → F → Polynomial F → Finset F),
-      (badB.card ≤ 7 * (n - idx.zkRows)
-        ∧ (∀ β, (badG β).card ≤ 7 * (n - idx.zkRows))
-        ∧ (∀ β γ,
-            (badA β γ).card ≤ n * (Index.gateAlphaCount + Index.permAlphaCount - 1))
-        ∧ (∀ β γ α (t : Polynomial F), t.natDegree < 7 * n →
-            (badZ β γ α t).card ≤ Index.degreeBound n))
-      ∧ ∀ (β γ α : F) (t : Polynomial F) (ζ : F),
-          β ∉ badB → γ ∉ badG β → α ∉ badA β γ → ζ ∉ badZ β γ α t →
-          ζ ≠ 1 → ζ ≠ idx.omega ^ (n - idx.zkRows) →
-          Accepts idx pub (evalsOf idx (extractTable idx.omega W) z ζ) t β γ α ζ →
-          Satisfies idx pub (extractTable idx.omega W) := by
+    (soundBadB idx W).card ≤ 7 * (n - idx.zkRows)
+      ∧ (∀ β, (soundBadG idx W β).card ≤ 7 * (n - idx.zkRows))
+      ∧ (∀ β γ,
+          (soundBadA idx pub W z β γ).card
+            ≤ n * (Index.gateAlphaCount + Index.permAlphaCount - 1))
+      ∧ (∀ β γ α (t : Polynomial F), t.natDegree < 7 * n →
+          (soundBadZ idx pub W z β γ α t).card ≤ Index.degreeBound n)
+    ∧ ∀ (β γ α : F) (t : Polynomial F) (ζ : F),
+        β ∉ soundBadB idx W → γ ∉ soundBadG idx W β → α ∉ soundBadA idx pub W z β γ →
+        ζ ∉ soundBadZ idx pub W z β γ α t →
+        ζ ≠ 1 → ζ ≠ idx.omega ^ (n - idx.zkRows) →
+        Accepts idx pub (evalsOf idx (extractTable idx.omega W) z ζ) t β γ α ζ →
+        Satisfies idx pub (extractTable idx.omega W) := by
   classical
+  -- unfold the named sets to their permutation-multiset / aggregate-family bodies …
+  simp only [soundBadB, soundBadG, soundBadA, soundBadZ, soundM1, soundM2]
+  -- … then abstract the two grand-product multisets, exactly as the underlying argument
   set m₁ : Multiset (F × F) :=
     Finset.univ.val.map fun c : Fin permCols × Fin (n - idx.zkRows) =>
       ((idx.permWitnessPoly (extractTable idx.omega W) c.1).eval (idx.omega ^ (c.2 : ℕ)),
@@ -528,13 +582,7 @@ theorem sound [DecidableEq F] [NeZero n] (idx : Index F n)
     intro f
     rw [Multiset.card_map]
     simp [Finset.card_univ, Fintype.card_prod, Fintype.card_fin]
-  refine ⟨Kimchi.GrandProduct.badBetas m₁ m₂, fun β => Kimchi.GrandProduct.badGammas m₁ m₂ β,
-    fun β γ => Kimchi.badAlphas
-      (idx.fullFamily pub (extractTable idx.omega W) z β γ) idx.omega n,
-    fun β γ α t => Kimchi.badZetas
-      (Kimchi.aggregate α
-        (idx.fullFamily pub (extractTable idx.omega W) z β γ)) t n,
-    ⟨?_, ?_, ?_, ?_⟩, ?_⟩
+  refine ⟨?_, ?_, ?_, ?_, ?_⟩
   · refine le_trans (Kimchi.GrandProduct.card_badBetas_le m₁ m₂) ?_
     rw [hm₁def, hm₂def, hcard, hcard]
     exact le_of_eq (max_self _)

--- a/formal/kimchi/Kimchi/Verifier/Capstone/Algebraic.lean
+++ b/formal/kimchi/Kimchi/Verifier/Capstone/Algebraic.lean
@@ -317,10 +317,10 @@ theorem kimchiProof_sound_algebraic [Field F] [AddCommGroup G]
                 (claimedEvals (ζ ^ 2 ^ σ.k) ((idx.omega * ζ) ^ 2 ^ σ.k) E)) →
           Satisfies idx pub
             (extractTable idx.omega fun col => assembledRow σ.k nc (aw₀ (wRow col))) := by
-  obtain ⟨badB, badG, badA, badZ, ⟨hB, hG, hA, hZ⟩, himp⟩ :=
+  obtain ⟨⟨hB, hG, hA, hZ⟩, himp⟩ :=
     kimchiProof_sound_of_openings σ idx hnc hk hbind comms hvk pub wC zC pubC hpubC
       aw₀ ρw₀ hrep
-  refine ⟨badB, badG, badA, badZ,
+  refine ⟨_, _, _, _,
     fun E ζ => badXiOf σ (flatten aw₀) ![ζ, idx.omega * ζ] (flatten E),
     fun E ζ ξ => badROf σ (flatten aw₀) ![ζ, idx.omega * ζ] (flatten E) ξ,
     ⟨hB, hG, hA, hZ,

--- a/formal/kimchi/Kimchi/Verifier/Capstone/Reflection.lean
+++ b/formal/kimchi/Kimchi/Verifier/Capstone/Reflection.lean
@@ -936,13 +936,113 @@ private theorem batchC_eq_flat (i : Fin batchRows) (c : Fin nc) :
 
 end GroupReconcile
 
-/-! ## The chunked run-level terminal roots -/
+/-! ## The chunked run-level terminal roots
+
+Residue-free AGM soundness of the deployed Pasta verifiers, stated over the run's own data.
+Each root pairs the Schwartz–Zippel cardinality bounds (`RunBounds`) with a guarded
+implication (`RunGuardImp`): at the run's own Fiat–Shamir challenges — provided they lie
+outside the exclusion sets and off the two boundary points `1`, `ω^(n − zkRows)` — the
+assembled witness table `runWTab` satisfies the circuit. The exclusion sets are the canonical
+Schwartz–Zippel sets `Protocol.soundBad{B,G,A,Z}` at the run's assembled witness columns
+`runW` and accumulator `runZ` — the same sets the openings seam
+`kimchiProof_sound_of_openings` pins for the run's per-chunk representations, so the proofs
+feed the seam directly. Both the exclusion sets and the satisfying table are explicit
+functions of the run, so the conclusion constrains *these* challenges and *this* table.
+
+That a genuine run's challenges avoid the exclusion sets is a hypothesis of `RunGuardImp`, as
+is the good-combination-challenge condition `hξ`/`hr`. Bounding the probability that the
+Fiat–Shamir challenges land in the (`card`-bounded) exclusion sets is the forking/density
+argument, which this development does not carry. -/
+
+/-- The assembled witness-column polynomials of a reflected run: the algebraic prover's own
+per-chunk representations `aRef` at the witness-row stream positions, assembled into
+degree-`< n` column polynomials. These are the `W` the openings seam pins for the run. -/
+noncomputable def runW {C : Ipa.CommitmentCurve} (σ : SRS C.Point) {nc : ℕ}
+    (cvk : KimchiVK C nc) (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    {n : ℕ} (_idx : Index C.ScalarField n)
+    (aRef : Fin (runInput C σ cvk cp pub).commitments.size
+      → Fin (2 ^ σ.k) → C.ScalarField) :
+    Fin wCols → Polynomial C.ScalarField :=
+  fun col => assembledRow σ.k nc
+    fun c => aRef ⟨(streamPos nc (wRow col) c : ℕ), (streamPos nc (wRow col) c).isLt⟩
+
+/-- The assembled permutation-accumulator polynomial of a reflected run — the `z` the
+openings seam pins, from `aRef` at the accumulator-row stream position. -/
+noncomputable def runZ {C : Ipa.CommitmentCurve} (σ : SRS C.Point) {nc : ℕ}
+    (cvk : KimchiVK C nc) (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    {n : ℕ} (_idx : Index C.ScalarField n)
+    (aRef : Fin (runInput C σ cvk cp pub).commitments.size
+      → Fin (2 ^ σ.k) → C.ScalarField) :
+    Polynomial C.ScalarField :=
+  assembledRow σ.k nc
+    fun c => aRef ⟨(streamPos nc zRow c : ℕ), (streamPos nc zRow c).isLt⟩
+
+/-- The assembled witness table of a reflected run: `runW` read as a table over the domain.
+This is the satisfying assignment the run-level roots deliver. -/
+noncomputable def runWTab {C : Ipa.CommitmentCurve} (σ : SRS C.Point) {nc : ℕ}
+    (cvk : KimchiVK C nc) (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    {n : ℕ} (idx : Index C.ScalarField n)
+    (aRef : Fin (runInput C σ cvk cp pub).commitments.size
+      → Fin (2 ^ σ.k) → C.ScalarField) :
+    Fin n → Fin wCols → C.ScalarField :=
+  extractTable idx.omega (runW σ cvk cp pub idx aRef)
+
+/-- The Schwartz–Zippel cardinality bounds on a reflected run's exclusion sets: the `β`/`γ`
+sets have card `≤ 7·(n − zkRows)`, the `α` set `≤ n·(gateAlphaCount + permAlphaCount − 1)`,
+and each `ζ` set (for a degree-`< 7n` quotient) `≤ degreeBound n`. -/
+def RunBounds {C : Ipa.CommitmentCurve} [Module C.ScalarField C.Point]
+    (σ : SRS C.Point) {nc : ℕ} (cvk : KimchiVK C nc) (cp : KimchiProof C nc σ.k)
+    (pub : Array C.ScalarField) {n : ℕ} [NeZero n] (idx : Index C.ScalarField n)
+    (aRef : Fin (runInput C σ cvk cp pub).commitments.size
+      → Fin (2 ^ σ.k) → C.ScalarField) : Prop :=
+  (Protocol.soundBadB idx (runW σ cvk cp pub idx aRef)).card ≤ 7 * (n - idx.zkRows)
+    ∧ (∀ β, (Protocol.soundBadG idx (runW σ cvk cp pub idx aRef) β).card
+        ≤ 7 * (n - idx.zkRows))
+    ∧ (∀ β γ, (Protocol.soundBadA idx (pubView idx pub) (runW σ cvk cp pub idx aRef)
+          (runZ σ cvk cp pub idx aRef) β γ).card
+        ≤ n * (Index.gateAlphaCount + Index.permAlphaCount - 1))
+    ∧ (∀ β γ α (t : Polynomial C.ScalarField), t.natDegree < 7 * n →
+        (Protocol.soundBadZ idx (pubView idx pub) (runW σ cvk cp pub idx aRef)
+          (runZ σ cvk cp pub idx aRef) β γ α t).card ≤ Index.degreeBound n)
+
+/-- The guarded satisfaction of a reflected run: when the run's own Fiat–Shamir challenges
+lie outside the canonical exclusion sets `Protocol.soundBad*` at `runW`/`runZ` and off the
+boundary points (`ζ ≠ 1`, `ζ ≠ ω^(n−zkRows)`), the assembled table `runWTab` satisfies the
+circuit. -/
+def RunGuardImp {C : Ipa.CommitmentCurve} [Module C.ScalarField C.Point]
+    (σ : SRS C.Point) {nc : ℕ} (cvk : KimchiVK C nc) (cp : KimchiProof C nc σ.k)
+    (pub : Array C.ScalarField) {n : ℕ} [NeZero n] (idx : Index C.ScalarField n)
+    (aRef : Fin (runInput C σ cvk cp pub).commitments.size
+      → Fin (2 ^ σ.k) → C.ScalarField)
+    (aT : Fin cp.tComm.size → Fin (2 ^ σ.k) → C.ScalarField) : Prop :=
+  (runOracles C σ cvk cp pub).beta ∉ Protocol.soundBadB idx (runW σ cvk cp pub idx aRef) →
+  (runOracles C σ cvk cp pub).gamma
+      ∉ Protocol.soundBadG idx (runW σ cvk cp pub idx aRef)
+          (runOracles C σ cvk cp pub).beta →
+  (runOracles C σ cvk cp pub).alpha
+      ∉ Protocol.soundBadA idx (pubView idx pub) (runW σ cvk cp pub idx aRef)
+          (runZ σ cvk cp pub idx aRef) (runOracles C σ cvk cp pub).beta
+          (runOracles C σ cvk cp pub).gamma →
+  (runOracles C σ cvk cp pub).zeta
+      ∉ Protocol.soundBadZ idx (pubView idx pub) (runW σ cvk cp pub idx aRef)
+          (runZ σ cvk cp pub idx aRef) (runOracles C σ cvk cp pub).beta
+          (runOracles C σ cvk cp pub).gamma (runOracles C σ cvk cp pub).alpha
+          (ftChunkAssembly σ.k cp.tComm.size aT) →
+  (runOracles C σ cvk cp pub).zeta ≠ 1 →
+  (runOracles C σ cvk cp pub).zeta ≠ idx.omega ^ (n - idx.zkRows) →
+  Satisfies idx (pubView idx pub) (runWTab σ cvk cp pub idx aRef)
 
 /-- **The run-level residue-free root, curve-generically**: from a genuine acceptance
 `kimchiVerify σ cvk cp pub = true` of the checked records at production chunking
-`nc · 2^σ.k = n`, the AGM path delivers the guarded
-`Satisfies idx (pubView idx pub) wTab` — the assembled witness table of the algebraic
-prover's own per-chunk representations. The two curve-specific facts enter as
+`nc · 2^σ.k = n`, the AGM path yields `RunBounds ∧ RunGuardImp` — the Schwartz–Zippel
+cardinality bounds together with the guarded satisfaction of the assembled table
+`runWTab σ cvk cp pub idx aRef`, the algebraic prover's own per-chunk representations read as
+a witness table. The exclusion sets and the table are the canonical named terms
+`Protocol.soundBad*` at `runW`/`runZ` (`RunBounds`/`RunGuardImp`), so the conclusion
+constrains the run's own Fiat–Shamir challenges; that those challenges avoid the exclusion
+sets, and the good-combination conditions `hξ`/`hr`, are hypotheses — the forking/density
+argument, not carried here. The two
+curve-specific facts enter as
 hypotheses: `hsmul`, the `.val`-scalar collapse of the point-count-backed `Module`
 instance, and `hFS`, the Fiat–Shamir transcript tree at the run's own warm data —
 taken ONCE and threaded to both consumers (the flat eval pins at step (5) and
@@ -993,32 +1093,7 @@ private theorem run_sound_algebraic_ft {C : Ipa.CommitmentCurve}
       ∉ badROf σ aRef (runInput C σ cvk cp pub).pointFn
           (runInput C σ cvk cp pub).evalFn
           (runInput C σ cvk cp pub).polyscale) :
-    ∃ (badB : Finset C.ScalarField) (badG : C.ScalarField → Finset C.ScalarField)
-        (badA : C.ScalarField → C.ScalarField → Finset C.ScalarField)
-        (badZ : C.ScalarField → C.ScalarField → C.ScalarField
-          → Polynomial C.ScalarField → Finset C.ScalarField)
-        (wTab : Fin n → Fin wCols → C.ScalarField),
-      (badB.card ≤ 7 * (n - idx.zkRows)
-        ∧ (∀ β, (badG β).card ≤ 7 * (n - idx.zkRows))
-        ∧ (∀ β γ,
-            (badA β γ).card ≤ n * (Index.gateAlphaCount + Index.permAlphaCount - 1))
-        ∧ (∀ β γ α (t : Polynomial C.ScalarField), t.natDegree < 7 * n →
-            (badZ β γ α t).card ≤ Index.degreeBound n))
-      ∧ ((runOracles C σ cvk cp pub).beta ∉ badB →
-          (runOracles C σ cvk cp pub).gamma
-            ∉ badG (runOracles C σ cvk cp pub).beta →
-          (runOracles C σ cvk cp pub).alpha
-            ∉ badA (runOracles C σ cvk cp pub).beta
-                (runOracles C σ cvk cp pub).gamma →
-          (runOracles C σ cvk cp pub).zeta
-            ∉ badZ (runOracles C σ cvk cp pub).beta
-                (runOracles C σ cvk cp pub).gamma
-                (runOracles C σ cvk cp pub).alpha
-                (ftChunkAssembly σ.k cp.tComm.size aT) →
-          (runOracles C σ cvk cp pub).zeta ≠ 1 →
-          (runOracles C σ cvk cp pub).zeta
-            ≠ idx.omega ^ (n - idx.zkRows) →
-          Satisfies idx (pubView idx pub) wTab) := by
+    RunBounds σ cvk cp pub idx aRef ∧ RunGuardImp σ cvk cp pub idx aRef aT := by
   obtain ⟨hvkc, homega, hzk, hshift, hendo, hmds, hlag⟩ := hvk
   -- (1) the body reflection: the guards and the warm acceptance
   obtain ⟨hlagsz, _hpubn, haccept⟩ :=
@@ -1046,8 +1121,8 @@ private theorem run_sound_algebraic_ft {C : Ipa.CommitmentCurve}
         = commitPolyMaskedChunk σ (-(idx.pubPoly (pubView idx pub))) (c : ℕ) :=
     fun c => publicCommitment_corresponds C σ cvk pub idx
       (fun a P => (hsmul a P).symm) hlag hlagsz hpub c
-  -- (4) the openings seam, fed directly
-  obtain ⟨badB, badG, badA, badZ, hbounds, himp⟩ :=
+  -- (4) the residue-free openings seam, fed directly — its exclusion sets are `runW`/`runZ`'s
+  obtain ⟨hbounds, himp⟩ :=
     kimchiProof_sound_of_openings σ idx hnc hk hbind cvk.comms hvkc (pubView idx pub)
       (fun col c => (cp.wComm[col])[c]) (fun c => cp.zComm[c])
       (fun c => (publicCommitment C σ cvk pub)[c])
@@ -1055,10 +1130,7 @@ private theorem run_sound_algebraic_ft {C : Ipa.CommitmentCurve}
       (fun i c => aRef ⟨(streamPos nc i c : ℕ), hlt i c⟩)
       (fun i c => ρRef ⟨(streamPos nc i c : ℕ), hlt i c⟩)
       hbound₀
-  refine ⟨badB, badG, badA, badZ,
-    extractTable idx.omega (fun col => assembledRow σ.k nc
-      (fun c => aRef ⟨(streamPos nc (wRow col) c : ℕ), hlt (wRow col) c⟩)),
-    hbounds, ?_⟩
+  refine ⟨hbounds, ?_⟩
   intro hβ hγ hα hζ hζ1 hζb
   -- (5) the eval pins from the run's single accepted opening (flat arity)
   obtain ⟨a, ρ, hopen⟩ := ipa_soundnessA σ _ _ _ hFS haccept
@@ -1146,8 +1218,13 @@ private theorem run_sound_algebraic_ft {C : Ipa.CommitmentCurve}
 /-- **The run-level residue-free root (Vesta)**: from a genuine acceptance
 `kimchiVerify σ cvk cp pub = true` of the checked records at production chunking
 `nc · 2^σ.k = n`, the AGM path delivers the guarded
-`Satisfies idx (pubView idx pub) wTab` — the assembled witness table of the algebraic
-prover's own per-chunk representations. A deployed run reaches this root through the
+`RunBounds ∧ RunGuardImp` — the Schwartz–Zippel cardinality bounds together with the guarded
+satisfaction of the assembled witness table `runWTab σ cvk cp pub idx aRef`, the algebraic
+prover's own per-chunk representations. The exclusion sets and the table are the canonical
+named terms `Protocol.soundBad*` at `runW`/`runZ` (`RunBounds`/`RunGuardImp`), so the
+conclusion constrains the run's own Fiat–Shamir challenges; that those challenges avoid the
+exclusion sets, and the conditions `hξ`/`hr`, are hypotheses (the forking/density argument).
+A deployed run reaches this root through the
 wire boundary: the client parses with `Wire.{KimchiVK,KimchiProof}.check` (a checked
 record cannot hold a ragged proof) and calls `kimchiVerify` on the result. The prover
 supplies SRS-basis representations of the run's `44·nc + 1` flat segment rows
@@ -1196,41 +1273,21 @@ theorem kimchiVesta_run_sound_algebraic_ft (σ : SRS IpaVesta.Point) {nc : ℕ}
       ∉ badROf σ aRef (runInput IpaVesta.curve σ cvk cp pub).pointFn
           (runInput IpaVesta.curve σ cvk cp pub).evalFn
           (runInput IpaVesta.curve σ cvk cp pub).polyscale) :
-    ∃ (badB : Finset Fp) (badG : Fp → Finset Fp) (badA : Fp → Fp → Finset Fp)
-        (badZ : Fp → Fp → Fp → Polynomial Fp → Finset Fp)
-        (wTab : Fin n → Fin wCols → Fp),
-      (badB.card ≤ 7 * (n - idx.zkRows)
-        ∧ (∀ β, (badG β).card ≤ 7 * (n - idx.zkRows))
-        ∧ (∀ β γ,
-            (badA β γ).card ≤ n * (Index.gateAlphaCount + Index.permAlphaCount - 1))
-        ∧ (∀ β γ α (t : Polynomial Fp), t.natDegree < 7 * n →
-            (badZ β γ α t).card ≤ Index.degreeBound n))
-      ∧ ((runOracles IpaVesta.curve σ cvk cp pub).beta ∉ badB →
-          (runOracles IpaVesta.curve σ cvk cp pub).gamma
-            ∉ badG (runOracles IpaVesta.curve σ cvk cp pub).beta →
-          (runOracles IpaVesta.curve σ cvk cp pub).alpha
-            ∉ badA (runOracles IpaVesta.curve σ cvk cp pub).beta
-                (runOracles IpaVesta.curve σ cvk cp pub).gamma →
-          (runOracles IpaVesta.curve σ cvk cp pub).zeta
-            ∉ badZ (runOracles IpaVesta.curve σ cvk cp pub).beta
-                (runOracles IpaVesta.curve σ cvk cp pub).gamma
-                (runOracles IpaVesta.curve σ cvk cp pub).alpha
-                (ftChunkAssembly σ.k cp.tComm.size aT) →
-          (runOracles IpaVesta.curve σ cvk cp pub).zeta ≠ 1 →
-          (runOracles IpaVesta.curve σ cvk cp pub).zeta
-            ≠ idx.omega ^ (n - idx.zkRows) →
-          Satisfies idx (pubView idx pub) wTab) :=
+    RunBounds σ cvk cp pub idx aRef ∧ RunGuardImp σ cvk cp pub idx aRef aT :=
   run_sound_algebraic_ft σ cvk cp pub idx Pasta.vesta_smul_val hnc hk hn hvk hpub
     htpos hbind hacc (kimchi_fiat_shamir_vesta σ cvk cp pub) aRef ρRef hrep aT ρT
     hTC hξ hr
 
 /-- **The run-level residue-free root (Pallas).** The Pallas-side twin of
-`kimchiVesta_run_sound_algebraic_ft`, over `Fq`/`IpaPallas`. The same trust surface:
-the sole axiom consumed is its Fiat–Shamir assumption `kimchi_fiat_shamir_pallas`
-(once, through `run_sound_algebraic_ft`), and the computational hypotheses — the AGM
-representations `aRef`/`ρRef`/`aT`/`ρT`, the good-challenge guards `hξ`/`hr`, and
-DL-binding `hbind` (see the `hbind` scope note in the `Bulletproof/Soundness.lean`
-module docstring) — stay in the statement. -/
+`kimchiVesta_run_sound_algebraic_ft`, over `Fq`/`IpaPallas`. Same shape: the conclusion is
+`RunBounds ∧ RunGuardImp` over the canonical exclusion sets `Protocol.soundBad*` at
+`runW`/`runZ` and the assembled table `runWTab …`, with the run's avoidance of the exclusion
+sets and the conditions `hξ`/`hr` left as hypotheses (the forking/density argument). The same
+trust surface: the sole axiom consumed is its Fiat–Shamir assumption
+`kimchi_fiat_shamir_pallas` (once, through `run_sound_algebraic_ft`), and the
+computational hypotheses — the AGM representations `aRef`/`ρRef`/`aT`/`ρT`, the
+good-challenge guards `hξ`/`hr`, and DL-binding `hbind` (see the `hbind` scope note in the
+`Bulletproof/Soundness.lean` module docstring) — stay in the statement. -/
 theorem kimchiPallas_run_sound_algebraic_ft (σ : SRS IpaPallas.Point) {nc : ℕ}
     (cvk : KimchiVK IpaPallas.curve nc) (cp : KimchiProof IpaPallas.curve nc σ.k)
     (pub : Array Fq) {n : ℕ} [NeZero n] (idx : Index Fq n)
@@ -1254,30 +1311,7 @@ theorem kimchiPallas_run_sound_algebraic_ft (σ : SRS IpaPallas.Point) {nc : ℕ
       ∉ badROf σ aRef (runInput IpaPallas.curve σ cvk cp pub).pointFn
           (runInput IpaPallas.curve σ cvk cp pub).evalFn
           (runInput IpaPallas.curve σ cvk cp pub).polyscale) :
-    ∃ (badB : Finset Fq) (badG : Fq → Finset Fq) (badA : Fq → Fq → Finset Fq)
-        (badZ : Fq → Fq → Fq → Polynomial Fq → Finset Fq)
-        (wTab : Fin n → Fin wCols → Fq),
-      (badB.card ≤ 7 * (n - idx.zkRows)
-        ∧ (∀ β, (badG β).card ≤ 7 * (n - idx.zkRows))
-        ∧ (∀ β γ,
-            (badA β γ).card ≤ n * (Index.gateAlphaCount + Index.permAlphaCount - 1))
-        ∧ (∀ β γ α (t : Polynomial Fq), t.natDegree < 7 * n →
-            (badZ β γ α t).card ≤ Index.degreeBound n))
-      ∧ ((runOracles IpaPallas.curve σ cvk cp pub).beta ∉ badB →
-          (runOracles IpaPallas.curve σ cvk cp pub).gamma
-            ∉ badG (runOracles IpaPallas.curve σ cvk cp pub).beta →
-          (runOracles IpaPallas.curve σ cvk cp pub).alpha
-            ∉ badA (runOracles IpaPallas.curve σ cvk cp pub).beta
-                (runOracles IpaPallas.curve σ cvk cp pub).gamma →
-          (runOracles IpaPallas.curve σ cvk cp pub).zeta
-            ∉ badZ (runOracles IpaPallas.curve σ cvk cp pub).beta
-                (runOracles IpaPallas.curve σ cvk cp pub).gamma
-                (runOracles IpaPallas.curve σ cvk cp pub).alpha
-                (ftChunkAssembly σ.k cp.tComm.size aT) →
-          (runOracles IpaPallas.curve σ cvk cp pub).zeta ≠ 1 →
-          (runOracles IpaPallas.curve σ cvk cp pub).zeta
-            ≠ idx.omega ^ (n - idx.zkRows) →
-          Satisfies idx (pubView idx pub) wTab) :=
+    RunBounds σ cvk cp pub idx aRef ∧ RunGuardImp σ cvk cp pub idx aRef aT :=
   run_sound_algebraic_ft σ cvk cp pub idx Pasta.pallas_smul_val hnc hk hn hvk hpub
     htpos hbind hacc (kimchi_fiat_shamir_pallas σ cvk cp pub) aRef ρRef hrep aT ρT
     hTC hξ hr

--- a/formal/kimchi/Kimchi/Verifier/Reduction/Soundness.lean
+++ b/formal/kimchi/Kimchi/Verifier/Reduction/Soundness.lean
@@ -343,7 +343,10 @@ chunk-COMBINED record. The satisfying table is the reference openings' own witne
 rows, ASSEMBLED (`assembledRow`) into degree-`< n` polynomials. The public row's
 claims are pinned to the negated public interpolant through `hpubC` — the carried
 public evaluations of the `nc > 1` wire are adversarial data, believed only through
-this binding. -/
+this binding. The exclusion sets are the canonical `Protocol.sound` sets
+(`Protocol.soundBadB`/`soundBadG`/`soundBadA`/`soundBadZ`) at this theorem's own assembled
+witness columns and accumulator, carried through as explicit named terms so the conclusion
+is stated over the same sets the run-level roots consume. -/
 theorem kimchiProof_sound_of_openings [Field F] [AddCommGroup G] [Module F G]
     {n : ℕ} [NeZero n] [DecidableEq F] (σ : SRS G)
     (idx : Index F n) {nc : ℕ} (hnc : 0 < nc) (hk : nc * 2 ^ σ.k = n)
@@ -355,18 +358,32 @@ theorem kimchiProof_sound_of_openings [Field F] [AddCommGroup G] [Module F G]
       pubC c = commitPolyMaskedChunk σ (-(idx.pubPoly pub)) (c : ℕ))
     (aw₀ : Fin batchRows → Fin nc → Fin (2 ^ σ.k) → F) (ρw₀ : Fin batchRows → Fin nc → F)
     (hbound₀ : ∀ i c, commit σ (aw₀ i c) (ρw₀ i c) = batchC wC zC pubC comms i c) :
-    ∃ (badB : Finset F) (badG : F → Finset F) (badA : F → F → Finset F)
-        (badZ : F → F → F → Polynomial F → Finset F),
-      (badB.card ≤ 7 * (n - idx.zkRows)
-        ∧ (∀ β, (badG β).card ≤ 7 * (n - idx.zkRows))
-        ∧ (∀ β γ,
-            (badA β γ).card ≤ n * (Index.gateAlphaCount + Index.permAlphaCount - 1))
+      ((Kimchi.Protocol.soundBadB idx
+            (fun col => assembledRow σ.k nc (aw₀ (wRow col)))).card ≤ 7 * (n - idx.zkRows)
+        ∧ (∀ β, (Kimchi.Protocol.soundBadG idx
+              (fun col => assembledRow σ.k nc (aw₀ (wRow col))) β).card
+            ≤ 7 * (n - idx.zkRows))
+        ∧ (∀ β γ, (Kimchi.Protocol.soundBadA idx pub
+              (fun col => assembledRow σ.k nc (aw₀ (wRow col)))
+              (assembledRow σ.k nc (aw₀ zRow)) β γ).card
+            ≤ n * (Index.gateAlphaCount + Index.permAlphaCount - 1))
         ∧ (∀ β γ α (t : Polynomial F), t.natDegree < 7 * n →
-            (badZ β γ α t).card ≤ Index.degreeBound n))
+            (Kimchi.Protocol.soundBadZ idx pub
+              (fun col => assembledRow σ.k nc (aw₀ (wRow col)))
+              (assembledRow σ.k nc (aw₀ zRow)) β γ α t).card ≤ Index.degreeBound n))
       ∧ ∀ (β γ α : F) (t : Polynomial F) (ζ : F)
           (E : Fin batchRows → Fin nc → Fin evalPts → F)
           (aw : Fin batchRows → Fin nc → Fin (2 ^ σ.k) → F) (ρw : Fin batchRows → Fin nc → F),
-          β ∉ badB → γ ∉ badG β → α ∉ badA β γ → ζ ∉ badZ β γ α t →
+          β ∉ Kimchi.Protocol.soundBadB idx
+              (fun col => assembledRow σ.k nc (aw₀ (wRow col))) →
+          γ ∉ Kimchi.Protocol.soundBadG idx
+              (fun col => assembledRow σ.k nc (aw₀ (wRow col))) β →
+          α ∉ Kimchi.Protocol.soundBadA idx pub
+              (fun col => assembledRow σ.k nc (aw₀ (wRow col)))
+              (assembledRow σ.k nc (aw₀ zRow)) β γ →
+          ζ ∉ Kimchi.Protocol.soundBadZ idx pub
+              (fun col => assembledRow σ.k nc (aw₀ (wRow col)))
+              (assembledRow σ.k nc (aw₀ zRow)) β γ α t →
           ζ ≠ 1 → ζ ≠ idx.omega ^ (n - idx.zkRows) →
           t.natDegree < 7 * n →
           (∀ i c, commit σ (aw i c) (ρw i c) = batchC wC zC pubC comms i c
@@ -411,9 +428,9 @@ theorem kimchiProof_sound_of_openings [Field F] [AddCommGroup G] [Module F G]
   have hdpub : (-(idx.pubPoly pub)).natDegree < nc * 2 ^ σ.k := by
     rw [hk, natDegree_neg]
     exact columnPoly_natDegree_lt idx.omega_prim _
-  obtain ⟨badB, badG, badA, badZ, hbounds, himp⟩ :=
+  obtain ⟨hb1, hb2, hb3, hb4, himp⟩ :=
     Kimchi.Protocol.sound idx pub W zg hzdeg
-  refine ⟨badB, badG, badA, badZ, hbounds, ?_⟩
+  refine ⟨⟨hb1, hb2, hb3, hb4⟩, ?_⟩
   intro β γ α t ζ E aw ρw hβ hγ hα hζ hζ₁ hζb ht hrow hteq
   -- cross-point uniqueness per chunk: fixed commitments bind the reference chunks
   have hwchunk : ∀ (col : Fin wCols) (c : Fin nc),
@@ -573,10 +590,10 @@ theorem kimchiProof_sound [Field F] [AddCommGroup G] [Module F G]
     (batchC wC zC pubC comms) ![ζ₀, idx.omega * ζ₀] E₀ (fun v j => A₀ (ι v) j)
     (fun v j => hFS₀ (ι v) j) hbind (fun v j => hacc₀ (ι v) j)
   choose ρ₀ hρ₀ using fun i => (hq₀ i).2.1
-  obtain ⟨badB, badG, badA, badZ, hbounds, himp⟩ :=
+  obtain ⟨hbounds, himp⟩ :=
     kimchiProof_sound_of_openings σ idx hnc hk hbind comms hvk pub wC zC pubC hpubC
       (fun i c => chunkCoeffs (2 ^ σ.k) (q₀ i) (c : ℕ)) ρ₀ (fun i c => hρ₀ i c)
-  refine ⟨badB, badG, badA, badZ,
+  refine ⟨_, _, _, _,
     extractTable idx.omega
       (fun col => assembledRow σ.k nc
         (fun c => chunkCoeffs (2 ^ σ.k) (q₀ (wRow col)) (c : ℕ))),

--- a/formal/kimchi/roots.txt
+++ b/formal/kimchi/roots.txt
@@ -98,5 +98,11 @@ Kimchi.Verifier.kimchiProof_sound_algebraic_ft
 -- openings seam fed directly, public row bound through the key's Lagrange chunk pin,
 -- Maller identity from the ft opening at the DOUBLE zeta^{2^k} collapse. Trust
 -- surface = kimchi_fiat_shamir (Poseidon-RO) + DL-binding (hbind) + CompElliptic.
+-- The conclusion is `RunBounds ∧ RunGuardImp` over the canonical Schwartz-Zippel exclusion
+-- sets `Protocol.soundBad*` (at the run's assembled `runW`/`runZ`) and the assembled table
+-- `runWTab` — explicit named terms, so the conclusion constrains the run's own Fiat-Shamir
+-- challenges. Scope: that a genuine run's challenges avoid the (card-bounded) exclusion sets,
+-- and the good-combination conditions `hξ`/`hr`, are hypotheses of `RunGuardImp` — the
+-- forking/density argument, not carried here.
 Kimchi.Verifier.kimchiVesta_run_sound_algebraic_ft
 Kimchi.Verifier.kimchiPallas_run_sound_algebraic_ft


### PR DESCRIPTION
## What

De-vacuates the terminal run-level AGM roots `kimchi{Vesta,Pallas}_run_sound_algebraic_ft`
(and the private `run_sound_algebraic_ft` they wrap), fixing finding **C1** of the
statement-correctness audit (`formal/docs/statement-audit-report.md`).

## The defect

The run-level roots concluded

```
∃ badB badG badA badZ wTab, (card bounds) ∧ (runOracles-guards → Satisfies idx (pubView idx pub) wTab)
```

with the `∃` in the **conclusion** — after the records `(σ, cvk, cp, pub)`, hence the
deterministic `runOracles` challenges, are fixed. So the statement was provable with **zero
hypotheses** via the degenerate witness `badB = badG = badA = ∅`,
`badZ := fun _ _ _ _ => {runζ}` (card `1 ≤ Index.degreeBound n = 9·n`), `wTab := 0`: the guard
`runζ ∉ {runζ}` is false, so the guarded implication is vacuous. The documented content lived
only in the proof term, not the statement.

## The fix

The bad sets and `wTab` become **explicit, fixed named terms** — no existential to instantiate:

- New named canonical bad-set defs in `Protocol/Equation.lean`
  (`soundBadB/G/A/Z`, over `soundM1/soundM2`) — the genuine
  `GrandProduct.badBetas/badGammas`, `badAlphas (idx.fullFamily …)`,
  `badZetas (aggregate α (idx.fullFamily …)) t n` read off the extracted witness table.
  `Protocol.sound` is restated to quantify these directly instead of behind an `∃`.
- `kimchiProof_sound_of_openings` (`Reduction/Soundness.lean`) is de-existentialized to the
  named sets. The **grid** `kimchiProof_sound` keeps its `∃` conclusion verbatim (proof-only
  change, re-wrapping the named sets) so its frozen consumer `Capstone/Standard.lean` still
  compiles unchanged.
- The run roots (`Capstone/Reflection.lean`) now conclude `RunBounds ∧ RunGuardImp` over the
  fixed `Protocol.soundBad*` sets at the run's own assembled `runW`/`runZ`, delivering the fixed
  table `runWTab := extractTable idx.omega (runW …)`. No `∃ badB … badZ wTab`, so the degenerate
  witness no longer typechecks.

## Scope / honesty

This closes the **statement-vacuity** gap only. The run-oracle avoidance guards
(`runOracles ∉ Protocol.soundBad*`, and `hξ`/`hr`) **remain undischarged hypotheses** of
`RunGuardImp` — discharging them is the deferred forking/density model, out of scope here and
documented in the roots' docstrings and `roots.txt`. The sibling standard-model roots
`kimchi{Vesta,Pallas}_run_sound` in `Capstone/Standard.lean` have the same shape (audit finding
M5) and are **not** touched here.

## Verification

- `lake build Kimchi` clean (incl. the frozen `Standard.lean`).
- `kimchi/scripts/check_axioms.sh`: all roots reduce to the **same** allowed axiom closure
  (`propext, Classical.choice, Quot.sound, Lean.ofReduceBool` + the four FS axioms) — no new
  axiom.
- `formal/scripts/check-style.sh` clean.
- No `sorry`/`admit`/`native_decide`/`maxHeartbeats`/linter-suppression added; `hbind` and the
  trust surface untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
