### PR TITLE
formal: switch CompElliptic from the l-adic fork to daira upstream @ a549e455

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,5 +3,5 @@
 	url = https://github.com/MinaProtocol/mina.git
 [submodule "formal/vendor/CompElliptic"]
 	path = formal/vendor/CompElliptic
-	url = https://github.com/l-adic/CompElliptic.git
+	url = https://github.com/daira/CompElliptic.git
 	branch = main

--- a/formal/kimchi/scripts/check_perm_fixture.lean
+++ b/formal/kimchi/scripts/check_perm_fixture.lean
@@ -1,4 +1,5 @@
 import CompElliptic.Fields.Pasta
+import Pasta.CompElliptic
 import Kimchi.Permutation.Wiring
 import FixtureKit.Parse
 import Lean.Data.Json

--- a/formal/pasta/Pasta/Basic.lean
+++ b/formal/pasta/Pasta/Basic.lean
@@ -3,6 +3,7 @@ import CompElliptic.CurveForms.ShortWeierstrass
 import CompElliptic.Curves.Pasta
 import CompElliptic.Curves.PastaOrder
 import CompElliptic.Fields.Pasta
+import Pasta.CompElliptic
 
 /-!
 # The Pasta group orders
@@ -27,6 +28,49 @@ namespace CompElliptic.CurveForms.ShortWeierstrass
 /-- The `SWCurve` as a Mathlib affine Weierstrass curve `y² = x³ + A·x + B`. -/
 abbrev SWCurve.toAffine {F : Type*} [Field F] (C : SWCurve F) : WeierstrassCurve.Affine F :=
   toW C.A C.B
+
+/-! ### Bridge to Mathlib's `Affine.Point`
+
+`SWPoint E` and Mathlib's affine point group `Point (toW E.A E.B)` are two representations of
+the same group: the computable structure (with `DecidableEq` / `native_decide`-friendly scalar
+mul) and Mathlib's inductive `Point` with its proven `AddCommGroup`. The transport maps
+`toPt` / `ofPt` are already mutually inverse on valid coordinates, so they package into an
+`Equiv`. This lets the `SWPoint`-native order theory (`CompElliptic.CurveOrder`,
+`Curves.PastaOrder`) transfer to `Nat.card (Point …)`, the form the `pallas_card` / `vesta_card`
+orders below are stated in. Upstream CompElliptic does not carry this bridge; it lives here. -/
+
+open WeierstrassCurve.Affine
+
+/-- The coordinates of any Mathlib point of `toW a b` are `Valid` (on the curve, or the `𝒪`
+sentinel). -/
+theorem valid_ofPt {F : Type*} [Field F] {a b : F} [(toW a b).IsElliptic]
+    (Q : Point (toW a b)) : Valid a b (ofPt Q) := by
+  cases Q with
+  | zero => exact Or.inr rfl
+  | some x y h => exact Or.inl (equation_toW.mp h.left)
+
+/-- `toPt` is a right inverse of `ofPt` (`b ≠ 0` so the `𝒪` sentinel round-trips). -/
+theorem toPt_ofPt {F : Type*} [Field F] [DecidableEq F] {a b : F} (hb : b ≠ 0)
+    [(toW a b).IsElliptic] (Q : Point (toW a b)) : toPt a b (ofPt Q) = Q := by
+  cases Q with
+  | zero => exact toPt_zero hb
+  | some x y h => exact toPt_some (equation_toW.mp h.left)
+
+/-- `SWPoint E` is equivalent to Mathlib's affine point group `Point (toW E.A E.B)`, via the
+coordinate transport `toPt` / `ofPt`. -/
+noncomputable def SWPoint.equivPoint {F : Type*} [Field F] [DecidableEq F] (E : SWCurve F) :
+    SWPoint E ≃ Point (toW E.A E.B) :=
+  haveI := instIsElliptic E
+  { toFun := fun P => toPt E.A E.B (P.x, P.y)
+    invFun := fun Q => ⟨(ofPt Q).1, (ofPt Q).2, valid_ofPt Q⟩
+    left_inv := fun P => SWPoint.ext_pair (ofPt_toPt E.B_nonzero P.onCurve)
+    right_inv := fun Q => toPt_ofPt E.B_nonzero Q }
+
+/-- The order counted on `SWPoint E` equals Mathlib's `Nat.card` of the affine point group — the
+bridge that carries the `SWPoint`-native order theory to the Mathlib-`Point` side. -/
+theorem SWPoint.card_eq_point {F : Type*} [Field F] [DecidableEq F] (E : SWCurve F) :
+    Nat.card (SWPoint E) = Nat.card (Point (toW E.A E.B)) :=
+  Nat.card_congr (SWPoint.equivPoint E)
 
 end CompElliptic.CurveForms.ShortWeierstrass
 

--- a/formal/pasta/Pasta/CompElliptic.lean
+++ b/formal/pasta/Pasta/CompElliptic.lean
@@ -1,0 +1,23 @@
+import CompElliptic.Fields.Pasta
+
+/-!
+# CompElliptic field-name compatibility shim
+
+Upstream `daira/CompElliptic` names the two Pasta fields `PallasBaseField` and
+`PallasScalarField` (with `VestaBaseField` / `VestaScalarField` role aliases). This project
+refers to them by the absolute names `Fp` and `Fq` throughout. These abbreviations restore
+those names in the `CompElliptic.Fields.Pasta` namespace, so every downstream module that
+`open CompElliptic.Fields.Pasta`s and writes `Fp` / `Fq` resolves against the upstream
+definitions unchanged. The point-group bridge to Mathlib's `Affine.Point` lives in
+`Pasta.Basic`, next to the order theory that consumes it.
+-/
+
+namespace CompElliptic.Fields.Pasta
+
+/-- The Pallas base field `𝔽ₚ` — also the Vesta scalar field (the Pasta cycle). -/
+abbrev Fp := PallasBaseField
+
+/-- The Pallas scalar field `𝔽_q` — also the Vesta base field (the Pasta cycle). -/
+abbrev Fq := PallasScalarField
+
+end CompElliptic.Fields.Pasta

--- a/formal/poseidon/Poseidon/Basic.lean
+++ b/formal/poseidon/Poseidon/Basic.lean
@@ -1,6 +1,7 @@
 import Mathlib.Algebra.Field.Defs
 import Mathlib.Data.Fin.VecNotation
 import CompElliptic.Fields.Pasta
+import Pasta.CompElliptic
 import Poseidon.ConstantsFq
 import Poseidon.ConstantsFp
 


### PR DESCRIPTION
## What

Replaces our `l-adic/CompElliptic` fork with **daira's upstream `CompElliptic` at
`a549e4555b17bbbe3c8d48aa7d5b493912ccfbe9`** (the `vendor/CompElliptic` submodule is
repointed at daira upstream and pinned there), and moves the two patches our fork carried
into the `pasta` shim package so the project builds unchanged.

Motivation: this is the prerequisite for taking `zcash/ironwood` as a direct dependency
(see `formal/docs/ironwood-refoundation-plan.md`) — ironwood pins the same
`daira/CompElliptic @ a549e455`, so sharing that exact commit dissolves the would-be
diamond (one CompElliptic in the workspace, byte-identical to ironwood's).

## The two fork patches, and where they went

The fork diverged from upstream in exactly two substantive places:

1. **Field-name rename** (`Fp`/`Fq` instead of upstream's `PallasBaseField`/`PallasScalarField`).
   Restored as a compatibility shim: new module `pasta/Pasta/CompElliptic.lean` declares
   `abbrev Fp := PallasBaseField` / `abbrev Fq := PallasScalarField` in the
   `CompElliptic.Fields.Pasta` namespace (defeq to upstream). Every `open
   CompElliptic.Fields.Pasta` + `Fp`/`Fq` site resolves unchanged; two modules that use
   `Fp`/`Fq` without transitively reaching the shim (`Poseidon.Basic`,
   `scripts/check_perm_fixture.lean`) get an explicit `import Pasta.CompElliptic`.

2. **`SWPoint ↔ Affine.Point` order bridge** (`SWPoint.equivPoint`, `SWPoint.card_eq_point`,
   `valid_ofPt`, `toPt_ofPt`). Relocated verbatim into `pasta/Pasta/Basic.lean`'s existing
   `CompElliptic.CurveForms.ShortWeierstrass` namespace block, next to the `pallas_card` /
   `vesta_card` order theorems that consume it. Its substrate (`toW`/`toPt`/`ofPt`/…) is
   upstream, unchanged; the two consumer call sites (`SWPoint.card_eq_point Pallas.curve`,
   `… Vesta.curve`) are untouched.

Switching to upstream also **re-gains** upstream's computable `instFintypeSWPoint` (the
`computable-fintype` PR our fork predated) and upstream's `TrustBoundary` /
`Meta.AxiomCheck` hygiene modules. No collision — the project defines no competing
`Fintype (SWPoint …)` instance.

## Verification

- `lake build` of the full workspace (Pasta, Poseidon, Bulletproof, Kimchi, KimchiFixture,
  Snarky, FixtureKit, BulletproofFixture): **green, 8576 jobs, 0 errors.**
- All three axiom gates pass with **identical closures** (the trust surface is unchanged):
  - `pasta`: 13 roots → standard axioms + trusted `native_decide` certificates.
  - `kimchi`: 48 roots → `{propext, Classical.choice, Quot.sound, Lean.ofReduceBool}` + the
    four FS axioms.
  - `bulletproof-pcs`: 7 roots → standard + declared FS axioms + the Pasta trust base.
- Fixture/trace checks pass: `check_perm_fixture`, `check_ps_witness`, `check_fq_sponge`,
  `check_sponge_vectors`, `check_ipa_fixture`, `check_kimchi_verifier`, `check_index_fixture`,
  `check_linearization`, `check_vk_correspond`.
- `scripts/check-style.sh` clean (95 files). Shake is neutral: the new `Pasta.CompElliptic`
  import is used (not flagged); the pre-existing `PastaOrder`/`Shifted` findings are
  unchanged by this PR.

## Notes

- `.gitmodules` URL changes from `l-adic/CompElliptic` to `daira/CompElliptic`; the
  submodule pointer moves `c47ad4d → a549e455`. Clone/CI must `git submodule update --init`
  as before (now fetching from daira).
- The l-adic fork becomes unreferenced by this repo (can be archived separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
