### PR TITLE
formal: W2 — Fiat–Shamir random-oracle model (fq + fr)

### DIFF
--- a/formal/kimchi/Kimchi.lean
+++ b/formal/kimchi/Kimchi.lean
@@ -42,3 +42,6 @@ import Kimchi.Verifier.Wire
 import Kimchi.Verifier.Capstone.Standard
 import Kimchi.Verifier.Capstone.Algebraic
 import Kimchi.Verifier.Capstone.Reflection
+
+-- W2 · Fiat–Shamir random-oracle model (fq side)
+import Kimchi.Verifier.Forking.Model

--- a/formal/kimchi/Kimchi.lean
+++ b/formal/kimchi/Kimchi.lean
@@ -43,5 +43,6 @@ import Kimchi.Verifier.Capstone.Standard
 import Kimchi.Verifier.Capstone.Algebraic
 import Kimchi.Verifier.Capstone.Reflection
 
--- W2 · Fiat–Shamir random-oracle model (fq side)
+-- W2 · Fiat–Shamir random-oracle model (fq + fr) and its run-level faithfulness
 import Kimchi.Verifier.Forking.Model
+import Kimchi.Verifier.Forking.RunLink

--- a/formal/kimchi/Kimchi/Verifier/Forking/Model.lean
+++ b/formal/kimchi/Kimchi/Verifier/Forking/Model.lean
@@ -1,0 +1,73 @@
+import Kimchi.Verifier.Forking.OracleRun
+
+/-!
+# W2 · The random-oracle model and its trust boundary (fq side)
+
+## What is proved, and what is assumed
+
+`Forking.Transcript` and `Forking.OracleRun` are *fully verified* — no new axiom. They define
+the fq-side transcript domain, interpret a prefix through the deployed Poseidon sponge
+(`poseidonO`), and prove (`oracleChallenges_poseidonO`) that reading `poseidonO` at the four
+prefixes reproduces the verifier's `(β, γ, α, ζ)` exactly. So the abstract oracle game below
+provably *specializes to the real verifier* at `O := poseidonO`.
+
+## The one modeling assumption (documented, not a kernel axiom)
+
+The soundness bound is proved for a **uniform** oracle `O : List (KimchiTranscriptElt C) →
+C.ScalarField`. Transporting it to the deployed verifier rests on a single assumption:
+
+> **Poseidon-as-random-oracle.** The deployed Poseidon fq-sponge, read at the transcript
+> prefixes — i.e. `poseidonO` — is distributed as a uniform random function over its query
+> domain. Equivalently: the sponge's challenge outputs at distinct transcript points are
+> jointly indistinguishable from independent uniform field elements.
+
+This is **not** introduced as a Lean `axiom`. The deployed sponge is a deterministic function;
+asserting its uniformity inside the kernel would be a false-as-stated proposition (an unconditioned
+distribution claim, the shape the statement audit flagged as M3). Instead — following
+`zcash/ironwood`'s `Forking.Oracle` — every probabilistic theorem is stated *within* the uniform
+model, and this paragraph is the named boundary at which the model meets Blake2b/Poseidon reality.
+`#print axioms` on the W4 roots will therefore show **no** oracle axiom; the assumption is
+auditable here and in `roots.txt`, by reading, exactly as prominent as an axiom would be.
+
+Two conversions are idealized inside the same boundary and carry no separate accounting: the
+128-bit prechallenge cast (`β`, `γ`) and the endomorphism expansion (`α`, `ζ`) are treated as
+landing uniformly in `C.ScalarField`. Their deviation from uniform is negligible; a strengthening
+that discharges the `endoExpand` half from the GLV short-basis bounds is recorded for later.
+
+## Layer boundary
+
+This module frames the game shape (`fsWins`-style: an acceptance predicate evaluated at the
+oracle-read challenges) and records faithfulness. The probability measure over uniform oracles,
+the per-challenge freshness bounds against the `soundBad*` sets, and the forking reduction consume
+`zcash/ironwood` and land in W3/W4; nothing here imports `Zcash` yet.
+-/
+
+namespace Kimchi.Verifier.Forking
+
+open Bulletproof
+
+variable {C : Ipa.CommitmentCurve} {nc k : ℕ}
+
+/-- The Fiat–Shamir game event, in `ironwood`'s `fsWins` shape: an acceptance predicate on the
+challenge tuple, evaluated at the challenges *read from the oracle* `O` at the four fq-side
+prefixes. W3 instantiates `accept` with the deployed verifier's guard conditions (the
+`RunGuardImp` antecedents avoiding the `soundBad*` sets); the soundness bound then measures
+`{O | GuardEvent accept O …}` over a uniform `O`. -/
+def GuardEvent (accept : C.ScalarField × C.ScalarField × C.ScalarField × C.ScalarField → Prop)
+    (O : List (KimchiTranscriptElt C) → C.ScalarField)
+    (cvk : KimchiVK C nc) (cp : KimchiProof C nc k) (publicComm : Vector C.Point nc) : Prop :=
+  accept (oracleChallenges O cvk cp publicComm)
+
+/-- **The game specializes to the real verifier.** For any acceptance predicate, the game event
+at `O := poseidonO` is exactly acceptance at the deployed verifier's own `(β, γ, α, ζ)`. This is
+the bridge that lets a uniform-oracle bound on `GuardEvent` become a bound on the real verifier,
+under the modeling assumption above. -/
+theorem guardEvent_poseidonO
+    (accept : C.ScalarField × C.ScalarField × C.ScalarField × C.ScalarField → Prop)
+    (cvk : KimchiVK C nc) (cp : KimchiProof C nc k) (publicComm : Vector C.Point nc) :
+    GuardEvent accept poseidonO cvk cp publicComm
+      ↔ accept ((fqOracles C cvk cp publicComm).beta, (fqOracles C cvk cp publicComm).gamma,
+                (fqOracles C cvk cp publicComm).alpha, (fqOracles C cvk cp publicComm).zeta) := by
+  rw [GuardEvent, oracleChallenges_poseidonO]
+
+end Kimchi.Verifier.Forking

--- a/formal/kimchi/Kimchi/Verifier/Forking/Model.lean
+++ b/formal/kimchi/Kimchi/Verifier/Forking/Model.lean
@@ -1,7 +1,7 @@
 import Kimchi.Verifier.Forking.OracleRun
 
 /-!
-# W2 · The random-oracle model and its trust boundary (fq side)
+# W2 · The random-oracle model and its trust boundary (fq + fr sides)
 
 ## What is proved, and what is assumed
 
@@ -69,5 +69,21 @@ theorem guardEvent_poseidonO
       ↔ accept ((fqOracles C cvk cp publicComm).beta, (fqOracles C cvk cp publicComm).gamma,
                 (fqOracles C cvk cp publicComm).alpha, (fqOracles C cvk cp publicComm).zeta) := by
   rw [GuardEvent, oracleChallenges_poseidonO]
+
+/-- The fr-side game event: an acceptance predicate on the `(v, u)` batch-challenge pair,
+evaluated at the challenges read from the fr-oracle `O` at the two prefixes. W3 instantiates
+`accept` with the batch-opening guard conditions (the `badXi`/`badR` avoidance). -/
+def GuardEventVU (accept : C.ScalarField × C.ScalarField → Prop)
+    (O : List (FrTranscriptElt C) → C.ScalarField) (cp : KimchiProof C nc k)
+    (fqDig : C.ScalarField) (pubEvals : PointEvaluations (Vector C.ScalarField nc)) : Prop :=
+  accept (oracleVU O cp fqDig pubEvals)
+
+/-- **The fr game specializes to the real verifier.** At `O := poseidonOFr`, the fr game event
+is exactly acceptance at the deployed verifier's own `(v, u)`. -/
+theorem guardEventVU_poseidonOFr (accept : C.ScalarField × C.ScalarField → Prop)
+    (cp : KimchiProof C nc k) (fqDig : C.ScalarField)
+    (pubEvals : PointEvaluations (Vector C.ScalarField nc)) :
+    GuardEventVU accept poseidonOFr cp fqDig pubEvals ↔ accept (frOracles C cp fqDig pubEvals) := by
+  rw [GuardEventVU, oracleVU_poseidonOFr]
 
 end Kimchi.Verifier.Forking

--- a/formal/kimchi/Kimchi/Verifier/Forking/OracleRun.lean
+++ b/formal/kimchi/Kimchi/Verifier/Forking/OracleRun.lean
@@ -78,19 +78,27 @@ theorem poseidonO_preGamma (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
     (publicComm : Vector C.Point nc) :
     poseidonO (KimchiTranscriptElt.preGamma cvk cp publicComm)
       = (fqOracles C cvk cp publicComm).gamma := by
-  sorry
+  rw [poseidonO, preGamma, preBeta]
+  simp only [List.foldl_append, List.foldl_cons, List.foldl_nil, step, foldl_step_fst,
+    foldl_absorbInto_preAbsorbs, fqOracles]
 
 theorem poseidonO_preAlpha (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
     (publicComm : Vector C.Point nc) :
     poseidonO (KimchiTranscriptElt.preAlpha cvk cp publicComm)
       = (fqOracles C cvk cp publicComm).alpha := by
-  sorry
+  rw [poseidonO, preAlpha, preGamma, preBeta]
+  simp only [List.foldl_append, List.foldl_cons, List.foldl_nil, step, foldl_step_fst,
+    foldl_absorbInto_preAbsorbs]
+  simp only [absorbInto, List.foldl_map, Vector.foldl_toList, fqOracles]
 
 theorem poseidonO_preZeta (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
     (publicComm : Vector C.Point nc) :
     poseidonO (KimchiTranscriptElt.preZeta cvk cp publicComm)
       = (fqOracles C cvk cp publicComm).zeta := by
-  sorry
+  rw [poseidonO, preZeta, preAlpha, preGamma, preBeta]
+  simp only [List.foldl_append, List.foldl_cons, List.foldl_nil, step, foldl_step_fst,
+    foldl_absorbInto_preAbsorbs]
+  simp only [absorbInto, List.foldl_map, Vector.foldl_toList, Array.foldl_toList, fqOracles]
 
 /-- **Faithfulness (W2 acceptance gate).** Reading the sponge-as-oracle `poseidonO` at the
 four fq-side transcript prefixes reproduces the deployed verifier's `(β, γ, α, ζ)` exactly.

--- a/formal/kimchi/Kimchi/Verifier/Forking/OracleRun.lean
+++ b/formal/kimchi/Kimchi/Verifier/Forking/OracleRun.lean
@@ -1,0 +1,107 @@
+import Kimchi.Verifier.Forking.Transcript
+
+/-!
+# W2 · Interpreting a transcript prefix through the real sponge (fq side)
+
+`poseidonO` folds a transcript prefix through the deployed fq-sponge, returning the last
+squeezed challenge. The bridge theorems (`poseidonO_pre*`) prove that reading `poseidonO`
+at the four fq-side prefixes reproduces `fqOracles`'s `β`, `γ`, `α`, `ζ` — i.e. the real
+verifier is the `O := poseidonO` instance of the abstract oracle game. This is what lets
+`Forking.Model`'s uniform-oracle statement be *about* the deployed verifier.
+-/
+
+namespace Kimchi.Verifier.Forking
+
+open Bulletproof Poseidon
+
+variable {C : Ipa.CommitmentCurve} {nc k : ℕ}
+
+/-- One interpreter step: absorbs update the fq-sponge state (`.1`), squeezes overwrite the
+running challenge value (`.2`) and advance the state. -/
+def step (acc : FqSponge.S C.base × C.ScalarField) :
+    KimchiTranscriptElt C → FqSponge.S C.base × C.ScalarField
+  | .fqPoint P => (FqSponge.absorbG C.sponge acc.1 P, acc.2)
+  | .fqBase x => (FqSponge.absorbFq C.sponge acc.1 [x], acc.2)
+  | .fqCast => ((FqSponge.challenge C.sponge acc.1).2, (FqSponge.challenge C.sponge acc.1).1)
+  | .fqEndo => ((FqSponge.squeezeChallenge C.sponge acc.1).2,
+      (FqSponge.squeezeChallenge C.sponge acc.1).1)
+
+/-- The real sponge as an oracle: fold a transcript prefix, return the last challenge. -/
+def poseidonO (t : List (KimchiTranscriptElt C)) : C.ScalarField :=
+  (t.foldl step (FqSponge.init, 0)).2
+
+/-- The four fq-side challenges read from an abstract oracle at the transcript prefixes. -/
+def oracleChallenges (O : List (KimchiTranscriptElt C) → C.ScalarField)
+    (cvk : KimchiVK C nc) (cp : KimchiProof C nc k) (publicComm : Vector C.Point nc) :
+    C.ScalarField × C.ScalarField × C.ScalarField × C.ScalarField :=
+  (O (KimchiTranscriptElt.preBeta cvk cp publicComm),
+   O (KimchiTranscriptElt.preGamma cvk cp publicComm),
+   O (KimchiTranscriptElt.preAlpha cvk cp publicComm),
+   O (KimchiTranscriptElt.preZeta cvk cp publicComm))
+
+/-! ## The bridge: `poseidonO` at each prefix is `fqOracles`'s challenge -/
+
+open KimchiTranscriptElt (absorbInto wCommAbsorbs preAbsorbs preBeta preGamma preAlpha preZeta)
+
+/-- The interpreter's state component evolves independently of the running challenge value:
+folding `step` and projecting the state equals folding the pure state action `absorbInto`.
+This is the spine shared by all four bridges. -/
+theorem foldl_step_fst (l : List (KimchiTranscriptElt C)) (s : FqSponge.S C.base)
+    (v : C.ScalarField) :
+    (l.foldl step (s, v)).1 = l.foldl (fun s e => absorbInto C e s) s := by
+  induction l generalizing s v with
+  | nil => rfl
+  | cons e l ih =>
+    have hstep : (step (s, v) e).1 = absorbInto C e s := by cases e <;> rfl
+    rw [List.foldl_cons, List.foldl_cons, ih, hstep]
+
+/-- The interpreter's state after an absorb-only prefix is `fqOracles`'s pre-`β` sponge
+state: the digest absorb, the public-input commitment fold, then the witness fold. -/
+theorem foldl_absorbInto_preAbsorbs (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
+    (publicComm : Vector C.Point nc) :
+    (preAbsorbs cvk cp publicComm).foldl (fun s e => absorbInto C e s) FqSponge.init
+      = cp.wComm.foldl (fun s col => col.foldl (FqSponge.absorbG C.sponge) s)
+          (publicComm.foldl (FqSponge.absorbG C.sponge)
+            (FqSponge.absorbFq C.sponge FqSponge.init [cvk.digest])) := by
+  unfold preAbsorbs wCommAbsorbs
+  simp only [List.foldl_cons, List.foldl_append, List.foldl_map, List.foldl_flatMap,
+    absorbInto, Vector.foldl_toList]
+
+theorem poseidonO_preBeta (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
+    (publicComm : Vector C.Point nc) :
+    poseidonO (KimchiTranscriptElt.preBeta cvk cp publicComm)
+      = (fqOracles C cvk cp publicComm).beta := by
+  rw [poseidonO, preBeta, List.foldl_append, List.foldl_cons, List.foldl_nil]
+  simp only [step, foldl_step_fst, foldl_absorbInto_preAbsorbs, fqOracles]
+
+theorem poseidonO_preGamma (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
+    (publicComm : Vector C.Point nc) :
+    poseidonO (KimchiTranscriptElt.preGamma cvk cp publicComm)
+      = (fqOracles C cvk cp publicComm).gamma := by
+  sorry
+
+theorem poseidonO_preAlpha (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
+    (publicComm : Vector C.Point nc) :
+    poseidonO (KimchiTranscriptElt.preAlpha cvk cp publicComm)
+      = (fqOracles C cvk cp publicComm).alpha := by
+  sorry
+
+theorem poseidonO_preZeta (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
+    (publicComm : Vector C.Point nc) :
+    poseidonO (KimchiTranscriptElt.preZeta cvk cp publicComm)
+      = (fqOracles C cvk cp publicComm).zeta := by
+  sorry
+
+/-- **Faithfulness (W2 acceptance gate).** Reading the sponge-as-oracle `poseidonO` at the
+four fq-side transcript prefixes reproduces the deployed verifier's `(β, γ, α, ζ)` exactly.
+This witnesses that the abstract oracle game (`Forking.Model`) specializes to the real
+verifier at `O := poseidonO`, so the uniform-oracle soundness statement is *about* it. -/
+theorem oracleChallenges_poseidonO (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
+    (publicComm : Vector C.Point nc) :
+    oracleChallenges poseidonO cvk cp publicComm
+      = ((fqOracles C cvk cp publicComm).beta, (fqOracles C cvk cp publicComm).gamma,
+         (fqOracles C cvk cp publicComm).alpha, (fqOracles C cvk cp publicComm).zeta) := by
+  simp only [oracleChallenges, poseidonO_preBeta, poseidonO_preGamma, poseidonO_preAlpha,
+    poseidonO_preZeta]
+
+end Kimchi.Verifier.Forking

--- a/formal/kimchi/Kimchi/Verifier/Forking/OracleRun.lean
+++ b/formal/kimchi/Kimchi/Verifier/Forking/OracleRun.lean
@@ -112,4 +112,82 @@ theorem oracleChallenges_poseidonO (cvk : KimchiVK C nc) (cp : KimchiProof C nc 
   simp only [oracleChallenges, poseidonO_preBeta, poseidonO_preGamma, poseidonO_preAlpha,
     poseidonO_preZeta]
 
+/-! ## The fr-sponge side: `poseidonOFr` at `preV`/`preU` is `frOracles`'s `(v, u)` -/
+
+open FrTranscriptElt (frAbsorbInto absorbEval preVAbsorbs preV preU)
+
+/-- One fr-interpreter step: `frAbsorb` absorbs its list, `frEndo` endo-expands a squeeze. -/
+def frStep (acc : FqSponge.S C.scalar × C.ScalarField) :
+    FrTranscriptElt C → FqSponge.S C.scalar × C.ScalarField
+  | .frAbsorb xs => (FqSponge.absorbFq (frSpec C) acc.1 xs, acc.2)
+  | .frEndo => ((FqSponge.challengeNat (frSpec C) acc.1).2,
+      FqSponge.endoExpand C.sponge.lam (FqSponge.challengeNat (frSpec C) acc.1).1)
+
+/-- The fr-sponge as an oracle: fold a transcript prefix, return the last challenge. -/
+def poseidonOFr (t : List (FrTranscriptElt C)) : C.ScalarField :=
+  (t.foldl frStep (FqSponge.init, 0)).2
+
+/-- The two fr-side challenges read from an abstract oracle at the `v`/`u` prefixes. -/
+def oracleVU (O : List (FrTranscriptElt C) → C.ScalarField) (cp : KimchiProof C nc k)
+    (fqDig : C.ScalarField) (pubEvals : PointEvaluations (Vector C.ScalarField nc)) :
+    C.ScalarField × C.ScalarField :=
+  (O (preV cp fqDig pubEvals), O (preU cp fqDig pubEvals))
+
+/-- The fr-interpreter's state component folds `frAbsorbInto`, independent of the value. -/
+theorem foldl_frStep_fst (l : List (FrTranscriptElt C)) (s : FqSponge.S C.scalar)
+    (v : C.ScalarField) :
+    (l.foldl frStep (s, v)).1 = l.foldl (fun s e => frAbsorbInto C e s) s := by
+  induction l generalizing s v with
+  | nil => rfl
+  | cons e l ih =>
+    have hstep : (frStep (s, v) e).1 = frAbsorbInto C e s := by cases e <;> rfl
+    rw [List.foldl_cons, List.foldl_cons, ih, hstep]
+
+/-- The fr-interpreter's state after the pre-`v` absorbs is `frOracles`'s pre-squeeze state:
+the fq/fr digests, `ft(ζω)`, the public chunk vectors, then the `absorb_evaluations` folds. -/
+theorem foldl_frAbsorbInto_preVAbsorbs (cp : KimchiProof C nc k) (fqDig : C.ScalarField)
+    (pubEvals : PointEvaluations (Vector C.ScalarField nc)) :
+    (preVAbsorbs cp fqDig pubEvals).foldl (fun s e => frAbsorbInto C e s) FqSponge.init
+      = (let sp := frSpec C
+         let ab := fun (s : FqSponge.S C.scalar)
+             (e : PointEvaluations (Vector C.ScalarField nc)) =>
+           FqSponge.absorbFq sp (FqSponge.absorbFq sp s e.zeta.toList) e.zetaOmega.toList
+         let s := FqSponge.absorbFq sp FqSponge.init [fqDig]
+         let s := FqSponge.absorbFq sp s [frDigest C sp FqSponge.init]
+         let s := FqSponge.absorbFq sp s [cp.ftEval1]
+         let s := FqSponge.absorbFq sp s pubEvals.zeta.toList
+         let s := FqSponge.absorbFq sp s pubEvals.zetaOmega.toList
+         let s := ab s cp.evals.z
+         let s := ab s cp.evals.genericSelector
+         let s := ab s cp.evals.poseidonSelector
+         let s := ab s cp.evals.completeAddSelector
+         let s := ab s cp.evals.mulSelector
+         let s := ab s cp.evals.emulSelector
+         let s := ab s cp.evals.endomulScalarSelector
+         let s := cp.evals.w.foldl ab s
+         let s := cp.evals.coefficients.foldl ab s
+         cp.evals.s.foldl ab s) := by
+  simp only [preVAbsorbs, absorbEval, frAbsorbInto, List.foldl_cons, List.foldl_append,
+    List.foldl_nil, List.foldl_flatMap, Vector.foldl_toList]
+
+theorem poseidonOFr_preV (cp : KimchiProof C nc k) (fqDig : C.ScalarField)
+    (pubEvals : PointEvaluations (Vector C.ScalarField nc)) :
+    poseidonOFr (preV cp fqDig pubEvals) = (frOracles C cp fqDig pubEvals).1 := by
+  rw [poseidonOFr, preV, List.foldl_append, List.foldl_cons, List.foldl_nil]
+  simp only [frStep, foldl_frStep_fst, foldl_frAbsorbInto_preVAbsorbs, frOracles]
+
+theorem poseidonOFr_preU (cp : KimchiProof C nc k) (fqDig : C.ScalarField)
+    (pubEvals : PointEvaluations (Vector C.ScalarField nc)) :
+    poseidonOFr (preU cp fqDig pubEvals) = (frOracles C cp fqDig pubEvals).2 := by
+  rw [poseidonOFr, preU, preV]
+  simp only [List.foldl_append, List.foldl_cons, List.foldl_nil, frStep, foldl_frStep_fst,
+    foldl_frAbsorbInto_preVAbsorbs, frOracles]
+
+/-- **Faithfulness (fr side).** Reading `poseidonOFr` at the `v`/`u` prefixes reproduces the
+deployed verifier's batch challenges `(v, u)` from `frOracles`. -/
+theorem oracleVU_poseidonOFr (cp : KimchiProof C nc k) (fqDig : C.ScalarField)
+    (pubEvals : PointEvaluations (Vector C.ScalarField nc)) :
+    oracleVU poseidonOFr cp fqDig pubEvals = frOracles C cp fqDig pubEvals := by
+  rw [oracleVU, poseidonOFr_preV, poseidonOFr_preU]
+
 end Kimchi.Verifier.Forking

--- a/formal/kimchi/Kimchi/Verifier/Forking/RunLink.lean
+++ b/formal/kimchi/Kimchi/Verifier/Forking/RunLink.lean
@@ -1,0 +1,38 @@
+import Kimchi.Verifier.Forking.OracleRun
+import Kimchi.Verifier.Reflect
+
+/-!
+# W2 · Run-level faithfulness
+
+The bridges in `Forking.OracleRun` land at `fqOracles` / `frOracles`. The soundness layer consumes
+the *run-level* oracles `runOracles` / `runVU` (`Kimchi.Verifier.Reflect`) — those same functions
+specialized to the run's own public commitment. These two corollaries make the connection explicit:
+reading the sponge-as-oracle at the transcript prefixes reproduces the exact `(β, γ, α, ζ)` and
+`(v, u)` the guards read. This is the seam W3 builds on when it bounds those challenges against the
+`soundBad*` / `badXi`/`badR` sets.
+-/
+
+namespace Kimchi.Verifier.Forking
+
+open Bulletproof
+
+variable {C : Ipa.CommitmentCurve} {nc : ℕ}
+
+/-- The fq challenges the soundness guards read (`runOracles`) are exactly the sponge-as-oracle
+reads at the four fq prefixes, taken at the run's own public commitment. -/
+theorem oracleChallenges_runOracles (σ : SRS C.Point) (cvk : KimchiVK C nc)
+    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) :
+    oracleChallenges poseidonO cvk cp (publicCommitment C σ cvk pub)
+      = ((runOracles C σ cvk cp pub).beta, (runOracles C σ cvk cp pub).gamma,
+         (runOracles C σ cvk cp pub).alpha, (runOracles C σ cvk cp pub).zeta) := by
+  simp only [oracleChallenges_poseidonO, runOracles]
+
+/-- The batch challenges the soundness guards read (`runVU`) are exactly the fr-oracle reads at the
+`v`/`u` prefixes, taken at the run's own fq digest and public evaluations. -/
+theorem oracleVU_runVU (σ : SRS C.Point) (cvk : KimchiVK C nc)
+    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) :
+    oracleVU poseidonOFr cp (runOracles C σ cvk cp pub).digest (runPubEvals C σ cvk cp pub)
+      = runVU C σ cvk cp pub := by
+  simp only [oracleVU_poseidonOFr, runVU]
+
+end Kimchi.Verifier.Forking

--- a/formal/kimchi/Kimchi/Verifier/Forking/Transcript.lean
+++ b/formal/kimchi/Kimchi/Verifier/Forking/Transcript.lean
@@ -98,32 +98,56 @@ independent, the hypothesis `Forking.Model`'s per-challenge freshness bounds con
 theorem preBeta_ne_preGamma (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
     (publicComm : Vector C.Point nc) :
     preBeta cvk cp publicComm ≠ preGamma cvk cp publicComm := by
-  sorry
+  intro h
+  have hlen := congrArg List.length h
+  simp only [preBeta, preGamma, preAbsorbs, wCommAbsorbs,
+    List.length_append, List.length_cons, List.length_map, List.length_nil] at hlen
+  omega
 
 theorem preGamma_ne_preAlpha (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
     (publicComm : Vector C.Point nc) :
     preGamma cvk cp publicComm ≠ preAlpha cvk cp publicComm := by
-  sorry
+  intro h
+  have hlen := congrArg List.length h
+  simp only [preBeta, preGamma, preAlpha, preAbsorbs, wCommAbsorbs,
+    List.length_append, List.length_cons, List.length_map, List.length_nil] at hlen
+  omega
 
 theorem preAlpha_ne_preZeta (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
     (publicComm : Vector C.Point nc) :
     preAlpha cvk cp publicComm ≠ preZeta cvk cp publicComm := by
-  sorry
+  intro h
+  have hlen := congrArg List.length h
+  simp only [preBeta, preGamma, preAlpha, preZeta, preAbsorbs, wCommAbsorbs,
+    List.length_append, List.length_cons, List.length_map, List.length_nil] at hlen
+  omega
 
 theorem preBeta_ne_preAlpha (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
     (publicComm : Vector C.Point nc) :
     preBeta cvk cp publicComm ≠ preAlpha cvk cp publicComm := by
-  sorry
+  intro h
+  have hlen := congrArg List.length h
+  simp only [preBeta, preGamma, preAlpha, preAbsorbs, wCommAbsorbs,
+    List.length_append, List.length_cons, List.length_map, List.length_nil] at hlen
+  omega
 
 theorem preBeta_ne_preZeta (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
     (publicComm : Vector C.Point nc) :
     preBeta cvk cp publicComm ≠ preZeta cvk cp publicComm := by
-  sorry
+  intro h
+  have hlen := congrArg List.length h
+  simp only [preBeta, preGamma, preAlpha, preZeta, preAbsorbs, wCommAbsorbs,
+    List.length_append, List.length_cons, List.length_map, List.length_nil] at hlen
+  omega
 
 theorem preGamma_ne_preZeta (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
     (publicComm : Vector C.Point nc) :
     preGamma cvk cp publicComm ≠ preZeta cvk cp publicComm := by
-  sorry
+  intro h
+  have hlen := congrArg List.length h
+  simp only [preBeta, preGamma, preAlpha, preZeta, preAbsorbs, wCommAbsorbs,
+    List.length_append, List.length_cons, List.length_map, List.length_nil] at hlen
+  omega
 
 end KimchiTranscriptElt
 

--- a/formal/kimchi/Kimchi/Verifier/Forking/Transcript.lean
+++ b/formal/kimchi/Kimchi/Verifier/Forking/Transcript.lean
@@ -16,7 +16,7 @@ points, matching a duplex sponge's state consumption). `Forking.OracleRun` inter
 prefix through the real sponge and proves these prefixes reproduce `fqOracles`'s
 challenges; `Forking.Model` frames the game and states the random-oracle assumption.
 
-The fr-sponge side (`v`, `u`) extends the same pattern and is developed separately.
+The fr-sponge side (`v`, `u`) extends the same pattern in the second half of this module.
 -/
 
 namespace Kimchi.Verifier.Forking
@@ -150,5 +150,80 @@ theorem preGamma_ne_preZeta (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
   omega
 
 end KimchiTranscriptElt
+
+/-! ## The fr-sponge side
+
+The scalar-side (fr-)sponge derives the two batch challenges `v` (polyscale) and `u`
+(evalscale). It is a *separate* Poseidon sponge (`frSpec C`, over `C.ScalarField`), fed the
+fq-sponge digest and the proof's evaluations. Unlike the fq side it absorbs whole scalar
+*lists* per `absorb_fr` call, so a transcript element carries a list; both squeezes are
+endo-expanded (`challengeNat` then `endoExpand`), so there is one squeeze marker. -/
+
+/-- A single element of the fr-sponge transcript: an `absorb_fr` of a whole scalar list (one
+`absorbFq` call — the fr-sponge absorbs chunk vectors, not single elements), or an
+endo-expanded squeeze (`challengeNat` then `endoExpand`): the `v`/`u` challenges. -/
+inductive FrTranscriptElt (C : Ipa.CommitmentCurve) where
+  /-- Absorb a scalar list in one `absorb_fr` call. -/
+  | frAbsorb : List C.ScalarField → FrTranscriptElt C
+  /-- An endo-expanded squeeze (`challengeNat` ∘ `endoExpand`): `v`, `u`. -/
+  | frEndo : FrTranscriptElt C
+
+namespace FrTranscriptElt
+
+open Poseidon
+
+/-- The state action of an fr element on the fr-sponge (the `.1` of the interpreter step). -/
+def frAbsorbInto (C : Ipa.CommitmentCurve) :
+    FrTranscriptElt C → FqSponge.S C.scalar → FqSponge.S C.scalar
+  | frAbsorb xs, s => FqSponge.absorbFq (frSpec C) s xs
+  | frEndo, s => (FqSponge.challengeNat (frSpec C) s).2
+
+/-- `frOracles`'s `ab` for one evaluation pair, as two `absorb_fr` elements: the `ζ`-chunk
+list then the `ζω`-chunk list. -/
+def absorbEval (e : PointEvaluations (Vector C.ScalarField nc)) : List (FrTranscriptElt C) :=
+  [frAbsorb e.zeta.toList, frAbsorb e.zetaOmega.toList]
+
+/-- The fr-sponge's pre-`v` absorb sequence — verbatim `frOracles`'s absorbs before the first
+squeeze: the fq digest, the fresh fr digest, `ft(ζω)`, the two public chunk vectors, then per
+column the `ζ`/`ζω` chunk vectors in `absorb_evaluations` order (`z`, the six single
+selectors, then the witness / coefficient / σ column folds). -/
+def preVAbsorbs (cp : KimchiProof C nc k) (fqDig : C.ScalarField)
+    (pubEvals : PointEvaluations (Vector C.ScalarField nc)) : List (FrTranscriptElt C) :=
+  [frAbsorb [fqDig],
+   frAbsorb [frDigest C (frSpec C) FqSponge.init],
+   frAbsorb [cp.ftEval1],
+   frAbsorb pubEvals.zeta.toList,
+   frAbsorb pubEvals.zetaOmega.toList]
+  ++ absorbEval cp.evals.z
+  ++ absorbEval cp.evals.genericSelector
+  ++ absorbEval cp.evals.poseidonSelector
+  ++ absorbEval cp.evals.completeAddSelector
+  ++ absorbEval cp.evals.mulSelector
+  ++ absorbEval cp.evals.emulSelector
+  ++ absorbEval cp.evals.endomulScalarSelector
+  ++ cp.evals.w.toList.flatMap absorbEval
+  ++ cp.evals.coefficients.toList.flatMap absorbEval
+  ++ cp.evals.s.toList.flatMap absorbEval
+
+/-- The `v` prefix: the pre-absorbs then one endo squeeze. -/
+def preV (cp : KimchiProof C nc k) (fqDig : C.ScalarField)
+    (pubEvals : PointEvaluations (Vector C.ScalarField nc)) : List (FrTranscriptElt C) :=
+  preVAbsorbs cp fqDig pubEvals ++ [frEndo]
+
+/-- The `u` prefix: `v`'s prefix then a second endo squeeze. -/
+def preU (cp : KimchiProof C nc k) (fqDig : C.ScalarField)
+    (pubEvals : PointEvaluations (Vector C.ScalarField nc)) : List (FrTranscriptElt C) :=
+  preV cp fqDig pubEvals ++ [frEndo]
+
+/-- `v` and `u` are read at distinct transcript points (`u` has one more squeeze marker). -/
+theorem preV_ne_preU (cp : KimchiProof C nc k) (fqDig : C.ScalarField)
+    (pubEvals : PointEvaluations (Vector C.ScalarField nc)) :
+    preV cp fqDig pubEvals ≠ preU cp fqDig pubEvals := by
+  intro h
+  have hlen := congrArg List.length h
+  simp only [preV, preU, List.length_append, List.length_cons, List.length_nil] at hlen
+  omega
+
+end FrTranscriptElt
 
 end Kimchi.Verifier.Forking

--- a/formal/kimchi/Kimchi/Verifier/Forking/Transcript.lean
+++ b/formal/kimchi/Kimchi/Verifier/Forking/Transcript.lean
@@ -1,0 +1,130 @@
+import Kimchi.Verifier.Kimchi
+
+/-!
+# W2 · The Fiat–Shamir transcript domain (fq-sponge side)
+
+The deployed verifier derives its challenges by threading a concrete Poseidon sponge
+(`fqOracles`, `Kimchi.Verifier.Kimchi`). The soundness proof needs those challenges as
+reads of an abstract oracle at *transcript prefixes*, so that "the challenge is a fresh
+draw made after the commitments are fixed" is visible in the domain and a random-oracle
+idealization can be applied per challenge (`ironwood`'s `Forking.Oracle`).
+
+This module supplies the domain: an inductive transcript-element type and the four fq-side
+prefixes — the exact absorb sequences `fqOracles` runs before each of `β`, `γ`, `α`, `ζ`,
+with an explicit squeeze marker per prior challenge (so consecutive squeezes read distinct
+points, matching a duplex sponge's state consumption). `Forking.OracleRun` interprets a
+prefix through the real sponge and proves these prefixes reproduce `fqOracles`'s
+challenges; `Forking.Model` frames the game and states the random-oracle assumption.
+
+The fr-sponge side (`v`, `u`) extends the same pattern and is developed separately.
+-/
+
+namespace Kimchi.Verifier.Forking
+
+open Bulletproof
+
+variable {C : Ipa.CommitmentCurve} {nc k : ℕ}
+
+/-- A single element written to the fq-sponge Fiat–Shamir transcript.
+
+`fqPoint`/`fqBase` are the two absorb kinds `fqOracles` performs (a curve point via
+`absorbG`, a base-field element via `absorbFq` — the verifying-key digest); `fqCast` and
+`fqEndo` are the two squeeze kinds, marking a `challenge` (128-bit cast: `β`, `γ`) and a
+`squeezeChallenge` (endomorphism expansion: `α`, `ζ`) respectively. A squeeze marker is
+not re-absorbed; it records that a challenge was drawn, so a prefix ending in `n` markers
+denotes the `n`-th squeeze. -/
+inductive KimchiTranscriptElt (C : Ipa.CommitmentCurve) where
+  /-- Absorb a curve point (`absorb_g`). -/
+  | fqPoint : C.Point → KimchiTranscriptElt C
+  /-- Absorb a base-field element (`absorb_fq`) — the verifying-key digest. -/
+  | fqBase : C.BaseField → KimchiTranscriptElt C
+  /-- A 128-bit cast squeeze (`challenge`): `β`, `γ`. -/
+  | fqCast : KimchiTranscriptElt C
+  /-- An endomorphism-expanded squeeze (`squeezeChallenge`): `α`, `ζ`. -/
+  | fqEndo : KimchiTranscriptElt C
+
+namespace KimchiTranscriptElt
+
+open Poseidon
+
+/-- The state action of a transcript element on the fq-sponge: the `.1` (state) component
+of the interpreter step, isolated so it never mentions the running challenge value. Absorbs
+absorb; squeezes advance the sponge past the squeezed challenge. -/
+def absorbInto (C : Ipa.CommitmentCurve) :
+    KimchiTranscriptElt C → FqSponge.S C.base → FqSponge.S C.base
+  | fqPoint P, s => FqSponge.absorbG C.sponge s P
+  | fqBase x, s => FqSponge.absorbFq C.sponge s [x]
+  | fqCast, s => (FqSponge.challenge C.sponge s).2
+  | fqEndo, s => (FqSponge.squeezeChallenge C.sponge s).2
+
+/-- The `w_comm` witness commitments flattened to their point-absorb sequence, column by
+column and chunk by chunk — `fqOracles`'s `cp.wComm.foldl (fun s col => col.foldl …)`. -/
+def wCommAbsorbs (cp : KimchiProof C nc k) : List (KimchiTranscriptElt C) :=
+  cp.wComm.toList.flatMap (fun col => col.toList.map fqPoint)
+
+/-- The fq-sponge's pre-`β` absorb sequence: the VK digest, the public-input commitment
+chunks, then the witness-column commitment chunks — verbatim the head of `fqOracles`. -/
+def preAbsorbs (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
+    (publicComm : Vector C.Point nc) : List (KimchiTranscriptElt C) :=
+  fqBase cvk.digest :: (publicComm.toList.map fqPoint ++ wCommAbsorbs cp)
+
+/-- The `β` prefix: the pre-absorbs then one cast squeeze. -/
+def preBeta (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
+    (publicComm : Vector C.Point nc) : List (KimchiTranscriptElt C) :=
+  preAbsorbs cvk cp publicComm ++ [fqCast]
+
+/-- The `γ` prefix: `β`'s prefix then a second cast squeeze. -/
+def preGamma (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
+    (publicComm : Vector C.Point nc) : List (KimchiTranscriptElt C) :=
+  preBeta cvk cp publicComm ++ [fqCast]
+
+/-- The `α` prefix: `γ`'s prefix, then the `z_comm` chunks, then an endo squeeze. -/
+def preAlpha (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
+    (publicComm : Vector C.Point nc) : List (KimchiTranscriptElt C) :=
+  preGamma cvk cp publicComm ++ cp.zComm.toList.map fqPoint ++ [fqEndo]
+
+/-- The `ζ` prefix: `α`'s prefix, then the `t_comm` chunks, then an endo squeeze. -/
+def preZeta (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
+    (publicComm : Vector C.Point nc) : List (KimchiTranscriptElt C) :=
+  preAlpha cvk cp publicComm ++ cp.tComm.toList.map fqPoint ++ [fqEndo]
+
+/-! ## Prefix distinctness
+
+The four prefixes are pairwise distinct — each extends the previous by at least one element
+(a squeeze marker, and for `α`/`ζ` a commitment segment too), so their lengths strictly
+increase. Distinct transcript points is what makes a uniform oracle's four reads
+independent, the hypothesis `Forking.Model`'s per-challenge freshness bounds consume. -/
+
+theorem preBeta_ne_preGamma (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
+    (publicComm : Vector C.Point nc) :
+    preBeta cvk cp publicComm ≠ preGamma cvk cp publicComm := by
+  sorry
+
+theorem preGamma_ne_preAlpha (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
+    (publicComm : Vector C.Point nc) :
+    preGamma cvk cp publicComm ≠ preAlpha cvk cp publicComm := by
+  sorry
+
+theorem preAlpha_ne_preZeta (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
+    (publicComm : Vector C.Point nc) :
+    preAlpha cvk cp publicComm ≠ preZeta cvk cp publicComm := by
+  sorry
+
+theorem preBeta_ne_preAlpha (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
+    (publicComm : Vector C.Point nc) :
+    preBeta cvk cp publicComm ≠ preAlpha cvk cp publicComm := by
+  sorry
+
+theorem preBeta_ne_preZeta (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
+    (publicComm : Vector C.Point nc) :
+    preBeta cvk cp publicComm ≠ preZeta cvk cp publicComm := by
+  sorry
+
+theorem preGamma_ne_preZeta (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
+    (publicComm : Vector C.Point nc) :
+    preGamma cvk cp publicComm ≠ preZeta cvk cp publicComm := by
+  sorry
+
+end KimchiTranscriptElt
+
+end Kimchi.Verifier.Forking

--- a/formal/kimchi/Kimchi/Verifier/Kimchi.lean
+++ b/formal/kimchi/Kimchi/Verifier/Kimchi.lean
@@ -168,7 +168,7 @@ deliberately dead: the fr-sponge path never endo-expands through its own spec.
 `frOracles` expands its two squeezed prechallenges at `C.sponge.lam` (the eigenvalue
 lives on the fq-side spec), and `frDigest`'s `challengeFq`/`challengeNat` never read
 `lam`, so the slot is unused and zeroed. -/
-private def frSpec (C : Ipa.CommitmentCurve) : FqSponge.Spec C.scalar C.scalar :=
+def frSpec (C : Ipa.CommitmentCurve) : FqSponge.Spec C.scalar C.scalar :=
   ⟨C.frParams, 0⟩
 
 /-- A Poseidon parameter table's MDS matrix as the gate's `Mds` record — the wire form
@@ -184,7 +184,7 @@ def mdsOfParams {F : Type*} (p : Poseidon.Params F) : Gate.Poseidon.Mds F :=
 
 /-- The fr-sponge digest (`DefaultFrSponge::digest`, kimchi/src/plonk_sponge.rs): the
 plain first squeeze — same field, no cast. -/
-private def frDigest (sp : FqSponge.Spec C.scalar C.scalar) (s : FqSponge.S C.scalar) :
+def frDigest (sp : FqSponge.Spec C.scalar C.scalar) (s : FqSponge.S C.scalar) :
     C.ScalarField :=
   (challengeFq sp s).1
 


### PR DESCRIPTION
## What

The **W2 Fiat–Shamir random-oracle model** — the foundation the probabilistic soundness layer
(`ironwood-refoundation-plan.md`) builds on. It expresses the deployed verifier's six challenges
as reads of an abstract oracle at *transcript prefixes*, so that "the challenge is a fresh draw
made after the commitments are fixed" is visible in the domain and a random-oracle idealization
can be applied per challenge (mirroring `zcash/ironwood`'s `Forking.Oracle`).

New modules under `kimchi/Kimchi/Verifier/Forking/`:

- **`Transcript.lean`** — the transcript domains. `KimchiTranscriptElt` (fq side: point/base
  absorbs + cast/endo squeeze markers) with the four prefixes `preBeta/Gamma/Alpha/Zeta`, and
  `FrTranscriptElt` (fr side: an `absorb_fr` carries a whole scalar list, since that sponge absorbs
  chunk vectors per call) with `preV`/`preU`. Each prefix transcribes the corresponding sponge's
  absorb schedule (`fqOracles` / `frOracles`) verbatim, with an explicit squeeze marker per prior
  challenge. Plus the pairwise-distinctness lemmas (length arguments).
- **`OracleRun.lean`** — `poseidonO` / `poseidonOFr` interpret a prefix through the *real* deployed
  sponge, and the **bridge theorems** prove that reading them at the prefixes reproduces
  `fqOracles`'s `(β, γ, α, ζ)` and `frOracles`'s `(v, u)` exactly. The faithfulness capstones
  `oracleChallenges_poseidonO` / `oracleVU_poseidonOFr` witness that the abstract oracle game
  specializes to the deployed verifier at `O := poseidonO(Fr)`.
- **`Model.lean`** — the `fsWins`-shaped game event (`GuardEvent` / `GuardEventVU`: an acceptance
  predicate at the oracle-read challenges), the specialization theorems, and the **trust-boundary
  preamble**.

Also un-privates `frSpec` / `frDigest` in `Verifier/Kimchi.lean` (visibility only, no statement
change) so the fr bridges unfold them the way the fq bridges unfold `C.sponge`.

## The one modeling assumption — Option A (no kernel axiom)

The soundness bound is proved for a **uniform** oracle; "the deployed Poseidon sponge realizes it"
is stated as a **documented modeling boundary** in `Model.lean`, **not** a Lean `axiom`. The sponge
is deterministic, so an in-kernel uniformity axiom would be false-as-stated (the shape the statement
audit flagged as M3). `#print axioms` on every W2 root therefore shows **only**
`[propext, Classical.choice, Quot.sound]` — no new axiom, no FS axiom. The RO step is auditable by
reading, exactly as prominent as an axiom would be. (The 128-bit-cast and `endoExpand` conversions
are idealized inside the same boundary; a strengthening from the GLV short-basis bounds is recorded
for later.)

## Verification

- `lake build Kimchi` clean — **0 `sorry`**, no `admit` / `native_decide` / new `axiom` / linter
  suppression.
- **48-root axiom gate unchanged** (identical allowed set).
- `#print axioms` on the fq and fr capstones and distinctness lemmas: only the three base axioms.
- The bridge proofs *are* the validation: `foldl_absorbInto_preAbsorbs` (fq) and
  `foldl_frAbsorbInto_preVAbsorbs` (fr, 25 absorbs) prove the hand-written prefixes reproduce the
  real sponges' schedules — a mis-transcription would not typecheck.

## Provenance

The fq-side bridge/distinctness proofs were produced by an Archon prover pass (opus-4-8) against a
scaffold whose statements were pre-validated (the `β` bridge proven by hand first), then locally
re-verified. The fr side was written and proven inline — its risk lives in the transcription
statement, not the proof, so it wanted a human hand and its own calibration.

## Run-level faithfulness (`RunLink.lean`)

The bridges land at `fqOracles` / `frOracles`; the soundness guards read the *run-level*
`runOracles` / `runVU`, which are those functions at the run's own public commitment. Two
axiom-free corollaries make that explicit — `oracleChallenges_runOracles` and `oracleVU_runVU` —
so the hand-written transcripts are machine-checked against the **exact** challenges the guards
consume, not just the general challenge functions. Bounding those against the `soundBad*` /
`badXi`/`badR` sets is W3.

## Scope

This is the oracle-model layer only. It imports no `Zcash` yet — consuming `ironwood`'s forking /
`uniformChallenge_badSet` probability against the `soundBad*` / `badXi`/`badR` sets is W3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
