### PR TITLE
formal: W3 — the guard-escape engine (challenge-vector measure bounds)

### DIFF
--- a/formal/kimchi/Kimchi.lean
+++ b/formal/kimchi/Kimchi.lean
@@ -46,3 +46,5 @@ import Kimchi.Verifier.Capstone.Reflection
 -- W2 · Fiat–Shamir random-oracle model (fq + fr) and its run-level faithfulness
 import Kimchi.Verifier.Forking.Model
 import Kimchi.Verifier.Forking.RunLink
+-- W3 · The guard-escape engine and the run-level escape bounds
+import Kimchi.Verifier.Forking.GuardEscape

--- a/formal/kimchi/Kimchi/Verifier/Capstone/Algebraic.lean
+++ b/formal/kimchi/Kimchi/Verifier/Capstone/Algebraic.lean
@@ -87,7 +87,7 @@ noncomputable def badROf {F G : Type*} [Field F] [DecidableEq F]
 
 /-- `badXiOf` counts at most `2 · (m − 1)` challenges (at the flattened batch's `44·nc`
 segments: `2·(44·nc − 1)`): a union of two counting-SZ bad sets over `Fin m`. -/
-private theorem card_badXiOf_le {F G : Type*} [Field F] [DecidableEq F]
+theorem card_badXiOf_le {F G : Type*} [Field F] [DecidableEq F]
     (σ : SRS G) {m : ℕ} (aw₀ : Fin m → Fin (2 ^ σ.k) → F)
     (x : Fin evalPts → F) (E : Fin m → Fin evalPts → F) :
     (badXiOf σ aw₀ x E).card ≤ 2 * (m - 1) := by
@@ -101,7 +101,7 @@ private theorem card_badXiOf_le {F G : Type*} [Field F] [DecidableEq F]
 
 /-- `badROf` counts at most `1 = 2 − 1` challenge: one counting-SZ bad set over
 `Fin evalPts`. -/
-private theorem card_badROf_le {F G : Type*} [Field F] [DecidableEq F]
+theorem card_badROf_le {F G : Type*} [Field F] [DecidableEq F]
     (σ : SRS G) {m : ℕ} (aw₀ : Fin m → Fin (2 ^ σ.k) → F)
     (x : Fin evalPts → F) (E : Fin m → Fin evalPts → F) (ξ : F) :
     (badROf σ aw₀ x E ξ).card ≤ 1 := by
@@ -349,7 +349,7 @@ noncomputable def ftChunkAssembly [Field F] (k nt : ℕ)
   ∑ j : Fin nt, rowPoly (aT j) * Polynomial.X ^ ((j : ℕ) * 2 ^ k)
 
 /-- The assembly meets the chunk-count degree bound `nt · 2^k`. -/
-private theorem ftChunkAssembly_natDegree_lt [Field F] (k : ℕ) {nt : ℕ} (hnt : 0 < nt)
+theorem ftChunkAssembly_natDegree_lt [Field F] (k : ℕ) {nt : ℕ} (hnt : 0 < nt)
     (aT : Fin nt → Fin (2 ^ k) → F) :
     (ftChunkAssembly k nt aT).natDegree < nt * 2 ^ k := by
   have h2k : 0 < 2 ^ k := Nat.two_pow_pos k

--- a/formal/kimchi/Kimchi/Verifier/Forking/Escape.lean
+++ b/formal/kimchi/Kimchi/Verifier/Forking/Escape.lean
@@ -1,0 +1,131 @@
+import Zcash.Snark.Soundness.Forking.Probability
+
+/-!
+# W3 · Sequential escape bounds over uniform challenge vectors
+
+The guard antecedents of `RunGuardImp` exclude each Fiat–Shamir challenge from a bad set
+determined by data absorbed *before* that challenge's squeeze — a chained family: `β`'s set is
+challenge-free, `γ`'s depends on `β`, and so on. This module proves the generic escape bounds:
+over a uniform challenge vector, the probability that *some* coordinate lands in its
+(earlier-coordinates-determined) bad set is at most the sum of the per-set cardinality bounds
+over `|F|`.
+
+Everything here is a statement about `PMF.uniformOfFintype (Fin k → F)` — the challenge vector's
+own distribution; no oracle table appears. W4 lifts these bounds to the finite-domain oracle
+game with `Zcash.Snark.uniformOfFintype_fresh_read_bound`, whose `S`-family is exactly the
+events below (that is why they are stated over `Fin k → F`) and whose injectivity input is the
+prefix distinctness proved in `Forking.Transcript`.
+
+Consumes `zcash/ironwood`'s `Forking.Probability` (the first `Zcash` import in the build):
+`uniformOfFintype_toOuterMeasure_finset`, `map_uniformOfFintype_equiv`, and
+`uniformOfFintype_prod_fiber_bound`.
+-/
+
+namespace Kimchi.Verifier.Forking
+
+open Zcash.Snark MeasureTheory
+open scoped ENNReal
+
+variable {F : Type*} [Fintype F] [DecidableEq F] [Nonempty F]
+
+/-- One coordinate's escape: if a bad-set family reads only the *other* coordinates and every
+member has card `≤ b`, a uniform vector's `i`-th coordinate lands in it with probability
+`≤ b / |F|`. The `i`-th coordinate is a fresh uniform draw against a set fixed by the rest. -/
+theorem escape_coord {k : ℕ} (i : Fin k) (S : (Fin k → F) → Finset F) {b : ℕ}
+    (hcard : ∀ χ, (S χ).card ≤ b)
+    (hdep : ∀ χ χ' : Fin k → F, (∀ j, j ≠ i → χ j = χ' j) → S χ = S χ') :
+    (PMF.uniformOfFintype (Fin k → F)).toOuterMeasure {χ | χ i ∈ S χ}
+      ≤ (b : ℝ≥0∞) / Fintype.card F := by
+  classical
+  set e : (Fin k → F) ≃ F × ({j : Fin k // j ≠ i} → F) := Equiv.piSplitAt i (fun _ => F)
+  -- the family read off the non-`i` coordinates alone
+  set S' : ({j : Fin k // j ≠ i} → F) → Set F :=
+    fun r => ↑(S (e.symm (Classical.arbitrary F, r))) with hS'
+  have hev : {χ : Fin k → F | χ i ∈ S χ} = e ⁻¹' {p | p.1 ∈ S' p.2} := by
+    ext χ
+    have h1 : (e χ).1 = χ i := rfl
+    have hSχ : S (e.symm (Classical.arbitrary F, (e χ).2)) = S χ := by
+      refine hdep _ _ fun j hj => ?_
+      simp [e, Equiv.piSplitAt, dif_neg hj]
+    simp only [Set.mem_setOf_eq, Set.mem_preimage, hS', Finset.mem_coe, h1, hSχ]
+  rw [hev, ← PMF.toOuterMeasure_map_apply, map_uniformOfFintype_equiv e]
+  refine uniformOfFintype_prod_fiber_bound S' fun r => ?_
+  rw [hS', uniformOfFintype_toOuterMeasure_finset]
+  exact ENNReal.div_le_div_right (by exact_mod_cast hcard _) _
+
+/-- Two chained challenges (the fr side, `v` then `u`): escape from a fixed set and a
+first-coordinate-determined set, with probability `≤ (b₁ + b₂)/|F|`. -/
+theorem escape2 (S₁ : Finset F) (S₂ : F → Finset F) {b₁ b₂ : ℕ}
+    (h₁ : S₁.card ≤ b₁) (h₂ : ∀ x, (S₂ x).card ≤ b₂) :
+    (PMF.uniformOfFintype (Fin 2 → F)).toOuterMeasure
+      {χ | χ 0 ∈ S₁ ∨ χ 1 ∈ S₂ (χ 0)} ≤ (b₁ + b₂ : ℝ≥0∞) / Fintype.card F := by
+  have h0 : (PMF.uniformOfFintype (Fin 2 → F)).toOuterMeasure {χ | χ 0 ∈ S₁}
+      ≤ (b₁ : ℝ≥0∞) / Fintype.card F :=
+    escape_coord 0 (fun _ => S₁) (fun _ => h₁) (fun _ _ _ => rfl)
+  have h1 : (PMF.uniformOfFintype (Fin 2 → F)).toOuterMeasure {χ | χ 1 ∈ S₂ (χ 0)}
+      ≤ (b₂ : ℝ≥0∞) / Fintype.card F :=
+    escape_coord 1 (fun χ => S₂ (χ 0)) (fun _ => h₂ _)
+      (fun χ χ' h => congrArg S₂ (h 0 (by decide)))
+  calc (PMF.uniformOfFintype (Fin 2 → F)).toOuterMeasure {χ | χ 0 ∈ S₁ ∨ χ 1 ∈ S₂ (χ 0)}
+      ≤ (PMF.uniformOfFintype (Fin 2 → F)).toOuterMeasure {χ | χ 0 ∈ S₁}
+        + (PMF.uniformOfFintype (Fin 2 → F)).toOuterMeasure {χ | χ 1 ∈ S₂ (χ 0)} := by
+        rw [Set.setOf_or]; exact measure_union_le _ _
+    _ ≤ (b₁ : ℝ≥0∞) / Fintype.card F + (b₂ : ℝ≥0∞) / Fintype.card F := add_le_add h0 h1
+    _ = (b₁ + b₂ : ℝ≥0∞) / Fintype.card F := ENNReal.div_add_div_same
+
+/-- Four chained challenges (the fq side, `β γ α ζ`): escape from a chained bad-set family,
+with probability `≤ (b₁ + b₂ + b₃ + b₄)/|F|`. -/
+theorem escape4 (S₁ : Finset F) (S₂ : F → Finset F) (S₃ : F → F → Finset F)
+    (S₄ : F → F → F → Finset F) {b₁ b₂ b₃ b₄ : ℕ}
+    (h₁ : S₁.card ≤ b₁) (h₂ : ∀ x, (S₂ x).card ≤ b₂)
+    (h₃ : ∀ x y, (S₃ x y).card ≤ b₃) (h₄ : ∀ x y z, (S₄ x y z).card ≤ b₄) :
+    (PMF.uniformOfFintype (Fin 4 → F)).toOuterMeasure
+      {χ | χ 0 ∈ S₁ ∨ χ 1 ∈ S₂ (χ 0) ∨ χ 2 ∈ S₃ (χ 0) (χ 1)
+        ∨ χ 3 ∈ S₄ (χ 0) (χ 1) (χ 2)}
+      ≤ (b₁ + b₂ + b₃ + b₄ : ℝ≥0∞) / Fintype.card F := by
+  have h0 : (PMF.uniformOfFintype (Fin 4 → F)).toOuterMeasure {χ | χ 0 ∈ S₁}
+      ≤ (b₁ : ℝ≥0∞) / Fintype.card F :=
+    escape_coord 0 (fun _ => S₁) (fun _ => h₁) (fun _ _ _ => rfl)
+  have h1 : (PMF.uniformOfFintype (Fin 4 → F)).toOuterMeasure {χ | χ 1 ∈ S₂ (χ 0)}
+      ≤ (b₂ : ℝ≥0∞) / Fintype.card F :=
+    escape_coord 1 (fun χ => S₂ (χ 0)) (fun _ => h₂ _)
+      (fun χ χ' h => congrArg S₂ (h 0 (by decide)))
+  have h2 : (PMF.uniformOfFintype (Fin 4 → F)).toOuterMeasure {χ | χ 2 ∈ S₃ (χ 0) (χ 1)}
+      ≤ (b₃ : ℝ≥0∞) / Fintype.card F :=
+    escape_coord 2 (fun χ => S₃ (χ 0) (χ 1)) (fun _ => h₃ _ _)
+      (fun χ χ' h => by
+        show S₃ (χ 0) (χ 1) = S₃ (χ' 0) (χ' 1)
+        rw [h 0 (by decide), h 1 (by decide)])
+  have h3 : (PMF.uniformOfFintype (Fin 4 → F)).toOuterMeasure
+        {χ | χ 3 ∈ S₄ (χ 0) (χ 1) (χ 2)} ≤ (b₄ : ℝ≥0∞) / Fintype.card F :=
+    escape_coord 3 (fun χ => S₄ (χ 0) (χ 1) (χ 2)) (fun _ => h₄ _ _ _)
+      (fun χ χ' h => by
+        show S₄ (χ 0) (χ 1) (χ 2) = S₄ (χ' 0) (χ' 1) (χ' 2)
+        rw [h 0 (by decide), h 1 (by decide), h 2 (by decide)])
+  have hu2 : (PMF.uniformOfFintype (Fin 4 → F)).toOuterMeasure
+        {χ | χ 1 ∈ S₂ (χ 0) ∨ χ 2 ∈ S₃ (χ 0) (χ 1) ∨ χ 3 ∈ S₄ (χ 0) (χ 1) (χ 2)}
+      ≤ (PMF.uniformOfFintype (Fin 4 → F)).toOuterMeasure {χ | χ 1 ∈ S₂ (χ 0)}
+        + (PMF.uniformOfFintype (Fin 4 → F)).toOuterMeasure
+            {χ | χ 2 ∈ S₃ (χ 0) (χ 1) ∨ χ 3 ∈ S₄ (χ 0) (χ 1) (χ 2)} := by
+    rw [Set.setOf_or]; exact measure_union_le _ _
+  have hu3 : (PMF.uniformOfFintype (Fin 4 → F)).toOuterMeasure
+        {χ | χ 2 ∈ S₃ (χ 0) (χ 1) ∨ χ 3 ∈ S₄ (χ 0) (χ 1) (χ 2)}
+      ≤ (PMF.uniformOfFintype (Fin 4 → F)).toOuterMeasure {χ | χ 2 ∈ S₃ (χ 0) (χ 1)}
+        + (PMF.uniformOfFintype (Fin 4 → F)).toOuterMeasure
+            {χ | χ 3 ∈ S₄ (χ 0) (χ 1) (χ 2)} := by
+    rw [Set.setOf_or]; exact measure_union_le _ _
+  calc (PMF.uniformOfFintype (Fin 4 → F)).toOuterMeasure
+        {χ | χ 0 ∈ S₁ ∨ χ 1 ∈ S₂ (χ 0) ∨ χ 2 ∈ S₃ (χ 0) (χ 1) ∨ χ 3 ∈ S₄ (χ 0) (χ 1) (χ 2)}
+      ≤ (PMF.uniformOfFintype (Fin 4 → F)).toOuterMeasure {χ | χ 0 ∈ S₁}
+        + (PMF.uniformOfFintype (Fin 4 → F)).toOuterMeasure
+            {χ | χ 1 ∈ S₂ (χ 0) ∨ χ 2 ∈ S₃ (χ 0) (χ 1) ∨ χ 3 ∈ S₄ (χ 0) (χ 1) (χ 2)} := by
+        rw [Set.setOf_or]; exact measure_union_le _ _
+    _ ≤ (b₁ : ℝ≥0∞) / Fintype.card F + ((b₂ : ℝ≥0∞) / Fintype.card F
+          + ((b₃ : ℝ≥0∞) / Fintype.card F + (b₄ : ℝ≥0∞) / Fintype.card F)) :=
+        add_le_add h0 (le_trans hu2 (add_le_add h1 (le_trans hu3 (add_le_add h2 h3))))
+    _ = (b₁ + b₂ + b₃ + b₄ : ℝ≥0∞) / Fintype.card F := by
+        rw [ENNReal.div_add_div_same, ENNReal.div_add_div_same, ENNReal.div_add_div_same]
+        congr 1
+        ring
+
+end Kimchi.Verifier.Forking

--- a/formal/kimchi/Kimchi/Verifier/Forking/Escape.lean
+++ b/formal/kimchi/Kimchi/Verifier/Forking/Escape.lean
@@ -26,7 +26,7 @@ namespace Kimchi.Verifier.Forking
 open Zcash.Snark MeasureTheory
 open scoped ENNReal
 
-variable {F : Type*} [Fintype F] [DecidableEq F] [Nonempty F]
+variable {F : Type*} [Fintype F] [Nonempty F]
 
 /-- One coordinate's escape: if a bad-set family reads only the *other* coordinates and every
 member has card `≤ b`, a uniform vector's `i`-th coordinate lands in it with probability

--- a/formal/kimchi/Kimchi/Verifier/Forking/GuardEscape.lean
+++ b/formal/kimchi/Kimchi/Verifier/Forking/GuardEscape.lean
@@ -1,0 +1,115 @@
+import Kimchi.Verifier.Forking.Escape
+import Kimchi.Verifier.Capstone.Reflection
+
+/-!
+# W3 · The run-level guard-escape bounds
+
+`RunGuardImp`'s antecedents exclude the run's challenges from the canonical bad sets; the
+terminal roots also take the batch guards `hξ`/`hr`. This module states those guard *failures*
+as events over a uniform challenge vector — the antecedents verbatim, with the challenge reads
+replaced by vector coordinates — and bounds their measure by `Forking.Escape`'s sequential
+escape lemmas plus the existing cardinality facts (`RunBounds`, `card_badXiOf_le`,
+`card_badROf_le`).
+
+These events are exactly the `S`-families W4 hands to
+`Zcash.Snark.uniformOfFintype_fresh_read_bound`: its `O ∘ φ` instantiation at the transcript
+prefixes reconnects the coordinates to `runOracles`/`runVU` through `Forking.RunLink`, turning
+each bound below into "the deployed run's guards fail with probability ≤ ε" in the
+random-oracle model.
+-/
+
+namespace Kimchi.Verifier.Forking
+
+open Bulletproof
+open scoped ENNReal
+
+variable {C : Ipa.CommitmentCurve} {nc : ℕ}
+
+/-- The fq-side guard-failure event: coordinate `0/1/2/3` is `β/γ/α/ζ`, and each tests the
+corresponding `RunGuardImp` antecedent's set — with the two `ζ` boundary points folded into the
+`ζ` set. -/
+noncomputable def runGuardsFailFq (σ : SRS C.Point) (cvk : KimchiVK C nc)
+    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) {n : ℕ} [NeZero n]
+    (idx : Index C.ScalarField n)
+    (aRef : Fin (runInput C σ cvk cp pub).commitments.size → Fin (2 ^ σ.k) → C.ScalarField)
+    (aT : Fin cp.tComm.size → Fin (2 ^ σ.k) → C.ScalarField) :
+    Set (Fin 4 → C.ScalarField) :=
+  {χ | χ 0 ∈ Protocol.soundBadB idx (runW σ cvk cp pub aRef)
+    ∨ χ 1 ∈ Protocol.soundBadG idx (runW σ cvk cp pub aRef) (χ 0)
+    ∨ χ 2 ∈ Protocol.soundBadA idx (pubView idx pub) (runW σ cvk cp pub aRef)
+        (runZ σ cvk cp pub aRef) (χ 0) (χ 1)
+    ∨ χ 3 ∈ Protocol.soundBadZ idx (pubView idx pub) (runW σ cvk cp pub aRef)
+        (runZ σ cvk cp pub aRef) (χ 0) (χ 1) (χ 2)
+        (ftChunkAssembly σ.k cp.tComm.size aT)
+        ∪ {1, idx.omega ^ (n - idx.zkRows)}}
+
+/-- **The fq escape bound.** Under `RunBounds` (the terminal roots' own cardinality
+conclusions) and the chunking side conditions, a uniform `(β, γ, α, ζ)` vector fails some fq
+guard with probability at most the summed set bounds (the `+ 2` is the two `ζ` boundary
+points) over `|F|`. -/
+theorem runGuardsFailFq_measure_le (σ : SRS C.Point) (cvk : KimchiVK C nc)
+    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) {n : ℕ} [NeZero n]
+    (idx : Index C.ScalarField n)
+    (aRef : Fin (runInput C σ cvk cp pub).commitments.size → Fin (2 ^ σ.k) → C.ScalarField)
+    (aT : Fin cp.tComm.size → Fin (2 ^ σ.k) → C.ScalarField)
+    (hB : RunBounds σ cvk cp pub idx aRef)
+    (htpos : 0 < cp.tComm.size) (hk : nc * 2 ^ σ.k = n) :
+    (PMF.uniformOfFintype (Fin 4 → C.ScalarField)).toOuterMeasure
+        (runGuardsFailFq σ cvk cp pub idx aRef aT)
+      ≤ (7 * (n - idx.zkRows) + 7 * (n - idx.zkRows)
+          + n * (Index.gateAlphaCount + Index.permAlphaCount - 1)
+          + (Index.degreeBound n + 2) : ℝ≥0∞) / Fintype.card C.ScalarField := by
+  have htdeg : (ftChunkAssembly σ.k cp.tComm.size aT).natDegree < 7 * n := by
+    refine lt_of_lt_of_le (ftChunkAssembly_natDegree_lt σ.k htpos aT) ?_
+    calc cp.tComm.size * 2 ^ σ.k
+        ≤ 7 * nc * 2 ^ σ.k := Nat.mul_le_mul_right _ cp.tComm_le
+      _ = 7 * n := by rw [mul_assoc, hk]
+  have h := escape4 (b₄ := Index.degreeBound n + 2)
+    (Protocol.soundBadB idx (runW σ cvk cp pub aRef))
+    (fun β => Protocol.soundBadG idx (runW σ cvk cp pub aRef) β)
+    (fun β γ => Protocol.soundBadA idx (pubView idx pub) (runW σ cvk cp pub aRef)
+      (runZ σ cvk cp pub aRef) β γ)
+    (fun β γ α => Protocol.soundBadZ idx (pubView idx pub) (runW σ cvk cp pub aRef)
+      (runZ σ cvk cp pub aRef) β γ α (ftChunkAssembly σ.k cp.tComm.size aT)
+      ∪ {1, idx.omega ^ (n - idx.zkRows)})
+    hB.1 (fun β => hB.2.1 β) (fun β γ => hB.2.2.1 β γ)
+    (fun β γ α => le_trans (Finset.card_union_le _ _)
+      (add_le_add (hB.2.2.2 β γ α _ htdeg)
+        (le_trans (Finset.card_insert_le _ _) (by simp))))
+  refine le_trans h (le_of_eq ?_)
+  congr 1
+  push_cast [ENNReal.natCast_sub]
+  ring
+
+/-- The fr-side guard-failure event: coordinate `0/1` is `v/u` (polyscale/evalscale), testing
+the terminal roots' `hξ`/`hr` sets at the run's own batch data. The `ζ`-derived inputs
+(`pointFn`/`evalFn`) enter as fixed parameters — the fr sponge runs after `ζ`. -/
+noncomputable def runVUFail (σ : SRS C.Point) (cvk : KimchiVK C nc)
+    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    (aRef : Fin (runInput C σ cvk cp pub).commitments.size → Fin (2 ^ σ.k) → C.ScalarField) :
+    Set (Fin 2 → C.ScalarField) :=
+  {χ | χ 0 ∈ badXiOf σ aRef (runInput C σ cvk cp pub).pointFn
+        (runInput C σ cvk cp pub).evalFn
+    ∨ χ 1 ∈ badROf σ aRef (runInput C σ cvk cp pub).pointFn
+        (runInput C σ cvk cp pub).evalFn (χ 0)}
+
+/-- **The fr escape bound.** A uniform `(v, u)` vector fails `hξ` or `hr` with probability at
+most `(2(m − 1) + 1)/|F|` at `m` = the run's flattened batch width. -/
+theorem runVUFail_measure_le (σ : SRS C.Point) (cvk : KimchiVK C nc)
+    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    (aRef : Fin (runInput C σ cvk cp pub).commitments.size → Fin (2 ^ σ.k) → C.ScalarField) :
+    (PMF.uniformOfFintype (Fin 2 → C.ScalarField)).toOuterMeasure
+        (runVUFail σ cvk cp pub aRef)
+      ≤ (2 * ((runInput C σ cvk cp pub).commitments.size - 1) + 1 : ℝ≥0∞)
+        / Fintype.card C.ScalarField := by
+  have h := escape2
+    (badXiOf σ aRef (runInput C σ cvk cp pub).pointFn (runInput C σ cvk cp pub).evalFn)
+    (fun ξ => badROf σ aRef (runInput C σ cvk cp pub).pointFn
+      (runInput C σ cvk cp pub).evalFn ξ)
+    (card_badXiOf_le σ aRef _ _) (card_badROf_le σ aRef _ _)
+  refine le_trans h (le_of_eq ?_)
+  congr 1
+  push_cast [ENNReal.natCast_sub]
+  ring
+
+end Kimchi.Verifier.Forking

--- a/formal/scripts/noshake.json
+++ b/formal/scripts/noshake.json
@@ -1,14 +1,51 @@
-{"ignoreImport": ["Kimchi.Columns", "Mathlib"],
- "ignore":
- {"Kimchi.Verifier.Reduction.Correspond": ["Kimchi.Index.Aggregate"],
-  "Kimchi.Verifier.Capstone.Standard": ["Bulletproof.Reflection"],
-  "Kimchi.Verifier.Capstone.Reflection": ["Bulletproof.Reflection"],
-  "Kimchi.Permutation.Wiring": ["Kimchi.Permutation.Copy"],
-  "Kimchi.Permutation.Permutation": ["Kimchi.GrandProduct"],
-  "Kimchi.Permutation.Copy": ["Kimchi.SchwartzZippel"],
-  "Kimchi.Gate.VarBaseMul": ["Kimchi.Gate.AddComplete", "Pasta.Basic"],
-  "Kimchi.Gate.Semantics.EndoMul": ["Kimchi.Gate.Semantics.VarBaseMul"],
-  "Kimchi.Gate.Generic": ["Mathlib.Tactic"],
-  "Kimchi.Gate.EndoMul": ["Kimchi.Gate.VarBaseMul"],
-  "Kimchi.Gate.AddComplete": ["Pasta.Basic"],
-  "Kimchi.Columns": ["Init"]}}
+{
+ "ignoreImport": [
+  "Kimchi.Columns",
+  "Mathlib"
+ ],
+ "ignore": {
+  "Kimchi.Verifier.Reduction.Correspond": [
+   "Kimchi.Index.Aggregate"
+  ],
+  "Kimchi.Verifier.Capstone.Standard": [
+   "Bulletproof.Reflection"
+  ],
+  "Kimchi.Verifier.Capstone.Reflection": [
+   "Bulletproof.Reflection"
+  ],
+  "Kimchi.Permutation.Wiring": [
+   "Kimchi.Permutation.Copy"
+  ],
+  "Kimchi.Permutation.Permutation": [
+   "Kimchi.GrandProduct"
+  ],
+  "Kimchi.Permutation.Copy": [
+   "Kimchi.SchwartzZippel"
+  ],
+  "Kimchi.Gate.VarBaseMul": [
+   "Kimchi.Gate.AddComplete",
+   "Pasta.Basic"
+  ],
+  "Kimchi.Gate.Semantics.EndoMul": [
+   "Kimchi.Gate.Semantics.VarBaseMul"
+  ],
+  "Kimchi.Gate.Generic": [
+   "Mathlib.Tactic"
+  ],
+  "Kimchi.Gate.EndoMul": [
+   "Kimchi.Gate.VarBaseMul"
+  ],
+  "Kimchi.Gate.AddComplete": [
+   "Pasta.Basic"
+  ],
+  "Kimchi.Columns": [
+   "Init"
+  ],
+  "Kimchi.Verifier.Forking.Escape": [
+   "Zcash.Snark.Soundness.Forking.Probability"
+  ],
+  "Kimchi.Verifier.Forking.GuardEscape": [
+   "Kimchi.Verifier.Forking.Escape"
+  ]
+ }
+}


### PR DESCRIPTION
## What

**W3 — the guard-escape engine**: the challenge-vector probability bounds behind
`RunGuardImp`'s guards, built on `zcash/ironwood`'s probability toolkit. This is the first PR
whose Lean source **imports `Zcash`** (ironwood's `Forking.Probability` — until now the
dependency was fetched but uncompiled). Scope doc: `formal/docs/w3-guard-escape-scope.md`.
Follows #273 (W2, merged).

New modules under `kimchi/Kimchi/Verifier/Forking/`:

- **`Escape.lean`** — the generic sequential escape bounds over a uniform challenge vector
  `PMF.uniformOfFintype (Fin k → F)`:
  * `escape_coord` — a coordinate that a bad-set family reads only *around* (not at) lands in
    its set with probability `≤ b/|F|`. Proof: split the vector at the coordinate
    (`Equiv.piSplitAt`), transport uniformity (`map_uniformOfFintype_equiv`), and apply
    ironwood's `uniformOfFintype_prod_fiber_bound`.
  * `escape2` / `escape4` — the chained union bounds (`(Σ bᵢ)/|F|`) for the fr (`v, u`) and fq
    (`β, γ, α, ζ`) chains.
- **`GuardEscape.lean`** — the run-level instantiation:
  * `runGuardsFailFq` — the failure event of `RunGuardImp`'s six fq antecedents, verbatim,
    with the challenge reads replaced by vector coordinates and the two `ζ` boundary points
    folded into the `ζ` set; `runGuardsFailFq_measure_le` bounds its measure by
    `(7(n−zk) + 7(n−zk) + n(K−1) + (9n+2))/|F|`, consuming **`RunBounds`** — the terminal
    roots' own cardinality conclusions — plus the chunking side conditions
    (`ftChunkAssembly`'s degree `< 7n` from `tComm_le` and `nc·2^k = n`).
  * `runVUFail` — the `hξ`/`hr` failure event at the run's batch data;
    `runVUFail_measure_le` bounds it by `(2(m−1)+1)/|F|` via the existing
    `card_badXiOf_le`/`card_badROf_le`.

Also un-`private`s three lemmas in `Capstone/Algebraic.lean` (`card_badXiOf_le`,
`card_badROf_le`, `ftChunkAssembly_natDegree_lt`) — visibility only, no statement change.

## One deliberate restaging vs. the plan's wording

The plan stated W3's deliverable as a measure over *oracles*. That form is not stateable here:
the only uniform-table measure in the toolkit (`uniformOfFintype (T → F)`) requires `Fintype T`,
and the transcript domain is infinite. Ironwood resolves this at the *game* layer
(`DomainReduction` over an `OracleComp` adversary's finite reachable support) — machinery W4
assembles anyway. So W3 delivers the bounds over the **challenge vector's own distribution**;
W4 lifts them to the oracle game with `uniformOfFintype_fresh_read_bound`, whose three inputs
are exactly what already exists: `φ`-injectivity ← W2's prefix distinctness, `S`/`hS` ← this
PR's events/bounds, `choice` ← the adversary's other reads. Nothing here is throwaway.

## Chronology (why the event shapes are sound)

Each set in the chain is a function only of data absorbed before its challenge's squeeze —
`soundBadB/G/A/Z` of `runW`/`runZ`/`ftChunkAssembly` (challenge-free, AGM-extracted) and the
earlier coordinates; the fr events take the ζ-derived `pointFn`/`evalFn` as fixed parameters
(the fr sponge runs after ζ). This is the C1 named-sets structure paying off: the events below
are `RunGuardImp`'s antecedents *verbatim* at vector coordinates.

## Verification

- `lake build Kimchi` clean — **0 `sorry`** (all six theorems proven; no Archon pass was
  needed — the spine closed exactly as scoped).
- 48-root axiom gate unchanged.
- `#print axioms` on all four W3 capstones: only `[propext, Classical.choice, Quot.sound]` —
  ironwood's probability lemmas are theorems, so consuming them adds **no axiom**.
- No `admit`/`native_decide`/linter suppression; no long lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
