### PR TITLE
bulletproof-pcs: split the IPA verifier into algebra + challenge derivation

### DIFF
--- a/formal/bulletproof-pcs/Bulletproof/Forking/Transcript.lean
+++ b/formal/bulletproof-pcs/Bulletproof/Forking/Transcript.lean
@@ -1,0 +1,129 @@
+import Bulletproof.Wire
+
+/-!
+# The IPA opening transcript as an oracle domain
+
+`Ipa.transcriptFrom` derives the opening challenges by threading a concrete Poseidon sponge.
+Discharging `poseidon_fiat_shamir_*` by a forking argument needs those challenges to be *reads
+of an oracle at transcript prefixes* instead: forking rewinds the adversary and reprograms the
+oracle, which is only meaningful if the verifier reads from one.
+
+This module supplies the domain, following the pattern proved out for the kimchi fq-sponge in
+`Kimchi/Verifier/Forking/`: an element type for the deployed absorb/squeeze schedule, the
+prefixes at which each challenge is drawn, an interpreter that runs the *real* sponge along a
+prefix, and bridge theorems pinning the interpreter's reads to `transcriptFrom`'s outputs.
+
+The schedule (`transcriptFrom`, the round loop of `SRS::verify`) is linear:
+
+1. `absorb_fr` the shifted combined inner product;
+2. squeeze `t` and map it to the `U` base (`challengeFq`, then `toGroup`);
+3. per round: absorb `L` and `R`, squeeze `uᵢ` (`squeezeChallenge`);
+4. absorb `δ`, squeeze the Schnorr challenge `c` (`squeezeChallenge`).
+
+Unlike the kimchi fq side, the challenges do **not** share a codomain: `t` is a base-field
+element (`challengeFq`) while `uᵢ` and `c` are scalar-field elements (`squeezeChallenge`,
+endo-expanded). So the model carries two oracles rather than one — `spongeOBase` for the `U`
+base and `spongeOScalar` for the round and Schnorr challenges.
+
+Everything here is stated at the **cold** start (`FqSponge.init`), which is what `Ipa.verify`
+— and hence the axiom being targeted — is anchored on. The warm start kimchi hands in is the
+harder case and is not modelled here.
+-/
+
+namespace Bulletproof.Ipa.Forking
+
+open CompElliptic.CurveForms.ShortWeierstrass
+open Poseidon Poseidon.FqSponge Bulletproof
+
+variable {C : Ipa.CommitmentCurve} {k m p : ℕ}
+
+/-- A single element of the IPA opening transcript: the two absorb kinds the deployed
+schedule performs, and the two squeeze kinds (a raw base-field squeeze for the `U` base, an
+endo-expanded squeeze for the round and Schnorr challenges). A squeeze marker records that a
+challenge was drawn; it is not re-absorbed. -/
+inductive IpaTranscriptElt (C : Ipa.CommitmentCurve) where
+  /-- `absorb_fr` of a scalar — the shifted combined inner product. -/
+  | frScalar : C.ScalarField → IpaTranscriptElt C
+  /-- `absorb_g` of a point — `L`, `R`, or `δ`. -/
+  | point : C.Point → IpaTranscriptElt C
+  /-- A raw base-field squeeze (`challengeFq`): the `U`-base preimage `t`. -/
+  | sqBase : IpaTranscriptElt C
+  /-- An endo-expanded squeeze (`squeezeChallenge`): a round challenge `uᵢ`, or `c`. -/
+  | sqEndo : IpaTranscriptElt C
+
+namespace IpaTranscriptElt
+
+/-- The state action of a transcript element on the sponge — the interpreter's state
+component, isolated so it never mentions a challenge value. -/
+def stepState (C : Ipa.CommitmentCurve) :
+    IpaTranscriptElt C → FqSponge.S C.base → FqSponge.S C.base
+  | frScalar x, s => FqSponge.absorbFr C.sponge s x
+  | point P, s => FqSponge.absorbG C.sponge s P
+  | sqBase, s => (FqSponge.challengeFq C.sponge s).2
+  | sqEndo, s => (FqSponge.squeezeChallenge C.sponge s).2
+
+/-- The absorbs preceding the `U`-base squeeze: the shifted combined inner product. -/
+def preTAbsorbs (inp : Ipa.Input C k m p) : List (IpaTranscriptElt C) :=
+  [frScalar (Ipa.shiftScalar C (Ipa.cipOf inp))]
+
+/-- The `U`-base prefix: the cip absorb, then the raw squeeze marker. -/
+def preT (inp : Ipa.Input C k m p) : List (IpaTranscriptElt C) :=
+  preTAbsorbs inp ++ [sqBase]
+
+/-- Rounds `0 … j-1` of the fold, each absorbing `L`, `R` and squeezing a challenge. -/
+def roundBlock (inp : Ipa.Input C k m p) (j : ℕ) : List (IpaTranscriptElt C) :=
+  (inp.proof.lr.toList.take j).flatMap fun LR => [point LR.1, point LR.2, sqEndo]
+
+/-- The prefix at which round `i`'s challenge `uᵢ` is drawn: the `U`-base prefix, then rounds
+`0 … i`, the last of which ends in this round's squeeze marker. -/
+def preU (inp : Ipa.Input C k m p) (i : Fin k) : List (IpaTranscriptElt C) :=
+  preT inp ++ roundBlock inp (i + 1)
+
+/-- The Schnorr prefix: the `U`-base prefix, all `k` rounds, the `δ` absorb, then a squeeze. -/
+def preC (inp : Ipa.Input C k m p) : List (IpaTranscriptElt C) :=
+  preT inp ++ roundBlock inp k ++ [point inp.proof.delta, sqEndo]
+
+end IpaTranscriptElt
+
+open IpaTranscriptElt
+
+/-! ## The deployed sponge as a pair of oracles
+
+A prefix ends with the marker of the challenge being read, so both oracles fold the *real*
+sponge along everything before that marker and then perform the squeeze it denotes. They differ
+only in which squeeze that is, matching the two challenge codomains. (The kimchi model threads a
+`(state, value)` pair instead; that does not transfer here, because `t` and `uᵢ`/`c` do not share
+a codomain.) -/
+
+/-- The base-field oracle: the raw squeeze the `U` base is derived from. -/
+def spongeOBase (t : List (IpaTranscriptElt C)) : C.BaseField :=
+  (FqSponge.challengeFq C.sponge (t.dropLast.foldl (fun s e => stepState C e s) FqSponge.init)).1
+
+/-- The scalar-field oracle: the endo-expanded squeeze of the round and Schnorr challenges. -/
+def spongeOScalar (t : List (IpaTranscriptElt C)) : C.ScalarField :=
+  (FqSponge.squeezeChallenge C.sponge
+    (t.dropLast.foldl (fun s e => stepState C e s) FqSponge.init)).1
+
+/-! ## Bridges: the oracle reads are `transcriptFrom`'s outputs
+
+These pin the hand-written prefixes to the deployed schedule — a mis-transcription makes them
+false, so they are the statements that make the model *about* the real verifier. -/
+
+/-- **The `U` base.** Mapping the base oracle's read at `preT` through `toGroup` gives
+`transcriptFrom`'s `U`. -/
+theorem toGroup_spongeOBase_preT (inp : Ipa.Input C k m p) :
+    C.toGroup (spongeOBase (preT inp)) = (Ipa.transcriptFrom C FqSponge.init inp).1 := by
+  simp only [spongeOBase, preT, preTAbsorbs, List.dropLast_concat, List.foldl_cons,
+    List.foldl_nil, stepState, Ipa.transcriptFrom]
+
+/-- **The round challenges.** The scalar oracle at `preU i` is round `i`'s challenge. -/
+theorem spongeOScalar_preU (inp : Ipa.Input C k m p) (i : Fin k) :
+    spongeOScalar (preU inp i) = (Ipa.transcriptFrom C FqSponge.init inp).2.1[i] := by
+  sorry
+
+/-- **The Schnorr challenge.** The scalar oracle at `preC` is `c`. -/
+theorem spongeOScalar_preC (inp : Ipa.Input C k m p) :
+    spongeOScalar (preC inp) = (Ipa.transcriptFrom C FqSponge.init inp).2.2 := by
+  sorry
+
+end Bulletproof.Ipa.Forking

--- a/formal/bulletproof-pcs/Bulletproof/Forking/Transcript.lean
+++ b/formal/bulletproof-pcs/Bulletproof/Forking/Transcript.lean
@@ -116,14 +116,243 @@ theorem toGroup_spongeOBase_preT (inp : Ipa.Input C k m p) :
   simp only [spongeOBase, preT, preTAbsorbs, List.dropLast_concat, List.foldl_cons,
     List.foldl_nil, stepState, Ipa.transcriptFrom]
 
+/-! ## Round-fold helpers for the two scalar bridges
+
+The scalar bridges are `k`-indexed, so — unlike the fixed-length kimchi fq helpers — they need
+a genuine induction over the round list. `rstep` is the deployed per-round step (definitionally
+`Ipa.roundChallengesAux`'s fold body); `mstate`/`mchals` are the model's post-`j`-rounds sponge
+state and the list of pushed challenges, and the lemmas below tie the deployed `Array.foldl` to
+the model `List.foldl`. -/
+
+/-- The deployed per-round step, named so the fold rewrites cleanly. Definitionally the body of
+`Ipa.roundChallengesAux`. -/
+private def rstep (C : Ipa.CommitmentCurve)
+    (acc : Array C.ScalarField × FqSponge.S C.base) (LR : C.Point × C.Point) :
+    Array C.ScalarField × FqSponge.S C.base :=
+  (acc.1.push (FqSponge.squeezeChallenge C.sponge
+      (FqSponge.absorbG C.sponge (FqSponge.absorbG C.sponge acc.2 LR.1) LR.2)).1,
+    (FqSponge.squeezeChallenge C.sponge
+      (FqSponge.absorbG C.sponge (FqSponge.absorbG C.sponge acc.2 LR.1) LR.2)).2)
+
+/-- `Ipa.roundChallengesAux` as a `List.foldl` of the named step over the array's list. -/
+private theorem roundChallengesAux_eq_foldl (s : FqSponge.S C.base)
+    (lr : Array (C.Point × C.Point)) :
+    Ipa.roundChallengesAux C s lr = lr.toList.foldl (rstep C) (#[], s) := by
+  unfold Ipa.roundChallengesAux
+  rw [← Array.foldl_toList]
+  rfl
+
+/-- The model sponge state after folding the round block of `L` from `s`. -/
+private def mstate (C : Ipa.CommitmentCurve) (s : FqSponge.S C.base)
+    (L : List (C.Point × C.Point)) : FqSponge.S C.base :=
+  match L with
+  | [] => s
+  | LR :: t =>
+    mstate C (FqSponge.squeezeChallenge C.sponge
+      (FqSponge.absorbG C.sponge (FqSponge.absorbG C.sponge s LR.1) LR.2)).2 t
+
+/-- The model list of round challenges pushed while folding the round block of `L` from `s`. -/
+private def mchals (C : Ipa.CommitmentCurve) (s : FqSponge.S C.base)
+    (L : List (C.Point × C.Point)) : List C.ScalarField :=
+  match L with
+  | [] => []
+  | LR :: t =>
+    (FqSponge.squeezeChallenge C.sponge
+      (FqSponge.absorbG C.sponge (FqSponge.absorbG C.sponge s LR.1) LR.2)).1 ::
+      mchals C (FqSponge.squeezeChallenge C.sponge
+        (FqSponge.absorbG C.sponge (FqSponge.absorbG C.sponge s LR.1) LR.2)).2 t
+
+/-- The deployed round fold's post-state is the model state (independent of the accumulator). -/
+private theorem rstep_foldl_state (L : List (C.Point × C.Point)) :
+    ∀ (pre : Array C.ScalarField) (s : FqSponge.S C.base),
+    (L.foldl (rstep C) (pre, s)).2 = mstate C s L := by
+  induction L with
+  | nil => intro pre s; rfl
+  | cons LR t ih =>
+    intro pre s
+    rw [List.foldl_cons]
+    have hr : rstep C (pre, s) LR =
+        (pre.push (FqSponge.squeezeChallenge C.sponge
+            (FqSponge.absorbG C.sponge (FqSponge.absorbG C.sponge s LR.1) LR.2)).1,
+         (FqSponge.squeezeChallenge C.sponge
+            (FqSponge.absorbG C.sponge (FqSponge.absorbG C.sponge s LR.1) LR.2)).2) := rfl
+    rw [hr, ih]
+    simp only [mstate]
+
+/-- The deployed round fold's array is the accumulator prepended to the model challenge list. -/
+private theorem rstep_foldl_toList (L : List (C.Point × C.Point)) :
+    ∀ (pre : Array C.ScalarField) (s : FqSponge.S C.base),
+    (L.foldl (rstep C) (pre, s)).1.toList = pre.toList ++ mchals C s L := by
+  induction L with
+  | nil => intro pre s; simp [mchals]
+  | cons LR t ih =>
+    intro pre s
+    rw [List.foldl_cons]
+    have hr : rstep C (pre, s) LR =
+        (pre.push (FqSponge.squeezeChallenge C.sponge
+            (FqSponge.absorbG C.sponge (FqSponge.absorbG C.sponge s LR.1) LR.2)).1,
+         (FqSponge.squeezeChallenge C.sponge
+            (FqSponge.absorbG C.sponge (FqSponge.absorbG C.sponge s LR.1) LR.2)).2) := rfl
+    rw [hr, ih]
+    simp only [mchals, Array.toList_push, List.append_assoc, List.singleton_append]
+
+/-- The deployed round fold's post-state, as the model state over the round list. -/
+private theorem roundChallengesAux_snd (s : FqSponge.S C.base)
+    (lr : Array (C.Point × C.Point)) :
+    (Ipa.roundChallengesAux C s lr).2 = mstate C s lr.toList := by
+  rw [roundChallengesAux_eq_foldl, rstep_foldl_state]
+
+/-- The deployed round fold's challenge array, as the model challenge list over the round list. -/
+private theorem roundChallengesAux_fst_toList (s : FqSponge.S C.base)
+    (lr : Array (C.Point × C.Point)) :
+    (Ipa.roundChallengesAux C s lr).1.toList = mchals C s lr.toList := by
+  rw [roundChallengesAux_eq_foldl, rstep_foldl_toList]
+  simp
+
+/-- Folding the model step over `L`'s round block from `s` yields the model state `mstate`. -/
+private theorem flatMap_block_foldl (M : List (C.Point × C.Point)) (s : FqSponge.S C.base) :
+    (M.flatMap (fun LR => [point LR.1, point LR.2, sqEndo])).foldl
+      (fun s e => stepState C e s) s = mstate C s M := by
+  induction M generalizing s with
+  | nil => simp [mstate]
+  | cons LR t ih =>
+    rw [List.flatMap_cons, List.foldl_append]
+    have hb : ([point LR.1, point LR.2, sqEndo] : List (IpaTranscriptElt C)).foldl
+        (fun s e => stepState C e s) s
+        = (FqSponge.squeezeChallenge C.sponge
+            (FqSponge.absorbG C.sponge (FqSponge.absorbG C.sponge s LR.1) LR.2)).2 := by
+      simp only [List.foldl_cons, List.foldl_nil, stepState]
+    rw [hb, ih]
+    simp only [mstate]
+
+/-- The `i`-th model challenge is the endo-squeeze after absorbing round `i`'s `L`, `R` on top of
+the model state after `i` rounds. Stated with `getElem?` to sidestep the length side-goal. -/
+private theorem mchals_getElem? (L : List (C.Point × C.Point)) :
+    ∀ (i : ℕ) (s : FqSponge.S C.base) (hi : i < L.length),
+    (mchals C s L)[i]? = some (FqSponge.squeezeChallenge C.sponge
+      (FqSponge.absorbG C.sponge (FqSponge.absorbG C.sponge
+        (mstate C s (L.take i)) (L[i]'hi).1) (L[i]'hi).2)).1 := by
+  induction L with
+  | nil => intro i s hi; simp at hi
+  | cons LR t ih =>
+    intro i s hi
+    cases i with
+    | zero =>
+      simp only [mchals, List.getElem?_cons_zero, List.take_zero, mstate,
+        List.getElem_cons_zero]
+    | succ j =>
+      simp only [mchals, List.getElem?_cons_succ, List.take_succ_cons,
+        List.getElem_cons_succ, mstate]
+      exact ih j _ (by simp only [List.length_cons] at hi; omega)
+
+/-- The `idx`-th deployed round challenge, characterised through `getElem?`. -/
+private theorem roundChallengesAux_getElem? (s : FqSponge.S C.base)
+    (lr : Array (C.Point × C.Point)) (idx : ℕ) (h : idx < lr.toList.length) :
+    (Ipa.roundChallengesAux C s lr).1[idx]? = some (FqSponge.squeezeChallenge C.sponge
+      (FqSponge.absorbG C.sponge (FqSponge.absorbG C.sponge
+        (mstate C s (lr.toList.take idx)) (lr.toList[idx]'h).1) (lr.toList[idx]'h).2)).1 := by
+  rw [← Array.getElem?_toList, roundChallengesAux_fst_toList]
+  exact mchals_getElem? lr.toList idx s h
+
+/-- `roundBlock` at `i+1` is `roundBlock` at `i` with round `i`'s block appended. -/
+private theorem roundBlock_succ (inp : Ipa.Input C k m p) (i : Fin k)
+    (hik : (i : ℕ) < inp.proof.lr.toList.length) :
+    roundBlock inp ((i : ℕ) + 1) = roundBlock inp (i : ℕ) ++
+      [point (inp.proof.lr.toList[(i : ℕ)]).1, point (inp.proof.lr.toList[(i : ℕ)]).2,
+        sqEndo] := by
+  simp only [roundBlock]
+  rw [List.take_succ_eq_append_getElem hik, List.flatMap_append]
+  simp
+
 /-- **The round challenges.** The scalar oracle at `preU i` is round `i`'s challenge. -/
 theorem spongeOScalar_preU (inp : Ipa.Input C k m p) (i : Fin k) :
     spongeOScalar (preU inp i) = (Ipa.transcriptFrom C FqSponge.init inp).2.1[i] := by
-  sorry
+  have hik : (i : ℕ) < inp.proof.lr.toList.length := by simp
+  -- The post-`challengeFq` state feeding the rounds (shared, verbatim, by both sides).
+  have hpreT : (preT inp).foldl (fun s e => stepState C e s) FqSponge.init
+      = (FqSponge.challengeFq C.sponge (FqSponge.absorbFr C.sponge FqSponge.init
+          (Ipa.shiftScalar C (Ipa.cipOf inp)))).2 := by
+    simp only [preT, preTAbsorbs, List.cons_append, List.nil_append, List.foldl_cons,
+      List.foldl_nil, stepState]
+  -- LHS: reduce the model fold to the endo-squeeze after round `i`'s two absorbs.
+  have hLHS : spongeOScalar (preU inp i)
+      = (FqSponge.squeezeChallenge C.sponge (FqSponge.absorbG C.sponge (FqSponge.absorbG C.sponge
+          (mstate C (FqSponge.challengeFq C.sponge (FqSponge.absorbFr C.sponge FqSponge.init
+              (Ipa.shiftScalar C (Ipa.cipOf inp)))).2 (inp.proof.lr.toList.take (i : ℕ)))
+          (inp.proof.lr.toList[(i : ℕ)]'hik).1) (inp.proof.lr.toList[(i : ℕ)]'hik).2)).1 := by
+    simp only [spongeOScalar, preU]
+    rw [roundBlock_succ inp i hik, List.dropLast_append_of_ne_nil (by simp),
+      List.dropLast_append_of_ne_nil (by simp)]
+    rw [show ([point (inp.proof.lr.toList[(i : ℕ)]'hik).1,
+          point (inp.proof.lr.toList[(i : ℕ)]'hik).2, sqEndo] :
+          List (IpaTranscriptElt C)).dropLast
+        = [point (inp.proof.lr.toList[(i : ℕ)]'hik).1,
+          point (inp.proof.lr.toList[(i : ℕ)]'hik).2] from rfl]
+    rw [List.foldl_append, List.foldl_append, hpreT]
+    rw [show (roundBlock inp (i : ℕ)).foldl (fun s e => stepState C e s)
+          (FqSponge.challengeFq C.sponge (FqSponge.absorbFr C.sponge FqSponge.init
+            (Ipa.shiftScalar C (Ipa.cipOf inp)))).2
+        = mstate C (FqSponge.challengeFq C.sponge (FqSponge.absorbFr C.sponge FqSponge.init
+            (Ipa.shiftScalar C (Ipa.cipOf inp)))).2 (inp.proof.lr.toList.take (i : ℕ)) from by
+        simp only [roundBlock]; exact flatMap_block_foldl _ _]
+    simp only [List.foldl_cons, List.foldl_nil, stepState]
+  -- RHS: the deployed challenge array read at `i`, via `roundChallengesAux_getElem?`.
+  have hRHS : (Ipa.transcriptFrom C FqSponge.init inp).2.1[i]
+      = (FqSponge.squeezeChallenge C.sponge (FqSponge.absorbG C.sponge (FqSponge.absorbG C.sponge
+          (mstate C (FqSponge.challengeFq C.sponge (FqSponge.absorbFr C.sponge FqSponge.init
+              (Ipa.shiftScalar C (Ipa.cipOf inp)))).2 (inp.proof.lr.toList.take (i : ℕ)))
+          (inp.proof.lr.toList[(i : ℕ)]'hik).1) (inp.proof.lr.toList[(i : ℕ)]'hik).2)).1 := by
+    simp only [Ipa.transcriptFrom, Ipa.roundChallenges]
+    have hsize : (i : ℕ) < (Ipa.roundChallengesAux C
+        (FqSponge.challengeFq C.sponge (FqSponge.absorbFr C.sponge FqSponge.init
+          (Ipa.shiftScalar C (Ipa.cipOf inp)))).2 inp.proof.lr.toArray).1.size := by
+      rw [Ipa.roundChallengesAux_size]; simp
+    have hg := roundChallengesAux_getElem? (FqSponge.challengeFq C.sponge
+      (FqSponge.absorbFr C.sponge FqSponge.init (Ipa.shiftScalar C (Ipa.cipOf inp)))).2
+      inp.proof.lr.toArray (i : ℕ) hik
+    rw [Array.getElem?_eq_getElem hsize] at hg
+    exact Option.some.inj hg
+  rw [hLHS, hRHS]
 
 /-- **The Schnorr challenge.** The scalar oracle at `preC` is `c`. -/
 theorem spongeOScalar_preC (inp : Ipa.Input C k m p) :
     spongeOScalar (preC inp) = (Ipa.transcriptFrom C FqSponge.init inp).2.2 := by
-  sorry
+  have hlen : inp.proof.lr.toList.length = k := by simp
+  have hpreT : (preT inp).foldl (fun s e => stepState C e s) FqSponge.init
+      = (FqSponge.challengeFq C.sponge (FqSponge.absorbFr C.sponge FqSponge.init
+          (Ipa.shiftScalar C (Ipa.cipOf inp)))).2 := by
+    simp only [preT, preTAbsorbs, List.cons_append, List.nil_append, List.foldl_cons,
+      List.foldl_nil, stepState]
+  -- LHS: after dropping the trailing `sqEndo`, the fold ends by absorbing `δ` on the
+  -- post-`k`-rounds model state.
+  have hLHS : spongeOScalar (preC inp)
+      = (FqSponge.squeezeChallenge C.sponge (FqSponge.absorbG C.sponge
+          (mstate C (FqSponge.challengeFq C.sponge (FqSponge.absorbFr C.sponge FqSponge.init
+              (Ipa.shiftScalar C (Ipa.cipOf inp)))).2 inp.proof.lr.toList) inp.proof.delta)).1 := by
+    simp only [spongeOScalar, preC]
+    rw [List.dropLast_append_of_ne_nil (by simp)]
+    rw [show ([point inp.proof.delta, sqEndo] : List (IpaTranscriptElt C)).dropLast
+        = [point inp.proof.delta] from rfl]
+    rw [List.foldl_append, List.foldl_append, hpreT]
+    rw [show (roundBlock inp k).foldl (fun s e => stepState C e s)
+          (FqSponge.challengeFq C.sponge (FqSponge.absorbFr C.sponge FqSponge.init
+            (Ipa.shiftScalar C (Ipa.cipOf inp)))).2
+        = mstate C (FqSponge.challengeFq C.sponge (FqSponge.absorbFr C.sponge FqSponge.init
+            (Ipa.shiftScalar C (Ipa.cipOf inp)))).2 inp.proof.lr.toList from by
+        simp only [roundBlock]
+        rw [show inp.proof.lr.toList.take k = inp.proof.lr.toList from by
+          conv_rhs => rw [← List.take_length (l := inp.proof.lr.toList)]
+          rw [hlen]]
+        exact flatMap_block_foldl _ _]
+    simp only [List.foldl_cons, List.foldl_nil, stepState]
+  -- RHS: `c` is the endo-squeeze after absorbing `δ` on the deployed post-round state.
+  have hRHS : (Ipa.transcriptFrom C FqSponge.init inp).2.2
+      = (FqSponge.squeezeChallenge C.sponge (FqSponge.absorbG C.sponge
+          (mstate C (FqSponge.challengeFq C.sponge (FqSponge.absorbFr C.sponge FqSponge.init
+              (Ipa.shiftScalar C (Ipa.cipOf inp)))).2 inp.proof.lr.toList) inp.proof.delta)).1 := by
+    simp only [Ipa.transcriptFrom, Ipa.roundChallenges]
+    rw [roundChallengesAux_snd]
+    rfl
+  rw [hLHS, hRHS]
 
 end Bulletproof.Ipa.Forking

--- a/formal/bulletproof-pcs/Bulletproof/Forking/Transcript.lean
+++ b/formal/bulletproof-pcs/Bulletproof/Forking/Transcript.lean
@@ -355,4 +355,60 @@ theorem spongeOScalar_preC (inp : Ipa.Input C k m p) :
     rfl
   rw [hLHS, hRHS]
 
+/-! ## The abstract Fiat–Shamir interface, and Poseidon as one instance
+
+The bridges above say the deployed challenges *are* reads of the sponge at transcript
+prefixes. Because the standalone opening verifier starts **cold** (`Ipa.verify = verifyFrom
+FqSponge.init`), those reads are functions of the transcript alone — which is exactly what
+lets the challenge source become a parameter, the way `zcash/ironwood` writes its verifier.
+(Kimchi's opening starts from the *warm* post-`ζ` state, so its challenges are not a function
+of the IPA transcript alone; that is why this abstraction is available here and not there.)
+
+`verifyOracle` is the opening verifier over an arbitrary source; `spongeFS` is the deployed
+Poseidon one; `verifyOracle_spongeFS` proves the abstract verifier at that instance *is*
+`Ipa.verify`. Substituting a uniformly random source — what a forking argument rewinds and
+reprograms — is then instantiating an argument, with the deployed verifier recovered as a
+theorem rather than assumed. -/
+
+/-- A source of opening challenges: a base-field squeeze for the `U` base and a scalar-field
+squeeze for the round and Schnorr challenges, each a function of the transcript prefix. Two
+squeezes rather than ironwood's one, because these two codomains differ. -/
+structure FiatShamir (C : Ipa.CommitmentCurve) where
+  /-- The raw base-field squeeze the `U` base is derived from. -/
+  squeezeBase : List (IpaTranscriptElt C) → C.BaseField
+  /-- The endo-expanded scalar squeeze of the round and Schnorr challenges. -/
+  squeezeScalar : List (IpaTranscriptElt C) → C.ScalarField
+
+/-- The opening transcript derived from a challenge source, at the prefixes the deployed
+schedule draws each challenge at. -/
+def transcriptOf (fs : FiatShamir C) (inp : Ipa.Input C k m p) :
+    C.Point × Vector C.ScalarField k × C.ScalarField :=
+  (C.toGroup (fs.squeezeBase (preT inp)),
+   Vector.ofFn fun i => fs.squeezeScalar (preU inp i),
+   fs.squeezeScalar (preC inp))
+
+/-- The opening verifier over an arbitrary challenge source: the deployed algebra
+(`Ipa.verifyWith`) at the challenges `fs` supplies. -/
+def verifyOracle (fs : FiatShamir C) (σ : SRS C.Point)
+    (inp : Ipa.Input C σ.k m p) : Bool :=
+  let (uBase, chals, c) := transcriptOf fs inp
+  Ipa.verifyWith C σ uBase chals c inp
+
+/-- The deployed source: the Poseidon sponge read at transcript prefixes from the cold start. -/
+def spongeFS (C : Ipa.CommitmentCurve) : FiatShamir C :=
+  ⟨spongeOBase, spongeOScalar⟩
+
+/-- **The abstract verifier at the Poseidon source is the deployed verifier.** Assembled from
+the three bridges. This is what makes the abstraction honest: the challenge source is a
+parameter, and the deployed verifier is recovered as a theorem rather than assumed. -/
+theorem verifyOracle_spongeFS (σ : SRS C.Point) (inp : Ipa.Input C σ.k m p) :
+    verifyOracle (spongeFS C) σ inp = Ipa.verify C σ inp := by
+  have ht : (transcriptOf (spongeFS C) inp) = Ipa.transcriptFrom C FqSponge.init inp := by
+    refine Prod.ext (toGroup_spongeOBase_preT inp)
+      (Prod.ext ?_ (spongeOScalar_preC inp))
+    refine Vector.ext fun i hi => ?_
+    simp only [transcriptOf, spongeFS, Vector.getElem_ofFn]
+    exact spongeOScalar_preU inp ⟨i, hi⟩
+  rw [verifyOracle, ht, Ipa.verify, Ipa.verifyFrom]
+
 end Bulletproof.Ipa.Forking

--- a/formal/bulletproof-pcs/Bulletproof/Reflection.lean
+++ b/formal/bulletproof-pcs/Bulletproof/Reflection.lean
@@ -164,7 +164,7 @@ theorem verify_reflects (σ : SRS C.Point) {m p : ℕ} (inp : Ipa.Input C σ.k m
       (fun i => (transcript C inp).2.1[i])
       inp.commitmentFn inp.pointFn inp.evalFn := by
   simp only [Ipa.transcript]
-  simp only [Ipa.verify, Ipa.verifyFrom] at hv
+  simp only [Ipa.verify, Ipa.verifyFrom, Ipa.verifyWith] at hv
   rw [Bool.and_eq_true] at hv
   obtain ⟨hsch, hsg⟩ := hv
   rw [decide_eq_true_eq] at hsch hsg

--- a/formal/bulletproof-pcs/Bulletproof/Wire.lean
+++ b/formal/bulletproof-pcs/Bulletproof/Wire.lean
@@ -259,9 +259,8 @@ fq-sponge state, verifier.rs:1184–1193), combine the claim, and check the Schn
 `sg`-correctness equations. The claim's shape is carried by its type (round count
 `σ.k`), so there are no runtime guards — rejecting ragged input is the wire parse's
 job. `σ.U` is never read — the deployed `U` is transcript-derived. -/
-def verifyFrom (σ : SRS C.Point) (s₀ : FqSponge.S C.base) (inp : Input C σ.k m p) :
-    Bool :=
-  let (uBase, chals, c) := transcriptFrom C s₀ inp
+def verifyWith (σ : SRS C.Point) (uBase : C.Point) (chals : Vector C.ScalarField σ.k)
+    (c : C.ScalarField) (inp : Input C σ.k m p) : Bool :=
   let chal : Fin σ.k → C.ScalarField := fun i => chals[i]
   let b0 := combinedB chal inp.evalscale inp.pointFn
   let v := cipOf inp
@@ -275,6 +274,16 @@ def verifyFrom (σ : SRS C.Point) (s₀ : FqSponge.S C.base) (inp : Input C σ.k
         + inp.proof.z2.val • σ.h)
   let sgOk := decide (inp.proof.sg = msm C σ.g (bPolyCoefficients chal))
   schnorr && sgOk
+
+/-- The opening acceptance at the deployed Fiat–Shamir schedule: `verifyWith` fed the
+transcript `transcriptFrom` derives by continuing the warm sponge. Definitionally the
+former body, so every existing statement about `verifyFrom` is unchanged; the split only
+names the boundary between the *derivation* (`transcriptFrom`) and the *algebra*
+(`verifyWith`), so an alternative challenge source can be supplied without touching either. -/
+def verifyFrom (σ : SRS C.Point) (s₀ : FqSponge.S C.base) (inp : Input C σ.k m p) :
+    Bool :=
+  let (uBase, chals, c) := transcriptFrom C s₀ inp
+  verifyWith C σ uBase chals c inp
 
 /-- The standalone acceptance decision: `verifyFrom` at the fresh sponge
 `FqSponge.init` — the cold start, validated against the production opening fixtures. -/


### PR DESCRIPTION
## What

Splits the IPA opening verifier into **algebra + challenge derivation**:

```lean
def Ipa.verifyWith (σ) (uBase : C.Point) (chals : Vector C.ScalarField σ.k)
    (c : C.ScalarField) (inp) : Bool := …          -- the two acceptance equations

def Ipa.verifyFrom (σ) (s₀) (inp) : Bool :=         -- unchanged meaning
  let (uBase, chals, c) := transcriptFrom C s₀ inp
  verifyWith C σ uBase chals c inp
```

`verifyFrom` (and therefore `verify`) is *definitionally* what it was; the split only names the
boundary. One downstream touch-up: `Bulletproof/Reflection.lean`'s `verify_reflects` needed
`Ipa.verifyWith` added to one `simp only` set — a repo-wide grep confirmed that was the only site
unfolding `verifyFrom`.

## Why — step 1 of eliminating the bulletproof-pcs Fiat–Shamir axioms

The package's headline `ipaVesta_sound`/`ipaPallas_sound` rest on one non-standard axiom per curve,
`Bulletproof.poseidon_fiat_shamir_{vesta,pallas}`: *an accepting run admits a de-blinded accepting
transcript tree.* Its own docstring says what would discharge it — "the rewinding/forking extraction
against [the sponge's] random-oracle behaviour", i.e. a forking lemma in the random-oracle model,
which `zcash/ironwood` supplies (already a dependency since #272).

Forking rewinds the adversary and **reprograms the oracle**, so it is only meaningful if the
verifier's challenges are *read from* an oracle rather than threaded from a concrete sponge state.
That needs a slot to put an oracle into — and the blocker was that the opening algebra consumed a
live `FqSponge.S` (via `transcriptFrom`) rather than challenge *values*. After this PR it consumes
values, so an alternative derivation can be supplied without touching the algebra.

Planned continuation on this package: model the IPA transcript in the oracle model (its schedule is
linear — absorb `cip`, squeeze `t → U`, per round absorb `L`/`R` and squeeze `uᵢ`, absorb `δ` and
squeeze `c`), state the game over a uniform oracle, apply ironwood's forking machinery, and
**discharge the two axioms**. That would remove 2 of the 4 non-standard axioms in the tree.

## Why bulletproof-pcs before kimchi

Deliberately starting on the smaller package. Its axiom is anchored on the **cold** `Ipa.verify`
(fresh sponge) and takes only `inp` — no `cvk`/`cp`/`pub` chain and no warm continuation, unlike
kimchi's. Its reflection is also `simp`-based and so tolerates this surgery, whereas
`Kimchi/Verifier/Reflect.lean`'s `kimchiVerify_reflects` rests on a bare definitional coercion whose
run functions are deliberately *shape-mirrored* to the verifier body ("so no sponge computation is
ever reduced"); parameterizing kimchi's challenge source breaks that mirror and must be propagated
through the run functions, `RunBounds`/`RunGuardImp` and the capstones in lockstep. That is a much
larger change and is deferred.

Note this PR does **not** break the kimchi mirror: both sides of that reflection simply say
`Ipa.verifyFrom`, regardless of its internals.

## Status — complete, sorry-free

Commit 2 adds `Bulletproof/Forking/Transcript.lean`: the oracle **domain** — element type for the
deployed schedule, the prefixes each challenge is drawn at (`preT`, `preU i`, `preC`), the
sponge-as-oracle interpreters, and the bridges to `transcriptFrom`.

Two structural differences from the kimchi fq-side model, both forced by the IPA's shape:
- **Two oracles, not one.** `t` is a *base*-field squeeze (`challengeFq`, mapped through `toGroup`
  to the `U` base); `uᵢ` and `c` are *scalar*-field endo-expanded squeezes. Hence `spongeOBase`
  and `spongeOScalar`.
- **A different prefix convention.** The kimchi model threads a `(state, value)` pair and reads
  `.2`; that cannot work across two codomains. Here a prefix ends with the marker of the challenge
  being read, and the oracle folds everything *before* it and performs that squeeze.

All three bridges are **proven**, so the model provably reproduces every challenge
`transcriptFrom` derives. `toGroup_spongeOBase_preT` came first as calibration (validating the
convention and the transcription); commit 3 closes `spongeOScalar_preU` / `spongeOScalar_preC`,
whose work is the container mismatch — the model folds `List.foldl` over a `flatMap`/`take` of
`lr.toList` while the deployed `roundChallengesAux` folds `Array.foldl` over `lr.toArray`. Eight
private helpers bridge it, with `roundBlock_succ` as the induction step.

## The abstraction (commit 4)

The point of the transcript model is to make the challenge source a **parameter**:

```lean
structure FiatShamir (C) where
  squeezeBase   : List (IpaTranscriptElt C) → C.BaseField
  squeezeScalar : List (IpaTranscriptElt C) → C.ScalarField

def verifyOracle (fs : FiatShamir C) (σ) (inp) : Bool := …    -- the verifier over ANY source
def spongeFS (C) : FiatShamir C := ⟨spongeOBase, spongeOScalar⟩

theorem verifyOracle_spongeFS : verifyOracle (spongeFS C) σ inp = Ipa.verify C σ inp
```

The theorem is what makes it honest: the deployed verifier is **recovered**, not assumed to be an
instance of the abstract one. Substituting a uniformly random source — what forking rewinds and
reprograms — is now instantiating an argument, i.e. ironwood's position, reached by proof.

This is available here *because* the standalone opening starts **cold**
(`Ipa.verify = verifyFrom FqSponge.init`), so every challenge is a function of the transcript
alone — exactly what `squeeze : List TranscriptElt → F` assumes. Kimchi's opening continues from
the warm post-`ζ` state, so its challenges are not a function of the IPA transcript at all. That
asymmetry is why this package is the tractable one, and it is recorded in the module docstring.

## Verification

- `lake build Bulletproof && lake build Kimchi && lake build Snarky` green, **0 `sorry`**.
- `#print axioms` on the three bridges and on `verifyOracle_spongeFS`: only
  `[propext, Classical.choice, Quot.sound]` — the model, the abstraction and its instantiation
  are all axiom-free.
- Axiom gate unchanged — nothing is added to or removed from the trust surface yet; this is the
  groundwork for the work that will shrink it.
- shake clean (verified locally before push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
