### PR TITLE
kimchi: retire KimchiFamily.htpos — accept the empty-quotient proofs production accepts

### DIFF
--- a/formal/kimchi/Kimchi/Verifier/Capstone/Algebraic.lean
+++ b/formal/kimchi/Kimchi/Verifier/Capstone/Algebraic.lean
@@ -353,6 +353,27 @@ theorem ftChunkAssembly_natDegree_lt [Field F] (k : ℕ) {nt : ℕ} (hnt : 0 < n
   have hpos : 0 < nt * 2 ^ k := Nat.mul_pos hnt h2k
   omega
 
+/-- **The arity-generic degree bound**: the assembly fits under any positive bound that
+dominates its chunk-count budget `nt · 2^k`, with NO positivity hypothesis on `nt`.
+
+The companion of `ftChunkAssembly_natDegree_lt`, which it calls on the positive branch.
+The `nt = 0` case — an empty quotient commitment, which the production verifier accepts
+(`verifier.rs:260` bounds `t_comm.len()` from above only) — makes the assembly the empty
+sum `0`, whose `natDegree` is `0`; there the bound is exactly `hm`. Note the positivity
+hypothesis cannot be dropped from `ftChunkAssembly_natDegree_lt` itself: at `nt = 0` its
+conclusion reads `0 < 0`.
+
+Project-local: this is what lets the ft-identity theorems below (and the reflection layer
+above them) govern the empty-quotient adversary without carrying a `0 < nt` hypothesis
+that production never enforces. -/
+theorem ftChunkAssembly_natDegree_lt_of_le [Field F] (k : ℕ) {nt m : ℕ} (hm : 0 < m)
+    (hle : nt * 2 ^ k ≤ m) (aT : Fin nt → Fin (2 ^ k) → F) :
+    (ftChunkAssembly k nt aT).natDegree < m := by
+  rcases Nat.eq_zero_or_pos nt with hnt | hnt
+  · subst hnt
+    simpa [ftChunkAssembly] using hm
+  · exact lt_of_lt_of_le (ftChunkAssembly_natDegree_lt k hnt aT) hle
+
 /-- The assembly evaluates as the `(ζ^(2^k))`-power combination of the chunk-row
 evaluations. -/
 private theorem ftChunkAssembly_eval [Field F] (k nt : ℕ)
@@ -477,7 +498,7 @@ it does not. -/
 theorem ft_identity_of_chunks_of_eq [Field F] [AddCommGroup G]
     [Module F G] (σ : SRS G)
     {nc : ℕ} (σ₆ : Polynomial F) (hσ₆ : σ₆.natDegree < nc * 2 ^ σ.k)
-    {nt : ℕ} (hnt0 : 0 < nt) (hnt : nt ≤ 7 * nc)
+    {nt : ℕ} (hnt : nt ≤ 7 * nc)
     (aT : Fin nt → Fin (2 ^ σ.k) → F)
     (pScalar ζ v0 : F) (n : ℕ) (hk : nc * 2 ^ σ.k = n)
     (a b : Fin (2 ^ σ.k) → F)
@@ -495,12 +516,14 @@ theorem ft_identity_of_chunks_of_eq [Field F] [AddCommGroup G]
     rw [eval_eq_sum_chunkPoly _ hσ₆ ζ, ← Fin.sum_univ_eq_sum_range]
     exact Finset.sum_congr rfl fun c _ => by rw [chunkPoly_eval]
   have hdeg : (ftChunkAssembly σ.k nt aT).natDegree < 7 * n := by
-    have h := ftChunkAssembly_natDegree_lt σ.k hnt0 aT
+    -- `hσ₆` already forces the `σ₆` budget positive, hence `0 < 7·n`; no `0 < nt` needed.
+    have hnpos : 0 < nc * 2 ^ σ.k := lt_of_le_of_lt (Nat.zero_le _) hσ₆
+    rw [hk] at hnpos
     have h2 : nt * 2 ^ σ.k ≤ 7 * (nc * 2 ^ σ.k) := by
       rw [← mul_assoc]
       exact Nat.mul_le_mul_right _ hnt
     rw [hk] at h2
-    omega
+    exact ftChunkAssembly_natDegree_lt_of_le σ.k (by omega) h2 aT
   refine ⟨hdeg, ?_⟩
   -- Expand the inner product of `b` linearly and conclude.
   have hipL : ∀ {m : ℕ} (u : Fin m → Fin (2 ^ σ.k) → F),
@@ -553,7 +576,7 @@ theorem ft_identity_of_chunks [Field F] [AddCommGroup G]
     {nc : ℕ}
     (σ₆ : Polynomial F) (hσ₆ : σ₆.natDegree < nc * 2 ^ σ.k)
     (Cσ6 : Fin nc → G) (hC : ∀ c : Fin nc, Cσ6 c = commitPolyChunk σ σ₆ (c : ℕ))
-    {nt : ℕ} (hnt0 : 0 < nt) (hnt : nt ≤ 7 * nc)
+    {nt : ℕ} (hnt : nt ≤ 7 * nc)
     (TC : Fin nt → G) (aT : Fin nt → Fin (2 ^ σ.k) → F) (ρT : Fin nt → F)
     (htc : ∀ j, commit σ (aT j) (ρT j) = TC j)
     (pScalar ζ v0 : F) (n : ℕ) (hk : nc * 2 ^ σ.k = n)
@@ -575,7 +598,6 @@ theorem ft_identity_of_chunks [Field F] [AddCommGroup G]
   have hab : a = b := by
     by_contra hne
     exact hntriv hne (hbind _ _ hrel).1
-  exact ft_identity_of_chunks_of_eq σ σ₆ hσ₆ hnt0 hnt aT pScalar ζ v0 n hk a b hb heval
-    hab
+  exact ft_identity_of_chunks_of_eq σ σ₆ hσ₆ hnt aT pScalar ζ v0 n hk a b hb heval hab
 
 end Kimchi.Verifier

--- a/formal/kimchi/Kimchi/Verifier/Capstone/Reflection.lean
+++ b/formal/kimchi/Kimchi/Verifier/Capstone/Reflection.lean
@@ -1099,7 +1099,6 @@ theorem run_sound_algebraic_at_of_vkrep {C : Ipa.CommitmentCurve}
     (beta gamma alpha zeta v u : C.ScalarField)
     (hnc : 0 < nc) (hk : nc * 2 ^ σ.k = n) (hn : cvk.n = n)
     (hvk : cvk.Corresponds σ idx)
-    (htpos : 0 < cp.tComm.size)
     (aRef : Fin (nc + 1 + tailRowCount * nc) → Fin (2 ^ σ.k) → C.ScalarField)
     (ρRef : Fin (nc + 1 + tailRowCount * nc) → C.ScalarField)
     (hrep : ∀ i, commit σ (aRef i) (ρRef i)
@@ -1167,7 +1166,7 @@ theorem run_sound_algebraic_at_of_vkrep {C : Ipa.CommitmentCurve}
     rw [hk]
     exact columnPoly_natDegree_lt idx.omega_prim _
   obtain ⟨htdeg, hteq0⟩ := ft_identity_of_chunks_of_eq σ (idx.sigmaPoly 6) hσ₆
-    htpos cp.tComm_le aT
+    cp.tComm_le aT
     (runPScalarAt C σ cvk cp beta gamma alpha zeta) zeta
     (runFtEval0At C σ cvk cp pub beta gamma alpha zeta) n hk (aRef ⟨nc, hsz⟩) _ rfl
     heval_ft (hftRep ⟨nc, hsz⟩ rfl)
@@ -1247,10 +1246,12 @@ theorem runBounds_of_chunking {C : Ipa.CommitmentCurve}
 /-- **The `ζ` cardinality bound at the run's own assembled quotient.** `RunBounds`' fourth
 clause is stated for an ARBITRARY polynomial of degree `< 7·n`; the game charges its `ζ` to
 the exclusion set at the run's assembled quotient `ftChunkAssembly σ.k cp.tComm.size aT`, so
-the degree side condition has to be discharged there. It is: `ftChunkAssembly_natDegree_lt`
-bounds the assembly's degree by `cp.tComm.size · 2^σ.k`, the wire invariant `cp.tComm_le`
-bounds the chunk count by `7·nc`, and the production chunking equation turns that into
-`7·n`. The bound therefore holds unconditionally at the assembly.
+the degree side condition has to be discharged there. It is: `ftChunkAssembly_natDegree_lt_of_le`
+bounds the assembly's degree by any positive bound dominating `cp.tComm.size · 2^σ.k`, the wire
+invariant `cp.tComm_le` bounds the chunk count by `7·nc`, and the production chunking equation
+turns that into `7·n` (positive, from the `NeZero n` instance). The bound therefore holds
+unconditionally at the assembly — in particular at an EMPTY quotient commitment, where the
+assembly is the zero polynomial.
 
 Project-local: it keeps the degree bookkeeping out of the game file, where the bound is
 needed once per point of the algebraic summand. -/
@@ -1259,13 +1260,13 @@ theorem runBounds_zeta_at_assembly {C : Ipa.CommitmentCurve} (σ : SRS C.Point) 
     {n : ℕ} [NeZero n] (idx : Index C.ScalarField n)
     (aRef : Fin (nc + 1 + tailRowCount * nc) → Fin (2 ^ σ.k) → C.ScalarField)
     (aT : Fin cp.tComm.size → Fin (2 ^ σ.k) → C.ScalarField)
-    (hk : nc * 2 ^ σ.k = n) (htpos : 0 < cp.tComm.size)
+    (hk : nc * 2 ^ σ.k = n)
     (hbounds : RunBounds σ cvk cp pub idx aRef) (beta gamma alpha : C.ScalarField) :
     (Protocol.soundBadZ idx (pubView idx pub) (runW σ cvk cp pub aRef)
         (runZ σ cvk cp pub aRef) beta gamma alpha
         (ftChunkAssembly σ.k cp.tComm.size aT)).card ≤ Index.degreeBound n := by
   refine hbounds.2.2.2 beta gamma alpha _ ?_
-  refine lt_of_lt_of_le (ftChunkAssembly_natDegree_lt σ.k htpos aT) ?_
+  refine ftChunkAssembly_natDegree_lt_of_le σ.k (by have := NeZero.pos n; omega) ?_ aT
   calc cp.tComm.size * 2 ^ σ.k
       ≤ 7 * nc * 2 ^ σ.k := Nat.mul_le_mul cp.tComm_le (le_refl _)
     _ = 7 * n := by rw [mul_assoc, hk]

--- a/formal/kimchi/Kimchi/Verifier/Forking/Honest.lean
+++ b/formal/kimchi/Kimchi/Verifier/Forking/Honest.lean
@@ -71,11 +71,11 @@ private def zeroEvals (C : Ipa.CommitmentCurve) (nc : ℕ) :
 
 /-- The all-zero proof.
 
-The quotient array is `nc` **zero** chunks rather than empty: `KimchiFamily.htpos`
-demands `0 < tComm.size`, so a family built on an empty array cannot exist. Taking `nc`
-chunks (rather than the single chunk of the blueprint) keeps `tComm_le` unconditional —
-`nc ≤ 7 * nc` — and none of the computations below change, since the polyscale
-combination of an all-zero list is `0` either way (`combineCommitments_eq_zero`). -/
+The quotient array is `nc` **zero** chunks rather than empty. Nothing forces the choice —
+the endpoints govern the empty quotient too, and `tComm_le` would hold there as well — it
+is a convenience: at `nc` chunks `tComm_le` is the unconditional `nc ≤ 7 * nc`, and none
+of the computations below change either way, since the polyscale combination of an
+all-zero list is `0` regardless (`combineCommitments_eq_zero`). -/
 private def zeroProof (C : Ipa.CommitmentCurve) (nc k : ℕ) : KimchiProof C nc k where
   wComm := Vector.replicate wCols (Vector.replicate nc 0)
   zComm := Vector.replicate nc 0
@@ -577,13 +577,6 @@ field, so the derived claim is the same claim — up to its own `proof` slot. -/
 private def zeroProofWith (C : Ipa.CommitmentCurve) (nc k : ℕ) (op : Ipa.Proof C k) :
     KimchiProof C nc k :=
   { zeroProof C nc k with opening := op }
-
-/-- The quotient array of the degenerate proof has `nc` chunks — the shape
-`KimchiFamily.htpos` reads, which is why `zeroProof` carries zero chunks rather than
-none. -/
-@[simp] private theorem zeroProofWith_tComm_size (nc k : ℕ) (op : Ipa.Proof C k) :
-    (zeroProofWith C nc k op).tComm.size = nc := by
-  simp [zeroProofWith, zeroProof]
 
 /-- **Replacing the opening changes only the claim's `proof` slot.** Definitional: the
 batch stream reads the evaluations, the commitment chunks and `ftEval1`, none of which the
@@ -1381,12 +1374,6 @@ private noncomputable def honestKimchiFamily
   hn := fun _ => rfl
   hvk := fun basis => honestVK_corresponds (srsOfBasis k basis) nc idx
   hpub := fun _ => hpc.symm
-  htpos := by
-    intro basis O
-    obtain ⟨op, hop⟩ :=
-      familyAdversary_run hsmul hne hk nc (indexAtCurve C idx) hω basis O
-    rw [hop, zeroProofWith_tComm_size]
-    exact hnc
   aRef := fun basis _ i =>
     (exists_rep_commitmentFn (srsOfBasis k basis) (indexAtCurve C idx) i).choose
   ρRef := fun basis _ i =>

--- a/formal/kimchi/Kimchi/Verifier/KnowledgeSoundness.lean
+++ b/formal/kimchi/Kimchi/Verifier/KnowledgeSoundness.lean
@@ -25,8 +25,7 @@ The SUB-SRS regime `max_poly_size > n` — the common o1js/Mina configuration �
 fragment, as are lookups, optional gates (range check, foreign field, xor, rot), and
 recursion (`prev_challenges = 0`). On the proof side the fragment also excludes proofs
 carrying optional-gate or lookup EVALUATION fields (production fr-absorbs those even against
-a basic-gate key, so such a proof's transcript differs), proofs with an empty quotient
-commitment (`htpos`; the wire parse now rejects them as a declared strengthening), ragged
+a basic-gate key, so such a proof's transcript differs), ragged
 chunk vectors, and openings of other than `σ.k` rounds. Mina/pickles proofs use recursion,
 lookups, optional gates and the sub-SRS regime, and are outside the fragment on four
 independent axes.
@@ -825,8 +824,10 @@ abbrev Coins (C : Ipa.CommitmentCurve) (nc k : ℕ) : Type := KimchiNode C nc k 
 Beyond an adversary and its query bound it carries (i) the circuit `idx` and its correspondence
 to the presented verifying key, so the extracted witness satisfies *the circuit the verifier
 checked*, and (ii) the AGM representations `aRef`/`ρRef` of the run's flat commitment stream
-and `aT`/`ρT` of the quotient chunks — the same data `kimchiVesta_run_sound_algebraic_ft` takes
-as hypotheses, here supplied by the family because we are in the algebraic group model. They
+and `aT`/`ρT` of the quotient chunks — the same data the reflection root
+`run_sound_algebraic_at_of_vkrep` takes as hypotheses (`ρT` one layer down, in
+`ft_identity_of_chunks`), here supplied by the family because we are in the algebraic group
+model. They
 are indexed by the oracle table as well as by the basis: kimchi's claim is adversary output, so
 it is table-dependent, unlike `DeployedFamily.claim`. -/
 structure KimchiFamily (C : Ipa.CommitmentCurve) [Module C.ScalarField C.Point]
@@ -859,9 +860,6 @@ structure KimchiFamily (C : Ipa.CommitmentCurve) [Module C.ScalarField C.Point]
   hvk : ∀ basis, (cvk basis).Corresponds (srsOfBasis k basis) idx
   /-- The public input has the circuit's arity. -/
   hpub : ∀ basis, (pub basis).size = idx.publicCount
-  /-- The quotient commitment is non-empty. Not algebraic-group data: this RESTRICTS the
-  adversary, and is required by `run_sound_algebraic_ft`. -/
-  htpos : ∀ basis O, 0 < ((adversary basis).run O).tComm.size
   /-- AGM: the SRS-basis coefficients of every commitment in the run's flat IPA stream. -/
   aRef : (basis : Zcash.Snark.AugmentedIndex (2 ^ k) → C.Point) →
     (O : KimchiNode C nc k → Prechallenge) →
@@ -3122,7 +3120,7 @@ private theorem arm4_hits_badChallenge
         (fam.readsOf basis O Squeeze.beta) (fam.readsOf basis O Squeeze.gamma)
         (fam.readsOf basis O Squeeze.alpha) (fam.readsOf basis O Squeeze.zeta)
         (fam.readsOf basis O Squeeze.polyscale) (fam.readsOf basis O Squeeze.evalscale)
-        fam.hnc fam.hkn (fam.hn basis) (fam.hvk basis) (fam.htpos basis O)
+        fam.hnc fam.hkn (fam.hn basis) (fam.hvk basis)
         (fam.aRef basis O) (fam.ρRef basis O) (fam.hrep basis O) (fam.aT basis O) hpins
         (fun i c => hvkh (VkRow.sigma i) c) (fun cc c => hvkh (VkRow.coeff cc) c)
         (fun jj c => hvkh (VkRow.sel jj) c) (fun c => hvkh VkRow.pub c)
@@ -3893,7 +3891,7 @@ private theorem szBadRun_card_le (basis : Zcash.Snark.AugmentedIndex (2 ^ k) →
   · exact hb.2.2.1 _ _
   · exact runBounds_zeta_at_assembly (srsOfBasis k basis) (fam.cvk basis)
       (fam.proofOf basis O) (fam.pub basis) fam.idx (fam.aRef basis O) (fam.aT basis O)
-      fam.hkn (fam.htpos basis O) hb _ _ _
+      fam.hkn hb _ _ _
   · exact card_zetaBoundaryBad_le fam.idx
   · exact card_badXiOf_le _ _ _ _
   · exact card_badROf_le _ _ _ _ _

--- a/formal/kimchi/Kimchi/Verifier/Wire.lean
+++ b/formal/kimchi/Kimchi/Verifier/Wire.lean
@@ -149,18 +149,20 @@ production never checks those chunk counts (ragged commitment vectors flow into 
 batch equations rather than `Err`-ing), but the checked record is uniform by type, so
 the parse fixes them. Fidelity direction: a production-accepted run with a ragged
 `w_comm` would have no Lean counterpart — such a run would fail the batched opening
-anyway, but that is an argument, not a check. Two further declared strengthenings of
-the same kind: the quotient commitment must be NON-EMPTY (production processes an
-empty `t_comm`; the endpoints' `htpos` hypothesis excludes it, so the wire boundary
-now matches the hypothesis — external-audit B-1), and `KimchiVK.check` pins every
-VK-side committed column to `nc` chunks, which production likewise never checks
-(honest keys are uniform; external-audit W-F4). -/
+anyway, but that is an argument, not a check. One further declared strengthening of
+the same kind: `KimchiVK.check` pins every VK-side committed column to `nc` chunks,
+which production likewise never checks (honest keys are uniform; external-audit W-F4).
+
+The quotient commitment is NOT pinned non-empty. An earlier revision guarded
+`0 < t_comm.size` to match a `htpos` hypothesis the endpoints then carried; that
+hypothesis has since been retired (external-audit O-2), so the empty quotient — which
+production accepts, `verifier.rs:260` bounding `t_comm.len()` from above only — now
+parses and is governed by the knowledge-soundness endpoints like any other run. -/
 def KimchiProof.check {C : Ipa.CommitmentCurve} (nc k : ℕ) (p : KimchiProof C) :
     Option (Kimchi.Verifier.KimchiProof C nc k) := do
   let wComm ← p.wComm.mapM (checkChunks nc)
   let zComm ← checkChunks nc p.zComm
   let opening ← p.opening.check k
-  guard (0 < p.tComm.size)
   if htc : p.tComm.size ≤ 7 * nc then
     let evals ← checkEvals nc p.evals
     let pubEvals ← match p.pubEvals with

--- a/formal/kimchi/scripts/check_kimchi_verifier.lean
+++ b/formal/kimchi/scripts/check_kimchi_verifier.lean
@@ -30,13 +30,20 @@ Each run checks the accept bit, then two negative matrices:
   REJECT): evaluation chunks on the ζ and ζω sides and beyond chunk 0 (`z` chunk 1, a
   witness-column chunk 1), the quotient commitment at chunk 0 and at the high chunk
   (`7·nc − 1`, the second `ft_comm` collapse group — exists only at `nc = 2`),
-  `ft_eval1`, and (where carried) a public-evaluation chunk;
+  an EMPTIED quotient commitment (which parses — production bounds `t_comm.len()` from
+  above only, verifier.rs:260 — and must fail the ft identity), `ft_eval1`, and (where
+  carried) a public-evaluation chunk;
 * **parse rejections** (`Wire.check` must return `none` — ragged or mis-pinned wire
   input, matching production's `Err` returns): a ragged evaluation chunk vector, a
   missing `evals_public` at `nc > 1` (production's `MissingPublicInputEvaluation`,
   verifier.rs:334–335), an oversized `t_comm` (`> 7·nc`), a wrong opening round count
   (an `lr` pair popped — this failure arises in the IPA-side `Ipa.Wire.Proof.check`
   and propagates through `KimchiProof.check`), and a ragged VK chunk vector.
+
+The emptied quotient carries one extra, positive assertion: that it PARSES. `verifyWire`
+is check-then-verify, so a parse rejection would flip its verdict for the wrong reason —
+the assertion is what keeps that corruption from agreeing vacuously if a
+`0 < t_comm.size` wire guard is ever reinstated (negative control NC-5).
 
 Every transcription judgment in the verifier (chunk absorb orders, the segment
 flattening of the batch, the `ft_comm` double collapse, the carried-public precedence)
@@ -100,6 +107,9 @@ def runChunked (C : Ipa.CommitmentCurve)
             { proof.evals.z with zeta := proof.evals.z.zeta.modify c (· + 1) }
           else
             { proof.evals.z with zetaOmega := proof.evals.z.zetaOmega.modify c (· + 1) } } }
+    -- The empty quotient commitment (audit O-2), used twice below: once as a
+    -- verify-level corruption, once as the parse-side non-vacuity control for it.
+    let emptyT : Wire.KimchiProof C := { proof with tComm := #[] }
     -- verify-level corruptions: each mutant still parses; the verdict must flip.
     let mut corrupts : Array (String × Bool) := #[]
     -- The nc-specific high-chunk corruption (the second ft_comm collapse group). Kept
@@ -116,6 +126,11 @@ def runChunked (C : Ipa.CommitmentCurve)
       corrupts := corrupts.push ("corrupted z eval (ζ, chunk 0)", !verify (bumpZ true 0))
       corrupts := corrupts.push ("corrupted t comm (chunk 0)",
         !verify { proof with tComm := proof.tComm.modify 0 (· + σ.h) })
+      -- The empty quotient. Production bounds `t_comm.len()` from above only
+      -- (verifier.rs:260), so this parses — and must be REJECTED at verify time, where
+      -- the quotient side of the ft collapse becomes the empty sum `0`.
+      corrupts := corrupts.push ("emptied t comm (the empty quotient, parses)",
+        !verify emptyT)
       corrupts := corrupts.push ("corrupted ft_eval1",
         !verify { proof with ftEval1 := proof.ftEval1 + 1 })
       if 1 < nc then
@@ -147,8 +162,6 @@ def runChunked (C : Ipa.CommitmentCurve)
     let mut parses : Array (String × Bool) := #[
       ("ragged z eval chunk vector", (ragged.check nc σ.k).isNone && !verify ragged),
       ("oversized t_comm (size > 7·nc)", (overT.check nc σ.k).isNone),
-      ("empty t_comm (the htpos wire pin, a declared strengthening)",
-        (({ proof with tComm := #[] } : Wire.KimchiProof C).check nc σ.k).isNone),
       ("wrong opening round count (lr pair popped; the IPA-side check)",
         (badLr.check nc σ.k).isNone),
       ("ragged VK chunk vector (sigma_comm[0])", (raggedVK.check nc).isNone)]
@@ -157,7 +170,16 @@ def runChunked (C : Ipa.CommitmentCurve)
       parses := parses.push ("missing evals_public at nc > 1", (noPub.check nc σ.k).isNone)
     for (name, rejected) in parses do
       IO.println s!"  {if rejected then "✓ none" else "✗ parsed (BUG)"}: {name}"
-    unless ok && corrupts.all (·.2) && parses.all (·.2) do
+    -- Non-vacuity of the emptied-quotient corruption above (audit O-2). `verify` is
+    -- check-then-verify, so a parse rejection would flip that verdict for the WRONG
+    -- reason. Production bounds `t_comm.len()` from above only (verifier.rs:260), so the
+    -- empty quotient must PARSE here and its rejection must be the ft identity's — the
+    -- quotient side of the collapse being the empty sum `0`. Reinstating a
+    -- `0 < t_comm.size` wire guard fails on THIS line (negative control NC-5).
+    let emptyParses := (emptyT.check nc σ.k).isSome
+    IO.println s!"  {if emptyParses then "✓ parses" else "✗ none (VACUOUS CONTROL)"}: \
+      emptied t comm reaches the verifier"
+    unless ok && emptyParses && corrupts.all (·.2) && parses.all (·.2) do
       throw (IO.userError s!"{path}: chunked kimchi verifier check FAILED")
 
 abbrev CV := IpaVesta.curve


### PR DESCRIPTION
## What

Retires the non-empty-quotient-commitment restriction from the formal verifier's wire layer and knowledge-soundness development. External audit item **B-1** (follow-up register **O-2**), strong form.

Production kimchi bounds `t_comm.len()` **from above only**; the Lean wire parse additionally required `0 < t_comm.size`, so the Lean-accepted wire language was strictly narrower than production's, and the knowledge-soundness family carried a matching `htpos` field restricting the adversary. This PR deletes both and lets the endpoints govern the empty-quotient adversary that production already accepts.

## How

One atomic cascade (no intermediate state compiles):

- **`Capstone/Algebraic.lean`** — new `ftChunkAssembly_natDegree_lt_of_le`, the arity-generic companion taking `0 < m` and `nt * 2^k ≤ m`; degenerate branch closed directly, positive branch delegates to the original. The original `ftChunkAssembly_natDegree_lt` deliberately keeps its `0 < nt` (at `nt = 0` its own conclusion reads `0 < 0`). `hnt0` dropped from `ft_identity_of_chunks{,_of_eq}`.
- **`Capstone/Reflection.lean`** — `htpos` dropped from `run_sound_algebraic_at_of_vkrep` and `runBounds_zeta_at_assembly`; `0 < 7·n` now comes from the ambient `[NeZero n]`.
- **`KnowledgeSoundness.lean`** — the `KimchiFamily.htpos` field and its two uses deleted; the fragment preamble no longer lists the empty-quotient exclusion; a dangling docstring reference repointed to `run_sound_algebraic_at_of_vkrep`.
- **`Forking/Honest.lean`** — the `htpos :=` assignment and the now-orphaned private `zeroProofWith_tComm_size` deleted.
- **`Wire.lean`** — the payoff: `guard (0 < p.tComm.size)` deleted; the accepted language now matches production.
- **`scripts/check_kimchi_verifier.lean`** — the empty-`t_comm` negative control moved from `parses` (parse must return `none`) to `corrupts` (`verify` must return `false`), **with a paired positive assertion that the mutant still parses**. Without it the control is vacuous under check-then-verify: reinstating the removed guard left the driver green. Proved load-bearing by mutation experiment (regression patched in, driver observed failing, restored byte-identical).

## Verification (at the tree this PR reconstructs)

Sorry census 0; no new axioms — kimchi axiom gate: all 52 roots reduce to `[propext, Classical.choice, Quot.sound]`; locked-target gate passes **without** `--regen` (no pinned statement changed); dead code 0 of 1545; style clean; all fixture drivers green, including the kimchi verifier driver with the strengthened control.

## Not in this PR

The prose record of the closure (`docs/external-audit-followup.md` §O-2, `docs/negative-controls.md` NC-5) ships with the docs sweep in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)