### PR TITLE
bulletproof-pcs, kimchi: prove the deployed extractor's worst-case cost bound (audit O-1a)

### DIFF
--- a/formal/bulletproof-pcs/Bulletproof/Forking/Deployed.lean
+++ b/formal/bulletproof-pcs/Bulletproof/Forking/Deployed.lean
@@ -852,6 +852,37 @@ def deployedExtractRuns (σ : SRS C.Point) (cip : C.ScalarField)
   kimchiExtractRuns { σ with U := uBaseOf C cip } b v P (expandPre C) A toOpening
     (nodes cip) (decodesFromPrefixes_nodes _ cip) O coins
 
+/-- **The deployed extractor's worst-case call count**: `(2n+1)^(k+1)` on any coin tape of node
+degree at most `n`. `kimchiExtractRuns_le` at this instantiation — the base swap
+`{ σ with U := uBaseOf C cip }` leaves `.k` untouched, so no re-indexing is involved.
+
+The caveat travels with the number and must be quoted with it: this is the **worst case**, and
+it is exponential in `k` and in the challenge domain. At the tape `exists_complete_bounded_coins`
+supplies, `n = 2 ^ 128`. It is not a concrete-security statement; what it replaces is the
+absence of any bound at all. -/
+theorem deployedExtractRuns_le (σ : SRS C.Point) (cip : C.ScalarField)
+    (b : Fin (2 ^ σ.k) → C.ScalarField) (v : C.ScalarField) (P : C.Point)
+    (A : Zcash.Snark.OracleComp (IpaNode C σ.k) Prechallenge (Ipa.Proof C σ.k))
+    (O : IpaNode C σ.k → Prechallenge)
+    (coins : Zcash.Snark.RecursiveForkCoins Prechallenge (σ.k + 1)) {n : ℕ}
+    (hB : coins.Bounded n) :
+    deployedExtractRuns σ cip b v P A O coins ≤ (2 * n + 1) ^ (σ.k + 1) :=
+  kimchiExtractRuns_le { σ with U := uBaseOf C cip } b v P (expandPre C) A toOpening
+    (nodes cip) (decodesFromPrefixes_nodes _ cip) O coins hB
+
+/-- **The deployed extractor always runs the adversary at least once**, on every table and every
+tape. `one_le_kimchiExtractRuns` at the same instantiation, and what keeps
+`deployedExtractRuns_le` from being vacuous: an upper bound cannot tell a real reduction from one
+that does nothing if the counter it bounds could be `0`. -/
+theorem one_le_deployedExtractRuns (σ : SRS C.Point) (cip : C.ScalarField)
+    (b : Fin (2 ^ σ.k) → C.ScalarField) (v : C.ScalarField) (P : C.Point)
+    (A : Zcash.Snark.OracleComp (IpaNode C σ.k) Prechallenge (Ipa.Proof C σ.k))
+    (O : IpaNode C σ.k → Prechallenge)
+    (coins : Zcash.Snark.RecursiveForkCoins Prechallenge (σ.k + 1)) :
+    1 ≤ deployedExtractRuns σ cip b v P A O coins :=
+  one_le_kimchiExtractRuns { σ with U := uBaseOf C cip } b v P (expandPre C) A toOpening
+    (nodes cip) (decodesFromPrefixes_nodes _ cip) O coins
+
 end Extractor
 
 /-- **The identity-ordered uniform tape** at every depth: each node carries the identity
@@ -867,6 +898,24 @@ complete by ironwood's `RecursiveForkTape.toCoins_complete`. -/
 theorem exists_complete_coins (d : ℕ) :
     ∃ coins : Zcash.Snark.RecursiveForkCoins Prechallenge d, coins.Complete :=
   ⟨(identityTape d).toCoins, Zcash.Snark.RecursiveForkTape.toCoins_complete _⟩
+
+/-- **One tape is complete *and* bounded**, at every depth: `identityTape`'s coins again, whose
+node degree is exactly `Fintype.card Prechallenge = 2 ^ 128` by ironwood's
+`RecursiveForkTape.toCoins_bounded`.
+
+The two conditions are genuinely independent, which is why this is a theorem and not a
+restatement of `exists_complete_coins`. `Complete` asks that every challenge occur somewhere in
+each node's order list and says nothing about that list's length; a complete tape whose orders
+repeat challenges is complete and unbounded. `Bounded` caps the length and says nothing about
+coverage. Every endpoint hypothesizes the first; the cost bound
+(`deployedExtractRuns_le`) needs the second. This says one witness discharges both at once,
+which is what lets `DeployedFamily.exists_complete_reductionEfficient`
+(`Forking/KnowledgeSoundness.lean`) name an explicit `R`. -/
+theorem exists_complete_bounded_coins (d : ℕ) :
+    ∃ coins : Zcash.Snark.RecursiveForkCoins Prechallenge d,
+      coins.Complete ∧ coins.Bounded (2 ^ 128) :=
+  ⟨(identityTape d).toCoins, Zcash.Snark.RecursiveForkTape.toCoins_complete _,
+    card_prechallenge ▸ Zcash.Snark.RecursiveForkTape.toCoins_bounded _⟩
 
 /-! ## The two anti-vacuity companions
 

--- a/formal/bulletproof-pcs/Bulletproof/Forking/Game.lean
+++ b/formal/bulletproof-pcs/Bulletproof/Forking/Game.lean
@@ -466,6 +466,150 @@ private def kimchiForkFrom [DecidableEq F] [DecidableEq G] [DecidableEq T]
                   (expand q₁) (expand q₂) (expand q₃) c₁ c₂ c₃)
                 runs := first.runs + second.runs + third.runs }
 
+/-! ### The worst-case run bound
+
+What the extractor *costs*, read off the same recursion it runs. The bound is **pointwise** in
+the oracle table and in the coin tape, which is what makes it usable on either averaging axis
+without a bridge between them: a pointwise bound sums over tapes at a fixed table and over
+tables at a fixed tape alike.
+
+It is a *worst case*, and an exponential one. At the deployed prechallenge domain the tape
+degree is `n = 2 ^ 128`, so the number is `(2 · 2 ^ 128 + 1) ^ (k + 1)` — the same regime as
+ironwood's `reductionEfficient_exponential`, and **not** a polynomial-AFK claim. What it does
+buy is that the call count is now *computed from the counter* rather than asserted to exist.
+-/
+
+/-- **An `n`-bounded coin tape makes at most `(2n+1)^(e+1)` adversary runs.** The structural
+port of ironwood's `recursiveAlgebraicForkFrom_runs_le`
+(`Forking/Adversary/Recursive.lean:578`) to *our* recursion, which differs from it in the one
+way that moves the arithmetic: the fork is indexed by certificate depth `e` with coins one level
+deeper, and the base case is the Schnorr fork, which runs a scan rather than costing a bare `1`.
+
+Hence the exponent `e + 1`, not `e`. At `e = 0` a losing run costs `1` and a winning run costs
+`1 + second.runs ≤ 1 + n`, both `≤ (2n+1)^1`; the slack `n` in `2n + 1` is exactly what pays for
+that extra leaf scan, so the sharper `(2n+1)^e` is *false* here.
+
+The two scan lemmas consumed are ironwood's own and are used verbatim at the alphabet `Pre`:
+they ask nothing of it beyond `[Zero Pre]` and `[DecidableEq Pre]`. -/
+private theorem kimchiForkFrom_runs_le [DecidableEq F] [DecidableEq G] [DecidableEq T]
+    [Zero Pre] [DecidableEq Pre]
+    (σ : SRS G) (b : Fin (2 ^ σ.k) → F) (v : F) (P : G) (expand : Pre → F)
+    (A : Zcash.Snark.OracleComp T Pre Pf)
+    (proofOf : Pf → OpeningProof F G σ.k) (prefixes : Pf → Fin (σ.k + 1) → T)
+    (dec : DecodesFromPrefixes σ proofOf prefixes) (n : ℕ) :
+    {e : ℕ} → (m : ℕ) → (hme : m + e = σ.k) → (O : T → Pre) → (p : Pf) →
+      (coins : Zcash.Snark.RecursiveForkCoins Pre (e + 1)) → coins.Bounded n →
+      (kimchiForkFrom σ b v P expand A proofOf prefixes dec m hme O p coins).runs
+        ≤ (2 * n + 1) ^ (e + 1)
+  | 0, m, hme, O, p, .node order child, hbounded => by
+      have horder : order.length ≤ n := hbounded.1
+      have hscan : ∀ (attempt : Pre → Zcash.Snark.RecursiveForkAttempt (F × F))
+          (seen : List Pre), (∀ q, (attempt q).runs ≤ 1) →
+          1 + (Zcash.Snark.nextForkChallenge attempt seen order).runs
+            ≤ (2 * n + 1) ^ (0 + 1) := by
+        intro attempt seen hq
+        have h := (Zcash.Snark.nextForkChallenge_runs_le attempt seen order 1 hq).trans
+          (by simpa using horder)
+        simp only [zero_add, pow_one]
+        omega
+      rw [kimchiForkFrom]
+      simp only []
+      split
+      · split
+        all_goals
+          exact hscan _ _ (fun q => by split <;> exact Nat.le_refl 1)
+      · simp only [zero_add, pow_one]
+        omega
+  | e + 1, m, hme, O, p, .node order child, hbounded => by
+      have horder : order.length ≤ n := hbounded.1
+      have hm : m < σ.k + 1 := by omega
+      have htail : m + 1 + e = σ.k := by omega
+      have hone : 1 ≤ (2 * n + 1) ^ (e + 1) := Nat.one_le_pow _ _ (by omega)
+      have hchild : ∀ (O' : T → Pre) (p' : Pf) (q : Pre),
+          (kimchiForkFrom σ b v P expand A proofOf prefixes dec (m + 1) htail O' p'
+            (child q)).runs ≤ (2 * n + 1) ^ (e + 1) := fun O' p' q =>
+        kimchiForkFrom_runs_le σ b v P expand A proofOf prefixes dec n (m + 1) htail O' p'
+          (child q) (hbounded.2 q)
+      let t : T := prefixes p ⟨m, hm⟩
+      let candidate : Pre → Zcash.Snark.RecursiveForkAttempt (KimchiForkCert F G e) := fun q =>
+        let O' := Function.update O t q
+        let p' := A.run O'
+        if prefixes p' ⟨m, hm⟩ = t then
+          kimchiForkFrom σ b v P expand A proofOf prefixes dec (m + 1) htail O' p' (child q)
+        else { output := none, runs := 1 }
+      have hcand : ∀ q, (candidate q).runs ≤ (2 * n + 1) ^ (e + 1) := by
+        intro q
+        dsimp only [candidate]
+        split
+        · exact hchild _ _ q
+        · exact hone
+      have hfirst : (kimchiForkFrom σ b v P expand A proofOf prefixes dec (m + 1) htail O p
+          (child (O t))).runs ≤ (2 * n + 1) ^ (e + 1) := hchild O p (O t)
+      have hsecond : (Zcash.Snark.nextForkChallenge candidate [O t] order).runs
+          ≤ n * (2 * n + 1) ^ (e + 1) :=
+        (Zcash.Snark.nextForkChallenge_runs_le candidate [O t] order _ hcand).trans
+          (Nat.mul_le_mul_right _ horder)
+      rw [kimchiForkFrom]
+      simp only []
+      split
+      · exact hfirst.trans (Nat.pow_le_pow_right (by omega) (by omega))
+      · rename_i c₁ hfirstSome
+        split
+        · calc _ ≤ (2 * n + 1) ^ (e + 1) + n * (2 * n + 1) ^ (e + 1) :=
+                Nat.add_le_add hfirst hsecond
+            _ ≤ (2 * n + 1) ^ (e + 1) * (2 * n + 1) := by ring_nf; omega
+            _ = (2 * n + 1) ^ (e + 1 + 1) := (pow_succ _ _).symm
+        · rename_i q₂ c₂ rest seen hsecondSome
+          have hrest : rest.length ≤ order.length :=
+            Zcash.Snark.nextForkChallenge_output_rest_length_le candidate [O t] hsecondSome
+          have hthird : (Zcash.Snark.nextForkChallenge candidate seen rest).runs
+              ≤ n * (2 * n + 1) ^ (e + 1) :=
+            (Zcash.Snark.nextForkChallenge_runs_le candidate seen rest _ hcand).trans
+              (Nat.mul_le_mul_right _ (hrest.trans horder))
+          split
+          all_goals
+            calc _ ≤ (2 * n + 1) ^ (e + 1) + n * (2 * n + 1) ^ (e + 1)
+                    + n * (2 * n + 1) ^ (e + 1) :=
+                  Nat.add_le_add (Nat.add_le_add hfirst hsecond) hthird
+              _ = (2 * n + 1) ^ (e + 1) * (2 * n + 1) := by ring
+              _ = (2 * n + 1) ^ (e + 1 + 1) := (pow_succ _ _).symm
+
+/-- **The counter is never zero.** Every arm of the fork charges at least the run it has already
+made: the base case bills `1` outright, and each recursive arm's total leads with `first.runs`.
+
+Anti-vacuity for the bound above, in the shape this project pins rather than argues
+(`docs/negative-controls.md`). An upper bound on a counter says nothing if the counter could be
+provably `0` — a "zero-call reduction" would satisfy `ReductionEfficient` at every `R`. This
+lemma is what rules that reading out. -/
+private theorem one_le_kimchiForkFrom_runs [DecidableEq F] [DecidableEq G] [DecidableEq T]
+    [Zero Pre] [DecidableEq Pre]
+    (σ : SRS G) (b : Fin (2 ^ σ.k) → F) (v : F) (P : G) (expand : Pre → F)
+    (A : Zcash.Snark.OracleComp T Pre Pf)
+    (proofOf : Pf → OpeningProof F G σ.k) (prefixes : Pf → Fin (σ.k + 1) → T)
+    (dec : DecodesFromPrefixes σ proofOf prefixes) :
+    {e : ℕ} → (m : ℕ) → (hme : m + e = σ.k) → (O : T → Pre) → (p : Pf) →
+      (coins : Zcash.Snark.RecursiveForkCoins Pre (e + 1)) →
+      1 ≤ (kimchiForkFrom σ b v P expand A proofOf prefixes dec m hme O p coins).runs
+  | 0, m, hme, O, p, .node order child => by
+      rw [kimchiForkFrom]
+      simp only []
+      split
+      · split <;> exact Nat.le_add_right 1 _
+      · exact Nat.le_refl 1
+  | e + 1, m, hme, O, p, .node order child => by
+      have hm : m < σ.k + 1 := by omega
+      have htail : m + 1 + e = σ.k := by omega
+      have hfirst : 1 ≤ (kimchiForkFrom σ b v P expand A proofOf prefixes dec (m + 1) htail O p
+          (child (O (prefixes p ⟨m, hm⟩)))).runs :=
+        one_le_kimchiForkFrom_runs σ b v P expand A proofOf prefixes dec (m + 1) htail O p _
+      rw [kimchiForkFrom]
+      simp only []
+      split
+      · exact hfirst
+      · split
+        · exact hfirst.trans (Nat.le_add_right _ _)
+        · split <;> exact hfirst.trans ((Nat.le_add_right _ _).trans (Nat.le_add_right _ _))
+
 end Extractor
 
 /-- **The extractor.** Given the oracle table and the fork tape, run the adversary, rewind it at
@@ -513,6 +657,50 @@ def kimchiExtractRuns [DecidableEq F] [DecidableEq G] [DecidableEq T]
     (O : T → Pre) (coins : Zcash.Snark.RecursiveForkCoins Pre (σ.k + 1)) : ℕ :=
   (kimchiForkFrom σ b v P expand A proofOf prefixes dec 0 (Nat.zero_add σ.k) O
     (A.run O) coins).runs
+
+/-- **The extractor's call count in closed form**, on any coin tape of node degree at most `n`:
+`(2n+1)^(k+1)`. `kimchiForkFrom_runs_le` at the root, `e := σ.k`, `m := 0`.
+
+What this is worth, stated honestly. It is the **worst case**, and it is exponential — both in
+the number of rounds `k` and in the challenge domain, since at the deployed instantiation
+`n = Fintype.card Prechallenge = 2 ^ 128`. It is therefore *not* a polynomial-AFK claim, the
+same caveat ironwood attaches to its own `reductionEfficient_exponential`. The conditional
+average `(6/δ)^k` under a good-challenge density floor is a different theorem, and it is not
+proved anywhere in this tree.
+
+What it does buy: this is the first bound here that is **computed from the counter** rather than
+obtained from a `sup` that never inspects it. Feeding it to `ReductionEfficient`
+(`Forking/KnowledgeSoundness.lean`) turns the endpoints' call-bound hypothesis from an
+existential over unexamined numbers into an explicit one. Paired with
+`one_le_kimchiExtractRuns`, which pins the counter away from `0`, the pair brackets the cost
+rather than merely capping it. -/
+theorem kimchiExtractRuns_le [DecidableEq F] [DecidableEq G] [DecidableEq T]
+    [Zero Pre] [DecidableEq Pre]
+    (σ : SRS G) (b : Fin (2 ^ σ.k) → F) (v : F) (P : G) (expand : Pre → F)
+    (A : Zcash.Snark.OracleComp T Pre Pf)
+    (proofOf : Pf → OpeningProof F G σ.k) (prefixes : Pf → Fin (σ.k + 1) → T)
+    (dec : DecodesFromPrefixes σ proofOf prefixes)
+    (O : T → Pre) (coins : Zcash.Snark.RecursiveForkCoins Pre (σ.k + 1)) {n : ℕ}
+    (hB : coins.Bounded n) :
+    kimchiExtractRuns σ b v P expand A proofOf prefixes dec O coins
+      ≤ (2 * n + 1) ^ (σ.k + 1) :=
+  kimchiForkFrom_runs_le σ b v P expand A proofOf prefixes dec n 0 (Nat.zero_add σ.k) O
+    (A.run O) coins hB
+
+/-- **The extractor always runs the adversary at least once**, on every table and every tape —
+`one_le_kimchiForkFrom_runs` at the root. The companion that keeps `kimchiExtractRuns_le` from
+being vacuous: a counter that could be `0` would satisfy every upper bound, and an upper bound
+alone cannot tell a real reduction from one that does nothing. -/
+theorem one_le_kimchiExtractRuns [DecidableEq F] [DecidableEq G] [DecidableEq T]
+    [Zero Pre] [DecidableEq Pre]
+    (σ : SRS G) (b : Fin (2 ^ σ.k) → F) (v : F) (P : G) (expand : Pre → F)
+    (A : Zcash.Snark.OracleComp T Pre Pf)
+    (proofOf : Pf → OpeningProof F G σ.k) (prefixes : Pf → Fin (σ.k + 1) → T)
+    (dec : DecodesFromPrefixes σ proofOf prefixes)
+    (O : T → Pre) (coins : Zcash.Snark.RecursiveForkCoins Pre (σ.k + 1)) :
+    1 ≤ kimchiExtractRuns σ b v P expand A proofOf prefixes dec O coins :=
+  one_le_kimchiForkFrom_runs σ b v P expand A proofOf prefixes dec 0 (Nat.zero_add σ.k) O
+    (A.run O) coins
 
 /-! ## The escape layer over `Pre`
 
@@ -1153,7 +1341,7 @@ what lets the tower below quantify over the varying base without a dependent tra
 private def srsAt (σ : SRS G) (uOf : Pf → (T → Pre) → G) (p : Pf) (O : T → Pre) : SRS G :=
   { σ with U := uOf p O }
 
-omit [Field F] in
+omit [Field F] [AddCommGroup G] in
 /-- The round count of the run's setup is the sampled setup's — by `rfl`, and stated so that the
 `omega` goals of the fork's arithmetic can be discharged after a `show`. -/
 @[simp] theorem srsAt_k (σ : SRS G) (uOf : Pf → (T → Pre) → G) (p : Pf) (O : T → Pre) :
@@ -1895,6 +2083,7 @@ private theorem adaptive_badSet_ofPrefix_union_measure_le {ι κ : Type*} [Finty
     · simp only [if_neg ht, Finset.card_empty]
       exact Nat.zero_le (c i)
 
+omit [Field F] in
 /-- **The endpoint's fourth summand, in the shape it is consumed.** Finitely many challenges, each
 squeezed at its own transcript node, each guarded by a set of *field* elements determined by that
 node together with strictly earlier ones, and each read into the field by its own injective map —
@@ -1923,6 +2112,7 @@ private theorem adaptive_badSet_ofPrefix_union_expand_measure_le
   · exact le_trans (Finset.card_le_card_of_injOn (expand i)
       (fun q hq => Finset.mem_preimage.mp hq) (hexp_inj i).injOn) (hcard i t w)
 
+omit [Field F] in
 /-- **The union charge from a run-level agreement law.**
 `adaptive_badSet_ofPrefix_union_expand_measure_le` with
 the exclusion sets given *at the run* — as functions `badRun i : (T → Pre) → Finset F` of the

--- a/formal/bulletproof-pcs/Bulletproof/Forking/KnowledgeSoundness.lean
+++ b/formal/bulletproof-pcs/Bulletproof/Forking/KnowledgeSoundness.lean
@@ -598,13 +598,23 @@ non-escape imply extraction — and it does not by itself bound the cost: `Reduc
 averages the run count over oracle tables, and a table on which the adversary loses costs
 exactly ONE run (`recursiveAlgebraicForkFrom` descends without rewinding and returns at the
 leaf), so the quantity gated here is the classical expected-forking cost, not the worst case.
-What is *proved* is only the worst case, ironwood's `(2·|F| + 1) ^ k`
-(`reductionEfficient_exponential`); a table-averaged bound is not proved here. Upstream's
-`ExpectedRuns.lean` proves `E[runs] ≤ (6/δ)^k` under a uniform good-challenge density floor,
-on the tape-averaged axis; porting it to this axis is open, as is any unconditional
-polynomial bound. The gate is therefore honest bookkeeping, not a security claim: it records
-*which* reductions the hardness assumption is taken against, with the extractor's cost an
-open item rather than a known-large one. -/
+
+What is *proved* is the worst case, and now for our own recursion rather than only upstream's:
+`DeployedFamily.reductionEfficient_of_bounded` below discharges `ReductionEfficient` at
+`R = (2n+1)^(k+1)` on any coin tape of node degree at most `n`, and
+`DeployedFamily.exists_complete_reductionEfficient` exhibits a single tape that is `Complete`
+*and* achieves it, at `n = 2 ^ 128`. That chain rests on `Bulletproof.Forking.kimchiExtractRuns_le`,
+which is pointwise in the table, so it crosses the averaging axis for free.
+
+The honest caveats, unchanged. The number is exponential in `k` and in the challenge domain —
+the same regime as ironwood's `reductionEfficient_exponential` — so it is bookkeeping, not a
+concrete-security claim. A *table-averaged* bound is still not proved here: upstream's
+`ExpectedRuns.lean` proves `E[runs] ≤ (6/δ)^k` under a uniform good-challenge density floor on
+the tape-averaged axis, and porting it to this axis remains open, as does any unconditional
+polynomial bound. What has changed is only that `R` is now computed from the counter instead of
+obtained from a `sup` that never inspects it (contrast `reductionEfficient_exists`, kept below
+for exactly that contrast), and that it is bounded away from `0` by
+`Bulletproof.Forking.one_le_kimchiExtractRuns`. -/
 
 section Capstone
 
@@ -687,6 +697,70 @@ theorem DeployedFamily.reductionEfficient_exists [Fintype C.Point]
   refine le_trans (Finset.le_sup (f := fun basis => ∑ O : Coins C k,
     fam.attemptRuns basis O coins) (Finset.mem_univ basis)) ?_
   exact Nat.le_mul_of_pos_right _ Fintype.card_pos
+
+/-- **A call bound computed from the counter**, on any coin tape of node degree at most `n`.
+The pointwise bound `deployedExtractRuns_le` summed over the oracle tables — upstream's
+`recursiveAlgebraicFork_sum_runs_le_unconditional` (`Recursive.lean:679`) is the same two-line
+`calc`. Because the input is pointwise in the table, no averaging argument is involved and the
+sum is trivial; that is precisely why this crosses the tape-vs-table axis that the conditional
+`(6/δ)^k` bound does not.
+
+Stands beside `reductionEfficient_exists`, which it does not supersede: that theorem's job is to
+record what `ReductionEfficient` fails to say, and it still says it. -/
+theorem DeployedFamily.reductionEfficient_of_bounded
+    (coins : Zcash.Snark.RecursiveForkCoins Prechallenge (k + 1)) {n : ℕ}
+    (hB : coins.Bounded n) :
+    fam.ReductionEfficient coins ((2 * n + 1) ^ (k + 1)) := by
+  intro basis
+  calc ∑ O : Coins C k, fam.attemptRuns basis O coins
+      ≤ ∑ _O : Coins C k, (2 * n + 1) ^ (k + 1) :=
+        Finset.sum_le_sum fun O _ =>
+          deployedExtractRuns_le (srsOfBasis k basis) (Ipa.cipOf (fam.claim basis))
+            (combinedEvalVector (2 ^ k) (fam.claim basis).evalscale (fam.claim basis).pointFn)
+            (Ipa.cipOf (fam.claim basis))
+            (combinedCommitment (fam.claim basis).polyscale (fam.claim basis).commitmentFn)
+            (fam.adversary basis) O coins hB
+    _ = _ := by rw [Finset.sum_const, Finset.card_univ, smul_eq_mul, Nat.mul_comm]
+
+/-- **The two coin-side hypotheses of every endpoint are jointly dischargeable, with an explicit
+proved `R`.** One tape is at once `Complete` — what the knowledge-soundness statements assume, so
+that non-escape forces extraction — and efficient at `R = (2 · 2 ^ 128 + 1) ^ (k + 1)`, a number
+this tree computes from the extractor's own counter rather than obtains from a `sup` over bases.
+
+That sentence is the whole content: before it, the efficiency gate could only be satisfied by an
+`R` nothing had inspected. It remains a *worst-case*, exponential number, and no polynomial or
+table-averaged claim follows from it. -/
+theorem DeployedFamily.exists_complete_reductionEfficient :
+    ∃ coins : Zcash.Snark.RecursiveForkCoins Prechallenge (k + 1),
+      coins.Complete ∧ fam.ReductionEfficient coins ((2 * 2 ^ 128 + 1) ^ (k + 1)) := by
+  obtain ⟨coins, hc, hb⟩ := exists_complete_bounded_coins (k + 1)
+  exact ⟨coins, hc, fam.reductionEfficient_of_bounded coins hb⟩
+
+/-- **No `R` below `1` satisfies the efficiency gate.** The extractor runs the adversary at least
+once on every oracle table (`one_le_deployedExtractRuns`), so the sum over tables is at least
+`Fintype.card (Coins C k)`, which `R * Fintype.card (Coins C k)` does not bound at `R = 0`.
+
+It does not make `hEff` non-trivial to *satisfy* — `exists_complete_reductionEfficient` does
+that — only rules out an `R` advertising a zero-call reduction, against which discrete-log
+hardness would be assumed for free. -/
+theorem DeployedFamily.one_le_of_reductionEfficient
+    (coins : Zcash.Snark.RecursiveForkCoins Prechallenge (k + 1)) {R : ℕ}
+    (h : fam.ReductionEfficient coins R) : 1 ≤ R := by
+  -- `ReductionEfficient` quantifies over every basis, so the basis is immaterial: take zero.
+  have hlow : 1 * Fintype.card (Coins C k)
+      ≤ ∑ O : Coins C k, fam.attemptRuns (fun _ => 0) O coins := by
+    calc 1 * Fintype.card (Coins C k) = ∑ _O : Coins C k, 1 := by
+          rw [Finset.sum_const, Finset.card_univ, smul_eq_mul, Nat.mul_comm]
+      _ ≤ _ := Finset.sum_le_sum fun O _ =>
+          one_le_deployedExtractRuns (srsOfBasis k (fun _ => 0))
+            (Ipa.cipOf (fam.claim (fun _ => 0)))
+            (combinedEvalVector (2 ^ k) (fam.claim (fun _ => 0)).evalscale
+              (fam.claim (fun _ => 0)).pointFn)
+            (Ipa.cipOf (fam.claim (fun _ => 0)))
+            (combinedCommitment (fam.claim (fun _ => 0)).polyscale
+              (fam.claim (fun _ => 0)).commitmentFn)
+            (fam.adversary (fun _ => 0)) O coins
+  exact Nat.le_of_mul_le_mul_right (hlow.trans (h fun _ => 0)) Fintype.card_pos
 
 /-! ### The capstone, per curve -/
 
@@ -808,14 +882,18 @@ fork tape is complete.
 2. *`δ` is not a reduction.* `derivedUDL_iff_residual_measure` proves it is the residual event's
    own measure. Only `ε` reduces to a standard problem. This is the price of kimchi's
    transcript-derived `U`, which halo2 does not pay — ironwood has no analogue.
-3. *The extractor's cost is UNPROVED, not known-large* (external-audit E-1).
-   `reductionEfficient_exists` obtains some `R` without inspecting the counter, and the only
-   proved bound is ironwood's worst case `(2·|F| + 1)^k` — but a losing table costs one run,
-   so the table-averaged quantity `ReductionEfficient` gates is the classical
-   expected-forking cost, unbounded by any theorem here. Because `ε` bounds the DL advantage
-   of this specific finder, a generic-group grounding of `ε` needs a cost bound this
-   development does not yet have; `ExpectedRuns.lean` upstream has the conditional bound
-   (`(6/δ)^k` under a fork-spread floor, tape-averaged) that would supply one.
+3. *The extractor's cost is bounded only in the worst case.*
+   `DeployedFamily.reductionEfficient_of_bounded` discharges `hEff` at `R = (2n + 1)^(k+1)`
+   on any tape of node degree at most `n`, and
+   `DeployedFamily.exists_complete_reductionEfficient` exhibits one tape that is `Complete`
+   and efficient at once, at `n = 2 ^ 128` — exponential in `k` and in the challenge domain.
+   No sub-worst-case bound is proved here: `ReductionEfficient` averages over the oracle
+   tables and a losing table costs one run, so what it gates is the classical
+   expected-forking cost, and upstream's tape-averaged `(6/δ)^k` does not cross that axis
+   (see the `ReductionEfficient` section docstring; external-audit O-1b, open). `ε` is still
+   assumed for this finder rather than derived from a time bound: at
+   `R = (2·2¹²⁸ + 1)^(k+1)` a reduction is permitted enough oracle calls to solve discrete log
+   outright, so `hHard` there is satisfiable only at `ε ≈ 1`.
 4. *One claim.* The statement is single-claim; recovering individual polynomials from a batch is
    the separate un-batching layer (`chunked_batch_soundness`).
 

--- a/formal/bulletproof-pcs/roots.txt
+++ b/formal/bulletproof-pcs/roots.txt
@@ -32,13 +32,27 @@ Bulletproof.Ipa.Forking.pallas_failure_measure_le
 -- What the headline does and does not claim. Roots so they cannot be swept:
 -- honestFamily_failure_set exhibits a family that accepts everywhere, so the bound is a
 -- statement about the extractor and not about acceptance being empty;
--- reductionEfficient_exists obtains a call bound WITHOUT inspecting the counter, so the
--- efficiency gate is not an efficiency claim; derivedUDL_iff_residual_measure shows the
--- δ summand is the residual event's own measure rather than a reduction to a standard
--- problem (only ε is that).
+-- reductionEfficient_exists obtains a call bound WITHOUT inspecting the counter, and is kept
+-- for exactly that contrast now that exists_complete_reductionEfficient supplies one that IS
+-- computed from the counter; derivedUDL_iff_residual_measure shows the δ summand is the
+-- residual event's own measure rather than a reduction to a standard problem (only ε is that).
 Bulletproof.Ipa.Forking.honestFamily_failure_set
 Bulletproof.Ipa.Forking.DeployedFamily.reductionEfficient_exists
 Bulletproof.Ipa.Forking.derivedUDL_iff_residual_measure
+
+-- The extractor's cost (audit O-1a). One tape is Complete AND achieves the explicit call
+-- bound R = (2·2^128 + 1)^(k+1), so the endpoints' two coin-side hypotheses are jointly
+-- dischargeable with a proved R rather than one a `sup` produced. WORST CASE and exponential
+-- in k and in the challenge domain -- not a concrete-security claim, and the table-averaged
+-- (6/δ)^k regime (O-1b) is still open. The walk reaches reductionEfficient_of_bounded,
+-- deployedExtractRuns_le, kimchiExtractRuns_le and exists_complete_bounded_coins from here.
+Bulletproof.Ipa.Forking.DeployedFamily.exists_complete_reductionEfficient
+-- The anti-vacuity companion, at the level the endpoints read the cost at. An upper bound on a
+-- counter is worthless if the counter could be 0, and what `hEff` supplies is the summed bound,
+-- not the counter: this rules out every R below 1. The walk reaches
+-- one_le_deployedExtractRuns and one_le_kimchiExtractRuns -- which pin the counter itself at
+-- >= 1 on every table and every tape -- so neither needs an entry of its own here.
+Bulletproof.Ipa.Forking.DeployedFamily.one_le_of_reductionEfficient
 
 -- The checked defences of the deployed model's two modelling steps, rooted for the same
 -- reason: nothing consumes an exhibit.

--- a/formal/bulletproof-pcs/scripts/check_axioms.lean
+++ b/formal/bulletproof-pcs/scripts/check_axioms.lean
@@ -51,7 +51,13 @@ def roots : List Name :=
     `Bulletproof.Ipa.Forking.winsAtBase_uBaseOf,
     `Bulletproof.Ipa.Forking.honestNode_wins_everywhere,
     `Bulletproof.Ipa.Forking.verifyWith_of_deferred_delta,
-    `Bulletproof.Ipa.Forking.exists_complete_coins ]
+    `Bulletproof.Ipa.Forking.exists_complete_coins,
+    -- the extractor's cost (audit O-1a): an explicit, proved call bound on the same tape that
+    -- witnesses `Complete`, plus the anti-vacuity companions pinning the counter away from 0
+    -- and ruling out every `R` below 1 in the gate the endpoints actually read
+    `Bulletproof.Ipa.Forking.DeployedFamily.exists_complete_reductionEfficient,
+    `Bulletproof.Forking.one_le_kimchiExtractRuns,
+    `Bulletproof.Ipa.Forking.DeployedFamily.one_le_of_reductionEfficient ]
 
 /-- The standard logical axioms, and nothing else — `native_decide` certificates are
     admitted separately, by defining module, in `isTrustedNativeDecide` below.

--- a/formal/bulletproof-pcs/scripts/check_locked_target.sh
+++ b/formal/bulletproof-pcs/scripts/check_locked_target.sh
@@ -123,13 +123,16 @@ fi
 # Deleting one now fails a LOCK — a statement-level decision needing sign-off — rather than
 # passing silently.
 exhibits_dep='sg_determined_of_verifyWith wireWins_pinTable pinTable_factors chainAt_sg
-              nodeTranscript_nodes uBaseOf_eq_transcript identityTape exists_complete_coins'
+              nodeTranscript_nodes uBaseOf_eq_transcript identityTape exists_complete_coins
+              exists_complete_bounded_coins'
 exhibits_ks='wireWins_U_irrelevant deployedExtract_U_irrelevant uRepresentationOfBreak
-             reductionEfficient_exists derivedUDL_iff_residual_measure honestFamily_failure_set'
+             reductionEfficient_exists derivedUDL_iff_residual_measure honestFamily_failure_set
+             exists_complete_reductionEfficient'
+exhibits_game='one_le_kimchiExtractRuns'
 exhibits_tr='verifyOracle_spongeFS verifyOracleFrom_spongeFSFrom spongeFS_eq_from
              toGroup_spongeOBase_preT'
 exhibits_hon='winsAtBase_uBaseOf honestNode_wins_everywhere'
-for pair in "$dep:$exhibits_dep" "$ks:$exhibits_ks" \
+for pair in "$dep:$exhibits_dep" "$ks:$exhibits_ks" "$game:$exhibits_game" \
             "Bulletproof/Forking/Transcript.lean:$exhibits_tr" \
             "Bulletproof/Forking/Honest.lean:$exhibits_hon"; do
   file="${pair%%:*}"; names="${pair#*:}"
@@ -144,4 +147,4 @@ for pair in "$dep:$exhibits_dep" "$ks:$exhibits_ks" \
 done
 
 echo "✓ locked target intact: statement, extractor type, conclusion type,"
-echo "  plain-def extractor, both anti-vacuity companions, and the 20 exhibits"
+echo "  plain-def extractor, both anti-vacuity companions, and the 23 exhibits"

--- a/formal/kimchi/Kimchi/Verifier/KnowledgeSoundness.lean
+++ b/formal/kimchi/Kimchi/Verifier/KnowledgeSoundness.lean
@@ -1759,6 +1759,79 @@ def ReductionEfficient (coins : Zcash.Snark.RecursiveForkCoins Prechallenge (k +
   ∀ basis : Zcash.Snark.AugmentedIndex (2 ^ k) → C.Point,
     ∑ O : Coins C nc k, fam.attemptRuns basis O coins ≤ R * Fintype.card (Coins C nc k)
 
+/-- **A call bound computed from the counter** — the analogue of
+`DeployedFamily.reductionEfficient_of_bounded`, consuming
+`Bulletproof.Forking.kimchiExtractRuns_le` directly (this family's `attemptRuns` calls the
+generic extractor at `fam.runSrs basis O`, not the standalone `deployedExtractRuns`).
+
+Pointwise in the oracle table, so the sum over tables is `Finset.sum_le_sum` followed by
+`Finset.sum_const` and nothing else. -/
+theorem reductionEfficient_of_bounded
+    (coins : Zcash.Snark.RecursiveForkCoins Prechallenge (k + 1)) {n : ℕ}
+    (hB : coins.Bounded n) :
+    fam.ReductionEfficient coins ((2 * n + 1) ^ (k + 1)) := by
+  intro basis
+  calc ∑ O : Coins C nc k, fam.attemptRuns basis O coins
+      ≤ ∑ _O : Coins C nc k, (2 * n + 1) ^ (k + 1) :=
+        Finset.sum_le_sum fun O _ =>
+          Bulletproof.Forking.kimchiExtractRuns_le (fam.runSrs basis O)
+            (combinedEvalVector (2 ^ k) (fam.claim basis O).evalscale (fam.claim basis O).pointFn)
+            (Ipa.cipOf (fam.claim basis O))
+            (combinedCommitment (fam.claim basis O).polyscale (fam.claim basis O).commitmentFn)
+            (expandPre C) (fam.adversary basis)
+            (fun cp => Bulletproof.Ipa.Forking.toOpening cp.opening)
+            (ipaPrefixes (fam.runSrs basis O) (fam.digest basis) (fam.publicComm basis))
+            (kimchiDecodesFromPrefixes (fam.runSrs basis O) (fam.digest basis)
+              (fam.publicComm basis))
+            O coins hB
+    _ = _ := by rw [Finset.sum_const, Finset.card_univ, smul_eq_mul, Nat.mul_comm]
+
+/-- **The endpoints' two coin-side hypotheses are jointly dischargeable here too**, with the
+same explicit `R = (2 · 2 ^ 128 + 1) ^ (k + 1)`: the identity tape
+(`Bulletproof.Ipa.Forking.exists_complete_bounded_coins`) is `Complete` — what the kimchi
+knowledge-soundness statements assume — and bounded by `Fintype.card Prechallenge` at every
+node, which is what the cost bound consumes.
+
+Worst case and exponential, as everywhere this number is quoted; it is not a concrete-security
+claim, and no table-averaged or polynomial bound follows from it. -/
+theorem exists_complete_reductionEfficient :
+    ∃ coins : Zcash.Snark.RecursiveForkCoins Prechallenge (k + 1),
+      coins.Complete ∧ fam.ReductionEfficient coins ((2 * 2 ^ 128 + 1) ^ (k + 1)) := by
+  obtain ⟨coins, hc, hb⟩ := Bulletproof.Ipa.Forking.exists_complete_bounded_coins (k + 1)
+  exact ⟨coins, hc, fam.reductionEfficient_of_bounded coins hb⟩
+
+/-- **No `R` below `1` satisfies the efficiency gate.** The extractor runs the adversary at least
+once on every oracle table (`Bulletproof.Forking.one_le_kimchiExtractRuns`), so the sum over
+tables is at least `Fintype.card (Coins C nc k)`, which `R * Fintype.card (Coins C nc k)` does
+not bound at `R = 0`.
+
+It does not make `hEff` non-trivial to *satisfy* — `exists_complete_reductionEfficient` does
+that — only rules out an `R` advertising a zero-call reduction, against which discrete-log
+hardness would be assumed for free. -/
+theorem one_le_of_reductionEfficient
+    (coins : Zcash.Snark.RecursiveForkCoins Prechallenge (k + 1)) {R : ℕ}
+    (h : fam.ReductionEfficient coins R) : 1 ≤ R := by
+  -- `ReductionEfficient` quantifies over every basis, so the basis is immaterial: take zero.
+  have hlow : 1 * Fintype.card (Coins C nc k)
+      ≤ ∑ O : Coins C nc k, fam.attemptRuns (fun _ => 0) O coins := by
+    calc 1 * Fintype.card (Coins C nc k) = ∑ _O : Coins C nc k, 1 := by
+          rw [Finset.sum_const, Finset.card_univ, smul_eq_mul, Nat.mul_comm]
+      _ ≤ _ := Finset.sum_le_sum fun O _ =>
+          Bulletproof.Forking.one_le_kimchiExtractRuns (fam.runSrs (fun _ => 0) O)
+            (combinedEvalVector (2 ^ k) (fam.claim (fun _ => 0) O).evalscale
+              (fam.claim (fun _ => 0) O).pointFn)
+            (Ipa.cipOf (fam.claim (fun _ => 0) O))
+            (combinedCommitment (fam.claim (fun _ => 0) O).polyscale
+              (fam.claim (fun _ => 0) O).commitmentFn)
+            (expandPre C) (fam.adversary (fun _ => 0))
+            (fun cp => Bulletproof.Ipa.Forking.toOpening cp.opening)
+            (ipaPrefixes (fam.runSrs (fun _ => 0) O) (fam.digest (fun _ => 0))
+              (fam.publicComm (fun _ => 0)))
+            (kimchiDecodesFromPrefixes (fam.runSrs (fun _ => 0) O) (fam.digest (fun _ => 0))
+              (fam.publicComm (fun _ => 0)))
+            O coins
+  exact Nat.le_of_mul_le_mul_right (hlow.trans (h fun _ => 0)) Fintype.card_pos
+
 /-- **Discrete log is hard for this family against `R`-call reductions** — the analogue of
 `DeployedFamily.DiscreteLogRelationHardFor`, and what pins `ε` and `δ`. `ε` is a genuine
 reduction to textbook discrete log; `δ` is the residual event's own measure, which is why the
@@ -4377,11 +4450,19 @@ the run's own Fiat–Shamir challenges land in an exclusion set (`szBudget`).
 
 **What the bound rests on.** Two cryptographic assumptions, both hypotheses: `hHard`, which
 prices the two discrete-log arms, and the fork tape's completeness. `hEff` fixes which
-reductions `hHard` is taken against; the extractor's cost is not bounded by any theorem in
-this development (external-audit E-1), so `ε` is assumed for the finder rather than derived
-from a time bound. Everything else is proved:
-the presence arm by the claim-adaptive extraction game, and the algebraic arm by the
-Fiat–Shamir-axiom-free run-soundness root together with the adaptive Schwartz–Zippel charge.
+reductions `hHard` is taken against, and it is dischargeable in this file:
+`KimchiFamily.reductionEfficient_of_bounded` proves it at `R = (2n + 1)^(k+1)` on any tape of
+node degree at most `n`, and `KimchiFamily.exists_complete_reductionEfficient` exhibits a single
+tape that is `Complete` and efficient at once, at `n = 2 ^ 128`. That `R` is the **worst case**,
+exponential in `k` and in the challenge domain, and no table-averaged bound follows from it
+(external-audit O-1b, open). So `ε` is still assumed for the finder rather than derived from a
+time bound: a reduction permitted that many oracle calls solves Pasta discrete log outright, so
+`hHard` at that `R` is satisfiable only at `ε ≈ 1`. Discharging `hEff` therefore buys
+bookkeeping — which reductions the assumption is quantified over — and not a stronger bound.
+
+Everything else is proved: the presence arm by the claim-adaptive extraction game, and the
+algebraic arm by the Fiat–Shamir-axiom-free run-soundness root together with the adaptive
+Schwartz–Zippel charge.
 The narrowing of the family class is `KimchiFamily`'s own `hrepPrefix`/`hTPrefix` — algebraic
 faithfulness, i.e. that a commitment's declared representation is fixed when the commitment is
 absorbed — which is what the algebraic group model means and what

--- a/formal/kimchi/roots.txt
+++ b/formal/kimchi/roots.txt
@@ -115,6 +115,18 @@ Kimchi.Permutation.sigmaSide_eval_row
 Kimchi.Verifier.KnowledgeSoundness.vesta_kimchi_knowledge_sound
 Kimchi.Verifier.KnowledgeSoundness.pallas_kimchi_knowledge_sound
 
+-- The extractor's cost for THIS family (audit O-1a). The call-bound hypothesis of the
+-- endpoints, discharged at an explicit R = (2·2^128 + 1)^(k+1) on the same tape that
+-- witnesses `Complete`. WORST CASE, exponential in k and in the challenge domain: it records
+-- which reductions the hardness assumption is taken against, and is not a security claim.
+-- The walk reaches KimchiFamily.reductionEfficient_of_bounded from here.
+Kimchi.Verifier.KnowledgeSoundness.KimchiFamily.exists_complete_reductionEfficient
+-- The floor under the same hypothesis: no R below 1 satisfies the efficiency gate, so `hEff`
+-- cannot be met by a number advertising a zero-call reduction. It lifts the counter's own
+-- >= 1 bound to the level the endpoints read it at, and does NOT make `hEff` easier to satisfy
+-- (that is the entry above).
+Kimchi.Verifier.KnowledgeSoundness.KimchiFamily.one_le_of_reductionEfficient
+
 -- Faithfulness: the deployed verifier IS the challenge-generic one at the sponge's own
 -- squeezes, stated at named sources rather than as an existential (an existential over the
 -- challenges is satisfied even by a verifier with Fiat-Shamir deleted).

--- a/formal/kimchi/scripts/check_axioms.lean
+++ b/formal/kimchi/scripts/check_axioms.lean
@@ -54,6 +54,11 @@ def roots : List Name :=
     -- over the standard axioms and the Pasta certificates alone.
     `Kimchi.Verifier.KnowledgeSoundness.vesta_kimchi_knowledge_sound,
     `Kimchi.Verifier.KnowledgeSoundness.pallas_kimchi_knowledge_sound,
+    -- The extractor's cost for this family (audit O-1a): the endpoints' call-bound hypothesis
+    -- discharged at an explicit, proved R on the same tape that witnesses `Complete`, and the
+    -- floor under that same hypothesis — no R below 1 satisfies it.
+    `Kimchi.Verifier.KnowledgeSoundness.KimchiFamily.exists_complete_reductionEfficient,
+    `Kimchi.Verifier.KnowledgeSoundness.KimchiFamily.one_le_of_reductionEfficient,
     `Kimchi.Verifier.Forking.honestKimchiFamily_wins,
     -- The Tier-2/3 surface (external-audit A-2): the faithfulness layer, the named
     -- anti-vacuity exhibits, and the REVISIT AGM lemmas are consumed by nothing, so no

--- a/formal/kimchi/scripts/check_locked_target.sh
+++ b/formal/kimchi/scripts/check_locked_target.sh
@@ -101,7 +101,8 @@ fi
 # THE EXHIBIT SET (see the bulletproof-pcs gate's note): certificates consumed by nothing
 # are indistinguishable from dead code once they leave roots.txt, so their existence is
 # pinned here instead of relying on review.
-for n in exists_ne_zero_kernel_scalarBasis kimchiVerify_eq_verifyWith; do
+for n in exists_ne_zero_kernel_scalarBasis kimchiVerify_eq_verifyWith \
+         exists_complete_reductionEfficient; do
   if ! grep -qE "^(theorem|def) $n\b" "$ks"; then
     echo "✗ EXHIBIT MISSING: $n (expected in $ks)"; exit 1
   fi
@@ -115,4 +116,4 @@ for n in vesta_honest_extraction_failure_measure_le \
 done
 
 echo "✓ kimchi locked target intact: both endpoint statements, Wins, ExtractsWitness,"
-echo "  relationFinder, the faithfulness bundle, and the six exhibits"
+echo "  relationFinder, the faithfulness bundle, and the seven exhibits"


### PR DESCRIPTION
## What

The first *proved* extractor-cost bound in this tree — external audit item **E-1**, follow-up register **O-1a** (the worst-case half of O-1). Purely additive; no statement changes, no pinned exhibit touched.

Until now, no theorem bounded the forking extractor's cost. The call budget `R` in `ReductionEfficient` came only from `reductionEfficient_exists`, which obtains *some* `R` by a `sup` without inspecting the counter — and the docstring cited upstream's `reductionEfficient_exponential` as if it covered us, but that theorem is about upstream's `recursiveAlgebraicForkFrom`; our deployed extractor is a **different recursion** (`kimchiForkFrom`: oracle codomain `Pre` ≠ challenge field, and a scanning Schnorr leaf where ironwood's is a bare `.leaf`). A Lean cost bound is a theorem about a specific term, so it had to be re-proved here.

## The route

1. **`Game.lean` — `kimchiForkFrom_runs_le`**: an `n`-bounded coin tape makes at most `(2n+1)^(e+1)` adversary runs. Structural port of ironwood's induction; the two generic scan lemmas (`nextForkChallenge_runs_le`, `nextForkChallenge_output_rest_length_le`) apply at `Pre` verbatim. The exponent is `e+1`, not `e`: our leaf runs the Schnorr scan, and `(2n+1)^e` is false at `e = 0`. Public wrapper `kimchiExtractRuns_le`; anti-vacuity companion `one_le_kimchiExtractRuns` pins the counter ≥ 1 on every table and tape.
2. **`Deployed.lean` — `exists_complete_bounded_coins`**: the identity tape is `Complete` **and** `Bounded (2^128)` *simultaneously*. The two are independent (a complete tape with redundant orders is unbounded); every endpoint hypothesizes the first while the cost bound consumes the second, so the joint witness is the load-bearing step.
3. **Both families — `reductionEfficient_of_bounded` / `exists_complete_reductionEfficient`**: the endpoints' two coin-side hypotheses are jointly dischargeable at the explicit `R = (2·2¹²⁸ + 1)^(k+1)` — no `sup`, no existential over unexamined counters. Plus `one_le_of_reductionEfficient` anti-vacuity companions, and the `ReductionEfficient`/endpoint docstrings rewritten (their "what is *proved* is only … upstream's" clauses stopped being true the moment this landed).

## What this does NOT claim

`R` is exponential in `k` and in the challenge domain, so this is bookkeeping, not concrete security: it records which reductions the hardness assumption is indexed against — parity with upstream's own state of the art for its recursion. The conditional average `(6/δ)^k` (register **O-1b**) remains open; it genuinely needs the tape-vs-table averaging bridge this bound deliberately sidesteps (a pointwise bound sums over either axis). `reductionEfficient_exists` stays unchanged beside the new theorems: its job is to say what `ReductionEfficient` does *not* do.

## Gates

New terminal declarations are rooted in both `roots.txt` and both `check_axioms.lean` — **the axiom-gate root counts grow accordingly (expected, not a regression)**; `check_locked_target.sh` existence-pins the coin-side exhibits. At the tree this PR reconstructs: sorry 0, no new axioms (closures are the three standard axioms), both locked-target gates pass **without** `--regen`, dead code 0, style clean, all fixture drivers green.

## Not in this PR

The register prose (`docs/external-audit-followup.md` §O-1a/O-1b split) ships with the docs sweep PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)