### PR TITLE
conditional-average extractor cost

### DIFF
--- a/formal/bulletproof-pcs/Bulletproof/Forking/Game.lean
+++ b/formal/bulletproof-pcs/Bulletproof/Forking/Game.lean
@@ -1,6 +1,6 @@
 import Bulletproof.Forking.Capstone
 import Bulletproof.Forking.Prover
-import Zcash.Snark.Soundness.Forking.Adversary.Recursive
+import Zcash.Snark.Soundness.Forking.Adversary.ExpectedRuns
 
 /-!
 # The Fiat–Shamir extraction game
@@ -610,6 +610,1033 @@ private theorem one_le_kimchiForkFrom_runs [DecidableEq F] [DecidableEq G] [Deci
         · exact hfirst.trans (Nat.le_add_right _ _)
         · split <;> exact hfirst.trans ((Nat.le_add_right _ _).trans (Nat.le_add_right _ _))
 
+/-! ### The conditional average under fork spread
+
+Everything above this point is **unconditional**: `kimchiForkFrom_runs_le` bounds the counter on
+every table and every tape at once, at the worst-case `(2n+1)^(e+1)`. This block is the
+**conditional** development — ironwood's `ExpectedRuns.lean`, ported to our recursion — which
+averages over the uniform tape at the far smaller `(6·|Pre|/(σ₀−1))^(e+1)`. It runs from the two
+pointwise bounds through `kimchiForkFrom_sum_runs_le_of_forkSpread`, the depth induction, to
+`kimchiExtractRuns_sum_le_of_forkSpread` at the root (stated below with the extractor, beside the
+unconditional `kimchiExtractRuns_le` it sits next to and does not replace).
+
+**A spread hypothesis is a hypothesis, and nothing in this tree proves one at deployed
+parameters.** `KimchiForkSpread σ₀` says every fork position the recursion can reach has at least
+`σ₀` nonzero challenges whose reprogrammed run still extracts. Deriving such a `σ₀` from an
+adversary's success probability `ε` is recorded **open research**
+(`docs/external-audit-followup.md` §O-1b): the naive split of the table space into spread and
+unspread halves fails, because the unspread half still costs the `(2·2¹²⁸+1)^(k+1)` worst case,
+which no probability weight absorbs. So every bound in this block is conditional on something a
+caller must supply, and none of them weakens or replaces the unconditional bound above — the two
+sit side by side.
+
+**Unproved is not unsatisfiable, and this block compiles the difference.**
+`exists_kimchiForkSpread_two_le_of_rounds` exhibits a parameter telescope carrying
+`KimchiForkSpread … 4` at *every* round count, node clause included, and
+`spreadExhibit_extractRuns_sum_le` reads the conditional bound there as
+`3 ^ (k + 1) * ∑ … ≤ 30 ^ (k + 1) * …` rather than as `0 ≤ …`. What stays open is a spread at
+*deployed* parameters, the ε → σ₀ question named above.
+
+**What is ported and what is instantiated.** Only upstream's §`NodeBound`
+(`ExpectedRuns.lean:426–568`) and §`SpreadTheorem` (`:583–910`) mention `recursiveAlgebraicForkFrom`
+and so must be restated here. Its rank-counting, marginalization, scan-bound and tape layers ask
+nothing of the challenge alphabet beyond `[Zero]`, `[DecidableEq]` and `[Fintype]`, so they are
+used at `Pre` verbatim; that genericity is pinned by literal `exact` in
+`scripts/check_ironwood_generic.lean` §9.
+
+**Where our recursion differs from upstream's**, and therefore where the transcription is not
+mechanical:
+
+* **Certificate depth `e`, coin depth `e + 1`.** Tapes here are `RecursiveForkTape Pre (e + 1)` and
+  the exponent is `e + 1`, exactly as in `kimchiForkFrom_runs_le` above.
+* **The depth-0 case does real work.** Upstream's depth-0 leaf costs a bare `1`; ours is the
+  Schnorr fork, which runs a scan keeping *two* of three branches. So it needs a spread floor of
+  its own and a rank argument of its own, with no upstream lemma to copy — which is why
+  `KimchiForkSpread` has two clauses where upstream's `ForkSpread` has one.
+* **The round prefix is read off the passed proof.** Upstream reads it off `A.run O`; our
+  recursion threads `p` and reads `prefixes p j`. The candidates and good sets below therefore
+  carry `p`, but the *predicate* `KimchiForkSpread` is taken on the **diagonal** `p = A.run O` —
+  which is the only pair the recursion ever visits, and which makes the predicate coincide with
+  upstream's `ForkSpread` rather than strengthen it. Demanding the floor off the diagonal would be
+  vacuous, not strong: `kimchiForkSpread_eq_zero_of_leaf_unstable` is that fact, compiled.
+* **The node floor is read at tape-derived coins**, which is the same doctrine at the other axis:
+  quantify only over what the recursion visits. `Zcash.Snark.RecursiveForkCoins` carries an
+  arbitrary sampling order, `[]` included, and an empty order makes the fork fail outright — so a
+  floor quantified over *all* coin trees forces `σ₀ = 0` at every `σ.k ≥ 1`. That is
+  `kimchiNodeFloor_eq_zero_of_forall_coins`, compiled. A tape's order enumerates the whole
+  alphabet, and the depth induction instantiates the floor only at tape-derived coins, so the
+  narrowing costs it nothing.
+-/
+
+/-- **The node's scan candidate**, named. This is *verbatim* the inline `attempt` lambda of
+`kimchiForkFrom`'s `e + 1` arm: rerun the adversary with round `m` reprogrammed to `q`, reject the
+run if its round-`m` prefix moved, and otherwise recurse. Upstream analogue: `scanCandidate`
+(`ExpectedRuns.lean:426`).
+
+Being *definitionally* that lambda is the point. Every bound below applies an upstream scan lemma
+to the recursion's own inlined term and lets defeq do the matching, as `kimchiForkFrom_runs_le`'s
+proof-local `candidate` already does — and as upstream's `scanCandidate` does, which
+`recursiveAlgebraicForkFrom` never calls by name either. -/
+def kimchiScanCandidate [DecidableEq F] [DecidableEq G] [DecidableEq T]
+    [Zero Pre] [DecidableEq Pre]
+    (σ : SRS G) (b : Fin (2 ^ σ.k) → F) (v : F) (P : G) (expand : Pre → F)
+    (A : Zcash.Snark.OracleComp T Pre Pf)
+    (proofOf : Pf → OpeningProof F G σ.k) (prefixes : Pf → Fin (σ.k + 1) → T)
+    (dec : DecodesFromPrefixes σ proofOf prefixes)
+    {e : ℕ} (m : ℕ) (hme : m + (e + 1) = σ.k) (O : T → Pre) (p : Pf)
+    (child : Pre → Zcash.Snark.RecursiveForkCoins Pre (e + 1)) (q : Pre) :
+    Zcash.Snark.RecursiveForkAttempt (KimchiForkCert F G e) :=
+  let j : Fin (σ.k + 1) := ⟨m, by omega⟩
+  let t : T := prefixes p j
+  let O' := Function.update O t q
+  let p' := A.run O'
+  if prefixes p' j = t then
+    kimchiForkFrom σ b v P expand A proofOf prefixes dec (m + 1) (by omega) O' p' (child q)
+  else { output := none, runs := 1 }
+
+/-- **The leaf's scan candidate**, named — the inline `attempt` lambda of `kimchiForkFrom`'s `0`
+arm, `letI := decideWins …` included. There is no upstream analogue: upstream's depth-0 leaf costs
+a bare `1` and scans nothing, whereas ours is the Schnorr fork and keeps two branches.
+
+It takes **no coins argument**. The leaf arm of `kimchiForkFrom` matches `.node order _` and
+ignores the child entirely, which is what makes the depth-0 tape sum factor through the order
+alone. It also takes no `DecodesFromPrefixes`: the leaf attempt reads only `proofOf p'`, and `dec`
+enters `kimchiForkFrom`'s leaf only when the certificate is *built*, outside the scan. -/
+def kimchiLeafCandidate [DecidableEq G] [DecidableEq T]
+    (σ : SRS G) (b : Fin (2 ^ σ.k) → F) (v : F) (P : G) (expand : Pre → F)
+    (A : Zcash.Snark.OracleComp T Pre Pf)
+    (proofOf : Pf → OpeningProof F G σ.k) (prefixes : Pf → Fin (σ.k + 1) → T)
+    (O : T → Pre) (p : Pf) (q : Pre) :
+    Zcash.Snark.RecursiveForkAttempt (F × F) :=
+  let j : Fin (σ.k + 1) := Fin.last σ.k
+  let t : T := prefixes p j
+  let O' := Function.update O t q
+  let p' := A.run O'
+  letI := decideWins σ b v P expand proofOf prefixes O' p'
+  if prefixes p' j = t ∧ Wins σ b v P expand proofOf prefixes O' p' then
+    { output := some ((proofOf p').z1, (proofOf p').z2), runs := 1 }
+  else { output := none, runs := 1 }
+
+/-- **A node's good set**: the nonzero challenges whose reprogrammed candidate returns a
+certificate. Upstream analogue: `goodChallenges` (`ExpectedRuns.lean:440`). Upstream states it as
+an `open Classical in noncomputable def`; here the predicate is genuinely decidable
+(`q ≠ 0` from `[DecidableEq Pre]`, `Option.isSome` a `Bool`), so it stays computable. Nothing on
+the extractor's own path depends on either choice; `scripts/check_extractor_computes.sh` is the
+gate for that. -/
+def kimchiGoodChallenges [DecidableEq F] [DecidableEq G] [DecidableEq T]
+    [Zero Pre] [DecidableEq Pre] [Fintype Pre]
+    (σ : SRS G) (b : Fin (2 ^ σ.k) → F) (v : F) (P : G) (expand : Pre → F)
+    (A : Zcash.Snark.OracleComp T Pre Pf)
+    (proofOf : Pf → OpeningProof F G σ.k) (prefixes : Pf → Fin (σ.k + 1) → T)
+    (dec : DecodesFromPrefixes σ proofOf prefixes)
+    {e : ℕ} (m : ℕ) (hme : m + (e + 1) = σ.k) (O : T → Pre) (p : Pf)
+    (child : Pre → Zcash.Snark.RecursiveForkCoins Pre (e + 1)) : Finset Pre :=
+  Finset.univ.filter (fun q : Pre => q ≠ 0 ∧
+    (kimchiScanCandidate σ b v P expand A proofOf prefixes dec m hme O p child q).output.isSome)
+
+/-- **The leaf's good set**, the same over `kimchiLeafCandidate`: the nonzero challenges whose
+reprogrammed run still wins at an unmoved final prefix, and so supplies the second branch the
+Schnorr fork consumes. No upstream analogue, for the reason given on `kimchiLeafCandidate`. -/
+def kimchiLeafGoodChallenges [DecidableEq G] [DecidableEq T] [Zero Pre] [DecidableEq Pre]
+    [Fintype Pre]
+    (σ : SRS G) (b : Fin (2 ^ σ.k) → F) (v : F) (P : G) (expand : Pre → F)
+    (A : Zcash.Snark.OracleComp T Pre Pf)
+    (proofOf : Pf → OpeningProof F G σ.k) (prefixes : Pf → Fin (σ.k + 1) → T)
+    (O : T → Pre) (p : Pf) : Finset Pre :=
+  Finset.univ.filter (fun q : Pre => q ≠ 0 ∧
+    (kimchiLeafCandidate σ b v P expand A proofOf prefixes O p q).output.isSome)
+
+/-- **Fork spread**, the hypothesis the conditional bound runs on: every position the recursion can
+reach has at least `σ₀` nonzero, prefix-stable, successful continuations. The bound then reads the
+density `(σ₀−1)/|Pre|` off it, after excluding the incumbent branch.
+
+Two clauses, where upstream's `ForkSpread` (`ExpectedRuns.lean:583`) has one:
+
+* the **node** floor, at every certificate depth `e + 1` and round `m`, read at the coins a
+  *tape* produces;
+* the **leaf** floor, at the Schnorr round. Upstream's depth-0 leaf costs a bare `1` and scans
+  nothing, so it needs no floor there; ours runs a scan keeping two of three branches, so the
+  depth-0 arithmetic needs a floor of its own. It takes no coins argument at all, which is why the
+  narrowing below touches only the node clause.
+
+**The floor is demanded on the diagonal `p = A.run O` only, and that makes this predicate
+*exactly* upstream's.** Upstream's recursion reads the round prefix off `A.run O` in the recursion
+itself, so its `ForkSpread` is a condition on the table alone; ours threads a proof `p` and reads
+`prefixes p j`, so the good sets above carry `p` as a parameter. Quantifying the floor over
+*arbitrary* pairs `(O, p)` would not be a harmless strengthening: at a prefix `t = prefixes p j`
+the adversary never lands on, no reprogrammed run can return to `t`, the good set is empty, and the
+predicate collapses to `σ₀ = 0` — the degeneracy
+`kimchiForkSpread_eq_zero_of_leaf_unstable` below exhibits at the leaf. Restricting to
+`p = A.run O` costs nothing, because that is the only pair the recursion ever visits:
+`kimchiForkFrom`'s `first` arm passes `(O, p)` through unchanged, its scan arm rebuilds
+`p' := A.run O'` before recursing, and `kimchiExtractRuns` enters at `(O, A.run O)`. So the two
+predicates coincide, and the bounds below are neither stronger nor weaker than upstream's on this
+axis.
+
+**The node floor is demanded at tape-derived coins only, for the same reason.** A coin node carries
+an arbitrary `order : List Pre`, and `[]` is legal; every scan it drives is then
+`nextForkChallenge attempt _ []`, which answers `none`. So a floor quantified over all coin trees
+collapses to `σ₀ = 0` at every `σ.k ≥ 1` — `kimchiNodeFloor_eq_zero_of_forall_coins`, stated at the
+un-narrowed clause so that it survives this definition. A tape's order is a full enumeration of
+`Pre`, and the depth induction reads the floor only at tape-derived coins, so nothing is lost.
+Upstream's `ForkSpread` (`ExpectedRuns.lean:583`) quantifies over arbitrary coins and degenerates
+by the same mechanism from `k ≥ 2`; it is a pinned dependency, so that is recorded, not patched.
+
+What remains strong is upstream's own ∀-table floor: a `σ₀` valid at *every* table. Deriving one
+from an adversary's success probability is the recorded open research, not a defect of either
+narrowing.
+
+Nothing in this tree proves a `KimchiForkSpread` at *deployed* parameters, by design. The predicate
+is nonetheless satisfiable above the degenerate floor, and at every round count:
+`exists_kimchiForkSpread_two_le_of_rounds` exhibits an instance at `σ₀ = 4` for each `σ.k`, with
+both clauses discharged. See the section preamble. -/
+def KimchiForkSpread [DecidableEq F] [DecidableEq G] [DecidableEq T]
+    [Zero Pre] [DecidableEq Pre] [Fintype Pre]
+    (σ : SRS G) (b : Fin (2 ^ σ.k) → F) (v : F) (P : G) (expand : Pre → F)
+    (A : Zcash.Snark.OracleComp T Pre Pf)
+    (proofOf : Pf → OpeningProof F G σ.k) (prefixes : Pf → Fin (σ.k + 1) → T)
+    (dec : DecodesFromPrefixes σ proofOf prefixes) (σ₀ : ℕ) : Prop :=
+  (∀ (e m : ℕ) (hme : m + (e + 1) = σ.k) (O : T → Pre)
+      (child : Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1)),
+    σ₀ ≤ (kimchiGoodChallenges σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+      (fun q => (child q).toCoins)).card)
+  ∧ (∀ (O : T → Pre),
+    σ₀ ≤ (kimchiLeafGoodChallenges σ b v P expand A proofOf prefixes O (A.run O)).card)
+
+/-- **A leaf position where every reprogrammed run fails has an empty good set.** Stated at a
+*general* pair `(O, p)`, and it is worth reading twice, because the two instantiations say
+different things.
+
+*Off* the diagonal it is the compiled justification for `KimchiForkSpread`'s quantifier: take any
+`p` whose final prefix `t = prefixes p (Fin.last σ.k)` the adversary never lands on. Then no
+`q` can make the reprogrammed run come back to `t`, `kimchiLeafCandidate` answers `none` for every
+`q`, and the good set is empty — so a predicate demanding `σ₀ ≤ 0` there would be satisfiable only
+at `σ₀ = 0`. `A`, `Pf` and `prefixes` are unconstrained parameters here, so that is not an exotic
+corner; it is why the predicate is taken on the diagonal.
+
+*On* the diagonal it says what the surviving hypothesis actually demands: at a table whose own run
+is Schnorr-unstable, `KimchiForkSpread` forces `σ₀ = 0` and the conditional bounds below degrade to
+`0 ≤ …`. That corollary is `kimchiForkSpread_eq_zero_of_leaf_unstable`. -/
+theorem kimchiLeafGoodChallenges_eq_empty_of_unstable [DecidableEq G] [DecidableEq T]
+    [Zero Pre] [DecidableEq Pre] [Fintype Pre]
+    (σ : SRS G) (b : Fin (2 ^ σ.k) → F) (v : F) (P : G) (expand : Pre → F)
+    (A : Zcash.Snark.OracleComp T Pre Pf)
+    (proofOf : Pf → OpeningProof F G σ.k) (prefixes : Pf → Fin (σ.k + 1) → T)
+    (O : T → Pre) (p : Pf)
+    (hbad : ∀ q : Pre,
+      (kimchiLeafCandidate σ b v P expand A proofOf prefixes O p q).output = none) :
+    kimchiLeafGoodChallenges σ b v P expand A proofOf prefixes O p = ∅ := by
+  rw [kimchiLeafGoodChallenges, Finset.filter_eq_empty_iff]
+  intro q _
+  rw [not_and, hbad q]
+  exact fun _ => Bool.false_ne_true
+
+/-- **A Schnorr-unstable table pins the spread floor to zero.** The anti-vacuity companion of
+`KimchiForkSpread`, in the shape `one_le_kimchiForkFrom_runs` uses for the unconditional bound:
+this project pins a degeneracy rather than arguing it in prose (`docs/negative-controls.md`).
+
+A conditional bound scaled by `σ₀ - 1` says nothing at `σ₀ ≤ 1`, so it matters *which* tables can
+force that. This is the sharp answer at the leaf: if the adversary's own run at `O` is unstable
+under every reprogramming of the final prefix — no `q` brings the rerun back to that prefix with a
+win — then the leaf good set is empty and `KimchiForkSpread σ₀` holds only at `σ₀ = 0`. So the
+hypothesis is not free: it asserts, table by table, that the Schnorr round really does have
+`σ₀` live continuations. -/
+theorem kimchiForkSpread_eq_zero_of_leaf_unstable [DecidableEq F] [DecidableEq G] [DecidableEq T]
+    [Zero Pre] [DecidableEq Pre] [Fintype Pre]
+    (σ : SRS G) (b : Fin (2 ^ σ.k) → F) (v : F) (P : G) (expand : Pre → F)
+    (A : Zcash.Snark.OracleComp T Pre Pf)
+    (proofOf : Pf → OpeningProof F G σ.k) (prefixes : Pf → Fin (σ.k + 1) → T)
+    (dec : DecodesFromPrefixes σ proofOf prefixes) {σ₀ : ℕ}
+    (hspread : KimchiForkSpread σ b v P expand A proofOf prefixes dec σ₀) (O : T → Pre)
+    (hbad : ∀ q : Pre,
+      (kimchiLeafCandidate σ b v P expand A proofOf prefixes O (A.run O) q).output = none) :
+    σ₀ = 0 := by
+  have h := hspread.2 O
+  rw [kimchiLeafGoodChallenges_eq_empty_of_unstable σ b v P expand A proofOf prefixes O
+    (A.run O) hbad, Finset.card_empty] at h
+  exact Nat.le_zero.mp h
+
+/-- **An empty sampling order makes the fork fail outright**, at every certificate depth. The
+coin-side companion of `kimchiLeafGoodChallenges_eq_empty_of_unstable`, and the mechanical fact
+behind the narrowing of `KimchiForkSpread`'s node clause to tape-derived coins.
+
+`Zcash.Snark.RecursiveForkCoins Pre (e + 1)` carries an *arbitrary* `order : List Pre`
+(`Recursive.lean:16`), so `.node [] grandchild` is a legal coin tree, and every scan it drives is
+`Zcash.Snark.nextForkChallenge attempt _ []`, whose `[]` case is `{ output := none, runs := 0 }`
+(`Recursive.lean:245`). Both arms of the recursion therefore answer `none`: the certificate
+depth-`0` arm returns `none` on both sides of its `Wins` guard, and the `e + 1` arm returns `none`
+whether or not the cached first branch succeeded, because the second scan finds nothing. No
+induction is involved — each arm bottoms out in one `rfl`.
+
+A *tape*-derived coin tree is never of this shape: a tape node's order is `List.ofFn ⇑order` for an
+equivalence `order : Fin (Fintype.card Pre) ≃ Pre`, hence a full enumeration
+(`RecursiveForkTape.mem_orderList`). That is why narrowing the node clause to tape-derived coins
+costs the depth induction nothing while removing this degeneracy's only source. -/
+private theorem kimchiForkFrom_output_eq_none_of_order_nil [DecidableEq F] [DecidableEq G]
+    [DecidableEq T] [Zero Pre] [DecidableEq Pre]
+    (σ : SRS G) (b : Fin (2 ^ σ.k) → F) (v : F) (P : G) (expand : Pre → F)
+    (A : Zcash.Snark.OracleComp T Pre Pf)
+    (proofOf : Pf → OpeningProof F G σ.k) (prefixes : Pf → Fin (σ.k + 1) → T)
+    (dec : DecodesFromPrefixes σ proofOf prefixes)
+    {e : ℕ} (m : ℕ) (hme : m + e = σ.k) (O : T → Pre) (p : Pf)
+    (grandchild : Pre → Zcash.Snark.RecursiveForkCoins Pre e) :
+    (kimchiForkFrom σ b v P expand A proofOf prefixes dec m hme O p
+        (.node [] grandchild)).output = none := by
+  cases e with
+  | zero =>
+      rw [kimchiForkFrom]
+      simp only []
+      split <;> rfl
+  | succ e =>
+      rw [kimchiForkFrom]
+      simp only []
+      split <;> rfl
+
+/-- **The good set at an empty-order child is empty.** `kimchiGoodChallenges` collects the nonzero
+challenges whose reprogrammed candidate returns a certificate; at a child that answers `none`
+whatever the reprogramming, there are none.
+
+Immediate from `kimchiForkFrom_output_eq_none_of_order_nil` once
+`kimchiScanCandidate`'s stability guard is split: the unstable branch is
+`{ output := none, runs := 1 }` outright, and the stable branch is the recursion at
+`.node [] grandchild`. -/
+theorem kimchiGoodChallenges_eq_empty_of_order_nil [DecidableEq F] [DecidableEq G] [DecidableEq T]
+    [Zero Pre] [DecidableEq Pre] [Fintype Pre]
+    (σ : SRS G) (b : Fin (2 ^ σ.k) → F) (v : F) (P : G) (expand : Pre → F)
+    (A : Zcash.Snark.OracleComp T Pre Pf)
+    (proofOf : Pf → OpeningProof F G σ.k) (prefixes : Pf → Fin (σ.k + 1) → T)
+    (dec : DecodesFromPrefixes σ proofOf prefixes)
+    {e : ℕ} (m : ℕ) (hme : m + (e + 1) = σ.k) (O : T → Pre) (p : Pf)
+    (grandchild : Pre → Zcash.Snark.RecursiveForkCoins Pre e) :
+    kimchiGoodChallenges σ b v P expand A proofOf prefixes dec m hme O p
+        (fun _ => .node [] grandchild) = ∅ := by
+  rw [kimchiGoodChallenges, Finset.filter_eq_empty_iff]
+  intro q _
+  rw [not_and]
+  intro _
+  simp only [kimchiScanCandidate]
+  split
+  · rw [kimchiForkFrom_output_eq_none_of_order_nil]
+    exact Bool.false_ne_true
+  · exact Bool.false_ne_true
+
+/-- **A node floor quantified over arbitrary coin trees pins the spread to zero.** The second
+degeneracy this block compiles rather than argues in prose (`docs/negative-controls.md`), and the
+permanent record of why `KimchiForkSpread`'s node clause quantifies over *tape-derived* coins.
+
+The hypothesis is written out inline — it is that clause as it stood before the narrowing, with
+`child` ranging over all of `Zcash.Snark.RecursiveForkCoins Pre (e + 1)` — so that the statement
+survives the fix and keeps saying what the fix bought. Read it as: at any positive round count
+that clause alone forces `σ₀ = 0`, so the conditional bounds below would have read `0 ≤ …` at every
+deployed parameter set, `σ.k` being nowhere near `0`.
+
+One instantiation is enough: certificate depth `e := 0`, round `m := σ.k - 1` (legal exactly
+because `1 ≤ σ.k`), the constant table `fun _ => 0`, and the empty-order child
+`fun _ => .node [] (fun _ => .leaf)`, at which `kimchiGoodChallenges_eq_empty_of_order_nil`
+applies.
+
+Upstream's `ForkSpread` (`ExpectedRuns.lean:583`) quantifies over `childC : F → RecursiveForkCoins
+F d` the same way and degenerates by the same mechanism one depth later: its certificate depth-`0`
+arm takes the forced `.leaf` and costs a bare `1` without scanning, so upstream is safe at `d = 0`
+and degenerate from `d ≥ 1`. Ours scans at depth `0` too, which is what moves the collapse a step
+earlier. `zcash/ironwood` is a pinned dependency: the observation is recorded, not patched. -/
+theorem kimchiNodeFloor_eq_zero_of_forall_coins [DecidableEq F] [DecidableEq G] [DecidableEq T]
+    [Zero Pre] [DecidableEq Pre] [Fintype Pre]
+    (σ : SRS G) (b : Fin (2 ^ σ.k) → F) (v : F) (P : G) (expand : Pre → F)
+    (A : Zcash.Snark.OracleComp T Pre Pf)
+    (proofOf : Pf → OpeningProof F G σ.k) (prefixes : Pf → Fin (σ.k + 1) → T)
+    (dec : DecodesFromPrefixes σ proofOf prefixes) (hk : 1 ≤ σ.k) {σ₀ : ℕ}
+    (h : ∀ (e m : ℕ) (hme : m + (e + 1) = σ.k) (O : T → Pre)
+        (child : Pre → Zcash.Snark.RecursiveForkCoins Pre (e + 1)),
+      σ₀ ≤ (kimchiGoodChallenges σ b v P expand A proofOf prefixes dec m hme O
+        (A.run O) child).card) :
+    σ₀ = 0 := by
+  have hme : σ.k - 1 + (0 + 1) = σ.k := by omega
+  have hfloor := h 0 (σ.k - 1) hme (fun _ => 0) (fun _ => .node [] (fun _ => .leaf))
+  rw [kimchiGoodChallenges_eq_empty_of_order_nil σ b v P expand A proofOf prefixes dec
+    (σ.k - 1) hme (fun _ => 0) (A.run fun _ => 0) (fun _ => .leaf), Finset.card_empty] at hfloor
+  exact Nat.le_zero.mp hfloor
+
+/-- **The leaf pays one cached run and at most its rank-`< 2` candidates.** The depth-0 pointwise
+bound, and the half of this block with no upstream counterpart: upstream's depth-0 leaf costs a
+bare `1`, while ours runs the Schnorr scan.
+
+Stated at a *tape* node — `.node (List.ofFn ⇑order) child` — because that is exactly what
+`RecursiveForkTape.toCoins` produces (`orderList order = List.ofFn ⇑order` by `rfl`) and because
+the rank machinery needs the sampling order to be a permutation. Upstream states its node bound the
+same way (`ExpectedRuns.lean:449`).
+
+The `1` is the cached run the leaf bills before scanning; the sum is upstream's
+`nextForkChallenge_runs_le_rank_sum` (`:368`) at `M := leafGood.erase q₁`, `seen := [q₁]`,
+`l₀ := []`, which is the same instantiation upstream's own `hscan₂` (`:490`) uses. -/
+theorem kimchiForkFrom_leaf_runs_le [DecidableEq F] [DecidableEq G] [DecidableEq T]
+    [Zero Pre] [DecidableEq Pre] [Fintype Pre]
+    (σ : SRS G) (b : Fin (2 ^ σ.k) → F) (v : F) (P : G) (expand : Pre → F)
+    (A : Zcash.Snark.OracleComp T Pre Pf)
+    (proofOf : Pf → OpeningProof F G σ.k) (prefixes : Pf → Fin (σ.k + 1) → T)
+    (dec : DecodesFromPrefixes σ proofOf prefixes)
+    (m : ℕ) (hme : m + 0 = σ.k) (O : T → Pre) (p : Pf)
+    (order : Fin (Fintype.card Pre) ≃ Pre)
+    (child : Pre → Zcash.Snark.RecursiveForkCoins Pre 0) :
+    (kimchiForkFrom σ b v P expand A proofOf prefixes dec m hme O p
+        (.node (List.ofFn (⇑order)) child)).runs
+      ≤ 1 + ∑ q ∈ Finset.univ.filter (fun q : Pre =>
+            Zcash.Snark.scanRank order
+              (insert q ((kimchiLeafGoodChallenges σ b v P expand A proofOf prefixes O p).erase
+                (O (prefixes p (Fin.last σ.k))))) q < 2),
+          (kimchiLeafCandidate σ b v P expand A proofOf prefixes O p q).runs := by
+  set q₁ : Pre := O (prefixes p (Fin.last σ.k)) with hq₁def
+  set M : Finset Pre :=
+    (kimchiLeafGoodChallenges σ b v P expand A proofOf prefixes O p).erase q₁ with hMdef
+  have hMgood : ∀ w ∈ M, w ≠ 0 ∧
+      (kimchiLeafCandidate σ b v P expand A proofOf prefixes O p w).output.isSome := by
+    intro w hw
+    have hw' := Finset.mem_of_mem_erase hw
+    rw [kimchiLeafGoodChallenges, Finset.mem_filter] at hw'
+    exact hw'.2
+  have hscan : (Zcash.Snark.nextForkChallenge
+      (fun q => kimchiLeafCandidate σ b v P expand A proofOf prefixes O p q) [q₁]
+      (List.ofFn (⇑order))).runs
+      ≤ ∑ q ∈ Finset.univ.filter (fun q : Pre =>
+          Zcash.Snark.scanRank order (insert q M) q < 2),
+        (kimchiLeafCandidate σ b v P expand A proofOf prefixes O p q).runs := by
+    apply Zcash.Snark.nextForkChallenge_runs_le_rank_sum _ order M hMgood [q₁] [] _
+      (by rw [List.nil_append])
+    · intro w hw hwseen
+      rw [List.mem_singleton] at hwseen
+      exact absurd (hwseen ▸ hw) (Finset.notMem_erase q₁ _)
+    · simp
+  rw [kimchiForkFrom]
+  simp only []
+  split
+  · split
+    all_goals exact Nat.add_le_add_left hscan 1
+  · exact Nat.le_add_right 1 _
+
+/-- **A node pays its first branch and at most twice its rank-`< 2` candidates.** The pointwise
+bound at certificate depth `e + 1`: upstream's `recursiveAlgebraicForkFrom_node_runs_le`
+(`ExpectedRuns.lean:448`), transcribed onto our recursion. Like the leaf bound it is stated at a
+tape node, for the same reason.
+
+**One difference changes the statement.** Upstream's bound leads with `1 +` because its node has an
+arm that aborts on a zero incumbent challenge and bills a unit for it; `kimchiForkFrom`'s `e + 1`
+case has no such arm — it goes straight to the recursive `first` — so the unit is dropped here.
+Everything else maps one-to-one: the second scan is bounded at `seen = [q₁]` and the third at the
+`(seen, rest)` its predecessor returned, both by `nextForkChallenge_runs_le_rank_sum` (`:368`)
+against the same good set, and `S + S = 2 * S` closes all three result branches. -/
+theorem kimchiForkFrom_node_runs_le [DecidableEq F] [DecidableEq G] [DecidableEq T]
+    [Zero Pre] [DecidableEq Pre] [Fintype Pre]
+    (σ : SRS G) (b : Fin (2 ^ σ.k) → F) (v : F) (P : G) (expand : Pre → F)
+    (A : Zcash.Snark.OracleComp T Pre Pf)
+    (proofOf : Pf → OpeningProof F G σ.k) (prefixes : Pf → Fin (σ.k + 1) → T)
+    (dec : DecodesFromPrefixes σ proofOf prefixes)
+    {e : ℕ} (m : ℕ) (hme : m + (e + 1) = σ.k) (O : T → Pre) (p : Pf)
+    (order : Fin (Fintype.card Pre) ≃ Pre)
+    (child : Pre → Zcash.Snark.RecursiveForkCoins Pre (e + 1)) :
+    (kimchiForkFrom σ b v P expand A proofOf prefixes dec m hme O p
+        (.node (List.ofFn (⇑order)) child)).runs
+      ≤ (kimchiForkFrom σ b v P expand A proofOf prefixes dec (m + 1) (by omega) O p
+          (child (O (prefixes p ⟨m, by omega⟩)))).runs
+        + 2 * ∑ q ∈ Finset.univ.filter (fun q : Pre =>
+              Zcash.Snark.scanRank order
+                (insert q ((kimchiGoodChallenges σ b v P expand A proofOf prefixes dec m hme O p
+                  child).erase (O (prefixes p ⟨m, by omega⟩)))) q < 2),
+            (kimchiScanCandidate σ b v P expand A proofOf prefixes dec m hme O p child q).runs := by
+  have hm : m < σ.k + 1 := by omega
+  have htail : m + 1 + e = σ.k := by omega
+  set q₁ : Pre := O (prefixes p ⟨m, hm⟩) with hq₁def
+  set M : Finset Pre :=
+    (kimchiGoodChallenges σ b v P expand A proofOf prefixes dec m hme O p child).erase q₁ with hMdef
+  set S : ℕ := ∑ q ∈ Finset.univ.filter (fun q : Pre =>
+      Zcash.Snark.scanRank order (insert q M) q < 2),
+    (kimchiScanCandidate σ b v P expand A proofOf prefixes dec m hme O p child q).runs with hSdef
+  have hMgood : ∀ w ∈ M, w ≠ 0 ∧ (kimchiScanCandidate σ b v P expand A proofOf prefixes dec
+      m hme O p child w).output.isSome := by
+    intro w hw
+    have hw' := Finset.mem_of_mem_erase hw
+    rw [kimchiGoodChallenges, Finset.mem_filter] at hw'
+    exact hw'.2
+  show (kimchiForkFrom σ b v P expand A proofOf prefixes dec m hme O p
+      (.node (List.ofFn (⇑order)) child)).runs
+      ≤ (kimchiForkFrom σ b v P expand A proofOf prefixes dec (m + 1) htail O p
+          (child q₁)).runs + 2 * S
+  rw [kimchiForkFrom]
+  simp only []
+  split
+  · -- the first branch failed: only its own cost is paid
+    exact Nat.le_add_right _ _
+  · rename_i c₁ hfirstSome
+    have hscan₂ : (Zcash.Snark.nextForkChallenge
+        (fun q => kimchiScanCandidate σ b v P expand A proofOf prefixes dec m hme O p child q)
+        [q₁] (List.ofFn (⇑order))).runs ≤ S := by
+      rw [hSdef]
+      apply Zcash.Snark.nextForkChallenge_runs_le_rank_sum _ order M hMgood [q₁] [] _
+        (by rw [List.nil_append])
+      · intro w hw hwseen
+        rw [List.mem_singleton] at hwseen
+        exact absurd (hwseen ▸ hw) (Finset.notMem_erase q₁ _)
+      · simp
+    split
+    · -- the second scan failed
+      exact Nat.add_le_add_left (hscan₂.trans (Nat.le_mul_of_pos_left S (by omega))) _
+    · rename_i q₂ c₂ rest seen hsecond
+      have hfresh := Zcash.Snark.nextForkChallenge_output_fresh _ [q₁] hsecond
+      obtain ⟨l₁, hdecomp, hfailL⟩ :=
+        Zcash.Snark.nextForkChallenge_output_decompose _ [q₁] _ hsecond
+      have hscan₃ : (Zcash.Snark.nextForkChallenge
+          (fun q => kimchiScanCandidate σ b v P expand A proofOf prefixes dec m hme O p child q)
+          seen rest).runs ≤ S := by
+        rw [hSdef]
+        apply Zcash.Snark.nextForkChallenge_runs_le_rank_sum _ order M hMgood seen (l₁ ++ [q₂]) rest
+          (by rw [hdecomp, List.append_assoc, List.singleton_append])
+        · intro w hw hwseen
+          rw [hfresh.2.2, List.mem_cons, List.mem_singleton] at hwseen
+          rcases hwseen with h | h
+          · rw [h]
+            exact List.mem_append.mpr (Or.inr (List.mem_singleton_self q₂))
+          · exact absurd (h ▸ hw) (Finset.notMem_erase q₁ _)
+        · have hsub : M.filter (· ∈ l₁ ++ [q₂]) ⊆ {q₂} := by
+            intro w hw
+            rw [Finset.mem_filter] at hw
+            rcases List.mem_append.mp hw.2 with hwl | hwq
+            · exfalso
+              obtain ⟨hw0, hwsome⟩ := hMgood w hw.1
+              have hwne₁ : w ∉ ([q₁] : List Pre) := by
+                rw [List.mem_singleton]
+                intro h
+                exact absurd (h ▸ hw.1) (Finset.notMem_erase q₁ _)
+              have hnone : (kimchiScanCandidate σ b v P expand A proofOf prefixes dec
+                  m hme O p child w).output = none := hfailL w hwl hw0 hwne₁
+              rw [hnone] at hwsome
+              simp at hwsome
+            · rw [List.mem_singleton] at hwq
+              rw [Finset.mem_singleton]
+              exact hwq
+          calc (M.filter (· ∈ l₁ ++ [q₂])).card
+              ≤ ({q₂} : Finset Pre).card := Finset.card_le_card hsub
+            _ = 1 := Finset.card_singleton q₂
+      split
+      all_goals
+        refine le_trans (Nat.add_le_add (Nat.add_le_add (le_refl _) hscan₂) hscan₃) ?_
+        rw [Nat.add_assoc, ← Nat.two_mul]
+
+/-- **The scan candidate's cost, with its stability test exposed.** A prefix-stable reprogramming
+pays the recursive extraction one round deeper; an unstable one pays the unit rerun and stops.
+Upstream analogue: `scanCandidate_runs_cases` (`ExpectedRuns.lean:557`), transcribed verbatim.
+
+Purely a normal form, but the one the depth induction needs: with the `if` lifted out of the
+`RecursiveForkAttempt` and onto the `ℕ`, `by_cases` on the condition splits the tape sum of scan
+costs into a branch the induction hypothesis closes and a branch that collapses to a constant. -/
+theorem kimchiScanCandidate_runs_cases [DecidableEq F] [DecidableEq G] [DecidableEq T]
+    [Zero Pre] [DecidableEq Pre]
+    (σ : SRS G) (b : Fin (2 ^ σ.k) → F) (v : F) (P : G) (expand : Pre → F)
+    (A : Zcash.Snark.OracleComp T Pre Pf)
+    (proofOf : Pf → OpeningProof F G σ.k) (prefixes : Pf → Fin (σ.k + 1) → T)
+    (dec : DecodesFromPrefixes σ proofOf prefixes)
+    {e : ℕ} (m : ℕ) (hme : m + (e + 1) = σ.k) (O : T → Pre) (p : Pf)
+    (child : Pre → Zcash.Snark.RecursiveForkCoins Pre (e + 1)) (q : Pre) :
+    (kimchiScanCandidate σ b v P expand A proofOf prefixes dec m hme O p child q).runs
+      = if prefixes (A.run (Function.update O (prefixes p ⟨m, by omega⟩) q)) ⟨m, by omega⟩
+            = prefixes p ⟨m, by omega⟩ then
+          (kimchiForkFrom σ b v P expand A proofOf prefixes dec (m + 1) (by omega)
+            (Function.update O (prefixes p ⟨m, by omega⟩) q)
+            (A.run (Function.update O (prefixes p ⟨m, by omega⟩) q)) (child q)).runs
+        else 1 := by
+  simp only [kimchiScanCandidate]
+  rw [apply_ite Zcash.Snark.RecursiveForkAttempt.runs]
+
+/-- **The depth-0 tape sum, under fork spread**: averaged over the uniform depth-1 tape, a Schnorr
+leaf costs at most `6·|Pre|/(σ₀−1)` runs. It is the base case of
+`kimchiForkFrom_sum_runs_le_of_forkSpread` below, and the one upstream does not have — its own base
+case is a bare `1`, ours runs a scan.
+
+The `6` has slack, and the arithmetic is worth stating because of it. Write `N = |Pre|`,
+`CP = |Fin N ≃ Pre|`, `B = σ₀ − 1`. A leaf run costs `≤ 1 + (its scan)`, and each leaf candidate
+costs exactly `1`, so the scan costs at most its number of rank-`< 2` candidates. Summing over the
+depth-1 tape space: the unit costs contribute `B·CP·|tapes₀|^N ≤ N·CP·|tapes₀|^N` (from `σ₀ ≤ N`),
+and the scans contribute `2·N·CP·|tapes₀|^N`, because
+`card_scanRank_lt_mul_le` (`ExpectedRuns.lean:139`) pays `B · #{orders : rank q < 2}
+≤ 2·CP` for **each** of the `N` challenges `q`. Total `3·N·CP·|tapes₀|^N`, and
+`|RecursiveForkTape Pre 1| = CP·|tapes₀|^N`.
+
+Note what is *not* needed: upstream's `2 ≤ σ₀` plays no part at depth 0, so it is absent here. The
+floor consumed is `KimchiForkSpread`'s **leaf** clause; the node clause is untouched at this depth.
+The proof deliberately keeps upstream's `succ`-case shape (transport along `equivSucc`,
+marginalize, then bound the two summands) rather than short-cutting through
+`RecursiveForkTape Pre 0 ≃ Unit`: the induction above transcribes that same skeleton at general
+depth, so a faithful depth-0 case is worth more than a clever one. -/
+theorem kimchiForkFrom_sum_runs_le_leaf [DecidableEq F] [DecidableEq G] [DecidableEq T]
+    [Zero Pre] [DecidableEq Pre] [Fintype Pre]
+    (σ : SRS G) (b : Fin (2 ^ σ.k) → F) (v : F) (P : G) (expand : Pre → F)
+    (A : Zcash.Snark.OracleComp T Pre Pf)
+    (proofOf : Pf → OpeningProof F G σ.k) (prefixes : Pf → Fin (σ.k + 1) → T)
+    (dec : DecodesFromPrefixes σ proofOf prefixes) {σ₀ : ℕ}
+    (hspread : KimchiForkSpread σ b v P expand A proofOf prefixes dec σ₀)
+    (m : ℕ) (hme : m + 0 = σ.k) (O : T → Pre) :
+    (σ₀ - 1) * ∑ tape : Zcash.Snark.RecursiveForkTape Pre 1,
+        (kimchiForkFrom σ b v P expand A proofOf prefixes dec m hme O (A.run O) tape.toCoins).runs
+      ≤ 6 * Fintype.card Pre * Fintype.card (Zcash.Snark.RecursiveForkTape Pre 1) := by
+  set N := Fintype.card Pre with hN
+  set B := σ₀ - 1 with hB
+  set CP := Fintype.card (Fin N ≃ Pre) with hCP
+  set CT := Fintype.card (Zcash.Snark.RecursiveForkTape Pre 0) with hCT
+  set q₁ : Pre := O (prefixes (A.run O) (Fin.last σ.k)) with hq₁def
+  set M : Finset Pre :=
+    (kimchiLeafGoodChallenges σ b v P expand A proofOf prefixes O (A.run O)).erase q₁ with hMdef
+  set f : Pre → ℕ := fun q =>
+    (kimchiLeafCandidate σ b v P expand A proofOf prefixes O (A.run O) q).runs with hf
+  -- the tape space factors, and the leaf good set is nonempty enough
+  have hcard : Fintype.card (Zcash.Snark.RecursiveForkTape Pre 1) = CP * CT ^ N := by
+    have h := Fintype.card_congr (Zcash.Snark.RecursiveForkTape.equivSucc (F := Pre) 0)
+    rwa [Fintype.card_prod, Fintype.card_fun] at h
+  have hgoodN :
+      (kimchiLeafGoodChallenges σ b v P expand A proofOf prefixes O (A.run O)).card ≤ N := by
+    rw [kimchiLeafGoodChallenges]
+    exact le_trans (Finset.card_filter_le _ _) (le_of_eq Finset.card_univ)
+  have hBN : B ≤ N := le_trans (Nat.sub_le σ₀ 1) (le_trans (hspread.2 O) hgoodN)
+  -- every leaf candidate costs exactly one run
+  have hf1 : ∀ q : Pre, f q = 1 := by
+    intro q
+    rw [hf]
+    simp only [kimchiLeafCandidate]
+    split <;> rfl
+  -- transport the tape sum to the (order, children) product
+  have htrans : ∑ tape : Zcash.Snark.RecursiveForkTape Pre 1,
+      (kimchiForkFrom σ b v P expand A proofOf prefixes dec m hme O (A.run O) tape.toCoins).runs
+      = ∑ pr : (Fin N ≃ Pre) × (Pre → Zcash.Snark.RecursiveForkTape Pre 0),
+          (kimchiForkFrom σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+            (Zcash.Snark.RecursiveForkTape.node pr.1 pr.2).toCoins).runs := by
+    rw [← Equiv.sum_comp (Zcash.Snark.RecursiveForkTape.equivSucc (F := Pre) 0).symm
+      (fun tape => (kimchiForkFrom σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+        tape.toCoins).runs)]
+    exact Finset.sum_congr rfl (fun pr _ => rfl)
+  -- the pointwise leaf bound, at a tape node
+  have hpoint : ∀ pr : (Fin N ≃ Pre) × (Pre → Zcash.Snark.RecursiveForkTape Pre 0),
+      (kimchiForkFrom σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+        (Zcash.Snark.RecursiveForkTape.node pr.1 pr.2).toCoins).runs
+      ≤ 1 + ∑ q ∈ Finset.univ.filter (fun q : Pre =>
+          Zcash.Snark.scanRank pr.1 (insert q M) q < 2), f q := fun pr =>
+    kimchiForkFrom_leaf_runs_le σ b v P expand A proofOf prefixes dec m hme O (A.run O) pr.1
+      (fun q => (pr.2 q).toCoins)
+  -- summed, with the order axis marginalized out of the scan term
+  have hsum : ∑ pr : (Fin N ≃ Pre) × (Pre → Zcash.Snark.RecursiveForkTape Pre 0),
+      (kimchiForkFrom σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+        (Zcash.Snark.RecursiveForkTape.node pr.1 pr.2).toCoins).runs
+      ≤ CP * CT ^ N
+        + ∑ _childT : Pre → Zcash.Snark.RecursiveForkTape Pre 0, ∑ q : Pre,
+            (Finset.univ.filter (fun order : Fin N ≃ Pre =>
+              Zcash.Snark.scanRank order (insert q M) q < 2)).card * f q := by
+    have hper : ∀ childT : Pre → Zcash.Snark.RecursiveForkTape Pre 0,
+        ∑ order : Fin N ≃ Pre, ∑ q ∈ Finset.univ.filter (fun q : Pre =>
+            Zcash.Snark.scanRank order (insert q M) q < 2), f q
+        = ∑ q : Pre, (Finset.univ.filter (fun order : Fin N ≃ Pre =>
+            Zcash.Snark.scanRank order (insert q M) q < 2)).card * f q := by
+      intro _childT
+      calc ∑ order : Fin N ≃ Pre, ∑ q ∈ Finset.univ.filter (fun q : Pre =>
+              Zcash.Snark.scanRank order (insert q M) q < 2), f q
+          = ∑ order : Fin N ≃ Pre, ∑ q : Pre,
+              (if Zcash.Snark.scanRank order (insert q M) q < 2 then f q else 0) :=
+            Finset.sum_congr rfl (fun order _ => Finset.sum_filter _ _)
+        _ = ∑ q : Pre, ∑ order : Fin N ≃ Pre,
+              (if Zcash.Snark.scanRank order (insert q M) q < 2 then f q else 0) :=
+            Finset.sum_comm
+        _ = ∑ q : Pre, (Finset.univ.filter (fun order : Fin N ≃ Pre =>
+              Zcash.Snark.scanRank order (insert q M) q < 2)).card * f q := by
+            refine Finset.sum_congr rfl (fun q _ => ?_)
+            rw [← Finset.sum_filter, Finset.sum_const, smul_eq_mul]
+    calc ∑ pr : (Fin N ≃ Pre) × (Pre → Zcash.Snark.RecursiveForkTape Pre 0),
+        (kimchiForkFrom σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+          (Zcash.Snark.RecursiveForkTape.node pr.1 pr.2).toCoins).runs
+        ≤ ∑ pr : (Fin N ≃ Pre) × (Pre → Zcash.Snark.RecursiveForkTape Pre 0),
+            (1 + ∑ q ∈ Finset.univ.filter (fun q : Pre =>
+              Zcash.Snark.scanRank pr.1 (insert q M) q < 2), f q) :=
+          Finset.sum_le_sum (fun pr _ => hpoint pr)
+      _ = (∑ _pr : (Fin N ≃ Pre) × (Pre → Zcash.Snark.RecursiveForkTape Pre 0), 1)
+          + ∑ pr : (Fin N ≃ Pre) × (Pre → Zcash.Snark.RecursiveForkTape Pre 0),
+              ∑ q ∈ Finset.univ.filter (fun q : Pre =>
+                Zcash.Snark.scanRank pr.1 (insert q M) q < 2), f q := by
+          rw [← Finset.sum_add_distrib]
+      _ = CP * CT ^ N
+          + ∑ _childT : Pre → Zcash.Snark.RecursiveForkTape Pre 0, ∑ q : Pre,
+              (Finset.univ.filter (fun order : Fin N ≃ Pre =>
+                Zcash.Snark.scanRank order (insert q M) q < 2)).card * f q := by
+          congr 1
+          · rw [Finset.sum_const, Finset.card_univ, smul_eq_mul, mul_one, Fintype.card_prod,
+              Fintype.card_fun]
+          · rw [Fintype.sum_prod_type_right]
+            exact Finset.sum_congr rfl (fun childT _ => hper childT)
+  -- each challenge is low-rank in at most a 2/|good set| fraction of the orders
+  have hOrderCount : ∀ q : Pre, B * (Finset.univ.filter (fun order : Fin N ≃ Pre =>
+      Zcash.Snark.scanRank order (insert q M) q < 2)).card ≤ 2 * CP := by
+    intro q
+    have hA := Zcash.Snark.card_scanRank_lt_mul_le (n := N) (insert q M)
+      (Finset.mem_insert_self q _) 2
+    refine le_trans (Nat.mul_le_mul_right _ ?_) hA
+    have herase : (kimchiLeafGoodChallenges σ b v P expand A proofOf prefixes O (A.run O)).card - 1
+        ≤ M.card := by
+      rw [hMdef]
+      exact Finset.pred_card_le_card_erase
+    have hgood := hspread.2 O
+    have hins : M.card ≤ (insert q M).card := Finset.card_le_card (Finset.subset_insert q _)
+    rw [hB]
+    omega
+  have hscans : B * ∑ q : Pre, (Finset.univ.filter (fun order : Fin N ≃ Pre =>
+      Zcash.Snark.scanRank order (insert q M) q < 2)).card * f q ≤ N * (2 * CP) := by
+    rw [Finset.mul_sum]
+    calc ∑ q : Pre, B * ((Finset.univ.filter (fun order : Fin N ≃ Pre =>
+          Zcash.Snark.scanRank order (insert q M) q < 2)).card * f q)
+        = ∑ q : Pre, B * (Finset.univ.filter (fun order : Fin N ≃ Pre =>
+            Zcash.Snark.scanRank order (insert q M) q < 2)).card := by
+          simp only [hf1, mul_one]
+      _ ≤ ∑ _q : Pre, 2 * CP := Finset.sum_le_sum (fun q _ => hOrderCount q)
+      _ = N * (2 * CP) := by rw [Finset.sum_const, Finset.card_univ, smul_eq_mul]
+  rw [hcard, htrans]
+  calc B * ∑ pr : (Fin N ≃ Pre) × (Pre → Zcash.Snark.RecursiveForkTape Pre 0),
+      (kimchiForkFrom σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+        (Zcash.Snark.RecursiveForkTape.node pr.1 pr.2).toCoins).runs
+      ≤ B * (CP * CT ^ N
+          + ∑ _childT : Pre → Zcash.Snark.RecursiveForkTape Pre 0, ∑ q : Pre,
+              (Finset.univ.filter (fun order : Fin N ≃ Pre =>
+                Zcash.Snark.scanRank order (insert q M) q < 2)).card * f q) :=
+        Nat.mul_le_mul_left _ hsum
+    _ ≤ N * (CP * CT ^ N) + 2 * N * (CP * CT ^ N) := by
+        rw [Nat.mul_add]
+        refine Nat.add_le_add (Nat.mul_le_mul_right _ hBN) ?_
+        calc B * ∑ _childT : Pre → Zcash.Snark.RecursiveForkTape Pre 0, ∑ q : Pre,
+              (Finset.univ.filter (fun order : Fin N ≃ Pre =>
+                Zcash.Snark.scanRank order (insert q M) q < 2)).card * f q
+            = ∑ _childT : Pre → Zcash.Snark.RecursiveForkTape Pre 0,
+                B * ∑ q : Pre, (Finset.univ.filter (fun order : Fin N ≃ Pre =>
+                  Zcash.Snark.scanRank order (insert q M) q < 2)).card * f q :=
+              Finset.mul_sum _ _ _
+          _ ≤ ∑ _childT : Pre → Zcash.Snark.RecursiveForkTape Pre 0, N * (2 * CP) :=
+              Finset.sum_le_sum (fun _ _ => hscans)
+          _ = CT ^ N * (N * (2 * CP)) := by
+              rw [Finset.sum_const, Finset.card_univ, smul_eq_mul, Fintype.card_fun]
+          _ = 2 * N * (CP * CT ^ N) := by ring
+    _ = 3 * N * (CP * CT ^ N) := by ring
+    _ ≤ 6 * N * (CP * CT ^ N) :=
+        Nat.mul_le_mul_right _ (Nat.mul_le_mul_right _ (by omega))
+
+/-- **The depth induction, under fork spread**: averaged over the uniform tape, the fork at
+certificate depth `e` costs at most `(6·|Pre|/(σ₀−1))^(e+1)` runs. Upstream's
+`recursiveAlgebraicForkFrom_sum_runs_le_of_forkSpread` (`ExpectedRuns.lean:590`), transcribed onto
+our recursion; the induction is on the certificate depth, and each step turns the pointwise node
+bound `kimchiForkFrom_node_runs_le` into a bound on the sum over tapes.
+
+**Three deviations from upstream, all in our favour.**
+
+* *The exponents shift by one.* Certificate depth `e` carries coin depth `e + 1`, so tapes are
+  `RecursiveForkTape Pre (e + 1)` and upstream's `d` is our `e + 1` everywhere in the arithmetic,
+  while the induction variable is `e`. The base case sits at tape depth `1`, the step at `e + 2`.
+* *The base case does real work.* Upstream's depth-0 leaf costs a bare `1`; ours runs the Schnorr
+  scan, so `e = 0` is `kimchiForkFrom_sum_runs_le_leaf` — a theorem with a rank argument and a
+  spread clause of its own — rather than a one-line computation.
+* *Two summands, not three.* `kimchiForkFrom_node_runs_le` has no leading `1 +`, because our
+  `e + 1` arm has no zero-incumbent abort; upstream's unit-cost summand and the calc branch that
+  pays for it are therefore absent. The closing arithmetic is
+  `N·(6N)^(e+1) + 4N·(6N)^(e+1) = 5N·(6N)^(e+1) ≤ (6N)^(e+2)`, so the `6` is kept with a factor of
+  slack rather than tightened.
+
+**Upstream's `2 ≤ σ₀` is not a hypothesis here**, so this statement is *weaker in hypotheses*, not
+merely re-indexed. Its only role upstream is to supply `1 ≤ |F|` to the step
+`CT^(N−1)·CT = CT^N`; here `[Zero Pre]` already gives `Nonempty Pre`, hence `1 ≤ |Pre|` outright.
+
+The floor is read on the diagonal `p = A.run O` throughout — the induction hypothesis is quantified
+over the table and is applied at two different tables in the step (`O` for the cached first branch,
+the reprogrammed `O'` for each scan candidate), which is exactly what the narrowed
+`KimchiForkSpread` supports and the un-narrowed one did not need. -/
+theorem kimchiForkFrom_sum_runs_le_of_forkSpread [DecidableEq F] [DecidableEq G] [DecidableEq T]
+    [Zero Pre] [DecidableEq Pre] [Fintype Pre]
+    (σ : SRS G) (b : Fin (2 ^ σ.k) → F) (v : F) (P : G) (expand : Pre → F)
+    (A : Zcash.Snark.OracleComp T Pre Pf)
+    (proofOf : Pf → OpeningProof F G σ.k) (prefixes : Pf → Fin (σ.k + 1) → T)
+    (dec : DecodesFromPrefixes σ proofOf prefixes) {σ₀ : ℕ}
+    (hspread : KimchiForkSpread σ b v P expand A proofOf prefixes dec σ₀) :
+    ∀ (e m : ℕ) (hme : m + e = σ.k) (O : T → Pre),
+      (σ₀ - 1) ^ (e + 1) * ∑ tape : Zcash.Snark.RecursiveForkTape Pre (e + 1),
+          (kimchiForkFrom σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+            tape.toCoins).runs
+        ≤ (6 * Fintype.card Pre) ^ (e + 1)
+            * Fintype.card (Zcash.Snark.RecursiveForkTape Pre (e + 1)) := by
+  intro e
+  induction e with
+  | zero =>
+      intro m hme O
+      simpa using
+        kimchiForkFrom_sum_runs_le_leaf σ b v P expand A proofOf prefixes dec hspread m hme O
+  | succ e ih =>
+      intro m hme O
+      have hm : m < σ.k + 1 := by omega
+      have htail : m + 1 + e = σ.k := by omega
+      set N := Fintype.card Pre with hN
+      set B := σ₀ - 1 with hB
+      set CP := Fintype.card (Fin N ≃ Pre) with hCP
+      set CT := Fintype.card (Zcash.Snark.RecursiveForkTape Pre (e + 1)) with hCT
+      have hN1 : 1 ≤ N := Fintype.card_pos
+      have hCTN : CT ^ (N - 1) * CT = CT ^ N := by
+        rw [← Nat.pow_succ]
+        congr 1
+        omega
+      obtain ⟨t0⟩ : Nonempty (Zcash.Snark.RecursiveForkTape Pre (e + 1)) :=
+        Zcash.Snark.RecursiveForkTape.instNonempty (e + 1)
+      have hgoodN : ∀ child : Pre → Zcash.Snark.RecursiveForkCoins Pre (e + 1),
+          (kimchiGoodChallenges σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+            child).card ≤ N := by
+        intro child
+        rw [kimchiGoodChallenges]
+        exact le_trans (Finset.card_filter_le _ _) (le_of_eq Finset.card_univ)
+      have hBN : B ≤ N := le_trans (Nat.sub_le σ₀ 1)
+        (le_trans (hspread.1 e m hme O (fun _ => t0)) (hgoodN (fun _ => t0.toCoins)))
+      have hcard : Fintype.card (Zcash.Snark.RecursiveForkTape Pre (e + 1 + 1))
+          = CP * CT ^ N := by
+        have h := Fintype.card_congr (Zcash.Snark.RecursiveForkTape.equivSucc (F := Pre) (e + 1))
+        rwa [Fintype.card_prod, Fintype.card_fun] at h
+      set q₁ : Pre := O (prefixes (A.run O) ⟨m, hm⟩) with hq₁
+      set g' : Zcash.Snark.RecursiveForkTape Pre (e + 1) → ℕ := fun tp =>
+        (kimchiForkFrom σ b v P expand A proofOf prefixes dec (m + 1) htail O (A.run O)
+          tp.toCoins).runs with hg'
+      set M : (Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1)) → Finset Pre := fun childT =>
+        (kimchiGoodChallenges σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+          (fun w => (childT w).toCoins)).erase q₁ with hM
+      set f : Pre → (Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1)) → ℕ := fun q childT =>
+        (kimchiScanCandidate σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+          (fun w => (childT w).toCoins) q).runs with hf
+      -- transport the tape sum to the (order, children) product
+      have htrans : ∑ tape : Zcash.Snark.RecursiveForkTape Pre (e + 1 + 1),
+          (kimchiForkFrom σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+            tape.toCoins).runs
+          = ∑ pr : (Fin N ≃ Pre) × (Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1)),
+              (kimchiForkFrom σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+                (Zcash.Snark.RecursiveForkTape.node pr.1 pr.2).toCoins).runs := by
+        rw [← Equiv.sum_comp (Zcash.Snark.RecursiveForkTape.equivSucc (F := Pre) (e + 1)).symm
+          (fun tape => (kimchiForkFrom σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+            tape.toCoins).runs)]
+        exact Finset.sum_congr rfl (fun pr _ => rfl)
+      -- the pointwise node bound, at a tape node
+      have hpoint : ∀ pr : (Fin N ≃ Pre) × (Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1)),
+          (kimchiForkFrom σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+            (Zcash.Snark.RecursiveForkTape.node pr.1 pr.2).toCoins).runs
+          ≤ g' (pr.2 q₁)
+            + 2 * ∑ q ∈ Finset.univ.filter (fun q : Pre =>
+                Zcash.Snark.scanRank pr.1 (insert q (M pr.2)) q < 2), f q pr.2 := fun pr =>
+        kimchiForkFrom_node_runs_le σ b v P expand A proofOf prefixes dec m hme O (A.run O) pr.1
+          (fun w => (pr.2 w).toCoins)
+      -- summed, with the first-branch axis marginalized and the order axis commuted inside
+      have hsum : ∑ pr : (Fin N ≃ Pre) × (Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1)),
+          (kimchiForkFrom σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+            (Zcash.Snark.RecursiveForkTape.node pr.1 pr.2).toCoins).runs
+          ≤ CP * (CT ^ (N - 1) * ∑ t : Zcash.Snark.RecursiveForkTape Pre (e + 1), g' t)
+            + 2 * ∑ childT : Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1), ∑ q : Pre,
+                (Finset.univ.filter (fun order : Fin N ≃ Pre =>
+                  Zcash.Snark.scanRank order (insert q (M childT)) q < 2)).card
+                  * f q childT := by
+        have hper : ∀ childT : Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1),
+            ∑ order : Fin N ≃ Pre, 2 * ∑ q ∈ Finset.univ.filter (fun q : Pre =>
+                Zcash.Snark.scanRank order (insert q (M childT)) q < 2), f q childT
+            = 2 * ∑ q : Pre, (Finset.univ.filter (fun order : Fin N ≃ Pre =>
+                Zcash.Snark.scanRank order (insert q (M childT)) q < 2)).card * f q childT := by
+          intro childT
+          rw [← Finset.mul_sum]
+          congr 1
+          calc ∑ order : Fin N ≃ Pre, ∑ q ∈ Finset.univ.filter (fun q : Pre =>
+                  Zcash.Snark.scanRank order (insert q (M childT)) q < 2), f q childT
+              = ∑ order : Fin N ≃ Pre, ∑ q : Pre,
+                  (if Zcash.Snark.scanRank order (insert q (M childT)) q < 2 then f q childT
+                    else 0) :=
+                Finset.sum_congr rfl (fun order _ => Finset.sum_filter _ _)
+            _ = ∑ q : Pre, ∑ order : Fin N ≃ Pre,
+                  (if Zcash.Snark.scanRank order (insert q (M childT)) q < 2 then f q childT
+                    else 0) :=
+                Finset.sum_comm
+            _ = ∑ q : Pre, (Finset.univ.filter (fun order : Fin N ≃ Pre =>
+                  Zcash.Snark.scanRank order (insert q (M childT)) q < 2)).card * f q childT := by
+                refine Finset.sum_congr rfl (fun q _ => ?_)
+                rw [← Finset.sum_filter, Finset.sum_const, smul_eq_mul]
+        calc ∑ pr : (Fin N ≃ Pre) × (Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1)),
+            (kimchiForkFrom σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+              (Zcash.Snark.RecursiveForkTape.node pr.1 pr.2).toCoins).runs
+            ≤ ∑ pr : (Fin N ≃ Pre) × (Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1)),
+                (g' (pr.2 q₁)
+                  + 2 * ∑ q ∈ Finset.univ.filter (fun q : Pre =>
+                      Zcash.Snark.scanRank pr.1 (insert q (M pr.2)) q < 2), f q pr.2) :=
+              Finset.sum_le_sum (fun pr _ => hpoint pr)
+          _ = (∑ pr : (Fin N ≃ Pre) × (Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1)),
+                  g' (pr.2 q₁))
+              + ∑ pr : (Fin N ≃ Pre) × (Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1)),
+                  2 * ∑ q ∈ Finset.univ.filter (fun q : Pre =>
+                    Zcash.Snark.scanRank pr.1 (insert q (M pr.2)) q < 2), f q pr.2 := by
+              rw [← Finset.sum_add_distrib]
+          _ = CP * (CT ^ (N - 1) * ∑ t : Zcash.Snark.RecursiveForkTape Pre (e + 1), g' t)
+              + 2 * ∑ childT : Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1), ∑ q : Pre,
+                  (Finset.univ.filter (fun order : Fin N ≃ Pre =>
+                    Zcash.Snark.scanRank order (insert q (M childT)) q < 2)).card
+                    * f q childT := by
+              congr 1
+              · rw [Fintype.sum_prod_type]
+                calc ∑ _o : Fin N ≃ Pre,
+                      ∑ c : Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1), g' (c q₁)
+                    = ∑ _o : Fin N ≃ Pre,
+                        CT ^ (N - 1) * ∑ t : Zcash.Snark.RecursiveForkTape Pre (e + 1), g' t :=
+                      Finset.sum_congr rfl (fun _ _ => Zcash.Snark.sum_eval_pi q₁ g')
+                  _ = CP * (CT ^ (N - 1)
+                        * ∑ t : Zcash.Snark.RecursiveForkTape Pre (e + 1), g' t) := by
+                      rw [Finset.sum_const, Finset.card_univ, smul_eq_mul]
+              · calc ∑ pr : (Fin N ≃ Pre) × (Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1)),
+                    2 * ∑ q ∈ Finset.univ.filter (fun q : Pre =>
+                      Zcash.Snark.scanRank pr.1 (insert q (M pr.2)) q < 2), f q pr.2
+                    = ∑ childT : Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1),
+                        ∑ order : Fin N ≃ Pre, 2 * ∑ q ∈ Finset.univ.filter (fun q : Pre =>
+                          Zcash.Snark.scanRank order (insert q (M childT)) q < 2),
+                          f q childT := by rw [Fintype.sum_prod_type_right]
+                  _ = ∑ childT : Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1),
+                        2 * ∑ q : Pre, (Finset.univ.filter (fun order : Fin N ≃ Pre =>
+                          Zcash.Snark.scanRank order (insert q (M childT)) q < 2)).card
+                            * f q childT :=
+                      Finset.sum_congr rfl (fun childT _ => hper childT)
+                  _ = 2 * ∑ childT : Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1), ∑ q : Pre,
+                        (Finset.univ.filter (fun order : Fin N ≃ Pre =>
+                          Zcash.Snark.scanRank order (insert q (M childT)) q < 2)).card
+                          * f q childT :=
+                      (Finset.mul_sum _ _ _).symm
+      -- each challenge is low-rank in at most a 2/|good set| fraction of the orders
+      have hOrderCount : ∀ (childT : Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1)) (q : Pre),
+          B * (Finset.univ.filter (fun order : Fin N ≃ Pre =>
+            Zcash.Snark.scanRank order (insert q (M childT)) q < 2)).card ≤ 2 * CP := by
+        intro childT q
+        have hA := Zcash.Snark.card_scanRank_lt_mul_le (n := N) (insert q (M childT))
+          (Finset.mem_insert_self q _) 2
+        refine le_trans (Nat.mul_le_mul_right _ ?_) hA
+        have herase : (kimchiGoodChallenges σ b v P expand A proofOf prefixes dec m hme O
+            (A.run O) (fun w => (childT w).toCoins)).card - 1 ≤ (M childT).card := by
+          rw [hM]
+          exact Finset.pred_card_le_card_erase
+        have hgood := hspread.1 e m hme O childT
+        have hins : (M childT).card ≤ (insert q (M childT)).card :=
+          Finset.card_le_card (Finset.subset_insert q _)
+        rw [hB]
+        omega
+      -- the scan candidates, marginalized and closed by the induction hypothesis
+      have hfsum : ∀ q : Pre, B ^ (e + 1)
+          * ∑ childT : Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1), f q childT
+          ≤ (6 * N) ^ (e + 1) * (CT ^ (N - 1) * CT) := by
+        intro q
+        have hmarg : ∑ childT : Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1), f q childT
+            = CT ^ (N - 1) * ∑ t : Zcash.Snark.RecursiveForkTape Pre (e + 1),
+                (kimchiScanCandidate σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+                  (fun _ => t.toCoins) q).runs := by
+          rw [hf]
+          exact Zcash.Snark.sum_eval_pi q
+            (fun t : Zcash.Snark.RecursiveForkTape Pre (e + 1) =>
+              (kimchiScanCandidate σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+                (fun _ => t.toCoins) q).runs)
+        have hinner : B ^ (e + 1) * ∑ t : Zcash.Snark.RecursiveForkTape Pre (e + 1),
+            (kimchiScanCandidate σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+              (fun _ => t.toCoins) q).runs ≤ (6 * N) ^ (e + 1) * CT := by
+          by_cases hcond : prefixes (A.run (Function.update O
+              (prefixes (A.run O) ⟨m, by omega⟩) q)) ⟨m, by omega⟩
+              = prefixes (A.run O) ⟨m, by omega⟩
+          · have hcases : ∀ t : Zcash.Snark.RecursiveForkTape Pre (e + 1),
+                (kimchiScanCandidate σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+                    (fun _ => t.toCoins) q).runs
+                = (kimchiForkFrom σ b v P expand A proofOf prefixes dec (m + 1) (by omega)
+                    (Function.update O (prefixes (A.run O) ⟨m, by omega⟩) q)
+                    (A.run (Function.update O (prefixes (A.run O) ⟨m, by omega⟩) q))
+                    t.toCoins).runs := by
+              intro t
+              rw [kimchiScanCandidate_runs_cases, if_pos hcond]
+            rw [Finset.sum_congr rfl (fun t _ => hcases t)]
+            exact ih (m + 1) (by omega) _
+          · have hcases : ∀ t : Zcash.Snark.RecursiveForkTape Pre (e + 1),
+                (kimchiScanCandidate σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+                  (fun _ => t.toCoins) q).runs = 1 := by
+              intro t
+              rw [kimchiScanCandidate_runs_cases, if_neg hcond]
+            rw [Finset.sum_congr rfl (fun t _ => hcases t), Finset.sum_const, Finset.card_univ,
+              smul_eq_mul, mul_one]
+            apply Nat.mul_le_mul_right
+            exact Nat.pow_le_pow_left (le_trans hBN (Nat.le_mul_of_pos_left N (by omega))) (e + 1)
+        calc B ^ (e + 1) * ∑ childT : Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1), f q childT
+            = B ^ (e + 1) * (CT ^ (N - 1) * ∑ t : Zcash.Snark.RecursiveForkTape Pre (e + 1),
+                (kimchiScanCandidate σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+                  (fun _ => t.toCoins) q).runs) := by rw [hmarg]
+          _ = CT ^ (N - 1) * (B ^ (e + 1) * ∑ t : Zcash.Snark.RecursiveForkTape Pre (e + 1),
+                (kimchiScanCandidate σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+                  (fun _ => t.toCoins) q).runs) := by ring
+          _ ≤ CT ^ (N - 1) * ((6 * N) ^ (e + 1) * CT) := Nat.mul_le_mul_left _ hinner
+          _ = (6 * N) ^ (e + 1) * (CT ^ (N - 1) * CT) := by ring
+      -- the first branch, closed by the induction hypothesis at the same table
+      have hgrec : B ^ (e + 1) * ∑ t : Zcash.Snark.RecursiveForkTape Pre (e + 1), g' t
+          ≤ (6 * N) ^ (e + 1) * CT := ih (m + 1) htail O
+      -- assemble
+      rw [htrans]
+      calc B ^ (e + 1 + 1)
+            * ∑ pr : (Fin N ≃ Pre) × (Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1)),
+              (kimchiForkFrom σ b v P expand A proofOf prefixes dec m hme O (A.run O)
+                (Zcash.Snark.RecursiveForkTape.node pr.1 pr.2).toCoins).runs
+          ≤ B ^ (e + 1 + 1)
+              * (CP * (CT ^ (N - 1) * ∑ t : Zcash.Snark.RecursiveForkTape Pre (e + 1), g' t)
+                + 2 * ∑ childT : Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1), ∑ q : Pre,
+                    (Finset.univ.filter (fun order : Fin N ≃ Pre =>
+                      Zcash.Snark.scanRank order (insert q (M childT)) q < 2)).card
+                      * f q childT) := Nat.mul_le_mul_left _ hsum
+        _ ≤ N * (6 * N) ^ (e + 1) * (CP * CT ^ N)
+            + 4 * N * (6 * N) ^ (e + 1) * (CP * CT ^ N) := by
+            rw [Nat.mul_add]
+            refine Nat.add_le_add ?_ ?_
+            · -- the first branches
+              calc B ^ (e + 1 + 1)
+                    * (CP * (CT ^ (N - 1) * ∑ t : Zcash.Snark.RecursiveForkTape Pre (e + 1), g' t))
+                  = B * CP * CT ^ (N - 1)
+                      * (B ^ (e + 1) * ∑ t : Zcash.Snark.RecursiveForkTape Pre (e + 1), g' t) := by
+                    rw [Nat.pow_succ]
+                    ring
+                _ ≤ B * CP * CT ^ (N - 1) * ((6 * N) ^ (e + 1) * CT) :=
+                    Nat.mul_le_mul_left _ hgrec
+                _ = B * (6 * N) ^ (e + 1) * (CP * (CT ^ (N - 1) * CT)) := by ring
+                _ = B * (6 * N) ^ (e + 1) * (CP * CT ^ N) := by rw [hCTN]
+                _ ≤ N * (6 * N) ^ (e + 1) * (CP * CT ^ N) :=
+                    Nat.mul_le_mul_right _ (Nat.mul_le_mul_right _ hBN)
+            · -- the scans
+              calc B ^ (e + 1 + 1)
+                    * (2 * ∑ childT : Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1), ∑ q : Pre,
+                        (Finset.univ.filter (fun order : Fin N ≃ Pre =>
+                          Zcash.Snark.scanRank order (insert q (M childT)) q < 2)).card
+                          * f q childT)
+                  = ∑ childT : Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1), ∑ q : Pre,
+                      (B * (Finset.univ.filter (fun order : Fin N ≃ Pre =>
+                        Zcash.Snark.scanRank order (insert q (M childT)) q < 2)).card)
+                        * (2 * (B ^ (e + 1) * f q childT)) := by
+                    simp only [Finset.mul_sum]
+                    refine Finset.sum_congr rfl (fun childT _ =>
+                      Finset.sum_congr rfl (fun q _ => ?_))
+                    rw [Nat.pow_succ]
+                    ring
+                _ ≤ ∑ childT : Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1), ∑ q : Pre,
+                      2 * CP * (2 * (B ^ (e + 1) * f q childT)) :=
+                    Finset.sum_le_sum (fun childT _ => Finset.sum_le_sum (fun q _ =>
+                      Nat.mul_le_mul_right _ (hOrderCount childT q)))
+                _ = 4 * CP * ∑ q : Pre, B ^ (e + 1)
+                      * ∑ childT : Pre → Zcash.Snark.RecursiveForkTape Pre (e + 1),
+                        f q childT := by
+                    rw [Finset.sum_comm]
+                    simp only [Finset.mul_sum]
+                    refine Finset.sum_congr rfl (fun q _ =>
+                      Finset.sum_congr rfl (fun childT _ => ?_))
+                    ring
+                _ ≤ 4 * CP * ∑ _q : Pre, (6 * N) ^ (e + 1) * (CT ^ (N - 1) * CT) :=
+                    Nat.mul_le_mul_left _ (Finset.sum_le_sum (fun q _ => hfsum q))
+                _ = 4 * N * (6 * N) ^ (e + 1) * (CP * CT ^ N) := by
+                    rw [Finset.sum_const, Finset.card_univ, smul_eq_mul, hCTN, ← hN]
+                    ring
+        _ = 5 * (N * (6 * N) ^ (e + 1) * (CP * CT ^ N)) := by ring
+        _ ≤ 6 * (N * (6 * N) ^ (e + 1) * (CP * CT ^ N)) :=
+            Nat.mul_le_mul_right _ (by omega)
+        _ = (6 * N) ^ (e + 1 + 1)
+              * Fintype.card (Zcash.Snark.RecursiveForkTape Pre (e + 1 + 1)) := by
+            rw [hcard, Nat.pow_succ]
+            ring
+
 end Extractor
 
 /-- **The extractor.** Given the oracle table and the fork tape, run the adversary, rewind it at
@@ -665,8 +1692,11 @@ What this is worth, stated honestly. It is the **worst case**, and it is exponen
 the number of rounds `k` and in the challenge domain, since at the deployed instantiation
 `n = Fintype.card Prechallenge = 2 ^ 128`. It is therefore *not* a polynomial-AFK claim, the
 same caveat ironwood attaches to its own `reductionEfficient_exponential`. The conditional
-average `(6/δ)^k` under a good-challenge density floor is a different theorem, and it is not
-proved anywhere in this tree.
+average `(6/δ)^k` under a good-challenge density floor is a different theorem: it is
+`kimchiExtractRuns_sum_le_of_forkSpread` below, and it neither supersedes nor weakens this one —
+it holds only over a `KimchiForkSpread` hypothesis that nothing in this tree discharges at deployed
+parameters (`exists_kimchiForkSpread_two_le_of_rounds` discharges it at toy ones, at every round
+count), and it averages over tapes rather than bounding pointwise.
 
 What it does buy: this is the first bound here that is **computed from the counter** rather than
 obtained from a `sup` that never inspects it. Feeding it to `ReductionEfficient`
@@ -701,6 +1731,409 @@ theorem one_le_kimchiExtractRuns [DecidableEq F] [DecidableEq G] [DecidableEq T]
     1 ≤ kimchiExtractRuns σ b v P expand A proofOf prefixes dec O coins :=
   one_le_kimchiForkFrom_runs σ b v P expand A proofOf prefixes dec 0 (Nat.zero_add σ.k) O
     (A.run O) coins
+
+/-- **The extractor's tape-averaged call count under fork spread**: `(6·|Pre|/(σ₀−1))^(k+1)`.
+`kimchiForkFrom_sum_runs_le_of_forkSpread` at the root, `e := σ.k`, `m := 0` — the same
+instantiation `kimchiExtractRuns_le` and `one_le_kimchiExtractRuns` make of their own recursive
+lemmas, and the endpoint of the conditional block.
+
+**This is the *conditional* counterpart of `kimchiExtractRuns_le`, not a replacement for it.**
+Three things it is not, spelled out because the difference is the whole content:
+
+* It is **conditional**. `KimchiForkSpread σ₀` is a hypothesis nothing in this tree proves at
+  deployed parameters, and by design: deriving a spread floor from an adversary's success
+  probability is recorded open research (`docs/external-audit-followup.md` §O-1b). Read as an
+  implication, not as a bound in force. It is not an implication out of an empty hypothesis
+  either — `spreadExhibit_extractRuns_sum_le` is this theorem at parameters that discharge it.
+* It is a **tape average**, not a pointwise bound: it caps `∑` over the uniform depth-`(k+1)` tape
+  at a fixed table, scaled by `(σ₀−1)^(k+1)`. `kimchiExtractRuns_le` still stands unweakened beside
+  it as the unconditional worst case on *every* tape, and remains the bound the endpoints read.
+* It does **not** discharge `ReductionEfficient` (`Forking/KnowledgeSoundness.lean`). That
+  predicate averages over *tables* at a fixed tape; this averages over *tapes* at a fixed table.
+  Crossing the two axes is a separate step (Fubini plus averaging to a witness tape), and it is not
+  taken here.
+
+It is also degenerate exactly where the hypothesis is: at `σ₀ ≤ 1` the left-hand side is `0` and
+the statement is empty. Two compiled exhibits say when that happens —
+`kimchiForkSpread_eq_zero_of_leaf_unstable` for a table that forces it, and
+`kimchiNodeFloor_eq_zero_of_forall_coins` for the coin quantifier that forced it before the node
+clause was narrowed. In the other direction, `spreadExhibit_extractRuns_sum_le` is this bound at a
+telescope that discharges the hypothesis at `σ₀ = 4` for every round count, and
+`spreadExhibit_card_le_extractRuns_sum` bounds that tape sum below by the number of tapes — so
+there the inequality is a real one at every depth. -/
+theorem kimchiExtractRuns_sum_le_of_forkSpread [DecidableEq F] [DecidableEq G] [DecidableEq T]
+    [Zero Pre] [DecidableEq Pre] [Fintype Pre]
+    (σ : SRS G) (b : Fin (2 ^ σ.k) → F) (v : F) (P : G) (expand : Pre → F)
+    (A : Zcash.Snark.OracleComp T Pre Pf)
+    (proofOf : Pf → OpeningProof F G σ.k) (prefixes : Pf → Fin (σ.k + 1) → T)
+    (dec : DecodesFromPrefixes σ proofOf prefixes) {σ₀ : ℕ}
+    (hspread : KimchiForkSpread σ b v P expand A proofOf prefixes dec σ₀) (O : T → Pre) :
+    (σ₀ - 1) ^ (σ.k + 1) * ∑ tape : Zcash.Snark.RecursiveForkTape Pre (σ.k + 1),
+        kimchiExtractRuns σ b v P expand A proofOf prefixes dec O tape.toCoins
+      ≤ (6 * Fintype.card Pre) ^ (σ.k + 1)
+          * Fintype.card (Zcash.Snark.RecursiveForkTape Pre (σ.k + 1)) :=
+  kimchiForkFrom_sum_runs_le_of_forkSpread σ b v P expand A proofOf prefixes dec hspread
+    σ.k 0 (Nat.zero_add σ.k) O
+
+/-! ### A satisfiable instance of the spread hypothesis
+
+Every theorem in the block above is an implication out of `KimchiForkSpread`, so once the node
+clause has been narrowed the honest question runs the other way: does that predicate have a model
+at `2 ≤ σ₀` at all? A hypothesis nothing satisfies makes the whole conditional layer vacuous just
+as surely as the empty-order coin trees did, and this project pins satisfiability rather than
+asserting it.
+
+This subsection exhibits a family, one member per round count `k`, over `T = Pf = Unit`,
+`Pre = Fin 5`, `F = G = ℚ` and the all-zero SRS. That adversary wins identically
+(`spreadExhibit_wins`) and its prefixes never move, so every reprogrammed run counts at every
+round: the leaf good set and each node good set contain all four nonzero prechallenges. Hence
+`KimchiForkSpread … 4` at every `k` (`spreadExhibit_forkSpread`), and
+`kimchiExtractRuns_sum_le_of_forkSpread` there reads a real inequality
+(`3 ^ (k + 1) * ∑ … ≤ 30 ^ (k + 1) * …`) rather than `0 ≤ …`.
+
+The node clause is what needed the work: it is vacuous only at `σ.k = 0`, and above that it asks
+for a certificate out of a positive-depth fork position. That is `spreadExhibit_forkFrom_isSome`,
+an induction on certificate depth over complete coin trees. Its three scans need one arithmetic
+fact between them — a challenge outside `{0, q₁, q₂}` — which is what fixes the alphabet at
+`Fin 5` and the floor at `4`.
+
+**What this does not settle: a spread at *deployed* parameters.** There `Pre = Fin (2 ^ 128)` and
+the adversary is a real one, which does not win identically; the floor would have to come from its
+success probability `ε`, and that derivation is the recorded open research
+(`docs/external-audit-followup.md` §O-1b). The exhibit deliberately does not touch it. What it
+does say is that the conditional layer above is non-vacuous at every certificate depth, not only
+at the Schnorr leaf.
+-/
+
+section SpreadExhibit
+
+/-- **The exhibit's SRS**, at an arbitrary round count `k`: `k` IPA rounds, and every group
+element `0`. The zero generators are what make `Wins` hold identically, whatever `k` is; the
+round count is a parameter precisely so that the node clause — vacuous only at `k = 0` — carries
+content at every `k ≥ 1`. Being a structure literal, its `k` field is *definitionally* `k`, so the
+`Fin (2 ^ σ.k)`-indexed data below typechecks without a cast. -/
+private def spreadExhibitSRS (k : ℕ) : SRS ℚ := { k := k, g := fun _ => 0, h := 0, U := 0 }
+
+/-- **The exhibit's evaluation vector**: the zero vector of length `2 ^ k`. -/
+private def spreadExhibitB (k : ℕ) : Fin (2 ^ (spreadExhibitSRS k).k) → ℚ := fun _ => 0
+
+/-- **The exhibit's adversary**: the machine that queries nothing and returns `()`, so
+`spreadExhibitA.run O = ()` on every table and on every reprogramming of one. It is
+`k`-independent — the adversary reads nothing, so there is nothing for the round count to
+change. -/
+private def spreadExhibitA : Zcash.Snark.OracleComp Unit (Fin 5) Unit := .pure ()
+
+/-- **The exhibit's endo-expansion**, constantly `0`. Injectivity and nonvanishing of `expand` are
+hypotheses of the *realization* lemmas, never of `KimchiForkSpread`, so the counting layer does not
+ask for them and the constant map is legal here. Also `k`-independent: `expand` is a map on the
+prechallenge alphabet, which no round count touches. -/
+private def spreadExhibitExpand : Fin 5 → ℚ := fun _ => 0
+
+/-- **The exhibit's proof map**: the all-zero opening proof, whatever the run — all `k` rounds of
+cross-terms included. -/
+private def spreadExhibitProofOf (k : ℕ) : Unit → OpeningProof ℚ ℚ (spreadExhibitSRS k).k :=
+  fun _ => { lr := fun _ => (0, 0), delta := 0, z1 := 0, z2 := 0, sg := 0 }
+
+/-- **The exhibit's prefix map**. `T = Unit`, so every prefix is the same point and the fork's
+stability test `prefixes p' j = t` closes by `rfl` — which is what lets every reprogrammed run
+count, at every round `j` and not only at the Schnorr one. -/
+private def spreadExhibitPrefixes (k : ℕ) :
+    Unit → Fin ((spreadExhibitSRS k).k + 1) → Unit := fun _ _ => ()
+
+/-- **Commit-then-challenge, discharged for the exhibit.** Both laws are `rfl` at the all-zero
+proof: `round_eq` compares `(0, 0)` with the constant `round` map at each of the `k` rounds, and
+`final_eq` does the same for `(δ, sg)`. (At `k = 0` the first is vacuous; nothing in the proof
+depends on which.) -/
+private def spreadExhibitDec (k : ℕ) :
+    DecodesFromPrefixes (spreadExhibitSRS k) (spreadExhibitProofOf k) (spreadExhibitPrefixes k)
+    where
+  round := fun _ => (0, 0)
+  final := fun _ => (0, 0)
+  round_eq := fun _ _ => rfl
+  final_eq := fun _ => rfl
+
+/-- **The exhibit's adversary wins on every table and every run, at every round count.** The one
+algebraic step, and it is arithmetic rather than geometry: with all-zero generators the recombined
+commitment is `0 + 0 • σ.U + ∑ (j : Fin k), ((u j)⁻¹ • 0 + u j • 0) = 0`, so the Schnorr equation
+reads `0 = 0` whatever `σ.U`, `σ.h` and the challenges are, and the `sg` check reads
+`0 = ∑ i, _ • (0 : ℚ) = 0`. Nothing here was ever about `k = 0`: the round sum is over an
+inhabited index type from `k = 1` on, but every summand is still `0`. -/
+private theorem spreadExhibit_wins (k : ℕ) (O : Unit → Fin 5) (p : Unit) :
+    Wins (spreadExhibitSRS k) (spreadExhibitB k) 0 0 spreadExhibitExpand (spreadExhibitProofOf k)
+      (spreadExhibitPrefixes k) O p := by
+  refine ⟨?_, ?_⟩ <;>
+    simp [spreadExhibitSRS, spreadExhibitProofOf, recombine, commitGen]
+
+/-- **Every reprogrammed leaf run succeeds.** The prefix test is `rfl` at `T = Unit` and the win
+test is `spreadExhibit_wins`, so `kimchiLeafCandidate` takes its `then` branch for every
+prechallenge `q` — including `q = 0`, which the good set then discards on its own nonzero
+clause. -/
+private theorem spreadExhibit_leafCandidate_isSome (k : ℕ) (O : Unit → Fin 5) (p : Unit)
+    (q : Fin 5) :
+    (kimchiLeafCandidate (spreadExhibitSRS k) (spreadExhibitB k) 0 0 spreadExhibitExpand
+      spreadExhibitA (spreadExhibitProofOf k) (spreadExhibitPrefixes k) O p q).output.isSome
+      = true := by
+  simp only [kimchiLeafCandidate]
+  rw [if_pos ⟨rfl, spreadExhibit_wins _ _ _⟩]
+  rfl
+
+/-- **`Fin 5` always holds a challenge the scans have not consumed.** A node runs three scans, and
+between them they exclude at most `{0, q₁, q₂}`; four nonzero prechallenges is therefore one more
+than the argument spends. This is the only arithmetic input to the fork-success induction below,
+and it is why the alphabet is `Fin 5` and the floor `σ₀ = 4`. Stated `∀`-closed over both
+exclusions because `decide` cannot see free variables. -/
+private theorem spreadExhibit_exists_fresh :
+    ∀ a b : Fin 5, ∃ u : Fin 5, u ≠ 0 ∧ u ≠ a ∧ u ≠ b := by decide
+
+/-- **The fork succeeds at every certificate depth, on every complete coin tree.** The heart of the
+exhibit, and the one genuine induction in it: against this adversary — which wins identically
+(`spreadExhibit_wins`) and whose prefixes never move (`T = Unit`) — `kimchiForkFrom` returns a
+certificate from *every* position it can be entered at, whatever the round count `k`, the
+certificate depth `e` and the round index `m`.
+
+The induction is on certificate depth, in the structural-recursion shape `kimchiForkFrom_runs_le`
+uses, and the hypothesis is `RecursiveForkCoins.Complete` — "every node's order list enumerates the
+whole alphabet, recursively" — rather than tape-derivedness, because `Complete`'s `.node` arm is
+literally what the scans need and matches `kimchiForkFrom`'s own pattern with no `toCoins` in the
+way. `RecursiveForkTape.toCoins_complete` supplies it for every tape, which is how the node clause
+of `KimchiForkSpread` reads it.
+
+At depth `0` the leaf arm takes its `then` branch by `spreadExhibit_wins`, and its single scan
+finds a challenge by `nextForkChallenge_isSome_of_good` at any `u ∉ {0, q₁}`. At depth `e + 1` the
+cached run succeeds by the induction hypothesis, and so does every reprogrammed one, so the first
+two scans succeed as before; the **third** scan is no harder —
+`nextForkChallenge_other_good_mem_rest` puts every *other* good challenge in the residual list
+`rest`, and `nextForkChallenge_output_fresh` identifies the seen set as `q₂ :: [q₁]`, so all that
+is needed is a `u ∉ {0, q₁, q₂}`. -/
+private theorem spreadExhibit_forkFrom_isSome (k : ℕ) :
+    {e : ℕ} → (m : ℕ) → (hme : m + e = (spreadExhibitSRS k).k) → (O : Unit → Fin 5) →
+      (p : Unit) → (coins : Zcash.Snark.RecursiveForkCoins (Fin 5) (e + 1)) → coins.Complete →
+      (kimchiForkFrom (spreadExhibitSRS k) (spreadExhibitB k) 0 0 spreadExhibitExpand
+          spreadExhibitA (spreadExhibitProofOf k) (spreadExhibitPrefixes k) (spreadExhibitDec k)
+          m hme O p coins).output.isSome = true
+  | 0, m, hme, O, p, .node order child, hc => by
+      obtain ⟨u, hu0, hu1, -⟩ := spreadExhibit_exists_fresh (O ()) (O ())
+      have hscan : (Zcash.Snark.nextForkChallenge
+          (fun q => kimchiLeafCandidate (spreadExhibitSRS k) (spreadExhibitB k) 0 0
+            spreadExhibitExpand spreadExhibitA (spreadExhibitProofOf k)
+            (spreadExhibitPrefixes k) O p q) [O ()] order).output.isSome = true :=
+        Zcash.Snark.nextForkChallenge_isSome_of_good _ _ (hc.1 u) hu0 (by simpa using hu1)
+          (spreadExhibit_leafCandidate_isSome k O p u)
+      rw [kimchiForkFrom]
+      simp only []
+      split
+      · split
+        · rename_i hnone
+          exact absurd hnone (Option.isSome_iff_ne_none.mp hscan)
+        · rfl
+      · exact absurd (spreadExhibit_wins k O p) (by assumption)
+  | e + 1, m, hme, O, p, .node order child, hc => by
+      have htail : m + 1 + e = (spreadExhibitSRS k).k := by omega
+      have hcand : ∀ q, (kimchiScanCandidate (spreadExhibitSRS k) (spreadExhibitB k) 0 0
+          spreadExhibitExpand spreadExhibitA (spreadExhibitProofOf k) (spreadExhibitPrefixes k)
+          (spreadExhibitDec k) m hme O p child q).output.isSome = true := by
+        intro q
+        rw [kimchiScanCandidate]
+        simp only []
+        rw [if_pos trivial]
+        exact spreadExhibit_forkFrom_isSome k (m + 1) htail _ _ (child q) (hc.2 q)
+      have hfirst : (kimchiForkFrom (spreadExhibitSRS k) (spreadExhibitB k) 0 0
+          spreadExhibitExpand spreadExhibitA (spreadExhibitProofOf k) (spreadExhibitPrefixes k)
+          (spreadExhibitDec k) (m + 1) htail O p (child (O ()))).output.isSome = true :=
+        spreadExhibit_forkFrom_isSome k (m + 1) htail O p (child (O ())) (hc.2 _)
+      have hsecond : (Zcash.Snark.nextForkChallenge
+          (fun q => kimchiScanCandidate (spreadExhibitSRS k) (spreadExhibitB k) 0 0
+            spreadExhibitExpand spreadExhibitA (spreadExhibitProofOf k) (spreadExhibitPrefixes k)
+            (spreadExhibitDec k) m hme O p child q) [O ()] order).output.isSome = true := by
+        obtain ⟨u, hu0, hu1, -⟩ := spreadExhibit_exists_fresh (O ()) (O ())
+        exact Zcash.Snark.nextForkChallenge_isSome_of_good _ _ (hc.1 u) hu0
+          (by simpa using hu1) (hcand u)
+      rw [kimchiForkFrom]
+      simp only []
+      split
+      · rename_i hnone
+        exact absurd hnone (Option.isSome_iff_ne_none.mp hfirst)
+      · rename_i c₁ hfirstSome
+        split
+        · rename_i hnone
+          exact absurd hnone (Option.isSome_iff_ne_none.mp hsecond)
+        · rename_i q₂ c₂ rest seen hsecondSome
+          have hsec : (Zcash.Snark.nextForkChallenge
+              (fun q => kimchiScanCandidate (spreadExhibitSRS k) (spreadExhibitB k) 0 0
+                spreadExhibitExpand spreadExhibitA (spreadExhibitProofOf k)
+                (spreadExhibitPrefixes k) (spreadExhibitDec k) m hme O p child q)
+              [O ()] order).output = some ((q₂, c₂), rest, seen) := hsecondSome
+          have hthird : (Zcash.Snark.nextForkChallenge
+              (fun q => kimchiScanCandidate (spreadExhibitSRS k) (spreadExhibitB k) 0 0
+                spreadExhibitExpand spreadExhibitA (spreadExhibitProofOf k)
+                (spreadExhibitPrefixes k) (spreadExhibitDec k) m hme O p child q)
+              seen rest).output.isSome = true := by
+            obtain ⟨u, hu0, hu1, hu2⟩ := spreadExhibit_exists_fresh (O ()) q₂
+            have hmem := Zcash.Snark.nextForkChallenge_other_good_mem_rest _ _ hsec (hc.1 u) hu0
+              (by simpa using hu1) (hcand u) hu2
+            have hfresh := Zcash.Snark.nextForkChallenge_output_fresh _ _ hsec
+            refine Zcash.Snark.nextForkChallenge_isSome_of_good _ _ hmem hu0 ?_ (hcand u)
+            rw [hfresh.2.2]
+            simp [hu1, hu2]
+          split
+          · rename_i hnone
+            exact absurd hnone (Option.isSome_iff_ne_none.mp hthird)
+          · rfl
+
+/-- **Every reprogrammed node run succeeds**, the node counterpart of
+`spreadExhibit_leafCandidate_isSome`: at these parameters the prefix test of `kimchiScanCandidate`
+holds outright (again `T = Unit`), so the candidate is the recursive fork itself, which
+`spreadExhibit_forkFrom_isSome` returns a certificate from. Stated at complete child coins because
+that is what the node clause of `KimchiForkSpread` supplies, via
+`RecursiveForkTape.toCoins_complete`. -/
+private theorem spreadExhibit_scanCandidate_isSome (k : ℕ) {e : ℕ} (m : ℕ)
+    (hme : m + (e + 1) = (spreadExhibitSRS k).k) (O : Unit → Fin 5) (p : Unit)
+    (child : Fin 5 → Zcash.Snark.RecursiveForkCoins (Fin 5) (e + 1))
+    (hc : ∀ q, (child q).Complete) (q : Fin 5) :
+    (kimchiScanCandidate (spreadExhibitSRS k) (spreadExhibitB k) 0 0 spreadExhibitExpand
+      spreadExhibitA (spreadExhibitProofOf k) (spreadExhibitPrefixes k) (spreadExhibitDec k)
+      m hme O p child q).output.isSome = true := by
+  rw [kimchiScanCandidate]
+  simp only []
+  rw [if_pos trivial]
+  exact spreadExhibit_forkFrom_isSome k (m + 1) (by omega) _ _ (child q) (hc q)
+
+/-- **The exhibit satisfies the spread hypothesis at `σ₀ = 4`, at every round count.** Both
+clauses, and both by the same count: the good set contains `Finset.univ.erase 0`, which has
+`5 - 1 = 4` elements.
+
+For the **node** clause that is `spreadExhibit_scanCandidate_isSome` — every nonzero challenge
+reprograms to a run whose recursive fork still returns a certificate, by
+`spreadExhibit_forkFrom_isSome` at the tape-derived child coins. For the **leaf** clause it is
+`spreadExhibit_leafCandidate_isSome`, unchanged from the `k = 0` reading.
+
+This is what separates "unproved" from "unsatisfiable" for `KimchiForkSpread`: it remains true that
+nothing in this tree proves a spread at *deployed* parameters, and deriving one from an adversary's
+success probability is still the recorded open research. -/
+theorem spreadExhibit_forkSpread (k : ℕ) :
+    KimchiForkSpread (spreadExhibitSRS k) (spreadExhibitB k) 0 0 spreadExhibitExpand spreadExhibitA
+      (spreadExhibitProofOf k) (spreadExhibitPrefixes k) (spreadExhibitDec k) 4 := by
+  constructor
+  · intro e m hme O child
+    have hsub : Finset.univ.erase (0 : Fin 5) ⊆
+        kimchiGoodChallenges (spreadExhibitSRS k) (spreadExhibitB k) 0 0 spreadExhibitExpand
+          spreadExhibitA (spreadExhibitProofOf k) (spreadExhibitPrefixes k) (spreadExhibitDec k)
+          m hme O (spreadExhibitA.run O) (fun q => (child q).toCoins) := by
+      intro q hq
+      rw [kimchiGoodChallenges, Finset.mem_filter]
+      exact ⟨Finset.mem_univ q, Finset.ne_of_mem_erase hq,
+        spreadExhibit_scanCandidate_isSome k m hme O (spreadExhibitA.run O) _
+          (fun w => Zcash.Snark.RecursiveForkTape.toCoins_complete (child w)) q⟩
+    calc (4 : ℕ) = (Finset.univ.erase (0 : Fin 5)).card := by
+          rw [Finset.card_erase_of_mem (Finset.mem_univ _), Finset.card_univ, Fintype.card_fin]
+      _ ≤ _ := Finset.card_le_card hsub
+  · intro O
+    have hsub : Finset.univ.erase (0 : Fin 5) ⊆
+        kimchiLeafGoodChallenges (spreadExhibitSRS k) (spreadExhibitB k) 0 0 spreadExhibitExpand
+          spreadExhibitA (spreadExhibitProofOf k) (spreadExhibitPrefixes k) O
+          (spreadExhibitA.run O) := by
+      intro q hq
+      rw [kimchiLeafGoodChallenges, Finset.mem_filter]
+      exact ⟨Finset.mem_univ q, Finset.ne_of_mem_erase hq,
+        spreadExhibit_leafCandidate_isSome k O (spreadExhibitA.run O) q⟩
+    calc (4 : ℕ) = (Finset.univ.erase (0 : Fin 5)).card := by
+          rw [Finset.card_erase_of_mem (Finset.mem_univ _), Finset.card_univ, Fintype.card_fin]
+      _ ≤ _ := Finset.card_le_card hsub
+
+/-- **`KimchiForkSpread` is satisfiable above the degenerate floor.** The type-clean headline of
+the exhibit: there really is a parameter telescope carrying a spread with `2 ≤ σ₀`, so the
+conditional block above is not an implication out of an empty hypothesis. Stated existentially so
+that it says nothing about *which* instance discharges it — the witness is
+`spreadExhibit_forkSpread` at round count `0`, and `exists_kimchiForkSpread_two_le_of_rounds` is
+the same claim at *every* round count. -/
+theorem exists_kimchiForkSpread_two_le :
+    ∃ (σ : SRS ℚ) (b : Fin (2 ^ σ.k) → ℚ) (v P : ℚ) (expand : Fin 5 → ℚ)
+      (A : Zcash.Snark.OracleComp Unit (Fin 5) Unit) (proofOf : Unit → OpeningProof ℚ ℚ σ.k)
+      (prefixes : Unit → Fin (σ.k + 1) → Unit) (dec : DecodesFromPrefixes σ proofOf prefixes)
+      (σ₀ : ℕ), 2 ≤ σ₀ ∧ KimchiForkSpread σ b v P expand A proofOf prefixes dec σ₀ :=
+  ⟨spreadExhibitSRS 0, spreadExhibitB 0, 0, 0, spreadExhibitExpand, spreadExhibitA,
+    spreadExhibitProofOf 0, spreadExhibitPrefixes 0, spreadExhibitDec 0, 4, by norm_num,
+    spreadExhibit_forkSpread 0⟩
+
+/-- **`KimchiForkSpread` is satisfiable above the degenerate floor at every round count.** The
+headline of this subsection, and the answer to the question the `σ.k = 0` exhibit left open: both
+clauses of the predicate — the node one included, which is vacuous only at `σ.k = 0` — have a model
+at `σ₀ = 4` for every `K`.
+
+The `σ.k = K` conjunct is what makes the statement say that. Without it the existential is
+discharged by the `K = 0` witness and adds nothing to `exists_kimchiForkSpread_two_le`; with it,
+the conditional layer above is non-vacuous at every certificate depth rather than only at the
+Schnorr leaf. What it does **not** say is anything about deployed parameters: see the subsection
+preamble. -/
+theorem exists_kimchiForkSpread_two_le_of_rounds (K : ℕ) :
+    ∃ (σ : SRS ℚ) (b : Fin (2 ^ σ.k) → ℚ) (v P : ℚ) (expand : Fin 5 → ℚ)
+      (A : Zcash.Snark.OracleComp Unit (Fin 5) Unit) (proofOf : Unit → OpeningProof ℚ ℚ σ.k)
+      (prefixes : Unit → Fin (σ.k + 1) → Unit) (dec : DecodesFromPrefixes σ proofOf prefixes)
+      (σ₀ : ℕ), σ.k = K ∧ 2 ≤ σ₀ ∧ KimchiForkSpread σ b v P expand A proofOf prefixes dec σ₀ :=
+  ⟨spreadExhibitSRS K, spreadExhibitB K, 0, 0, spreadExhibitExpand, spreadExhibitA,
+    spreadExhibitProofOf K, spreadExhibitPrefixes K, spreadExhibitDec K, 4, rfl, by norm_num,
+    spreadExhibit_forkSpread K⟩
+
+/-- **The conditional bound, at parameters that discharge its hypothesis, at every round count.**
+`kimchiExtractRuns_sum_le_of_forkSpread` applied to `spreadExhibit_forkSpread`: with `σ₀ = 4`,
+`σ.k = k` and `|Pre| = 5` the scale factor is `(σ₀ − 1)^(k+1) = 3^(k+1)` and the cap is
+`(6·|Pre|)^(k+1) = 30^(k+1)` per tape, so the conclusion is an inequality with a nonzero left-hand
+side rather than the `0 ≤ …` the un-narrowed hypothesis would have forced.
+`spreadExhibit_card_le_extractRuns_sum` is the companion that compiles "nonzero" instead of
+asserting it. -/
+theorem spreadExhibit_extractRuns_sum_le (k : ℕ) :
+    3 ^ (k + 1) * ∑ tape : Zcash.Snark.RecursiveForkTape (Fin 5) (k + 1),
+        kimchiExtractRuns (spreadExhibitSRS k) (spreadExhibitB k) 0 0 spreadExhibitExpand
+          spreadExhibitA (spreadExhibitProofOf k) (spreadExhibitPrefixes k) (spreadExhibitDec k)
+          (fun _ => 0) tape.toCoins
+      ≤ 30 ^ (k + 1) * Fintype.card (Zcash.Snark.RecursiveForkTape (Fin 5) (k + 1)) := by
+  -- `(spreadExhibitSRS k).k` is definitionally `k`, so each of the four differences between this
+  -- statement and the general bound at these parameters is a `rfl`; discharging them one at a
+  -- time keeps the closing match syntactic, which a single defeq check is not cheap enough to do.
+  have hscale : (3 : ℕ) ^ (k + 1) = (4 - 1) ^ ((spreadExhibitSRS k).k + 1) := rfl
+  have hcap : (30 : ℕ) ^ (k + 1)
+      = (6 * Fintype.card (Fin 5)) ^ ((spreadExhibitSRS k).k + 1) := rfl
+  have hcard : Fintype.card (Zcash.Snark.RecursiveForkTape (Fin 5) (k + 1))
+      = Fintype.card (Zcash.Snark.RecursiveForkTape (Fin 5) ((spreadExhibitSRS k).k + 1)) := rfl
+  have hsum : (∑ tape : Zcash.Snark.RecursiveForkTape (Fin 5) (k + 1),
+        kimchiExtractRuns (spreadExhibitSRS k) (spreadExhibitB k) 0 0 spreadExhibitExpand
+          spreadExhibitA (spreadExhibitProofOf k) (spreadExhibitPrefixes k) (spreadExhibitDec k)
+          (fun _ => 0) tape.toCoins)
+      = ∑ tape : Zcash.Snark.RecursiveForkTape (Fin 5) ((spreadExhibitSRS k).k + 1),
+        kimchiExtractRuns (spreadExhibitSRS k) (spreadExhibitB k) 0 0 spreadExhibitExpand
+          spreadExhibitA (spreadExhibitProofOf k) (spreadExhibitPrefixes k) (spreadExhibitDec k)
+          (fun _ => 0) tape.toCoins :=
+    rfl
+  rw [hscale, hcap, hcard, hsum]
+  exact kimchiExtractRuns_sum_le_of_forkSpread (spreadExhibitSRS k) (spreadExhibitB k) 0 0
+    spreadExhibitExpand spreadExhibitA (spreadExhibitProofOf k) (spreadExhibitPrefixes k)
+    (spreadExhibitDec k) (spreadExhibit_forkSpread k) (fun _ => 0)
+
+/-- **The exhibit's tape sum is at least the number of tapes**, so the inequality above is a real
+one at every round count rather than `0 ≤ 0`. `one_le_kimchiExtractRuns` says the extractor bills
+at least one run per tape; summing that floor over the uniform tape space is
+`Finset.card_nsmul_le_sum` at `n := 1`.
+
+This is the anti-vacuity companion of `spreadExhibit_extractRuns_sum_le`, in the shape this
+project pins rather than argues (`docs/negative-controls.md`): an upper bound on a sum says
+nothing if the sum could be provably `0`. -/
+theorem spreadExhibit_card_le_extractRuns_sum (k : ℕ) :
+    Fintype.card (Zcash.Snark.RecursiveForkTape (Fin 5) (k + 1))
+      ≤ ∑ tape : Zcash.Snark.RecursiveForkTape (Fin 5) (k + 1),
+        kimchiExtractRuns (spreadExhibitSRS k) (spreadExhibitB k) 0 0 spreadExhibitExpand
+          spreadExhibitA (spreadExhibitProofOf k) (spreadExhibitPrefixes k) (spreadExhibitDec k)
+          (fun _ => 0) tape.toCoins := by
+  have h := Finset.card_nsmul_le_sum
+    (Finset.univ : Finset (Zcash.Snark.RecursiveForkTape (Fin 5) (k + 1)))
+    (fun tape => kimchiExtractRuns (spreadExhibitSRS k) (spreadExhibitB k) 0 0 spreadExhibitExpand
+      spreadExhibitA (spreadExhibitProofOf k) (spreadExhibitPrefixes k) (spreadExhibitDec k)
+      (fun _ => 0) tape.toCoins) 1
+    (fun tape _ => one_le_kimchiExtractRuns (spreadExhibitSRS k) (spreadExhibitB k) 0 0
+      spreadExhibitExpand spreadExhibitA (spreadExhibitProofOf k) (spreadExhibitPrefixes k)
+      (spreadExhibitDec k) (fun _ => 0) tape.toCoins)
+  simpa [Finset.card_univ] using h
+
+end SpreadExhibit
 
 /-! ## The escape layer over `Pre`
 

--- a/formal/bulletproof-pcs/Bulletproof/Forking/KnowledgeSoundness.lean
+++ b/formal/bulletproof-pcs/Bulletproof/Forking/KnowledgeSoundness.lean
@@ -107,7 +107,8 @@ structure DeployedFamily (C : Ipa.CommitmentCurve) [Module C.ScalarField C.Point
 
 /-- The oracle table the adversary and the extractor share — ironwood's `Coins`
 (`Algebraic.lean:857`) carries the recursive fork tape alongside; here that tape stays a
-parameter, which makes the bound hold for every complete tape rather than on average. -/
+parameter, which makes the bound hold for every complete tape rather than on average; the
+conditional `(6/δ)^(k+1)` bound lives only on the average — see the twin in `§ 11`. -/
 abbrev Coins (C : Ipa.CommitmentCurve) (k : ℕ) : Type := IpaNode C k → Prechallenge
 
 namespace DeployedFamily
@@ -608,10 +609,11 @@ which is pointwise in the table, so it crosses the averaging axis for free.
 
 The honest caveats, unchanged. The number is exponential in `k` and in the challenge domain —
 the same regime as ironwood's `reductionEfficient_exponential` — so it is bookkeeping, not a
-concrete-security claim. A *table-averaged* bound is still not proved here: upstream's
-`ExpectedRuns.lean` proves `E[runs] ≤ (6/δ)^k` under a uniform good-challenge density floor on
-the tape-averaged axis, and porting it to this axis remains open, as does any unconditional
-polynomial bound. What has changed is only that `R` is now computed from the counter instead of
+concrete-security claim. Upstream's `ExpectedRuns.lean` proves `E[runs] ≤ (6/δ)^k` under a uniform
+good-challenge density floor on the tape-averaged axis; that port now exists here, conditionally,
+on upstream's joint table-and-tape axis — see the *conditional average axis* subsection below. It
+leaves the per-tape axis `ReductionEfficient` reads unaveraged, and any unconditional polynomial
+bound is still open. What has changed is only that `R` is now computed from the counter instead of
 obtained from a `sup` that never inspects it (contrast `reductionEfficient_exists`, kept below
 for exactly that contrast), and that it is bounded away from `0` by
 `Bulletproof.Forking.one_le_kimchiExtractRuns`. -/
@@ -729,7 +731,8 @@ this tree computes from the extractor's own counter rather than obtains from a `
 
 That sentence is the whole content: before it, the efficiency gate could only be satisfied by an
 `R` nothing had inspected. It remains a *worst-case*, exponential number, and no polynomial or
-table-averaged claim follows from it. -/
+table-averaged claim follows from it — for the conditional averaged story, on the separate joint
+axis, see `reductionEfficientAvg_of_forkSpreadFamily` and the twin endpoints in `§ 11`. -/
 theorem DeployedFamily.exists_complete_reductionEfficient :
     ∃ coins : Zcash.Snark.RecursiveForkCoins Prechallenge (k + 1),
       coins.Complete ∧ fam.ReductionEfficient coins ((2 * 2 ^ 128 + 1) ^ (k + 1)) := by
@@ -760,6 +763,246 @@ theorem DeployedFamily.one_le_of_reductionEfficient
             (combinedCommitment (fam.claim (fun _ => 0)).polyscale
               (fam.claim (fun _ => 0)).commitmentFn)
             (fam.adversary (fun _ => 0)) O coins
+  exact Nat.le_of_mul_le_mul_right (hlow.trans (h fun _ => 0)) Fintype.card_pos
+
+/-! ### The conditional average axis
+
+Six declarations and one arithmetic helper, standing **beside** the per-tape block above and
+replacing nothing in it:
+`KimchiForkSpreadFamily` (the spread hypothesis at every basis of one family),
+`attemptRuns_sum_le_of_forkSpreadFamily` (the call count summed over table *and* tape jointly),
+`ReductionEfficientAvg` (that sum read as an efficiency gate),
+`reductionEfficientAvg_of_forkSpreadFamily` (the bridge from the bound to the gate), and its two
+anti-vacuity companions `reductionEfficientAvg_of_worstCase` (the gate is reachable
+unconditionally, so it is not a predicate only an unwitnessed hypothesis can satisfy) and
+`one_le_of_reductionEfficientAvg` (no `R` below `1` satisfies it).
+
+Two axes, two branches. `ReductionEfficient` above fixes one tape and averages over tables; it is
+the **worst-case** branch — its `R` holds for *every* complete tape — and it stays unweakened, and
+it is still the branch both `ipaVesta_knowledge_sound` and `ipaPallas_knowledge_sound` read. This
+block is the **conditional** branch, on ironwood's joint `Coins` axis (`Algebraic.lean:857` bundles
+the table with the tape). Nothing here discharges any endpoint's `hEff`: the *primary* endpoints
+are stated against `ReductionEfficient` and are untouched. The twinning against
+`ReductionEfficientAvg` is the probability half of this branch, and it is done — `§ 11` carries it,
+ending in the second pair of endpoints `ipaVesta_knowledge_sound_avg` /
+`ipaPallas_knowledge_sound_avg`, which stand beside the primary pair rather than replacing it.
+
+`KimchiForkSpreadFamily` is a hypothesis, and unlike the abstract layer it has **no family-level
+witness at all**. `Bulletproof.Forking.exists_kimchiForkSpread_two_le_of_rounds` exhibits a spread
+at `σ₀ = 4` over `Pre = Fin 5`, but it lives at the abstract layer and instantiates no
+`DeployedFamily`, whose prechallenge alphabet has `2 ^ 128` elements. The exhibit does not transfer.
+
+The predicate also quantifies over the `DecodesFromPrefixes` witness rather than naming the
+deployed one, which is `private` to `Forking/Deployed.lean`. That asks for the spread at *every*
+commit-then-challenge witness, so it is a stronger hypothesis and every theorem below it is
+correspondingly weaker — the safe direction, but a real cost. Nothing instantiates it at more than
+the deployed witness, which unification supplies.
+
+**The regime caveat travels with the number.** `(6/δ)^(k+1)` at `k = 15` is about `2 ^ 54` calls at
+`δ = 1/2` and about `2 ^ 339` at `δ = 2 ^ (-20)` — worse than solving discrete log outright. The
+bound says something only for adversaries whose per-round good-challenge density is not tiny. -/
+
+/-- **The fork-spread hypothesis, at every basis of one family.** `KimchiForkSpread σ₀` at exactly
+the instantiation `DeployedFamily.attemptRuns` runs: the SRS with `U` overridden to
+`uBaseOf C (Ipa.cipOf (fam.claim basis))`, the combined evaluation vector and commitment of
+`fam.claim basis`, and `fam.adversary basis` against the deployed prefixes `nodes`.
+
+A hypothesis, not a theorem: nothing in this tree proves it, at deployed parameters or otherwise
+(see the subsection preamble on why the abstract exhibit does not transfer).
+
+The `dec` binder is universally quantified because the deployed `DecodesFromPrefixes` witness is
+`private`. Demanding the spread at every such witness strengthens the hypothesis and so weakens
+everything derived from it; at each use site the binder is instantiated, by unification, at the
+deployed witness alone. -/
+def DeployedFamily.KimchiForkSpreadFamily (σ₀ : ℕ) : Prop :=
+  ∀ (basis : Zcash.Snark.AugmentedIndex (2 ^ k) → C.Point)
+    (dec : DecodesFromPrefixes (F := C.ScalarField)
+      { srsOfBasis k basis with U := uBaseOf C (Ipa.cipOf (fam.claim basis)) }
+      toOpening (nodes (Ipa.cipOf (fam.claim basis)))),
+    KimchiForkSpread { srsOfBasis k basis with U := uBaseOf C (Ipa.cipOf (fam.claim basis)) }
+      (combinedEvalVector (2 ^ k) (fam.claim basis).evalscale (fam.claim basis).pointFn)
+      (Ipa.cipOf (fam.claim basis))
+      (combinedCommitment (fam.claim basis).polyscale (fam.claim basis).commitmentFn)
+      (expandPre C) (fam.adversary basis) toOpening (nodes (Ipa.cipOf (fam.claim basis))) dec σ₀
+
+/-- Fubini plus a constant-sum collapse: a bound `d · ∑ b, f a b ≤ B · |β|` holding at every `a`
+sums to `d · ∑ (a, b), f a b ≤ B · |α × β|`.
+
+**Keep this at variables.** Inlining the same four steps at the concrete `Coins C k × tape` types
+in `attemptRuns_sum_le_of_forkSpreadFamily` cost ~29 GB of elaborator memory and five minutes —
+enough to OOM-kill a 30 GB build — because `Finset.sum_le_sum` and `ring` then compare
+`Fintype.card` atoms whose instance terms carry the whole `IpaNode` structure. At `α`, `β` and `f`
+abstract the work is free, and the concrete instance appears once. -/
+private theorem sum_prod_le_of_forall {α β : Type*} [Fintype α] [Fintype β]
+    (f : α → β → ℕ) (d B : ℕ) (h : ∀ a, d * ∑ b, f a b ≤ B * Fintype.card β) :
+    d * ∑ c : α × β, f c.1 c.2 ≤ B * Fintype.card (α × β) := by
+  calc d * ∑ c : α × β, f c.1 c.2 = ∑ a, d * ∑ b, f a b := by
+        rw [Fintype.sum_prod_type, Finset.mul_sum]
+    _ ≤ ∑ _a : α, B * Fintype.card β := Finset.sum_le_sum fun a _ => h a
+    _ = B * Fintype.card (α × β) := by
+        rw [Finset.sum_const, Finset.card_univ, smul_eq_mul, Fintype.card_prod]; ring
+
+/-- **The call count summed over table and tape jointly**, at one basis:
+`(σ₀ − 1) ^ (k + 1) · ∑ ≤ (6 · 2 ^ 128) ^ (k + 1) · |tables × tapes|`. Upstream's
+`recursiveAlgebraicFork_oracle_tape_sum_runs_le_unconditional` (`Recursive.lean:698`) is the
+unconditional twin of this shape, summing over the same product against `Fintype.card` of it.
+
+The content is `Bulletproof.Forking.kimchiExtractRuns_sum_le_of_forkSpread` — a tape sum at each
+fixed table — plus Fubini. There is no quantifier commute anywhere in it: the table stays
+universally quantified inside the sum, and no witness tape is chosen.
+
+The bridge to the M2 corollary is definitional: `attemptRuns` unfolds to `deployedExtractRuns`,
+which unfolds to `kimchiExtractRuns` at these very arguments, so `exact` closes it with both
+`DecodesFromPrefixes` slots left to unification. The Fubini half is `sum_prod_le_of_forall`, kept
+abstract for the reason recorded there. -/
+theorem DeployedFamily.attemptRuns_sum_le_of_forkSpreadFamily {σ₀ : ℕ}
+    (hs : fam.KimchiForkSpreadFamily σ₀)
+    (basis : Zcash.Snark.AugmentedIndex (2 ^ k) → C.Point) :
+    (σ₀ - 1) ^ (k + 1)
+        * ∑ c : Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1),
+            fam.attemptRuns basis c.1 c.2.toCoins
+      ≤ (6 * 2 ^ 128) ^ (k + 1)
+          * Fintype.card (Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)) := by
+  -- The M2 corollary at each table, with both `DecodesFromPrefixes` slots left as metavariables:
+  -- the private deployed witness sitting inside `attemptRuns`'s unfolding solves them. The
+  -- expected type is what drives that unification, so this stays an `exact` against the stated
+  -- goal: as a bare `have h := …` neither slot can be solved.
+  have key : ∀ O : Coins C k,
+      (σ₀ - 1) ^ (k + 1)
+          * ∑ τ : Zcash.Snark.RecursiveForkTape Prechallenge (k + 1),
+              fam.attemptRuns basis O τ.toCoins
+        ≤ (6 * Fintype.card Prechallenge) ^ (k + 1)
+            * Fintype.card (Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)) := by
+    intro O
+    exact kimchiExtractRuns_sum_le_of_forkSpread
+      { srsOfBasis k basis with U := uBaseOf C (Ipa.cipOf (fam.claim basis)) }
+      (combinedEvalVector (2 ^ k) (fam.claim basis).evalscale (fam.claim basis).pointFn)
+      (Ipa.cipOf (fam.claim basis))
+      (combinedCommitment (fam.claim basis).polyscale (fam.claim basis).commitmentFn)
+      (expandPre C) (fam.adversary basis) toOpening (nodes (Ipa.cipOf (fam.claim basis))) _
+      (hs basis _) O
+  -- Fubini and the constant-sum collapse, at variables; then `|Prechallenge| = 2 ^ 128`.
+  have main := sum_prod_le_of_forall
+    (fun (O : Coins C k) (τ : Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)) =>
+      fam.attemptRuns basis O τ.toCoins)
+    ((σ₀ - 1) ^ (k + 1)) ((6 * Fintype.card Prechallenge) ^ (k + 1)) key
+  rwa [card_prechallenge] at main
+
+/-- **The extractor makes at most `R` calls on average over table *and* tape** — ironwood's
+`ReductionEfficient` (`Algebraic.lean:1407`) term for term, at our types, with the product spelled
+out because our `Coins` bundles no tape.
+
+Read it next to `DeployedFamily.ReductionEfficient` above, which is the different, worst-case
+predicate: that one fixes a tape and averages over tables only, and it is the one the endpoints
+assume. This is the second branch, not a replacement. -/
+def DeployedFamily.ReductionEfficientAvg (R : ℕ) : Prop :=
+  ∀ basis : Zcash.Snark.AugmentedIndex (2 ^ k) → C.Point,
+    ∑ c : Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1),
+        fam.attemptRuns basis c.1 c.2.toCoins
+      ≤ R * Fintype.card (Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1))
+
+/-- **A fork spread at every basis gives an average call bound.** The joint-axis sum bound divided
+through by `(σ₀ − 1) ^ (k + 1)`, which is what makes `ReductionEfficientAvg` a reachable predicate
+rather than a floating one.
+
+`hR` is `R ≥ (6 · 2 ^ 128 / (σ₀ − 1)) ^ (k + 1)` written multiplicatively. Nothing is divided:
+over `ℕ`, `d · S ≤ B · c` does not give `S ≤ (B / d) · c` — at `d = 2`, `B = 3`, `c = 3`, `S = 4`
+the premise holds and the conclusion fails. The cancellation is `Nat.le_of_mul_le_mul_left`, whose
+positivity side condition is where `hσ` is spent. -/
+theorem DeployedFamily.reductionEfficientAvg_of_forkSpreadFamily {σ₀ R : ℕ} (hσ : 2 ≤ σ₀)
+    (hs : fam.KimchiForkSpreadFamily σ₀)
+    (hR : (6 * 2 ^ 128) ^ (k + 1) ≤ (σ₀ - 1) ^ (k + 1) * R) :
+    fam.ReductionEfficientAvg R := by
+  intro basis
+  have hpos : 0 < (σ₀ - 1) ^ (k + 1) := Nat.one_le_pow _ _ (by omega)
+  refine Nat.le_of_mul_le_mul_left ?_ hpos
+  calc (σ₀ - 1) ^ (k + 1)
+        * ∑ c : Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1),
+            fam.attemptRuns basis c.1 c.2.toCoins
+      ≤ (6 * 2 ^ 128) ^ (k + 1)
+          * Fintype.card (Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)) :=
+        fam.attemptRuns_sum_le_of_forkSpreadFamily hs basis
+    _ ≤ ((σ₀ - 1) ^ (k + 1) * R)
+          * Fintype.card (Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)) :=
+        Nat.mul_le_mul_right _ hR
+    _ = (σ₀ - 1) ^ (k + 1)
+          * (R
+              * Fintype.card
+                  (Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1))) := by
+        rw [Nat.mul_assoc]
+
+/-- **The average branch is non-empty, unconditionally** — the anti-vacuity companion of
+`ReductionEfficientAvg`, and the reason the twin endpoints in `§ 11` are not conditional on a
+hypothesis nothing in this tree can satisfy.
+
+Without it, the only route to `ReductionEfficientAvg` would be
+`reductionEfficientAvg_of_forkSpreadFamily`, whose `KimchiForkSpreadFamily` premise has no witness
+at any layer. With it, the predicate is reachable outright, at the same worst-case number
+`(2 · 2 ^ 128 + 1) ^ (k + 1)` that `exists_complete_reductionEfficient` reaches on the per-tape
+axis — and here with **no** tape chosen and no completeness side condition, because
+`Zcash.Snark.RecursiveForkTape.toCoins_bounded` (`Forking/Adversary/Recursive.lean:157`) bounds
+*every* tape's node degree by `Fintype.card Prechallenge`, which `card_prechallenge` evaluates.
+
+It supersedes nothing: the interesting bound is still the conditional
+`(6 · 2 ^ 128 / (σ₀ − 1)) ^ (k + 1)`, and this number is exponential in `k` and in the challenge
+domain, so it is bookkeeping rather than a concrete-security claim. The proof is
+`deployedExtractRuns_le` pointwise in the tape, then `sum_prod_le_of_forall` at `d = 1`. -/
+theorem DeployedFamily.reductionEfficientAvg_of_worstCase :
+    fam.ReductionEfficientAvg ((2 * 2 ^ 128 + 1) ^ (k + 1)) := by
+  intro basis
+  -- The pointwise worst-case bound, summed over the tapes at each fixed table.
+  have key : ∀ O : Coins C k,
+      1 * ∑ τ : Zcash.Snark.RecursiveForkTape Prechallenge (k + 1),
+          fam.attemptRuns basis O τ.toCoins
+        ≤ (2 * 2 ^ 128 + 1) ^ (k + 1)
+            * Fintype.card (Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)) := by
+    intro O
+    rw [one_mul]
+    calc ∑ τ : Zcash.Snark.RecursiveForkTape Prechallenge (k + 1),
+            fam.attemptRuns basis O τ.toCoins
+        ≤ ∑ _τ : Zcash.Snark.RecursiveForkTape Prechallenge (k + 1),
+            (2 * 2 ^ 128 + 1) ^ (k + 1) :=
+          Finset.sum_le_sum fun τ _ =>
+            deployedExtractRuns_le (srsOfBasis k basis) (Ipa.cipOf (fam.claim basis))
+              (combinedEvalVector (2 ^ k) (fam.claim basis).evalscale (fam.claim basis).pointFn)
+              (Ipa.cipOf (fam.claim basis))
+              (combinedCommitment (fam.claim basis).polyscale (fam.claim basis).commitmentFn)
+              (fam.adversary basis) O τ.toCoins
+              (card_prechallenge ▸ Zcash.Snark.RecursiveForkTape.toCoins_bounded τ)
+      _ = _ := by rw [Finset.sum_const, Finset.card_univ, smul_eq_mul, Nat.mul_comm]
+  -- Fubini and the constant-sum collapse, at variables, at `d = 1`.
+  have main := sum_prod_le_of_forall
+    (fun (O : Coins C k) (τ : Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)) =>
+      fam.attemptRuns basis O τ.toCoins)
+    1 ((2 * 2 ^ 128 + 1) ^ (k + 1)) key
+  rwa [one_mul] at main
+
+/-- **No `R` below `1` satisfies the average efficiency gate either** — the joint-axis twin of
+`one_le_of_reductionEfficient`, and it rules out the same degenerate reading: an `R = 0` gate would
+advertise a zero-call reduction, against which discrete-log hardness would be assumed for free.
+
+The extractor runs the adversary at least once at every (table, tape) pair
+(`one_le_deployedExtractRuns`), so the joint sum is at least the cardinality of the pair type,
+which `R * Fintype.card …` does not bound at `R = 0`. Satisfiability is
+`reductionEfficientAvg_of_worstCase`'s job, not this one's. -/
+theorem DeployedFamily.one_le_of_reductionEfficientAvg {R : ℕ}
+    (h : fam.ReductionEfficientAvg R) : 1 ≤ R := by
+  -- `ReductionEfficientAvg` quantifies over every basis, so the basis is immaterial: take zero.
+  have hlow : 1 * Fintype.card (Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1))
+      ≤ ∑ c : Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1),
+          fam.attemptRuns (fun _ => 0) c.1 c.2.toCoins := by
+    calc 1 * Fintype.card (Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1))
+        = ∑ _c : Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1), 1 := by
+          rw [Finset.sum_const, Finset.card_univ, smul_eq_mul, Nat.mul_comm]
+      _ ≤ _ := Finset.sum_le_sum fun c _ =>
+          one_le_deployedExtractRuns (srsOfBasis k (fun _ => 0))
+            (Ipa.cipOf (fam.claim (fun _ => 0)))
+            (combinedEvalVector (2 ^ k) (fam.claim (fun _ => 0)).evalscale
+              (fam.claim (fun _ => 0)).pointFn)
+            (Ipa.cipOf (fam.claim (fun _ => 0)))
+            (combinedCommitment (fam.claim (fun _ => 0)).polyscale
+              (fam.claim (fun _ => 0)).commitmentFn)
+            (fam.adversary (fun _ => 0)) c.1 c.2.toCoins
   exact Nat.le_of_mul_le_mul_right (hlow.trans (h fun _ => 0)) Fintype.card_pos
 
 /-! ### The capstone, per curve -/
@@ -890,7 +1133,10 @@ fork tape is complete.
    No sub-worst-case bound is proved here: `ReductionEfficient` averages over the oracle
    tables and a losing table costs one run, so what it gates is the classical
    expected-forking cost, and upstream's tape-averaged `(6/δ)^k` does not cross that axis
-   (see the `ReductionEfficient` section docstring; external-audit O-1b, open). `ε` is still
+   (see the `ReductionEfficient` section docstring; external-audit O-1b). The joint-axis twin
+   `ipaVesta_knowledge_sound_avg` (`§ 11`) now states the conditional average form, over a
+   larger probability space in which the fork tape is sampled; *this* statement's `hEff` is
+   still the worst-case per-tape branch, and neither endpoint implies the other. `ε` is still
    assumed for this finder rather than derived from a time bound: at
    `R = (2·2¹²⁸ + 1)^(k+1)` a reduction is permitted enough oracle calls to solve discrete log
    outright, so `hHard` there is satisfiable only at `ε ≈ 1`.
@@ -916,7 +1162,9 @@ theorem ipaVesta_knowledge_sound {k m p : ℕ}
   rwa [vesta_card_setup k] at h
 
 /-- **The deployed Pallas IPA verifier is knowledge-sound, in the random-oracle model.** The
-Pallas twin of `ipaVesta_knowledge_sound`; same statement, same assumptions, same four limits. -/
+Pallas twin of `ipaVesta_knowledge_sound`; same statement, same assumptions, same four limits —
+including limit 3's pointer at the joint-axis form `ipaPallas_knowledge_sound_avg` (`§ 11`), which
+states the conditional average bound and does not weaken this one's worst-case `hEff`. -/
 theorem ipaPallas_knowledge_sound {k m p : ℕ}
     (B : IpaPallas.Point) (fam : DeployedFamily IpaPallas.curve k m p)
     (coins : Zcash.Snark.RecursiveForkCoins Prechallenge (k + 1))
@@ -1026,5 +1274,416 @@ theorem honestFamily_failure_set
   exact honestFamily_accepts_everywhere hsmul hne _ q.2
 
 end Honest
+
+/-! ## 11. The joint (table × tape) axis
+
+The **conditional** branch of the development, standing beside — never replacing — the per-tape
+**worst-case** branch of `§ 4`–`§ 9`. Everything here is the same argument moved onto ironwood's
+own coin axis: upstream's `ComputedAlgebraicFSFamily` bundles `Coins = (oracle table) × (fork
+tape)` (`Forking/Adversary/Algebraic.lean:857`) and measures its endpoint over
+`(AugmentedIndex … → Fp) × family.Coins` (`:1464`), so the tape is *sampled inside the probability
+space*. Ours splits that pair — `Coins C k` is the table alone and the tape is a fixed
+parameter — which is what makes the per-tape bound hold for **every** complete tape. This section
+adds upstream's shape; it does not swap ours.
+
+The counting half of this branch is `§ 9`'s `### The conditional average axis`
+(`KimchiForkSpreadFamily`, `attemptRuns_sum_le_of_forkSpreadFamily`, `ReductionEfficientAvg`,
+`reductionEfficientAvg_of_forkSpreadFamily`, `reductionEfficientAvg_of_worstCase`,
+`one_le_of_reductionEfficientAvg`). This is its probability half, and the two headline twins
+`ipaVesta_knowledge_sound_avg` / `ipaPallas_knowledge_sound_avg` at the end read both.
+
+**`hcoins` vanishes, and that is a genuine improvement.** Every per-tape statement carries
+`coins.Complete` as a hypothesis, because a tape that never offers some challenge cannot force
+extraction. Here the tape is `q.2.2.toCoins` for a *sampled* `q.2.2`, and
+`Zcash.Snark.RecursiveForkTape.toCoins_complete` (`Forking/Adversary/Recursive.lean:147`) holds
+for **every** tape, so completeness is discharged structurally at the one place that needed it
+(`presence_summand_avg`'s call to `deployedExtract_failure_measure_le`). No statement below
+carries a completeness argument.
+
+**What is paid for it.** The measured event lives over a larger space: a bad fork tape is now
+charged to the failure probability rather than assumed away. Neither branch implies the other,
+and the primary endpoints `ipaVesta_knowledge_sound` / `ipaPallas_knowledge_sound` still read the
+worst-case branch.
+
+**What is still assumed.** `ReductionEfficientAvg` is reachable two ways: unconditionally at the
+worst-case `(2 · 2 ^ 128 + 1) ^ (k + 1)` (`reductionEfficientAvg_of_worstCase`), and at the
+conditional `(6 · 2 ^ 128 / (σ₀ − 1)) ^ (k + 1)` from a fork spread
+(`reductionEfficientAvg_of_forkSpreadFamily`). Only the second is interesting, and
+`DeployedFamily.KimchiForkSpreadFamily` has **no witness at any layer**:
+`Bulletproof.Forking.exists_kimchiForkSpread_two_le_of_rounds` exhibits a spread at `σ₀ = 4` over
+`Pre = Fin 5`, at the abstract layer, instantiating no `DeployedFamily` (whose prechallenge
+alphabet has `2 ^ 128` elements). The regime caveat travels with the number: `(6/δ) ^ (k + 1)` at
+`k = 15` is about `2 ^ 54` calls at `δ = 1/2` and about `2 ^ 339` at `δ = 2 ^ (-20)` — worse than
+solving discrete log outright.
+
+Nothing here averages, commutes or pigeonholes over tapes: the cover is pointwise in the tape,
+and no witness tape is ever chosen. -/
+
+section JointAxis
+
+variable {C : Ipa.CommitmentCurve} {k m p : ℕ} [Module C.ScalarField C.Point]
+variable (fam : DeployedFamily C k m p)
+
+/-- **The relation finder on the joint axis** — `relationFinder` with the fork tape read off the
+sampled coin pair rather than fixed as a parameter, so that it has the shape
+`(basis) → ρ → Option (AlgebraicRelationWitness …)` at `ρ := Coins C k × RecursiveForkTape …`
+that `Zcash.Snark.relSetWithCoins` and `TextbookDLWithCoinsAdvantageLE` consume. It is upstream's
+`ComputedAlgebraicFSFamily.relationFinder` (`Forking/Adversary/Algebraic.lean:876`) shape, whose
+coins already bundle the tape.
+
+The coin type is written out rather than abbreviated: what an endpoint quantifies over is exactly
+what a reader has to check, and this tree spells it out. -/
+def relationFinderAvg :
+    (bs : SetupIndex (2 ^ k) → C.Point) →
+      Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1) →
+        Option (Zcash.Snark.AlgebraicRelationWitness (F := C.ScalarField) bs) :=
+  fun bs c => relationFinder fam c.2.toCoins bs c.1
+
+/-- **The derived-`U` discrete-log assumption on the joint axis** — `DerivedUDLAdvantageLE`'s twin
+over `(SetupIndex (2 ^ k) → C.ScalarField) × (Coins C k × RecursiveForkTape Prechallenge (k + 1))`,
+with the fork tape sampled alongside the setup basis and the oracle table.
+
+There is deliberately no `derivedULogAvg`: `derivedULog` already takes the tape as an argument, so
+repackaging it would cost a declaration to root and pin and buy nothing. Everything the per-tape
+docstring says about *what* is assumed carries over unchanged — only the space grows. -/
+def DerivedUDLAdvantageLEAvg (B : C.Point) (bound : ℝ≥0∞) : Prop :=
+  (PMF.uniformOfFintype ((SetupIndex (2 ^ k) → C.ScalarField) ×
+      (Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)))).toOuterMeasure
+      {q | (derivedULog fam B q.2.2.toCoins q.1 q.2.1).isSome} ≤ bound
+
+/-- **`δ` is the residual event's own measure, on the joint axis too** — the twin of
+`derivedUDL_iff_residual_measure`, and its point is unchanged by the axis move.
+
+`ε` bounds the win set of the *discrete-log game*, over `F × ι × (ι → F) × ρ`: a genuine
+reduction, connecting this protocol to a studied problem. `δ` bounds a set on the *same* space as
+the conclusion, and this equivalence says it is the third piece of `three_way_cover_avg`
+restated. So assuming `δ` small is assuming that slice of the conclusion, not deducing it — which
+is why the `U`-touching runs are described as unreduced rather than charged. -/
+theorem derivedUDLAvg_iff_residual_measure (B : C.Point) (δ : ℝ≥0∞) :
+    DerivedUDLAdvantageLEAvg fam B δ ↔
+      (PMF.uniformOfFintype ((SetupIndex (2 ^ k) → C.ScalarField) ×
+          (Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)))).toOuterMeasure
+        {q | TouchesU fam (Zcash.Snark.scalarBasis B q.1) q.2.1 q.2.2.toCoins} ≤ δ := by
+  have hset : {q : (SetupIndex (2 ^ k) → C.ScalarField) ×
+        (Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)) |
+        TouchesU fam (Zcash.Snark.scalarBasis B q.1) q.2.1 q.2.2.toCoins}
+      = {q | (derivedULog fam B q.2.2.toCoins q.1 q.2.1).isSome} := by
+    ext q
+    exact (derivedULog_isSome_iff fam B q.2.2.toCoins q.1 q.2.1).symm
+  rw [hset]
+  exact Iff.rfl
+
+/-- **A bound holding on every doubly-indexed fibre lifts to the triple product.** Two applications
+of ironwood's Fubini fibre bounds: `Zcash.Snark.uniformOfFintype_prod_fiber_bound_right`
+(`Forking/Probability.lean:125`) at `B := ρ₁ × ρ₂`, whose fibre obligation is
+`Zcash.Snark.uniformOfFintype_prod_fiber_bound` (`:92`) at `A := ρ₁`, `B := ρ₂`.
+
+**Keep this at variables**, for the reason recorded at `sum_prod_le_of_forall`: the same steps
+inlined at the concrete `(SetupIndex … → C.ScalarField) × (Coins C k × RecursiveForkTape …)` types
+make the elaborator compare `Fintype.card` atoms carrying the whole `IpaNode` structure. -/
+private theorem uniform_prod_prod_fiber_bound {A ρ₁ ρ₂ : Type*}
+    [Fintype A] [Fintype ρ₁] [Fintype ρ₂] [Nonempty A] [Nonempty ρ₁] [Nonempty ρ₂]
+    (S : A → ρ₂ → Set ρ₁) {β : ℝ≥0∞}
+    (hS : ∀ a τ, (PMF.uniformOfFintype ρ₁).toOuterMeasure (S a τ) ≤ β) :
+    (PMF.uniformOfFintype (A × (ρ₁ × ρ₂))).toOuterMeasure {q | q.2.1 ∈ S q.1 q.2.2} ≤ β := by
+  refine Zcash.Snark.uniformOfFintype_prod_fiber_bound_right
+    (fun a => {c : ρ₁ × ρ₂ | c.1 ∈ S a c.2}) fun a => ?_
+  exact Zcash.Snark.uniformOfFintype_prod_fiber_bound (S a) (hS a)
+
+/-- **The three-way cover on the joint axis.** A run that accepts and yields no opening either
+produced nothing at all (the presence rung), or produced a setup-basis relation (charged to
+textbook DL), or produced a `U`-touching break (the residual).
+
+`three_way_cover` is proved at an arbitrary `coins`, so this is the same `by_cases`/`cases`
+argument read at `coins := q.2.2.toCoins`: the cover is **pointwise in the tape** and no new
+mathematics enters with the enlarged space. -/
+private theorem three_way_cover_avg (B : C.Point) :
+    {q : (SetupIndex (2 ^ k) → C.ScalarField) ×
+        (Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)) |
+        wireWins (srsOfBasis k (augOfSetup (Zcash.Snark.scalarBasis B q.1)))
+            (fam.claim (augOfSetup (Zcash.Snark.scalarBasis B q.1))) q.2.1
+            ((fam.adversary (augOfSetup (Zcash.Snark.scalarBasis B q.1))).run q.2.1) ∧
+          ¬ fam.HasOpening (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 q.2.2.toCoins}
+      ⊆ {q | q.2.1 ∈ fam.acceptExtractionFailure
+              (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.2.toCoins}
+        ∪ (↑(Zcash.Snark.relSetWithCoins B (relationFinderAvg fam)) :
+            Set ((SetupIndex (2 ^ k) → C.ScalarField) ×
+              (Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1))))
+        ∪ {q | TouchesU fam (Zcash.Snark.scalarBasis B q.1) q.2.1 q.2.2.toCoins} := by
+  classical
+  intro q hq
+  obtain ⟨hacc, hnoopen⟩ := hq
+  by_cases hsome :
+      (fam.attempt (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 q.2.2.toCoins).isSome
+  · obtain ⟨x, hx⟩ := Option.isSome_iff_exists.mp hsome
+    cases x with
+    | inl o => exact absurd ⟨o, hx⟩ hnoopen
+    | inr rel =>
+      by_cases hu : rel.coeffs Zcash.Snark.AugmentedIndex.u = 0
+      · refine Or.inl (Or.inr ?_)
+        simp only [Finset.mem_coe, Zcash.Snark.relSetWithCoins, Finset.mem_filter,
+          Finset.mem_univ, true_and]
+        show (relationFinderAvg fam (Zcash.Snark.scalarBasis B q.1) q.2).isSome = true
+        simp only [relationFinderAvg, relationFinder, hx, dif_pos hu, Option.isSome_some]
+      · exact Or.inr ⟨rel, hx, hu⟩
+  · exact Or.inl (Or.inl ⟨hacc, Option.not_isSome_iff_eq_none.mp hsome⟩)
+
+/-- **First summand on the joint axis — and the one place `hcoins` used to be spent.**
+`deployedExtract_failure_measure_le` (the LOCKED target) lifted across *both* sampled
+coordinates by `uniform_prod_prod_fiber_bound`.
+
+Its completeness hypothesis is supplied by the sampled tape itself, through
+`Zcash.Snark.RecursiveForkTape.toCoins_complete`, which holds for **every** tape. That is why no
+statement on this axis carries a `hcoins` argument: the per-tape branch has to assume completeness
+of the one fixed tape, and here it is a theorem about the sampled one. Nothing about the locked
+statement changes. -/
+private theorem presence_summand_avg
+    (hsmul : ∀ (z : C.ScalarField) (Q : C.Point), z • Q = z.val • Q)
+    (hinj : Function.Injective (expandPre C)) (hne : ∀ q, expandPre C q ≠ 0) (B : C.Point) :
+    (PMF.uniformOfFintype ((SetupIndex (2 ^ k) → C.ScalarField) ×
+        (Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)))).toOuterMeasure
+        {q | q.2.1 ∈ fam.acceptExtractionFailure
+          (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.2.toCoins}
+      ≤ (fam.Q + k + 1) * (3 / (2 ^ 128 : ℕ)) := by
+  refine uniform_prod_prod_fiber_bound
+    (fun (s : SetupIndex (2 ^ k) → C.ScalarField)
+        (τ : Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)) =>
+      fam.acceptExtractionFailure (augOfSetup (Zcash.Snark.scalarBasis B s)) τ.toCoins)
+    fun s τ => ?_
+  exact deployedExtract_failure_measure_le hsmul hinj hne
+    (srsOfBasis k (augOfSetup (Zcash.Snark.scalarBasis B s)))
+    (fam.claim (augOfSetup (Zcash.Snark.scalarBasis B s)))
+    (fam.pg (augOfSetup (Zcash.Snark.scalarBasis B s)))
+    (fam.pw (augOfSetup (Zcash.Snark.scalarBasis B s)))
+    (fam.hP (augOfSetup (Zcash.Snark.scalarBasis B s)))
+    (fam.adversary (augOfSetup (Zcash.Snark.scalarBasis B s)))
+    (fam.queryBound (augOfSetup (Zcash.Snark.scalarBasis B s))) τ.toCoins
+    (Zcash.Snark.RecursiveForkTape.toCoins_complete τ)
+
+/-- **Second summand on the joint axis — one upstream call.**
+`Zcash.Snark.relationWithCoins_prob_le_of_textbookDL` (`AGM/ProbabilityCoins.lean:182`) is generic
+in the coin type as well as the index (`{ρ} [Fintype ρ] [Nonempty ρ]`), so instantiating
+`ρ := Coins C k × RecursiveForkTape Prechallenge (k + 1)` needs no new upstream work and the
+per-tape proof carries over unchanged. -/
+theorem relation_summand_avg (B : C.Point) {ε : ℝ≥0∞}
+    (hDL : Zcash.Snark.TextbookDLWithCoinsAdvantageLE B (relationFinderAvg fam) ε) :
+    (PMF.uniformOfFintype ((SetupIndex (2 ^ k) → C.ScalarField) ×
+        (Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)))).toOuterMeasure
+        (Zcash.Snark.relSetWithCoins B (relationFinderAvg fam))
+      ≤ Fintype.card (SetupIndex (2 ^ k)) * ε :=
+  Zcash.Snark.relationWithCoins_prob_le_of_textbookDL B _ hDL
+
+/-- **Third summand on the joint axis — the residual, by its own assumption.** -/
+theorem residual_summand_avg (B : C.Point) {δ : ℝ≥0∞}
+    (hU : DerivedUDLAdvantageLEAvg fam B δ) :
+    (PMF.uniformOfFintype ((SetupIndex (2 ^ k) → C.ScalarField) ×
+        (Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)))).toOuterMeasure
+        {q | TouchesU fam (Zcash.Snark.scalarBasis B q.1) q.2.1 q.2.2.toCoins}
+      ≤ δ :=
+  (derivedUDLAvg_iff_residual_measure fam B δ).mp hU
+
+/-- **Deployed IPA knowledge soundness under textbook discrete log, on the joint axis.**
+
+`deployedExtract_noOpening_measure_le_of_textbookDL`'s twin, with the fork tape sampled alongside
+the setup basis and the oracle table. The right-hand side is **identical** — the recursive query
+loss `(Q + k + 1) · 3 / 2 ^ 128`, the fixed-slot discrete-log loss
+`|SetupIndex (2 ^ k)| · ε = (2 ^ k + 1) · ε`, and the derived-`U` loss `δ` — and there is **no**
+completeness hypothesis, discharged inside `presence_summand_avg`.
+
+What is paid for that is the space: a fork tape on which the extractor does badly is now charged
+to the measured event rather than excluded by `hcoins`. Neither this statement nor its per-tape
+sibling implies the other. -/
+theorem deployedExtract_noOpening_measure_le_of_textbookDL_avg
+    (hsmul : ∀ (z : C.ScalarField) (Q : C.Point), z • Q = z.val • Q)
+    (hinj : Function.Injective (expandPre C)) (hne : ∀ q, expandPre C q ≠ 0)
+    (B : C.Point) {ε δ : ℝ≥0∞}
+    (hDL : Zcash.Snark.TextbookDLWithCoinsAdvantageLE B (relationFinderAvg fam) ε)
+    (hUDL : DerivedUDLAdvantageLEAvg fam B δ) :
+    (PMF.uniformOfFintype ((SetupIndex (2 ^ k) → C.ScalarField) ×
+        (Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)))).toOuterMeasure
+        {q | wireWins (srsOfBasis k (augOfSetup (Zcash.Snark.scalarBasis B q.1)))
+                (fam.claim (augOfSetup (Zcash.Snark.scalarBasis B q.1))) q.2.1
+                ((fam.adversary (augOfSetup (Zcash.Snark.scalarBasis B q.1))).run q.2.1) ∧
+          ¬ fam.HasOpening (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 q.2.2.toCoins}
+      ≤ (fam.Q + k + 1) * (3 / (2 ^ 128 : ℕ))
+        + Fintype.card (SetupIndex (2 ^ k)) * ε + δ := by
+  classical
+  refine le_trans (MeasureTheory.measure_mono (three_way_cover_avg fam B)) ?_
+  refine le_trans (MeasureTheory.measure_union_le _ _) ?_
+  refine add_le_add (le_trans (MeasureTheory.measure_union_le _ _) ?_)
+    (residual_summand_avg fam B hUDL)
+  exact add_le_add (presence_summand_avg fam hsmul hinj hne B) (relation_summand_avg fam B hDL)
+
+/-- **Discrete log is hard for this family against `R`-call reductions, on the joint axis** —
+`DeployedFamily.DiscreteLogRelationHardFor`'s twin, gated by `ReductionEfficientAvg` and carrying
+both advantage bounds for the same reason: kimchi's `U` is transcript derived, so the `U`-touching
+breaks cannot be charged to textbook discrete log and `δ` has no upstream counterpart.
+
+What is genuinely better here: the reduction samples its own fork tape as part of its randomness,
+which is what a real reduction does. The per-tape form instead assumes an advantage bound at one
+externally fixed tape, which is a hypothesis about a tape the reduction did not choose.
+
+Read `derivedUDLAvg_iff_residual_measure` next to this, exactly as on the per-tape axis: the `δ`
+component is the residual event's own measure, not a reduction to a standard problem. Only the `ε`
+component is a genuine reduction. -/
+def DeployedFamily.DiscreteLogRelationHardForAvg (B : C.Point) (R : ℕ) (ε δ : ℝ≥0∞) : Prop :=
+  fam.ReductionEfficientAvg R →
+    Zcash.Snark.TextbookDLWithCoinsAdvantageLE B (relationFinderAvg fam) ε ∧
+      DerivedUDLAdvantageLEAvg fam B δ
+
+/-- **Deployed IPA knowledge soundness on the joint axis, under per-family discrete-log hardness
+gated by the extractor call bound.** The twin of
+`deployedExtract_knowledgeSoundness_under_DL`, and like it one application of the terminal above
+it: the measured event and the bound are exactly
+`deployedExtract_noOpening_measure_le_of_textbookDL_avg`'s, and what changes is that hardness is
+assumed only against reductions respecting the average call bound `R`. -/
+private theorem deployedExtract_knowledgeSoundness_under_DL_avg
+    (hsmul : ∀ (z : C.ScalarField) (Q : C.Point), z • Q = z.val • Q)
+    (hinj : Function.Injective (expandPre C)) (hne : ∀ q, expandPre C q ≠ 0)
+    (B : C.Point) {R : ℕ} {ε δ : ℝ≥0∞}
+    (hHard : fam.DiscreteLogRelationHardForAvg B R ε δ)
+    (hEff : fam.ReductionEfficientAvg R) :
+    (PMF.uniformOfFintype ((SetupIndex (2 ^ k) → C.ScalarField) ×
+        (Coins C k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)))).toOuterMeasure
+        {q | wireWins (srsOfBasis k (augOfSetup (Zcash.Snark.scalarBasis B q.1)))
+                (fam.claim (augOfSetup (Zcash.Snark.scalarBasis B q.1))) q.2.1
+                ((fam.adversary (augOfSetup (Zcash.Snark.scalarBasis B q.1))).run q.2.1) ∧
+          ¬ fam.HasOpening (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 q.2.2.toCoins}
+      ≤ (fam.Q + k + 1) * (3 / (2 ^ 128 : ℕ))
+        + Fintype.card (SetupIndex (2 ^ k)) * ε + δ :=
+  deployedExtract_noOpening_measure_le_of_textbookDL_avg fam hsmul hinj hne B
+    (hHard hEff).1 (hHard hEff).2
+
+/-! ### The joint-axis capstone, per curve -/
+
+/-- **Vesta, joint-axis capstone form.** The average-gated statement at the deployed curve, with
+every curve hypothesis discharged. -/
+private theorem vesta_knowledgeSoundness_under_DL_avg {k m p : ℕ}
+    (B : IpaVesta.Point) (fam : DeployedFamily IpaVesta.curve k m p) {R : ℕ} {ε δ : ℝ≥0∞}
+    (hHard : fam.DiscreteLogRelationHardForAvg B R ε δ)
+    (hEff : fam.ReductionEfficientAvg R) :
+    (PMF.uniformOfFintype ((SetupIndex (2 ^ k) → IpaVesta.curve.ScalarField) ×
+        (Coins IpaVesta.curve k ×
+          Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)))).toOuterMeasure
+        {q | wireWins (srsOfBasis k (augOfSetup (Zcash.Snark.scalarBasis B q.1)))
+                (fam.claim (augOfSetup (Zcash.Snark.scalarBasis B q.1))) q.2.1
+                ((fam.adversary (augOfSetup (Zcash.Snark.scalarBasis B q.1))).run q.2.1) ∧
+          ¬ fam.HasOpening (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 q.2.2.toCoins}
+      ≤ (fam.Q + k + 1) * (3 / (2 ^ 128 : ℕ))
+        + Fintype.card (SetupIndex (2 ^ k)) * ε + δ :=
+  deployedExtract_knowledgeSoundness_under_DL_avg fam Pasta.vesta_smul_val
+    expandPre_vesta_injective expandPre_vesta_ne_zero B hHard hEff
+
+/-- **Pallas, joint-axis capstone form.** -/
+private theorem pallas_knowledgeSoundness_under_DL_avg {k m p : ℕ}
+    (B : IpaPallas.Point) (fam : DeployedFamily IpaPallas.curve k m p) {R : ℕ} {ε δ : ℝ≥0∞}
+    (hHard : fam.DiscreteLogRelationHardForAvg B R ε δ)
+    (hEff : fam.ReductionEfficientAvg R) :
+    (PMF.uniformOfFintype ((SetupIndex (2 ^ k) → IpaPallas.curve.ScalarField) ×
+        (Coins IpaPallas.curve k ×
+          Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)))).toOuterMeasure
+        {q | wireWins (srsOfBasis k (augOfSetup (Zcash.Snark.scalarBasis B q.1)))
+                (fam.claim (augOfSetup (Zcash.Snark.scalarBasis B q.1))) q.2.1
+                ((fam.adversary (augOfSetup (Zcash.Snark.scalarBasis B q.1))).run q.2.1) ∧
+          ¬ fam.HasOpening (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 q.2.2.toCoins}
+      ≤ (fam.Q + k + 1) * (3 / (2 ^ 128 : ℕ))
+        + Fintype.card (SetupIndex (2 ^ k)) * ε + δ :=
+  deployedExtract_knowledgeSoundness_under_DL_avg fam Pasta.pallas_smul_val
+    expandPre_pallas_injective expandPre_pallas_ne_zero B hHard hEff
+
+/-! ### The headline twins: knowledge soundness on the joint axis, per curve
+
+One statement per curve, every curve-specific hypothesis discharged and every constant evaluated,
+standing beside `ipaVesta_knowledge_sound` / `ipaPallas_knowledge_sound` rather than replacing
+them. Read the caveats in the docstrings as part of the claim — each is a real limit, and each is
+stated because a reader who skips them would overclaim. -/
+
+/-- **The deployed Vesta IPA verifier is knowledge-sound on the joint (table × tape) axis, in the
+random-oracle model.**
+
+For a family of `Q`-query algebraic adversaries against the deployed Vesta IPA opening verifier,
+over a uniformly sampled setup basis, a uniform challenge oracle **and a uniform fork tape**: the
+probability that an adversary makes the **executable wire verifier** accept while the **executable
+extractor** fails to return an opening is at most
+
+`(Q + k + 1) · 3 / 2¹²⁸  +  (2ᵏ + 1) · ε  +  δ`.
+
+The extractor is `deployedExtract`, a plain computable `def` whose `#eval` on a fixture is checked
+by `scripts/check_extractor_computes.sh` — the guard that separates a reduction which *computes*
+the witness from one that merely asserts it exists. Acceptance is `Ipa.verifyWith`'s own `Bool`,
+not a re-modelled predicate.
+
+**What is assumed.** `hHard`: discrete log is `(ε, δ)`-hard for this family against reductions
+making at most `R` black-box calls **on average over table and tape**. `hEff`: the extractor
+respects that average call bound. There is no `hcoins`.
+
+**The trade against `ipaVesta_knowledge_sound`, stated so it cannot be misread.** *Gained*: the
+efficiency gate is `ReductionEfficientAvg`, which `reductionEfficientAvg_of_forkSpreadFamily`
+discharges from a fork spread at the conditional `(6 · 2¹²⁸ / (σ₀ − 1))^(k+1)` rather than only at
+the worst-case `(2 · 2¹²⁸ + 1)^(k+1)`; and the completeness hypothesis `hcoins` is gone,
+discharged structurally by `Zcash.Snark.RecursiveForkTape.toCoins_complete` rather than assumed.
+*Paid*: the measured event lives over a larger space — the fork tape is sampled, so a bad tape is
+charged to the failure probability rather than assumed away. **Neither endpoint implies the
+other**, and the per-tape statement is untouched.
+
+**Four limits, all real.**
+1. *Random-oracle model.* The challenges are a uniform table, where the deployed protocol squeezes
+   them from the Poseidon sponge. `verifyOracle_spongeFS` (`Forking/Transcript.lean`) proves the
+   abstract verifier at the sponge source *is* `Ipa.verify`; replacing the sponge by a uniform
+   table is the idealization, and it is carried by no Lean axiom.
+2. *`δ` is not a reduction.* `derivedUDLAvg_iff_residual_measure` proves it is the residual event's
+   own measure. Only `ε` reduces to a standard problem. This is the price of kimchi's
+   transcript-derived `U`, which halo2 does not pay — ironwood has no analogue.
+3. *The extractor's cost is bounded, but only worst-case unconditionally.*
+   `DeployedFamily.reductionEfficientAvg_of_worstCase` discharges `hEff` outright at
+   `R = (2 · 2¹²⁸ + 1)^(k+1)` — exponential in `k` and in the challenge domain, and at that `R` a
+   reduction is permitted enough oracle calls to solve discrete log outright, so `hHard` there is
+   satisfiable only at `ε ≈ 1`. The sub-worst-case route,
+   `DeployedFamily.reductionEfficientAvg_of_forkSpreadFamily`, reaches
+   `R = (6 · 2¹²⁸ / (σ₀ − 1))^(k+1)` — but only from `DeployedFamily.KimchiForkSpreadFamily σ₀`,
+   which has **no witness at any layer**: the `σ₀ = 4` exhibit
+   `Bulletproof.Forking.exists_kimchiForkSpread_two_le_of_rounds` lives over `Pre = Fin 5` at the
+   abstract layer and instantiates no `DeployedFamily`. And the regime caveat travels with the
+   number: `(6/δ)^(k+1)` at `k = 15` is about `2⁵⁴` calls at `δ = 1/2` but about `2³³⁹` at
+   `δ = 2⁻²⁰`, worse than solving discrete log outright.
+4. *One claim.* The statement is single-claim; recovering individual polynomials from a batch is
+   the separate un-batching layer (`chunked_batch_soundness`).
+
+The query-loss term is unconditional — it holds against an unbounded adversary — and at realistic
+`Q` it dominates the other two by tens of bits. -/
+theorem ipaVesta_knowledge_sound_avg {k m p : ℕ}
+    (B : IpaVesta.Point) (fam : DeployedFamily IpaVesta.curve k m p) {R : ℕ} {ε δ : ℝ≥0∞}
+    (hHard : fam.DiscreteLogRelationHardForAvg B R ε δ)
+    (hEff : fam.ReductionEfficientAvg R) :
+    (PMF.uniformOfFintype ((SetupIndex (2 ^ k) → IpaVesta.curve.ScalarField) ×
+        (Coins IpaVesta.curve k ×
+          Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)))).toOuterMeasure
+        {q | wireWins (srsOfBasis k (augOfSetup (Zcash.Snark.scalarBasis B q.1)))
+                (fam.claim (augOfSetup (Zcash.Snark.scalarBasis B q.1))) q.2.1
+                ((fam.adversary (augOfSetup (Zcash.Snark.scalarBasis B q.1))).run q.2.1) ∧
+          ¬ fam.HasOpening (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 q.2.2.toCoins}
+      ≤ (fam.Q + k + 1) * (3 / (2 ^ 128 : ℕ)) + ((2 ^ k + 1 : ℕ) : ℝ≥0∞) * ε + δ := by
+  have h := vesta_knowledgeSoundness_under_DL_avg B fam hHard hEff
+  rwa [vesta_card_setup k] at h
+
+/-- **The deployed Pallas IPA verifier is knowledge-sound on the joint (table × tape) axis, in the
+random-oracle model.** The Pallas twin of `ipaVesta_knowledge_sound_avg`; same statement, same
+assumptions, same trade against `ipaPallas_knowledge_sound`, same four limits. -/
+theorem ipaPallas_knowledge_sound_avg {k m p : ℕ}
+    (B : IpaPallas.Point) (fam : DeployedFamily IpaPallas.curve k m p) {R : ℕ} {ε δ : ℝ≥0∞}
+    (hHard : fam.DiscreteLogRelationHardForAvg B R ε δ)
+    (hEff : fam.ReductionEfficientAvg R) :
+    (PMF.uniformOfFintype ((SetupIndex (2 ^ k) → IpaPallas.curve.ScalarField) ×
+        (Coins IpaPallas.curve k ×
+          Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)))).toOuterMeasure
+        {q | wireWins (srsOfBasis k (augOfSetup (Zcash.Snark.scalarBasis B q.1)))
+                (fam.claim (augOfSetup (Zcash.Snark.scalarBasis B q.1))) q.2.1
+                ((fam.adversary (augOfSetup (Zcash.Snark.scalarBasis B q.1))).run q.2.1) ∧
+          ¬ fam.HasOpening (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 q.2.2.toCoins}
+      ≤ (fam.Q + k + 1) * (3 / (2 ^ 128 : ℕ)) + ((2 ^ k + 1 : ℕ) : ℝ≥0∞) * ε + δ := by
+  have h := pallas_knowledgeSoundness_under_DL_avg B fam hHard hEff
+  rwa [vesta_card_setup k] at h
+
+end JointAxis
 
 end Bulletproof.Ipa.Forking

--- a/formal/bulletproof-pcs/roots.txt
+++ b/formal/bulletproof-pcs/roots.txt
@@ -54,6 +54,74 @@ Bulletproof.Ipa.Forking.DeployedFamily.exists_complete_reductionEfficient
 -- >= 1 on every table and every tape -- so neither needs an entry of its own here.
 Bulletproof.Ipa.Forking.DeployedFamily.one_le_of_reductionEfficient
 
+-- Audit O-1b (M3', half 1): the CONDITIONAL branch of the cost, on upstream's joint
+-- table-and-tape axis. Beside the per-tape worst-case block above, which it replaces nothing
+-- of and which is still what both endpoints read. Conditional on KimchiForkSpreadFamily, a
+-- hypothesis nothing in this tree proves and which -- unlike the abstract layer -- has no
+-- family-level witness at all, so the block has no in-tree consumer and needs a root. The walk
+-- from this one entry reaches all three of its companions -- KimchiForkSpreadFamily,
+-- attemptRuns_sum_le_of_forkSpreadFamily and ReductionEfficientAvg -- so none needs its own.
+Bulletproof.Ipa.Forking.DeployedFamily.reductionEfficientAvg_of_forkSpreadFamily
+-- The average branch's own anti-vacuity pair (M3', half 2). reductionEfficientAvg_of_worstCase
+-- makes ReductionEfficientAvg reachable WITHOUT KimchiForkSpreadFamily -- otherwise the twin
+-- endpoints below would be gated on a hypothesis nothing in this tree can satisfy -- and
+-- one_le_of_reductionEfficientAvg rules out an R = 0 gate on this axis exactly as
+-- one_le_of_reductionEfficient does on the per-tape one. Neither is reachable from the twin
+-- endpoints, which take ReductionEfficientAvg as a hypothesis rather than discharging it.
+Bulletproof.Ipa.Forking.DeployedFamily.reductionEfficientAvg_of_worstCase
+Bulletproof.Ipa.Forking.DeployedFamily.one_le_of_reductionEfficientAvg
+
+-- THE HEADLINE TWINS (M3', half 2): the same knowledge-soundness bound on upstream's joint
+-- (table x tape) axis, with the fork tape SAMPLED rather than fixed. Same right-hand side
+-- (Q + k + 1)·3/2^128 + (2^k + 1)·ε + δ, no coins.Complete hypothesis (discharged structurally
+-- by RecursiveForkTape.toCoins_complete), gated by ReductionEfficientAvg. They stand beside
+-- the per-tape headline above, which they replace nothing of; neither implies the other. The
+-- walk from these two reaches the whole probability half -- relationFinderAvg,
+-- DerivedUDLAdvantageLEAvg, derivedUDLAvg_iff_residual_measure, the three summands, the
+-- three-way cover, the terminal bound and DiscreteLogRelationHardForAvg -- so none needs its own.
+Bulletproof.Ipa.Forking.ipaVesta_knowledge_sound_avg
+Bulletproof.Ipa.Forking.ipaPallas_knowledge_sound_avg
+
+-- Audit O-1b: the conditional tape-averaged run bound. The terminal of the fork-spread counting
+-- layer in Forking/Game.lean -- conditional on a KimchiForkSpread hypothesis nothing in this tree
+-- proves AT DEPLOYED PARAMETERS, so it has no in-tree consumer and needs a root. (It is not an
+-- implication out of an empty hypothesis: see exists_kimchiForkSpread_two_le below.) The walk
+-- reaches the whole layer from it: the depth induction kimchiForkFrom_sum_runs_le_of_forkSpread,
+-- both pointwise bounds (kimchiForkFrom_node_runs_le, kimchiForkFrom_leaf_runs_le), the depth-0
+-- tape sum kimchiForkFrom_sum_runs_le_leaf, kimchiScanCandidate_runs_cases, and the
+-- candidate/good-set definitions KimchiForkSpread, kimchiScanCandidate, kimchiLeafCandidate,
+-- kimchiGoodChallenges, kimchiLeafGoodChallenges. (This entry replaced the M1 TEMPORARY group at
+-- iter-013, exactly as that group's own comment instructed: the corollary consumed both of its
+-- lines.)
+Bulletproof.Forking.kimchiExtractRuns_sum_le_of_forkSpread
+
+-- The anti-vacuity companions of that hypothesis, both exhibits, so nothing consumes them.
+-- (a) a table whose own run is Schnorr-unstable forces sigma0 = 0 and collapses the conditional
+--     bound to `0 <= ...`. The walk reaches kimchiLeafGoodChallenges_eq_empty_of_unstable from it.
+Bulletproof.Forking.kimchiForkSpread_eq_zero_of_leaf_unstable
+-- (b) the coin-side degeneracy (O-1b milestone M4''): a node floor quantified over ARBITRARY coin
+--     trees admits empty sampling orders, which make the fork fail outright, so it forces
+--     sigma0 = 0 at every sigma.k >= 1 -- which is why the node clause reads tape-derived coins.
+--     Stated at the un-narrowed clause so it survives the fix. The walk reaches
+--     kimchiGoodChallenges_eq_empty_of_order_nil and the private
+--     kimchiForkFrom_output_eq_none_of_order_nil from it.
+Bulletproof.Forking.kimchiNodeFloor_eq_zero_of_forall_coins
+
+-- The satisfiability companion, in the other direction: KimchiForkSpread is not a predicate
+-- nothing satisfies. Over Pre = Fin 5 with all-zero generators the adversary wins identically and
+-- its prefixes never move, so BOTH clauses hold at sigma0 = 4 at EVERY round count (O-1b
+-- milestone M5) -- the node clause included, which is vacuous only at sigma.k = 0 -- and the
+-- conditional bound reads a real inequality (3^(k+1) * sum <= 30^(k+1) * |tapes|) rather than
+-- `0 <= ...`. Four roots because none reaches another: two existential headlines (the sigma.k = 0
+-- instance, kept because its statement is quoted downstream, and the every-round-count form,
+-- whose sigma.k = K conjunct is what makes it say more), the applied bound, and its anti-vacuity
+-- companion |tapes| <= sum. The walk reaches spreadExhibit_forkSpread, the fork-success induction
+-- spreadExhibit_forkFrom_isSome and the private exhibit data from them.
+Bulletproof.Forking.exists_kimchiForkSpread_two_le
+Bulletproof.Forking.exists_kimchiForkSpread_two_le_of_rounds
+Bulletproof.Forking.spreadExhibit_extractRuns_sum_le
+Bulletproof.Forking.spreadExhibit_card_le_extractRuns_sum
+
 -- The checked defences of the deployed model's two modelling steps, rooted for the same
 -- reason: nothing consumes an exhibit.
 -- (a) Fiat-Shamir faithfulness: the abstract verifier fed the Poseidon sponge's own reads IS

--- a/formal/bulletproof-pcs/scripts/check_axioms.lean
+++ b/formal/bulletproof-pcs/scripts/check_axioms.lean
@@ -5,6 +5,10 @@ nothing else. There is NO Fiat-Shamir axiom: the random-oracle idealisation ente
 knowledge-soundness results only as the game's uniform challenge table. DL-binding is a
 hypothesis throughout, never an axiom.
 
+The root list is a deletion guard as well as an axiom guard: a name absent from the environment
+fails with `axiom-check root not in environment`, so removing a listed declaration — even
+together with its `roots.txt` line — cannot pass silently.
+
 Run from `formal/bulletproof-pcs/`:  lake env lean scripts/check_axioms.lean
 (or from `formal/`:                  lake env lean bulletproof-pcs/scripts/check_axioms.lean)
 -/
@@ -57,7 +61,69 @@ def roots : List Name :=
     -- and ruling out every `R` below 1 in the gate the endpoints actually read
     `Bulletproof.Ipa.Forking.DeployedFamily.exists_complete_reductionEfficient,
     `Bulletproof.Forking.one_le_kimchiExtractRuns,
-    `Bulletproof.Ipa.Forking.DeployedFamily.one_le_of_reductionEfficient ]
+    `Bulletproof.Ipa.Forking.DeployedFamily.one_le_of_reductionEfficient,
+    -- audit O-1b: the fork-spread counting layer, from the candidate definitions through the
+    -- two pointwise bounds and the depth induction to the tape-averaged bound at the extractor.
+    -- Conditional on a spread hypothesis nothing in this tree proves AT DEPLOYED PARAMETERS, so
+    -- these carry no trust on their own -- they are pinned for the existence guard, so that a
+    -- deletion sweep over an unconsumed layer fails loudly rather than silently. (The hypothesis
+    -- is not one nothing satisfies: see the exhibit pinned below.)
+    `Bulletproof.Forking.kimchiScanCandidate,
+    `Bulletproof.Forking.kimchiLeafCandidate,
+    `Bulletproof.Forking.kimchiGoodChallenges,
+    `Bulletproof.Forking.kimchiLeafGoodChallenges,
+    `Bulletproof.Forking.KimchiForkSpread,
+    `Bulletproof.Forking.kimchiForkFrom_leaf_runs_le,
+    `Bulletproof.Forking.kimchiForkFrom_node_runs_le,
+    `Bulletproof.Forking.kimchiScanCandidate_runs_cases,
+    `Bulletproof.Forking.kimchiForkFrom_sum_runs_le_leaf,
+    `Bulletproof.Forking.kimchiForkFrom_sum_runs_le_of_forkSpread,
+    `Bulletproof.Forking.kimchiExtractRuns_sum_le_of_forkSpread,
+    -- and its anti-vacuity companions: the empty-good-set lemma and the sigma0 = 0 corollary it
+    -- feeds, which is what keeps the diagonal narrowing of `KimchiForkSpread` honest
+    `Bulletproof.Forking.kimchiLeafGoodChallenges_eq_empty_of_unstable,
+    `Bulletproof.Forking.kimchiForkSpread_eq_zero_of_leaf_unstable,
+    -- the same pair on the coin axis (milestone M4''): empty sampling orders make the fork fail
+    -- outright, so a node floor over arbitrary coin trees forces sigma0 = 0 at every sigma.k >= 1
+    `Bulletproof.Forking.kimchiGoodChallenges_eq_empty_of_order_nil,
+    `Bulletproof.Forking.kimchiNodeFloor_eq_zero_of_forall_coins,
+    -- and the companion in the other direction (milestone M5) -- the hypothesis is satisfiable
+    -- above the degenerate floor at EVERY round count, over Pre = Fin 5 with sigma0 = 4, node
+    -- clause included; plus the applied bound there and its |tapes| <= sum anti-vacuity companion
+    `Bulletproof.Forking.spreadExhibit_forkSpread,
+    `Bulletproof.Forking.exists_kimchiForkSpread_two_le,
+    `Bulletproof.Forking.exists_kimchiForkSpread_two_le_of_rounds,
+    `Bulletproof.Forking.spreadExhibit_extractRuns_sum_le,
+    `Bulletproof.Forking.spreadExhibit_card_le_extractRuns_sum,
+    -- audit O-1b (M3', half 1): the CONDITIONAL/AVERAGE branch of the extractor's cost, on
+    -- upstream's joint table-and-tape axis. It stands beside the per-tape worst-case branch
+    -- pinned above and weakens none of it; both endpoints still read `ReductionEfficient`, and
+    -- nothing here discharges their `hEff`. Conditional on `KimchiForkSpreadFamily`, which has
+    -- no family-level witness in this tree, so like the block above these carry no trust of
+    -- their own and are pinned for the existence guard.
+    `Bulletproof.Ipa.Forking.DeployedFamily.KimchiForkSpreadFamily,
+    `Bulletproof.Ipa.Forking.DeployedFamily.attemptRuns_sum_le_of_forkSpreadFamily,
+    `Bulletproof.Ipa.Forking.DeployedFamily.ReductionEfficientAvg,
+    `Bulletproof.Ipa.Forking.DeployedFamily.reductionEfficientAvg_of_forkSpreadFamily,
+    -- audit O-1b (M3', half 2): the PROBABILITY half of that same conditional/average branch,
+    -- and the twin endpoints reading it. The measured event moves onto the joint axis (the fork
+    -- tape is sampled, not fixed), the bound is unchanged, and `coins.Complete` is discharged
+    -- structurally rather than assumed. Like the counting half these carry no trust of their
+    -- own: the interesting `R` is still conditional on `KimchiForkSpreadFamily`, which has no
+    -- family-level witness in this tree, and the PRIMARY endpoints
+    -- `ipa{Vesta,Pallas}_knowledge_sound` still read the per-tape worst-case branch, unweakened.
+    -- The two anti-vacuity companions are what keep the average gate from being unreachable.
+    `Bulletproof.Ipa.Forking.DeployedFamily.reductionEfficientAvg_of_worstCase,
+    `Bulletproof.Ipa.Forking.DeployedFamily.one_le_of_reductionEfficientAvg,
+    `Bulletproof.Ipa.Forking.relationFinderAvg,
+    `Bulletproof.Ipa.Forking.DerivedUDLAdvantageLEAvg,
+    `Bulletproof.Ipa.Forking.derivedUDLAvg_iff_residual_measure,
+    `Bulletproof.Ipa.Forking.relation_summand_avg,
+    `Bulletproof.Ipa.Forking.residual_summand_avg,
+    `Bulletproof.Ipa.Forking.deployedExtract_noOpening_measure_le_of_textbookDL_avg,
+    `Bulletproof.Ipa.Forking.DeployedFamily.DiscreteLogRelationHardForAvg,
+    `Bulletproof.Ipa.Forking.ipaVesta_knowledge_sound_avg,
+    `Bulletproof.Ipa.Forking.ipaPallas_knowledge_sound_avg ]
 
 /-- The standard logical axioms, and nothing else — `native_decide` certificates are
     admitted separately, by defining module, in `isTrustedNativeDecide` below.

--- a/formal/bulletproof-pcs/scripts/check_ironwood_generic.lean
+++ b/formal/bulletproof-pcs/scripts/check_ironwood_generic.lean
@@ -1,19 +1,21 @@
 import Bulletproof.Forking.Game
+import Zcash.Snark.Soundness.Forking.Adversary.ExpectedRuns
 
 /-!
 # The reuse seam: our fork game IS ironwood's, at a prechallenge alphabet
 
-`Forking/Game.lean` proves its escape and counting layer over an abstract `variable {T Pre Pf}`
-(Game.lean:114) — an alphabet with no instances at all. This file records what the *deployed*
-alphabet buys: `Fin (2 ^ 128)` carries `Zero`, `DecidableEq`, `Fintype` and `Nonempty`, and with
-those, ironwood's own scanner, escape set, counting bound and coin-tree traversal apply by literal
-`exact`. So the corresponding blocks of `Game.lean` are duplicates of upstream, not forced ports.
+`Forking/Game.lean` proves its escape and counting layer over an abstract
+`variable {T Pre Pf : Type*}` block — an alphabet with no instances at all. This file records what
+the *deployed* alphabet buys: `Fin (2 ^ 128)` carries `Zero`, `DecidableEq`, `Fintype` and
+`Nonempty`, and with those, ironwood's own scanner, escape set, counting bound and coin-tree
+traversal apply by literal `exact`. So the corresponding blocks of `Game.lean` are duplicates of
+upstream, not forced ports.
 
 Two further facts are pinned here because the whole abstraction rests on them:
 
-* the frozen `Wins` (Game.lean:129) *is* `Zcash.Snark.fsWinsFull` (Adaptive.lean:30) at `m = 0`,
-  by `Iff.rfl` — so one game statement serves bare IPA (`m = 0`) and kimchi (`m > 0`), and the win
-  condition stays `VerifierAcceptsAt`, the wire verifier, with no bridging lemma;
+* the frozen `Wins` (`Game.lean`'s `def Wins`) *is* `Zcash.Snark.fsWinsFull` (Adaptive.lean:30) at
+  `m = 0`, by `Iff.rfl` — so one game statement serves bare IPA (`m = 0`) and kimchi (`m > 0`), and
+  the win condition stays `VerifierAcceptsAt`, the wire verifier, with no bridging lemma;
 * the error divides by `Fintype.card Pre = 2 ^ 128`, never by a field cardinality.
 
 Every example below is discharged by `exact`ing an upstream declaration. Nothing is proved here,
@@ -51,7 +53,15 @@ example (T P : Type) (k : ℕ) (prefixes : P → Fin k → T)
 
 /-! ## 3. The upstream scanner, at `Pre`, by `exact`.
 
-Literal instantiations of the upstream names that Game.lean:248/373/518 re-prove. -/
+Literal instantiations of the upstream scan names `Game.lean` *consumes* rather than re-proves:
+`nextForkChallenge_runs_le` and `nextForkChallenge_output_rest_length_le` in
+`kimchiForkFrom_runs_le`, `nextForkChallenge_two_more` in `nextFork_fst_ne_none` /
+`nextFork_snd_ne_none`, `nextForkChallenge_isSome_of_good` and
+`nextForkChallenge_other_good_mem_rest` in the spread exhibit's `spreadExhibit_forkFrom_isSome`,
+and `nextForkChallenge_output_fresh` / `_output_attempt` in `kimchiForkFrom_realizes` —
+`_output_fresh` also in `kimchiForkFrom_leaf_runs_le` and in `spreadExhibit_forkFrom_isSome`. The
+point of the pins below is that each such name typechecks at `Pre` by `exact`, so none of those
+consumers needed an alphabet-specific restatement. -/
 
 theorem pre_scan_isSome {α : Type*} (attempt : Pre → RecursiveForkAttempt α)
     (seen : List Pre) {q : Pre} {order : List Pre}
@@ -100,10 +110,11 @@ example {T : Type} [Fintype T] [DecidableEq T] {α : Type}
 /-! ## 6. THE HEADLINE: the endpoint bound shape, at arbitrary `m`, from upstream names only.
 
 `good t O q` is the per-round "the reprogrammed candidate extracts" predicate — the only thing we
-write. `hforce` is the escape-or-extract dichotomy our fork recursion supplies (Game.lean:950).
-Note where `m` does and does not appear: the pre-IPA reads enter `fsWinsFull` and cost nothing in
-the bound, because only the `N` forked prefixes are completed. This is the exact shape of
-`kimchiExtract_failure_measure_le` (Game.lean:1447) with the escape layer replaced by upstream's. -/
+write. `hforce` is the escape-or-extract dichotomy our fork recursion supplies
+(`kimchiExtract_isSome_of_not_escape_of_stableBase`). Note where `m` does and does not appear: the
+pre-IPA reads enter `fsWinsFull` and cost nothing in the bound, because only the `N` forked prefixes
+are completed. This is the exact shape of `kimchiExtract_failure_measure_le` with the escape layer
+replaced by upstream's. -/
 
 theorem shared_failure_measure_le {T Pf : Type*} [Fintype T] [DecidableEq T] {m N Q : ℕ}
     (A : OracleComp T Pre Pf) (accept : Pf → (Fin m → Pre) → (Fin N → Pre) → Prop)
@@ -153,8 +164,10 @@ example {F G T Pf : Type} [Field F] [AddCommGroup G] [Module F G]
 
 `Recursive.lean`'s section line (:1057) binds `[Field F]`, but Lean includes a section variable in
 a `def` only by use, and these defs never touch the algebra — the `omit` at :1072 is for the
-adjacent theorem. Instantiating them at an alphabet with no algebra, not even `DecidableEq`, shows
-Game.lean:612/623/1052 are duplicates rather than forced ports. -/
+adjacent theorem. Instantiating them at an alphabet with no algebra, not even `DecidableEq`, is
+what licenses `Game.lean` to *consume* `RecursiveForkReached`, `recursiveForkReached_child` and
+`RecursiveRunHistory` directly rather than re-state them — which is what its "Reached tape nodes"
+and run-history preambles say it does. -/
 
 structure Bare where
   /-- Any payload at all: this alphabet deliberately has no algebraic structure. -/
@@ -170,5 +183,86 @@ example (T P : Type) (k d m : ℕ) (hmk : m + (d + 1) = k) (pfx : P → Fin k �
 example (T P : Type) (k m : ℕ) (h : m ≤ k) (pfx : P → Fin k → T) (O : T → Bare) (p : P)
     (hist : Fin m → T × Bare) : Prop :=
   RecursiveRunHistory k m h pfx O p hist
+
+/-! ## 9. The rank / marginalization / scan-bound / tape layer is alphabet-generic too.
+
+The layer O-1b's *conditional* average-run bound is built on. Upstream states all of it under
+`variable {F : Type*} [DecidableEq F]`, adding `[Zero F]` where the scanner appears and
+`[Fintype F]` where a cardinality does — **no `Field`, no `AddCommGroup`, no `Module`** — so each
+declaration below instantiates at the prechallenge alphabet by a literal `exact`.
+
+That is the evidence for the shape of the O-1b port: only §`NodeBound` (`ExpectedRuns.lean:426–568`)
+and §`SpreadTheorem` (`:583–910`) mention `recursiveAlgebraicForkFrom`, so only those two must be
+restated for *our* recursion (`kimchiForkFrom`, which differs in its depth indexing and in doing
+real work at the leaf). Both now are: `kimchiForkFrom_node_runs_le` /
+`kimchiForkFrom_leaf_runs_le` for §`NodeBound`, and `kimchiForkFrom_sum_runs_le_of_forkSpread` with
+its root corollary `kimchiExtractRuns_sum_le_of_forkSpread` for §`SpreadTheorem`. Everything below
+`:426` is instantiated, not ported. A failure in this section
+means that reuse claim no longer holds and the corresponding block of `Game.lean` has become a
+forced port. -/
+
+/-- A challenge's zero-based rank in a sampling order (`ExpectedRuns.lean:18`). -/
+example (order : Fin (Fintype.card Pre) ≃ Pre) (A : Finset Pre) (q : Pre) : ℕ :=
+  scanRank order A q
+
+/-- At most `j` members of `A` have rank below `j` (`ExpectedRuns.lean:39`). -/
+theorem pre_card_filter_scanRank_lt_le (order : Fin (Fintype.card Pre) ≃ Pre) (A : Finset Pre)
+    (j : ℕ) :
+    (A.filter (fun q => scanRank order A q < j)).card ≤ j :=
+  card_filter_scanRank_lt_le order A j
+
+open Classical in
+/-- A member of `A` has rank below `j` in at most a `j/|A|` fraction of the sampling orders
+(`ExpectedRuns.lean:139`). This is the counting step that turns "twice the rank-`< 2` candidates"
+into a `1/|good set|` density, and it is the one that makes the `6` land. -/
+theorem pre_card_scanRank_lt_mul_le (A : Finset Pre) {q : Pre} (hq : q ∈ A) (j : ℕ) :
+    A.card * (Finset.univ.filter
+        (fun order : Fin (Fintype.card Pre) ≃ Pre => scanRank order A q < j)).card
+      ≤ j * Fintype.card (Fin (Fintype.card Pre) ≃ Pre) :=
+  card_scanRank_lt_mul_le A hq j
+
+/-- Marginalizing one coordinate of a finite function space (`ExpectedRuns.lean:164`). Used to
+factor a sum over child tapes into `|tapes|^(N-1)` copies of a sum over one child
+(here at `α := Pre`, the alphabet indexing a node's children). -/
+theorem pre_sum_eval_pi {β : Type*} [Fintype β] (q : Pre) (g : β → ℕ) :
+    ∑ f : Pre → β, g (f q) = Fintype.card β ^ (Fintype.card Pre - 1) * ∑ b : β, g b :=
+  sum_eval_pi q g
+
+open Classical in
+/-- A scan pays only candidates preceded by fewer than two good challenges
+(`ExpectedRuns.lean:368`) — the pointwise ingredient of both of O-1b's per-row bounds. -/
+theorem pre_nextForkChallenge_runs_le_rank_sum {α : Type*}
+    (attempt : Pre → RecursiveForkAttempt α) (order : Fin (Fintype.card Pre) ≃ Pre)
+    (M : Finset Pre) (hM : ∀ q ∈ M, q ≠ 0 ∧ (attempt q).output.isSome)
+    (seen l₀ l' : List Pre) (hdec : List.ofFn (⇑order) = l₀ ++ l')
+    (hMseen : ∀ q ∈ M, q ∈ seen → q ∈ l₀)
+    (hMl₀ : (M.filter (· ∈ l₀)).card ≤ 1) :
+    (nextForkChallenge attempt seen l').runs
+      ≤ ∑ q ∈ Finset.univ.filter (fun q : Pre => scanRank order (insert q M) q < 2),
+          (attempt q).runs :=
+  nextForkChallenge_runs_le_rank_sum attempt order M hM seen l₀ l' hdec hMseen hMl₀
+
+/-! The uniform tape (`Recursive.lean:23`) and its coin erasure. `orderList` is definitionally
+`List.ofFn`, which is what lets a tape node be handed straight to the rank lemmas above; and
+`equivSucc` is what turns a depth-`d+1` tape sum into a sum over `(order, children)` pairs. -/
+
+/-- The tape space at the prechallenge alphabet is finite and inhabited (`Recursive.lean:23`). -/
+example (d : ℕ) : Fintype (RecursiveForkTape Pre d) := inferInstance
+
+/-- A tape node's sampling order erases to `List.ofFn` on the nose (`Recursive.lean:32`, `:37`). -/
+theorem pre_toCoins_node {d : ℕ} (order : Fin (Fintype.card Pre) ≃ Pre)
+    (child : Pre → RecursiveForkTape Pre d) :
+    (RecursiveForkTape.node order child).toCoins
+      = .node (List.ofFn (⇑order)) (fun q => (child q).toCoins) :=
+  rfl
+
+/-- A positive-depth tape is one order and one child tape per challenge (`Recursive.lean:63`), so
+its cardinality factors — the shape every depth-`d+1` tape sum is transported along. -/
+theorem pre_card_tape_succ (d : ℕ) :
+    Fintype.card (RecursiveForkTape Pre (d + 1))
+      = Fintype.card (Fin (Fintype.card Pre) ≃ Pre)
+          * Fintype.card (RecursiveForkTape Pre d) ^ Fintype.card Pre := by
+  have h := Fintype.card_congr (RecursiveForkTape.equivSucc (F := Pre) d)
+  rwa [Fintype.card_prod, Fintype.card_fun] at h
 
 end Bulletproof.Forking.IronwoodGeneric

--- a/formal/bulletproof-pcs/scripts/check_ironwood_generic.sh
+++ b/formal/bulletproof-pcs/scripts/check_ironwood_generic.sh
@@ -15,5 +15,6 @@ fi
 if [[ -n "$out" ]]; then
   echo "✗ unexpected output (expected none)"; echo "--- got ---"; echo "$out"; exit 1
 fi
-echo "✓ ironwood's PrefixDecode, scanner, escape triple, counting bound and coin-tree traversal"
-echo "  all instantiate at codomain Fin (2^128); our Wins IS fsWinsFull at m = 0 by Iff.rfl"
+echo "✓ ironwood's PrefixDecode, scanner, escape triple, counting bound, coin-tree traversal and"
+echo "  rank/marginalization/scan-bound/tape layer all instantiate at codomain Fin (2^128);"
+echo "  our Wins IS fsWinsFull at m = 0 by Iff.rfl"

--- a/formal/bulletproof-pcs/scripts/check_locked_target.sh
+++ b/formal/bulletproof-pcs/scripts/check_locked_target.sh
@@ -121,13 +121,20 @@ fi
 # hypothetical: the dead-code sweep at e7c431b2 deleted kimchi's concrete-index exhibits for
 # exactly this reason, which the external audit found and generalized in its addendum.)
 # Deleting one now fails a LOCK — a statement-level decision needing sign-off — rather than
-# passing silently.
+# passing silently. (Their axiom closures are pinned separately by scripts/check_axioms.lean,
+# which also throws when a listed root leaves the environment — these pins are a second,
+# independent guard, not the only one.)
+#
+# COUNTING CONVENTION, shared with the kimchi gate: the closing message's exhibit count is the
+# number of names in the lists below and nothing else. The guards checked by the separate
+# `if`s above are named beside that count, never folded into it.
 exhibits_dep='sg_determined_of_verifyWith wireWins_pinTable pinTable_factors chainAt_sg
               nodeTranscript_nodes uBaseOf_eq_transcript identityTape exists_complete_coins
               exists_complete_bounded_coins'
 exhibits_ks='wireWins_U_irrelevant deployedExtract_U_irrelevant uRepresentationOfBreak
              reductionEfficient_exists derivedUDL_iff_residual_measure honestFamily_failure_set
-             exists_complete_reductionEfficient'
+             exists_complete_reductionEfficient
+             DeployedFamily.one_le_of_reductionEfficient'
 exhibits_game='one_le_kimchiExtractRuns'
 exhibits_tr='verifyOracle_spongeFS verifyOracleFrom_spongeFSFrom spongeFS_eq_from
              toGroup_spongeOBase_preT'
@@ -147,4 +154,4 @@ for pair in "$dep:$exhibits_dep" "$ks:$exhibits_ks" "$game:$exhibits_game" \
 done
 
 echo "✓ locked target intact: statement, extractor type, conclusion type,"
-echo "  plain-def extractor, both anti-vacuity companions, and the 23 exhibits"
+echo "  plain-def extractor, both anti-vacuity companions, and the 24 exhibits"

--- a/formal/kimchi/Kimchi/Verifier/Forking/Honest.lean
+++ b/formal/kimchi/Kimchi/Verifier/Forking/Honest.lean
@@ -1795,6 +1795,60 @@ theorem pallas_honest_extraction_failure_measure_le
   rintro q ⟨hext, hb⟩
   exact ⟨pallasHonestFamily_wins B q.1 hb q.2, hext⟩
 
+/-- **The joint-axis twin of `vesta_honest_extraction_failure_measure_le`.** The same
+anti-vacuity guard against the averaged endpoint `vesta_kimchi_knowledge_sound_avg`: on the
+honest family the measured set is again a statement about the extractor alone, now over the
+joint `(table × tape)` space. Two things change beside the space. The event's challenge-table
+coordinate is `q.2.1` and its coins are `q.2.2.toCoins`, read off the sampled fork tape; and
+the completeness hypothesis `hcoins` is **gone** — the averaged endpoint discharges it
+structurally through `RecursiveForkTape.toCoins_complete`, so this guard has one fewer
+hypothesis than its per-tape twin. The family still wins on the whole non-excluded slice
+(`vestaHonestFamily_wins`, which is uniform in the challenge table), so the containment is the
+same one line. -/
+theorem vesta_honest_extraction_failure_measure_le_avg
+    (B : Bulletproof.IpaVesta.Point) {R : ℕ} {ε δ : ℝ≥0∞}
+    (hHard : vestaHonestFamily.DiscreteLogRelationHardForAvg B R ε δ)
+    (hEff : vestaHonestFamily.ReductionEfficientAvg R) :
+    (PMF.uniformOfFintype
+        ((SetupIndex (2 ^ 2) → Bulletproof.IpaVesta.curve.ScalarField) ×
+          (Coins Bulletproof.IpaVesta.curve 1 2 ×
+            Zcash.Snark.RecursiveForkTape Prechallenge (2 + 1)))).toOuterMeasure
+        ({q | ¬ vestaHonestFamily.ExtractsWitness
+              (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 q.2.2.toCoins}
+          ∩ {q | q.1 SetupIndex.blind ≠ 0})
+      ≤ (vestaHonestFamily.Q + 2 + 1) * (3 / (2 ^ 128 : ℕ))
+        + ((2 ^ 2 + 1 : ℕ) : ℝ≥0∞) * ε + δ
+        + ((vestaHonestFamily.Q + 1 : ℕ) : ℝ≥0∞)
+          * ((szBudget 1 (2 ^ 2) vestaHonestFamily.idx.zkRows : ℝ≥0∞) / (2 ^ 128 : ℕ)) := by
+  refine le_trans (MeasureTheory.OuterMeasure.mono _ ?_)
+    (vesta_kimchi_knowledge_sound_avg B vestaHonestFamily hHard hEff)
+  rintro q ⟨hext, hb⟩
+  exact ⟨vestaHonestFamily_wins B q.1 hb q.2.1, hext⟩
+
+/-- **The joint-axis twin of `pallas_honest_extraction_failure_measure_le`** — the Pallas side
+of `vesta_honest_extraction_failure_measure_le_avg`, against
+`pallas_kimchi_knowledge_sound_avg`; same space, same absence of `hcoins`, same one-line
+containment. -/
+theorem pallas_honest_extraction_failure_measure_le_avg
+    (B : Bulletproof.IpaPallas.Point) {R : ℕ} {ε δ : ℝ≥0∞}
+    (hHard : pallasHonestFamily.DiscreteLogRelationHardForAvg B R ε δ)
+    (hEff : pallasHonestFamily.ReductionEfficientAvg R) :
+    (PMF.uniformOfFintype
+        ((SetupIndex (2 ^ 2) → Bulletproof.IpaPallas.curve.ScalarField) ×
+          (Coins Bulletproof.IpaPallas.curve 1 2 ×
+            Zcash.Snark.RecursiveForkTape Prechallenge (2 + 1)))).toOuterMeasure
+        ({q | ¬ pallasHonestFamily.ExtractsWitness
+              (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 q.2.2.toCoins}
+          ∩ {q | q.1 SetupIndex.blind ≠ 0})
+      ≤ (pallasHonestFamily.Q + 2 + 1) * (3 / (2 ^ 128 : ℕ))
+        + ((2 ^ 2 + 1 : ℕ) : ℝ≥0∞) * ε + δ
+        + ((pallasHonestFamily.Q + 1 : ℕ) : ℝ≥0∞)
+          * ((szBudget 1 (2 ^ 2) pallasHonestFamily.idx.zkRows : ℝ≥0∞) / (2 ^ 128 : ℕ)) := by
+  refine le_trans (MeasureTheory.OuterMeasure.mono _ ?_)
+    (pallas_kimchi_knowledge_sound_avg B pallasHonestFamily hHard hEff)
+  rintro q ⟨hext, hb⟩
+  exact ⟨pallasHonestFamily_wins B q.1 hb q.2.1, hext⟩
+
 end Trivial
 
 end Kimchi.Verifier.Forking

--- a/formal/kimchi/Kimchi/Verifier/KnowledgeSoundness.lean
+++ b/formal/kimchi/Kimchi/Verifier/KnowledgeSoundness.lean
@@ -816,7 +816,9 @@ def warmBase {nc : ℕ} (σ : SRS C.Point) (cvk : KimchiVK C nc) (pub : Array C.
 /-- **The oracle table** the adversary and the extractor share. Ironwood's `Coins`
 (ironwood's `Forking/Adversary/Algebraic.lean:857`) carries the recursive fork tape
 alongside; here that tape stays a
-parameter, which makes the bound hold for every complete tape rather than on average. -/
+parameter, which makes the bound hold for every complete tape rather than on average; the
+conditional `(6 · 2 ^ 128 / (σ₀ − 1)) ^ (k + 1)` bound lives only on the average — see
+`KimchiFamily.ReductionEfficientAvg`. -/
 abbrev Coins (C : Ipa.CommitmentCurve) (nc k : ℕ) : Type := KimchiNode C nc k → Prechallenge
 
 /-- **A basis-indexed kimchi adversary family** — the analogue of `DeployedFamily`.
@@ -1793,7 +1795,9 @@ knowledge-soundness statements assume — and bounded by `Fintype.card Prechalle
 node, which is what the cost bound consumes.
 
 Worst case and exponential, as everywhere this number is quoted; it is not a concrete-security
-claim, and no table-averaged or polynomial bound follows from it. -/
+claim, and no table-averaged or polynomial bound follows from it — the conditional average branch
+below (`ReductionEfficientAvg` and its bridge) is a **separate statement**, proved on the joint
+table-and-tape axis, not a consequence of this `R`. -/
 theorem exists_complete_reductionEfficient :
     ∃ coins : Zcash.Snark.RecursiveForkCoins Prechallenge (k + 1),
       coins.Complete ∧ fam.ReductionEfficient coins ((2 * 2 ^ 128 + 1) ^ (k + 1)) := by
@@ -1835,12 +1839,286 @@ theorem one_le_of_reductionEfficient
 /-- **Discrete log is hard for this family against `R`-call reductions** — the analogue of
 `DeployedFamily.DiscreteLogRelationHardFor`, and what pins `ε` and `δ`. `ε` is a genuine
 reduction to textbook discrete log; `δ` is the residual event's own measure, which is why the
-two are named separately. -/
+two are named separately.
+
+Its joint-axis twin is `DiscreteLogRelationHardForAvg` (`§ 18`), gated by `ReductionEfficientAvg`
+and stated over the sampled fork tape. Neither implies the other: this one fixes a tape the
+reduction did not choose, that one lets the reduction sample its own. -/
 def DiscreteLogRelationHardFor (B : C.Point)
     (coins : Zcash.Snark.RecursiveForkCoins Prechallenge (k + 1)) (R : ℕ) (ε δ : ℝ≥0∞) : Prop :=
   fam.ReductionEfficient coins R →
     Zcash.Snark.TextbookDLWithCoinsAdvantageLE B (fam.relationFinder coins) ε ∧
       fam.DerivedUDLAdvantageLE B coins δ
+
+/-! ### The conditional average axis
+
+Five declarations and one arithmetic helper, standing **beside** the per-tape block above and
+replacing nothing in it: `KimchiForkSpreadFamily` (the spread hypothesis at every basis *and*
+every oracle table of one family), `attemptRuns_sum_le_of_forkSpreadFamily` (the call count summed
+over table and tape jointly), `ReductionEfficientAvg` (that sum read as an efficiency gate),
+`reductionEfficientAvg_of_forkSpreadFamily` (the bridge from the bound to the gate), and its two
+anti-vacuity companions `reductionEfficientAvg_of_worstCase` (the gate is reachable
+unconditionally, so it is not a predicate only an unwitnessed hypothesis can satisfy) and
+`one_le_of_reductionEfficientAvg` (no `R` below `1` satisfies it). This is the kimchi twin of
+`Bulletproof/Forking/KnowledgeSoundness.lean`'s block of the same name.
+
+**What this branch is.** Upstream's own coin axis, added beside ours. Ironwood's family bundles
+`Coins = (oracle table) × (fork tape)` and measures its endpoint with the tape sampled inside the
+probability space; ours splits that pair, and the split is exactly what makes the per-tape bound
+hold for *every* complete tape. This section adds upstream's shape.
+
+**What it is not: a replacement.** The per-tape branch — `Coins`, `ReductionEfficient`,
+`relationFinder`, `attemptRuns`, `reductionEfficient_of_bounded`,
+`exists_complete_reductionEfficient`, `one_le_of_reductionEfficient`,
+`DiscreteLogRelationHardFor`, and both endpoints in `§ 17` — is the **worst-case** branch and
+stands verbatim and unweakened; it is still the branch `vesta_kimchi_knowledge_sound` and
+`pallas_kimchi_knowledge_sound` read. Neither branch implies the other: this one fixes nothing
+and averages over the product, that one fixes a tape and averages over tables only.
+
+**What it costs and what is still assumed.** `ReductionEfficientAvg` is reachable two ways: at the
+worst-case `(2 · 2 ^ 128 + 1) ^ (k + 1)`, unconditionally and with no tape chosen
+(`reductionEfficientAvg_of_worstCase`), and at the conditional
+`(6 · 2 ^ 128 / (σ₀ − 1)) ^ (k + 1)` (`reductionEfficientAvg_of_forkSpreadFamily`). Only the
+second is interesting, and `KimchiForkSpreadFamily` has **no witness at any layer**:
+`Bulletproof.Forking.exists_kimchiForkSpread_two_le_of_rounds` exhibits a spread at `σ₀ = 4` over
+`Pre = Fin 5`, at the abstract layer, instantiating no family whose prechallenge alphabet has
+`2 ^ 128` elements — the exhibit does not transfer. And the regime caveat travels with the number:
+`(6/δ) ^ (k + 1)` at `k = 15` is about `2 ^ 54` calls at `δ = 1/2` and about `2 ^ 339` at
+`δ = 2 ^ (-20)`, worse than solving discrete log outright.
+
+**What is not here.** The probability half of this branch — the averaged relation finder, the
+averaged cover and the two twin endpoints against `ReductionEfficientAvg` — is not in this
+section. Nothing below reaches a knowledge-soundness statement; this is the counting layer only. -/
+
+/-- Fubini plus a constant-sum collapse: a bound `d · ∑ b, f a b ≤ B · |β|` holding at every `a`
+sums to `d · ∑ (a, b), f a b ≤ B · |α × β|`.
+
+**Keep this at variables.** Inlining the same four steps at the concrete
+`Coins C nc k × tape` types in `attemptRuns_sum_le_of_forkSpreadFamily` is what cost ~29 GB of
+elaborator memory and five minutes on the bulletproof side — enough to OOM-kill a 30 GB build —
+because `Finset.sum_le_sum` and `ring` then compare `Fintype.card` atoms whose instance terms
+carry the whole node structure. The risk is higher here than there: `KimchiNode C nc k` bundles
+`PreIpaData` and `EvalsView`, and is heavier than `IpaNode`. At `α`, `β` and `f` abstract the work
+is free and the concrete instance appears once.
+
+`Bulletproof/Forking/KnowledgeSoundness.lean`'s copy is `private` to that module, so this is a
+second copy rather than a reuse. -/
+private theorem sum_prod_le_of_forall {α β : Type*} [Fintype α] [Fintype β]
+    (f : α → β → ℕ) (d B : ℕ) (h : ∀ a, d * ∑ b, f a b ≤ B * Fintype.card β) :
+    d * ∑ c : α × β, f c.1 c.2 ≤ B * Fintype.card (α × β) := by
+  calc d * ∑ c : α × β, f c.1 c.2 = ∑ a, d * ∑ b, f a b := by
+        rw [Fintype.sum_prod_type, Finset.mul_sum]
+    _ ≤ ∑ _a : α, B * Fintype.card β := Finset.sum_le_sum fun a _ => h a
+    _ = B * Fintype.card (α × β) := by
+        rw [Finset.sum_const, Finset.card_univ, smul_eq_mul, Fintype.card_prod]; ring
+
+/-- **The fork-spread hypothesis, at every basis and every oracle table of one family.**
+`Bulletproof.Forking.KimchiForkSpread σ₀` at exactly the instantiation `attemptRuns` runs: the SRS
+with `U` overridden to the family's WARM post-`ζ` base `fam.warmBase basis O`, the combined
+evaluation vector, `Ipa.cipOf` and combined commitment of `fam.claim basis O`, `fam.adversary
+basis`, and the deployed prefixes and decoder at that SRS.
+
+**Why it is indexed by the table as well as the basis.** Kimchi's claim is adversary output, so
+both the claim and the SRS the extractor runs against — `fam.runSrs basis O` is `srsOfBasis` with
+its opening base replaced by the base the run's own sponge squeezes after `ζ` — are functions of
+the oracle table. The predicate therefore demands the spread at every `(basis, table)` pair, i.e.
+at every warm base the family can reach. `DeployedFamily.KimchiForkSpreadFamily` needs only the
+basis, because `DeployedFamily.claim` depends on the basis alone; this is neither a weakening nor
+a strengthening of that one, it is what this instantiation requires.
+
+**Why the `dec` slot is named here.** The bulletproof twin ∀-quantifies its `DecodesFromPrefixes`
+witness because the deployed one is `private` to another module. That cost is not paid here:
+`kimchiDecodesFromPrefixes` is `private` to *this* file, so this declaration names it. Demanding
+the spread at one witness rather than all of them makes this hypothesis strictly **weaker** than
+its bulletproof model, and every theorem over it correspondingly **stronger**.
+
+A hypothesis, not a theorem: nothing in this tree proves it, at deployed parameters or otherwise
+(see the subsection preamble on why the abstract exhibit does not transfer, and on the regime in
+which the number it buys says anything at all). -/
+def KimchiForkSpreadFamily (σ₀ : ℕ) : Prop :=
+  ∀ (basis : Zcash.Snark.AugmentedIndex (2 ^ k) → C.Point) (O : Coins C nc k),
+    Bulletproof.Forking.KimchiForkSpread (fam.runSrs basis O)
+      (combinedEvalVector (2 ^ k) (fam.claim basis O).evalscale (fam.claim basis O).pointFn)
+      (Ipa.cipOf (fam.claim basis O))
+      (combinedCommitment (fam.claim basis O).polyscale (fam.claim basis O).commitmentFn)
+      (expandPre C) (fam.adversary basis)
+      (fun cp => Bulletproof.Ipa.Forking.toOpening cp.opening)
+      (ipaPrefixes (fam.runSrs basis O) (fam.digest basis) (fam.publicComm basis))
+      (kimchiDecodesFromPrefixes (fam.runSrs basis O) (fam.digest basis) (fam.publicComm basis))
+      σ₀
+
+/-- **The call count summed over table and tape jointly**, at one basis:
+`(σ₀ − 1) ^ (k + 1) · ∑ ≤ (6 · 2 ^ 128) ^ (k + 1) · |tables × tapes|`.
+
+The content is `Bulletproof.Forking.kimchiExtractRuns_sum_le_of_forkSpread` — a tape sum at each
+fixed table — plus Fubini. `attemptRuns` *is* `kimchiExtractRuns` at these arguments, by
+definition, so each instance is one `exact`; in the inner sum the table is fixed and only the tape
+varies, so the corollary's SRS, `b`, `v` and `P` arguments are constant across it even though all
+four depend on the table.
+
+There is no quantifier commute anywhere in this: the table stays universally quantified inside the
+sum, and no witness tape is ever chosen. The Fubini half is `sum_prod_le_of_forall`, kept abstract
+for the reason recorded there. -/
+theorem attemptRuns_sum_le_of_forkSpreadFamily {σ₀ : ℕ}
+    (hs : fam.KimchiForkSpreadFamily σ₀)
+    (basis : Zcash.Snark.AugmentedIndex (2 ^ k) → C.Point) :
+    (σ₀ - 1) ^ (k + 1)
+        * ∑ c : Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1),
+            fam.attemptRuns basis c.1 c.2.toCoins
+      ≤ (6 * 2 ^ 128) ^ (k + 1)
+          * Fintype.card (Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)) := by
+  -- The M2 corollary at each table, at the very arguments `attemptRuns` passes.
+  have key : ∀ O : Coins C nc k,
+      (σ₀ - 1) ^ (k + 1)
+          * ∑ τ : Zcash.Snark.RecursiveForkTape Prechallenge (k + 1),
+              fam.attemptRuns basis O τ.toCoins
+        ≤ (6 * Fintype.card Prechallenge) ^ (k + 1)
+            * Fintype.card (Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)) := by
+    intro O
+    exact Bulletproof.Forking.kimchiExtractRuns_sum_le_of_forkSpread (fam.runSrs basis O)
+      (combinedEvalVector (2 ^ k) (fam.claim basis O).evalscale (fam.claim basis O).pointFn)
+      (Ipa.cipOf (fam.claim basis O))
+      (combinedCommitment (fam.claim basis O).polyscale (fam.claim basis O).commitmentFn)
+      (expandPre C) (fam.adversary basis)
+      (fun cp => Bulletproof.Ipa.Forking.toOpening cp.opening)
+      (ipaPrefixes (fam.runSrs basis O) (fam.digest basis) (fam.publicComm basis))
+      (kimchiDecodesFromPrefixes (fam.runSrs basis O) (fam.digest basis) (fam.publicComm basis))
+      (hs basis O) O
+  -- Fubini and the constant-sum collapse, at variables; then `|Prechallenge| = 2 ^ 128`.
+  have main := sum_prod_le_of_forall
+    (fun (O : Coins C nc k) (τ : Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)) =>
+      fam.attemptRuns basis O τ.toCoins)
+    ((σ₀ - 1) ^ (k + 1)) ((6 * Fintype.card Prechallenge) ^ (k + 1)) key
+  rwa [card_prechallenge] at main
+
+/-- **The extractor makes at most `R` calls on average over table *and* tape** — ironwood's
+`ReductionEfficient` term for term, at our types, with the product spelled out because our `Coins`
+bundles no tape.
+
+Read it next to `KimchiFamily.ReductionEfficient` above, which is the different, worst-case
+predicate: that one fixes a tape and averages over tables only, and it is the one the endpoints
+assume. This is the second branch, not a replacement. -/
+def ReductionEfficientAvg (R : ℕ) : Prop :=
+  ∀ basis : Zcash.Snark.AugmentedIndex (2 ^ k) → C.Point,
+    ∑ c : Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1),
+        fam.attemptRuns basis c.1 c.2.toCoins
+      ≤ R * Fintype.card (Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1))
+
+/-- **A fork spread at every basis and table gives an average call bound.** The joint-axis sum
+bound divided through by `(σ₀ − 1) ^ (k + 1)`, which is what makes `ReductionEfficientAvg` a
+reachable predicate rather than a floating one.
+
+`hR` is `R ≥ (6 · 2 ^ 128 / (σ₀ − 1)) ^ (k + 1)` written multiplicatively. Nothing is divided:
+over `ℕ`, `d · S ≤ B · c` does not give `S ≤ (B / d) · c` — at `d = 2`, `B = 3`, `c = 3`, `S = 4`
+the premise holds and the conclusion fails. The cancellation is `Nat.le_of_mul_le_mul_left`, whose
+positivity side condition is where `hσ` is spent. -/
+theorem reductionEfficientAvg_of_forkSpreadFamily {σ₀ R : ℕ} (hσ : 2 ≤ σ₀)
+    (hs : fam.KimchiForkSpreadFamily σ₀)
+    (hR : (6 * 2 ^ 128) ^ (k + 1) ≤ (σ₀ - 1) ^ (k + 1) * R) :
+    fam.ReductionEfficientAvg R := by
+  intro basis
+  have hpos : 0 < (σ₀ - 1) ^ (k + 1) := Nat.one_le_pow _ _ (by omega)
+  refine Nat.le_of_mul_le_mul_left ?_ hpos
+  calc (σ₀ - 1) ^ (k + 1)
+        * ∑ c : Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1),
+            fam.attemptRuns basis c.1 c.2.toCoins
+      ≤ (6 * 2 ^ 128) ^ (k + 1)
+          * Fintype.card (Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)) :=
+        fam.attemptRuns_sum_le_of_forkSpreadFamily hs basis
+    _ ≤ ((σ₀ - 1) ^ (k + 1) * R)
+          * Fintype.card (Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)) :=
+        Nat.mul_le_mul_right _ hR
+    _ = (σ₀ - 1) ^ (k + 1)
+          * (R
+              * Fintype.card
+                  (Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1))) := by
+        rw [Nat.mul_assoc]
+
+/-- **The average branch is non-empty, unconditionally** — the anti-vacuity companion of
+`ReductionEfficientAvg`.
+
+Without it the only route into that predicate would be
+`reductionEfficientAvg_of_forkSpreadFamily`, whose `KimchiForkSpreadFamily` premise has no witness
+at any layer, and anything gated on it would be a statement whose hypothesis nothing in this tree
+can supply. With it the predicate is reachable outright, at the same worst-case number
+`(2 · 2 ^ 128 + 1) ^ (k + 1)` that `exists_complete_reductionEfficient` reaches on the per-tape
+axis — and here with **no** tape chosen and no completeness side condition, because
+`Zcash.Snark.RecursiveForkTape.toCoins_bounded` bounds *every* tape's node degree by
+`Fintype.card Prechallenge`, which `card_prechallenge` evaluates.
+
+Satisfiability is this theorem's job; `one_le_of_reductionEfficientAvg` below does the other half
+of the bracket, ruling out a degenerate `R`. It supersedes nothing: the interesting bound is still
+the conditional `(6 · 2 ^ 128 / (σ₀ − 1)) ^ (k + 1)`, and this number is exponential in `k` and in
+the challenge domain, so it is bookkeeping rather than a concrete-security claim. -/
+theorem reductionEfficientAvg_of_worstCase :
+    fam.ReductionEfficientAvg ((2 * 2 ^ 128 + 1) ^ (k + 1)) := by
+  intro basis
+  -- The pointwise worst-case bound, summed over the tapes at each fixed table.
+  have key : ∀ O : Coins C nc k,
+      1 * ∑ τ : Zcash.Snark.RecursiveForkTape Prechallenge (k + 1),
+          fam.attemptRuns basis O τ.toCoins
+        ≤ (2 * 2 ^ 128 + 1) ^ (k + 1)
+            * Fintype.card (Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)) := by
+    intro O
+    rw [one_mul]
+    calc ∑ τ : Zcash.Snark.RecursiveForkTape Prechallenge (k + 1),
+            fam.attemptRuns basis O τ.toCoins
+        ≤ ∑ _τ : Zcash.Snark.RecursiveForkTape Prechallenge (k + 1),
+            (2 * 2 ^ 128 + 1) ^ (k + 1) :=
+          Finset.sum_le_sum fun τ _ =>
+            Bulletproof.Forking.kimchiExtractRuns_le (fam.runSrs basis O)
+              (combinedEvalVector (2 ^ k) (fam.claim basis O).evalscale
+                (fam.claim basis O).pointFn)
+              (Ipa.cipOf (fam.claim basis O))
+              (combinedCommitment (fam.claim basis O).polyscale (fam.claim basis O).commitmentFn)
+              (expandPre C) (fam.adversary basis)
+              (fun cp => Bulletproof.Ipa.Forking.toOpening cp.opening)
+              (ipaPrefixes (fam.runSrs basis O) (fam.digest basis) (fam.publicComm basis))
+              (kimchiDecodesFromPrefixes (fam.runSrs basis O) (fam.digest basis)
+                (fam.publicComm basis))
+              O τ.toCoins
+              (card_prechallenge ▸ Zcash.Snark.RecursiveForkTape.toCoins_bounded τ)
+      _ = _ := by rw [Finset.sum_const, Finset.card_univ, smul_eq_mul, Nat.mul_comm]
+  -- Fubini and the constant-sum collapse, at variables, at `d = 1`.
+  have main := sum_prod_le_of_forall
+    (fun (O : Coins C nc k) (τ : Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)) =>
+      fam.attemptRuns basis O τ.toCoins)
+    1 ((2 * 2 ^ 128 + 1) ^ (k + 1)) key
+  rwa [one_mul] at main
+
+/-- **No `R` below `1` satisfies the average efficiency gate either** — the joint-axis twin of
+`one_le_of_reductionEfficient`, and it rules out the same degenerate reading: an `R = 0` gate would
+advertise a zero-call reduction, against which discrete-log hardness would be assumed for free.
+
+The extractor runs the adversary at least once at every `(table, tape)` pair
+(`Bulletproof.Forking.one_le_kimchiExtractRuns`), so the joint sum is at least the cardinality of
+the pair type, which `R * Fintype.card …` does not bound at `R = 0`. It does not establish
+satisfiability — that is `reductionEfficientAvg_of_worstCase`'s job, not this one's. -/
+theorem one_le_of_reductionEfficientAvg {R : ℕ}
+    (h : fam.ReductionEfficientAvg R) : 1 ≤ R := by
+  -- `ReductionEfficientAvg` quantifies over every basis, so the basis is immaterial: take zero.
+  have hlow :
+      1 * Fintype.card (Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1))
+        ≤ ∑ c : Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1),
+            fam.attemptRuns (fun _ => 0) c.1 c.2.toCoins := by
+    calc 1 * Fintype.card (Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1))
+        = ∑ _c : Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1), 1 := by
+          rw [Finset.sum_const, Finset.card_univ, smul_eq_mul, Nat.mul_comm]
+      _ ≤ _ := Finset.sum_le_sum fun c _ =>
+          Bulletproof.Forking.one_le_kimchiExtractRuns (fam.runSrs (fun _ => 0) c.1)
+            (combinedEvalVector (2 ^ k) (fam.claim (fun _ => 0) c.1).evalscale
+              (fam.claim (fun _ => 0) c.1).pointFn)
+            (Ipa.cipOf (fam.claim (fun _ => 0) c.1))
+            (combinedCommitment (fam.claim (fun _ => 0) c.1).polyscale
+              (fam.claim (fun _ => 0) c.1).commitmentFn)
+            (expandPre C) (fam.adversary (fun _ => 0))
+            (fun cp => Bulletproof.Ipa.Forking.toOpening cp.opening)
+            (ipaPrefixes (fam.runSrs (fun _ => 0) c.1) (fam.digest (fun _ => 0))
+              (fam.publicComm (fun _ => 0)))
+            (kimchiDecodesFromPrefixes (fam.runSrs (fun _ => 0) c.1) (fam.digest (fun _ => 0))
+              (fam.publicComm (fun _ => 0)))
+            c.1 c.2.toCoins
+  exact Nat.le_of_mul_le_mul_right (hlow.trans (h fun _ => 0)) Fintype.card_pos
 
 end KimchiFamily
 
@@ -4455,9 +4733,11 @@ reductions `hHard` is taken against, and it is dischargeable in this file:
 node degree at most `n`, and `KimchiFamily.exists_complete_reductionEfficient` exhibits a single
 tape that is `Complete` and efficient at once, at `n = 2 ^ 128`. That `R` is the **worst case**,
 exponential in `k` and in the challenge domain, and no table-averaged bound follows from it
-(external-audit O-1b, open). So `ε` is still assumed for the finder rather than derived from a
-time bound: a reduction permitted that many oracle calls solves Pasta discrete log outright, so
-`hHard` at that `R` is satisfiable only at `ε ≈ 1`. Discharging `hEff` therefore buys
+(external-audit O-1b, open). The conditional table-and-tape-averaged bound is a **separate
+statement, not a consequence** of this one — neither implies the other — and it is
+`vesta_kimchi_knowledge_sound_avg` in `§ 18`. So `ε` is still assumed for the finder rather than
+derived from a time bound: a reduction permitted that many oracle calls solves Pasta discrete log
+outright, so `hHard` at that `R` is satisfiable only at `ε ≈ 1`. Discharging `hEff` therefore buys
 bookkeeping — which reductions the assumption is quantified over — and not a stronger bound.
 
 Everything else is proved: the presence arm by the claim-adaptive extraction game, and the
@@ -4500,7 +4780,11 @@ theorem vesta_kimchi_knowledge_sound {nc k n : ℕ} [NeZero n]
 `vesta_kimchi_knowledge_sound`, over `Fq`/`IpaPallas`; same shape, same four summands, same
 axiom footprint, same modeled-fragment scope (see the Vesta endpoint's docstring and the
 module preamble). Every step of the argument is curve-generic; only the four per-curve facts
-about the expansions and the scalar action are re-discharged. -/
+about the expansions and the scalar action are re-discharged.
+
+As on the Vesta side, the conditional table-and-tape-averaged bound is a **separate statement,
+not a consequence** of this one — neither implies the other — and it is
+`pallas_kimchi_knowledge_sound_avg` in `§ 18`. -/
 theorem pallas_kimchi_knowledge_sound {nc k n : ℕ} [NeZero n]
     (B : IpaPallas.Point) (fam : KimchiFamily IpaPallas.curve nc k n)
     (coins : Zcash.Snark.RecursiveForkCoins Prechallenge (k + 1))
@@ -4520,5 +4804,498 @@ theorem pallas_kimchi_knowledge_sound {nc k n : ℕ} [NeZero n]
   exact fam.wins_notExtracts_measure_le_of_arms B coins hHard hEff hpres
     (fam.openedUnsatisfying_measure_prod_le Pasta.pallas_smul_val
       (natCast_prechallenge_injective (by decide)) expandPre_pallas_injective B coins)
+
+/-! ## 18. The joint (table × tape) axis
+
+The **conditional** branch of the kimchi development, standing beside — never replacing — the
+per-tape **worst-case** branch of `§ 9`, `§ 15`, `§ 16` and `§ 17`.
+
+**What this branch is.** Upstream's own coin axis, added *beside* ours. Ironwood's
+`ComputedAlgebraicFSFamily` bundles `Coins = (oracle table) × (fork tape)` and measures its
+endpoint with the tape sampled inside the probability space; ours splits that pair — `Coins C nc
+k` is the table alone and the tape is a fixed parameter — and that split is exactly what makes the
+per-tape bound hold for *every* complete tape. This section adds upstream's shape; it does not
+swap ours.
+
+**What it is not: a replacement.** The per-tape branch — `Coins`, `ReductionEfficient`,
+`relationFinder`, `attemptRuns`, `DiscreteLogRelationHardFor`, `reductionEfficient_of_bounded`,
+`exists_complete_reductionEfficient`, `one_le_of_reductionEfficient`, and both endpoints of
+`§ 17` — is the **worst-case** branch and stands verbatim and unweakened. Neither branch implies
+the other: this one fixes nothing and averages over the product, that one fixes a tape and
+averages over tables only. A standing directive, not a preference.
+
+**Where the halves are.** The counting half is `§ 9`'s `### The conditional average axis`
+(`KimchiForkSpreadFamily`, `attemptRuns_sum_le_of_forkSpreadFamily`, `ReductionEfficientAvg`,
+`reductionEfficientAvg_of_forkSpreadFamily`, `reductionEfficientAvg_of_worstCase`,
+`one_le_of_reductionEfficientAvg`). This is the probability half, and the two twins
+`vesta_kimchi_knowledge_sound_avg` / `pallas_kimchi_knowledge_sound_avg` at the end read both.
+
+**`hcoins` vanishes, and that is the branch's headline improvement.** Every per-tape statement
+carries `coins.Complete` as a hypothesis, because a tape that never offers some challenge cannot
+force extraction. Here the tape is `q.2.2.toCoins` for a *sampled* `q.2.2`, and
+`Zcash.Snark.RecursiveForkTape.toCoins_complete` holds for **every** tape, so completeness is
+discharged structurally at the one place that needed it —
+`acceptExtractionFailure_measure_prod_le_avg`, where it is a theorem about the sampled tape rather
+than an assumption about an externally fixed one. No statement below carries a completeness
+argument.
+
+**What is paid for it.** The measured event lives over a larger space: a fork tape on which the
+extractor does badly is now charged to the failure probability rather than assumed away.
+
+**What is still assumed, and what it costs.** `ReductionEfficientAvg` is reachable two ways:
+unconditionally at the worst-case `(2 · 2 ^ 128 + 1) ^ (k + 1)`
+(`reductionEfficientAvg_of_worstCase`), and at the conditional
+`(6 · 2 ^ 128 / (σ₀ − 1)) ^ (k + 1)` from a fork spread
+(`reductionEfficientAvg_of_forkSpreadFamily`). Only the second is interesting, and
+`KimchiForkSpreadFamily` has **no witness at any layer**:
+`Bulletproof.Forking.exists_kimchiForkSpread_two_le_of_rounds` exhibits a spread at `σ₀ = 4` over
+`Pre = Fin 5`, at the abstract layer, instantiating no family whose prechallenge alphabet has
+`2 ^ 128` elements. The regime caveat travels with the number: `(6/δ) ^ (k + 1)` at `k = 15` is
+about `2 ^ 54` calls at `δ = 1/2` and about `2 ^ 339` at `δ = 2 ^ (-20)` — worse than solving
+discrete log outright.
+
+**What is not restated here.** The anti-vacuity guards `honestKimchiFamily_wins` and
+`honestKimchiFamily_failure_set` are stated on the per-tape space and are left there. The win
+conjunct does not read the tape, so nothing about them is weakened; the averaged restatements are
+`Kimchi.Verifier.Forking.vesta_/pallas_honest_extraction_failure_measure_le_avg`, downstream in
+`Verifier/Forking/Honest.lean` where the honest families live.
+
+Nothing here averages, commutes or pigeonholes over tapes: the cover is pointwise in the tape, and
+no witness tape is ever chosen. -/
+
+section JointAxis
+
+variable [Module C.ScalarField C.Point]
+
+/-- **The measure transport this branch rests on.** A bound over `(A × ρ₂) × ρ₁` for a predicate
+of the three coordinates is the same bound over `A × (ρ₁ × ρ₂)`.
+
+Mathematically it is one bijection: `q ↦ ((q.1, q.2.2), q.2.1)` relates the two spaces, uniform
+measure pushes forward to uniform measure along any bijection
+(`Zcash.Snark.map_uniformOfFintype_equiv`), and the event on the left is *literally* the preimage
+of the event on the right, so `PMF.toOuterMeasure_map_apply` finishes it. The `Equiv` is built by
+hand rather than composed out of `Equiv.prodAssoc` and `Equiv.prodComm` precisely so that the
+preimage identity stays `rfl` and no set rewriting is needed.
+
+It is what carries the `S`-generic product bounds of `Bulletproof/Forking/Game.lean` — whose fork
+tape rides in the index slot `S := (setup scalars) × tape`, giving a bound over
+`((setup × tape) × Coins)` — onto the space `(setup × (Coins × tape))` this section measures.
+One helper serves both arm (1) and arm (4).
+
+**Keep this at `{A ρ₁ ρ₂}`, which is a memory decision and not a style one.** Same reason as
+`sum_prod_le_of_forall` in `§ 9`: the elaborator's blow-up trigger here is big-operator and
+`Fintype.card` comparison at heavy concrete atoms, and `KimchiNode C nc k` — which bundles
+`PreIpaData` and `EvalsView` — is heavier than anything the bulletproof twin
+(`uniform_prod_prod_fiber_bound`) had to carry. At abstract types the work is free and the
+concrete instance appears once, at each use site. -/
+private theorem uniform_prod_assoc_swap {A ρ₁ ρ₂ : Type*}
+    [Fintype A] [Fintype ρ₁] [Fintype ρ₂] [Nonempty A] [Nonempty ρ₁] [Nonempty ρ₂]
+    (p : A → ρ₁ → ρ₂ → Prop) {β : ℝ≥0∞}
+    (h : (PMF.uniformOfFintype ((A × ρ₂) × ρ₁)).toOuterMeasure
+        {x | p x.1.1 x.2 x.1.2} ≤ β) :
+    (PMF.uniformOfFintype (A × (ρ₁ × ρ₂))).toOuterMeasure {q | p q.1 q.2.1 q.2.2} ≤ β := by
+  rw [← Zcash.Snark.map_uniformOfFintype_equiv
+      (⟨fun x => (x.1.1, (x.2, x.1.2)), fun q => ((q.1, q.2.2), q.2.1),
+        fun _ => rfl, fun _ => rfl⟩ : (A × ρ₂) × ρ₁ ≃ A × (ρ₁ × ρ₂)),
+    PMF.toOuterMeasure_map_apply]
+  exact h
+
+namespace KimchiFamily
+
+variable {nc k n : ℕ} [NeZero n] (fam : KimchiFamily C nc k n)
+
+/-- **The relation finder on the joint axis** — `relationFinder` with the fork tape read off the
+sampled coin pair rather than fixed as a parameter, so that it has the shape
+`(basis) → ρ → Option (AlgebraicRelationWitness …)` at
+`ρ := Coins C nc k × RecursiveForkTape Prechallenge (k + 1)` that `Zcash.Snark.relSetWithCoins`
+and `Zcash.Snark.TextbookDLWithCoinsAdvantageLE` consume. It is upstream's
+`ComputedAlgebraicFSFamily.relationFinder` shape, whose coins already bundle the tape.
+
+`noncomputable` for the same reason `relationFinder` is: the key-gated `attempt` is.
+
+The coin type is written out rather than abbreviated: what an endpoint quantifies over is exactly
+what a reader has to check, and this tree spells it out. -/
+noncomputable def relationFinderAvg :
+    (bs : SetupIndex (2 ^ k) → C.Point) →
+      Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1) →
+        Option (Zcash.Snark.AlgebraicRelationWitness (F := C.ScalarField) bs) :=
+  fun bs c => fam.relationFinder c.2.toCoins bs c.1
+
+/-- **The derived-`U` discrete-log assumption on the joint axis** — `DerivedUDLAdvantageLE`'s twin
+over `(SetupIndex (2 ^ k) → C.ScalarField) × (Coins C nc k × RecursiveForkTape Prechallenge
+(k + 1))`, with the fork tape sampled alongside the setup basis and the oracle table.
+
+Everything the per-tape docstring says about *what* is assumed carries over unchanged — the base
+whose discrete log is computed is still the WARM post-`ζ` one, and this is still an assumption
+about a slice of the conclusion rather than a reduction. Only the space grows.
+
+There is deliberately no `derivedULogAvg`: `derivedULog` already takes the tape as an argument, so
+repackaging it would cost a declaration to root and pin and buy nothing. -/
+def DerivedUDLAdvantageLEAvg (B : C.Point) (bound : ℝ≥0∞) : Prop :=
+  (PMF.uniformOfFintype ((SetupIndex (2 ^ k) → C.ScalarField) ×
+      (Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)))).toOuterMeasure
+      {q | (fam.derivedULog B q.2.2.toCoins q.1 q.2.1).isSome} ≤ bound
+
+/-- **The four-way cover on the joint axis.** The same four arms as `four_way_cover` — produced
+nothing at all (arm (1)); produced a relation among the sampled setup generators (arm (2));
+produced a break touching the transcript-derived base (arm (3)); produced a left payload whose
+assembled table fails the circuit (arm (4)) — over the enlarged space, with the tape read off the
+sampled coin pair.
+
+`four_way_cover` is proved at an **arbitrary** `coins`, so this is the identical `by_cases`/`cases`
+argument read at `coins := q.2.2.toCoins`: the cover is **pointwise in the tape** and no new
+mathematics enters with the enlarged space. No tape is chosen, nothing is summed over bases, and
+no quantifier is commuted. -/
+private theorem four_way_cover_avg (B : C.Point) :
+    {q : (SetupIndex (2 ^ k) → C.ScalarField) ×
+        (Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)) |
+        fam.Wins (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 ∧
+          ¬ fam.ExtractsWitness (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 q.2.2.toCoins}
+      ⊆ {q | q.2.1 ∈ fam.acceptExtractionFailure
+              (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.2.toCoins}
+        ∪ (↑(Zcash.Snark.relSetWithCoins B fam.relationFinderAvg) :
+            Set ((SetupIndex (2 ^ k) → C.ScalarField) ×
+              (Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1))))
+        ∪ {q | fam.TouchesU (Zcash.Snark.scalarBasis B q.1) q.2.1 q.2.2.toCoins}
+        ∪ {q | fam.Wins (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 ∧
+              fam.OpenedUnsatisfying
+                (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 q.2.2.toCoins} := by
+  classical
+  intro q hq
+  obtain ⟨hacc, hnoext⟩ := hq
+  by_cases hsome :
+      (fam.attempt (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 q.2.2.toCoins).isSome
+  · obtain ⟨x, hx⟩ := Option.isSome_iff_exists.mp hsome
+    cases x with
+    | inl a =>
+      exact Or.inr ⟨hacc, a, hx, fun hs => hnoext ⟨a, hx, hs⟩⟩
+    | inr rel =>
+      by_cases hu : rel.coeffs Zcash.Snark.AugmentedIndex.u = 0
+      · refine Or.inl (Or.inl (Or.inr ?_))
+        simp only [Finset.mem_coe, Zcash.Snark.relSetWithCoins, Finset.mem_filter,
+          Finset.mem_univ, true_and]
+        show (fam.relationFinderAvg (Zcash.Snark.scalarBasis B q.1) q.2).isSome = true
+        simp only [KimchiFamily.relationFinderAvg, KimchiFamily.relationFinder, hx, dif_pos hu,
+          Option.isSome_some]
+      · exact Or.inl (Or.inr ⟨rel, hx, hu⟩)
+  · exact Or.inl (Or.inl (Or.inl ⟨hacc, Option.not_isSome_iff_eq_none.mp hsome⟩))
+
+/-- **Summand (II) on the joint axis — one upstream call.**
+`Zcash.Snark.relationWithCoins_prob_le_of_textbookDL` is generic in the coin type as well as the
+index (`{ρ} [Fintype ρ] [Nonempty ρ]`), so instantiating
+`ρ := Coins C nc k × RecursiveForkTape Prechallenge (k + 1)` needs no new upstream work and the
+per-tape proof carries over unchanged; `card_setupIndex` turns its `Fintype.card` factor into the
+`2 ^ k + 1` the endpoints state. -/
+theorem relation_summand_avg (B : C.Point) {ε : ℝ≥0∞}
+    (hDL : Zcash.Snark.TextbookDLWithCoinsAdvantageLE B fam.relationFinderAvg ε) :
+    (PMF.uniformOfFintype ((SetupIndex (2 ^ k) → C.ScalarField) ×
+        (Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)))).toOuterMeasure
+        (Zcash.Snark.relSetWithCoins B fam.relationFinderAvg)
+      ≤ ((2 ^ k + 1 : ℕ) : ℝ≥0∞) * ε := by
+  have h := Zcash.Snark.relationWithCoins_prob_le_of_textbookDL B fam.relationFinderAvg hDL
+  rwa [card_setupIndex] at h
+
+/-- **Summand (III) on the joint axis — the residual, by its own assumption.**
+`DerivedUDLAdvantageLEAvg` is stated at the derived-base log finder's support, and
+`derivedULog_isSome_iff` — which holds at every `coins`, hence at the sampled tape — says that
+support *is* arm (3), so the bound transfers by rewriting the set. -/
+theorem residual_summand_avg (B : C.Point) {δ : ℝ≥0∞}
+    (hU : fam.DerivedUDLAdvantageLEAvg B δ) :
+    (PMF.uniformOfFintype ((SetupIndex (2 ^ k) → C.ScalarField) ×
+        (Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)))).toOuterMeasure
+        {q | fam.TouchesU (Zcash.Snark.scalarBasis B q.1) q.2.1 q.2.2.toCoins}
+      ≤ δ := by
+  have hset : {q : (SetupIndex (2 ^ k) → C.ScalarField) ×
+        (Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)) |
+        fam.TouchesU (Zcash.Snark.scalarBasis B q.1) q.2.1 q.2.2.toCoins}
+      = {q | (fam.derivedULog B q.2.2.toCoins q.1 q.2.1).isSome} := by
+    ext q
+    exact (fam.derivedULog_isSome_iff B q.2.2.toCoins q.1 q.2.1).symm
+  rw [hset]
+  exact hU
+
+/-- **The presence summand at an abstract index, with the fork tape carried by the index.** The
+`§ 15` instantiation of `kimchiExtract_failure_measure_prod_le_of_stableBase` with two slots left
+open: the basis map `bs : S → …` and the coin family `coins : S → …`, over an arbitrary finite
+nonempty index `S`.
+
+This is the **`S`-slot trick** in the shape that makes it usable. The abstract bound is generic in
+`S` and — decisively — takes its fork tape as an `S`-indexed *family*
+`coins : ∀ s : S, RecursiveForkCoins Pre ((σ s).k + 1)`, so a tape sampled alongside the setup can
+ride in the index and be read back at each `s`. `§ 15`'s own call is the case `S := (setup
+scalars)`, `bs := augOfSetup ∘ scalarBasis B`, `coins := const`; the joint axis is the case
+`S := (setup scalars) × tape`, `bs := fun s => augOfSetup (scalarBasis B s.1)`,
+`coins := fun s => s.2.toCoins`.
+
+**Keep `bs` an opaque variable, and keep this declaration separate: that is a heartbeat decision,
+not a style one.** Instantiating the abstract bound directly at
+`bs s := augOfSetup (Zcash.Snark.scalarBasis B s.1)` repeats that term in twenty argument slots,
+and the `hstable` slot then has to unify the family's own claim map against the abstract `κ` by
+whnf through all of them; measured here, that overruns the 200000-heartbeat budget outright
+(`(deterministic) timeout at whnf`). At an opaque `bs` each slot is one application and the same
+unification is far inside the budget. Do not inline it back.
+
+Nothing in `§ 15` or in either primary endpoint reads this: the per-tape branch is the worst-case
+branch, it stays verbatim, and its proof path does not move. This is a second, additional copy of
+the same instantiation, which is what the two-branch discipline asks for.
+
+The reasons behind the individual arguments are `§ 15`'s and unchanged — the p-ignoring claim map,
+the base-stable form rather than `_of_stableU` (the warm post-`ζ` base does not factor through the
+claimed value), and the two expansion facts as hypotheses rather than instances, since `expandPre`
+is injective and nonvanishing per curve. The containment is `winsAt_of_wins` on the win conjunct
+and `ipaAttempt_eq_none_of_attempt` on the failure conjunct. -/
+private theorem acceptExtractionFailure_measure_prod_le_index {S : Type*} [Fintype S] [Nonempty S]
+    (hsmul : ∀ (z : C.ScalarField) (P : C.Point), z • P = z.val • P)
+    (hexp_inj : Function.Injective (expandPre C))
+    (hexp_ne : ∀ q : Prechallenge, expandPre C q ≠ 0)
+    (bs : S → Zcash.Snark.AugmentedIndex (2 ^ k) → C.Point)
+    (coins : S → Zcash.Snark.RecursiveForkCoins Prechallenge (k + 1))
+    (hcoins : ∀ s : S, (coins s).Complete) :
+    (PMF.uniformOfFintype (S × Coins C nc k)).toOuterMeasure
+        {x | x.2 ∈ fam.acceptExtractionFailure (bs x.1) (coins x.1)}
+      ≤ (fam.Q + k + 1) * (3 / Fintype.card Prechallenge) := by
+  classical
+  refine le_trans (MeasureTheory.measure_mono ?_)
+    (kimchiExtract_failure_measure_prod_le_of_stableBase (S := S)
+      (fun s => srsOfBasis k (bs s))
+      (fun s _ O => claimTriple
+        (runClaim (srsOfBasis k (bs s)) (fam.cvk (bs s)) (fam.pub (bs s)) (fam.digest (bs s))
+          ((fam.adversary (bs s)).run O) O))
+      (fun s _ O => (fam.pgOf (bs s) O, fam.pwOf (bs s) O))
+      (fun s _ O => fam.hPOf (bs s) O)
+      (fun s _ O => fam.warmBase (bs s) O)
+      (expandPre C) hexp_inj hexp_ne
+      (fun s => fam.adversary (bs s))
+      (fun s => fam.queryBound (bs s))
+      (fun _ cp => Bulletproof.Ipa.Forking.toOpening cp.opening)
+      (fun s => ipaPrefixes (srsOfBasis k (bs s)) (fam.digest (bs s)) (fam.publicComm (bs s)))
+      (fun s => kimchiDecodesFromPrefixes (srsOfBasis k (bs s)) (fam.digest (bs s))
+        (fam.publicComm (bs s)))
+      (fun s => kimchiPrefixDecode (srsOfBasis k (bs s)) (fam.digest (bs s))
+        (fam.publicComm (bs s)))
+      (fun s => fam.baseStable_warmBase (bs s))
+      (fun s => fam.claimStable_runClaimTriple (bs s))
+      coins hcoins (k := k) (fun _ => le_rfl))
+  rintro ⟨s, O⟩ ⟨hwin, hnone⟩
+  exact ⟨fam.winsAt_of_wins hsmul _ O hwin,
+    fam.ipaAttempt_eq_none_of_attempt _ O (coins s) hnone⟩
+
+/-- **Arm (1) on the joint axis, and no `hcoins`.** The presence summand of `§ 15` over the
+enlarged space, at the same bound `(Q + k + 1) · 3 / |Prechallenge|`.
+
+Two moves, both already made: `acceptExtractionFailure_measure_prod_le_index` at
+`S := (SetupIndex (2 ^ k) → C.ScalarField) × RecursiveForkTape Prechallenge (k + 1)` — the tape
+riding in the index slot, the basis read at `s.1` and the tape at `s.2` — bounds the event over
+`((setup × tape) × Coins)`, and `uniform_prod_assoc_swap` carries that to the
+`(setup × (Coins × tape))` this section measures.
+
+**The completeness hypothesis is discharged, not assumed.** The per-tape statement must assume
+`coins.Complete` of one externally fixed tape; here it is a *theorem* about the sampled one, since
+`Zcash.Snark.RecursiveForkTape.toCoins_complete` holds for every tape. That is the branch's
+headline improvement and it is spent exactly here. -/
+private theorem acceptExtractionFailure_measure_prod_le_avg
+    (hsmul : ∀ (z : C.ScalarField) (P : C.Point), z • P = z.val • P)
+    (hexp_inj : Function.Injective (expandPre C))
+    (hexp_ne : ∀ q : Prechallenge, expandPre C q ≠ 0)
+    (B : C.Point) :
+    (PMF.uniformOfFintype ((SetupIndex (2 ^ k) → C.ScalarField) ×
+        (Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)))).toOuterMeasure
+        {q | q.2.1 ∈ fam.acceptExtractionFailure
+          (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.2.toCoins}
+      ≤ (fam.Q + k + 1) * (3 / Fintype.card Prechallenge) := by
+  refine uniform_prod_assoc_swap
+    (fun (s : SetupIndex (2 ^ k) → C.ScalarField) (O : Coins C nc k)
+        (τ : Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)) =>
+      O ∈ fam.acceptExtractionFailure (augOfSetup (Zcash.Snark.scalarBasis B s)) τ.toCoins) ?_
+  exact fam.acceptExtractionFailure_measure_prod_le_index
+    (S := (SetupIndex (2 ^ k) → C.ScalarField) ×
+      Zcash.Snark.RecursiveForkTape Prechallenge (k + 1))
+    hsmul hexp_inj hexp_ne (fun s => augOfSetup (Zcash.Snark.scalarBasis B s.1))
+    (fun s => s.2.toCoins) (fun s => Zcash.Snark.RecursiveForkTape.toCoins_complete s.2)
+
+/-- **Arm (4) on the joint axis.** The algebraic summand of `§ 16` over the enlarged space, at the
+same bound `(Q + 1) · szBudget / 2 ¹²⁸`.
+
+Cheaper than arm (1), for a structural reason worth stating: `openedUnsatisfying_measure_le`
+already bounds arm (4) at a **fixed basis and fixed coins**, and that bound mentions neither the
+basis nor the tape. So `measure_prod_le_of_forall_fibre` at the same index type
+`S := (setup scalars) × tape` lifts it for free — its fibre obligation at `s` is literally the
+fixed-basis bound at `augOfSetup (scalarBasis B s.1)` and `s.2.toCoins` — and
+`uniform_prod_assoc_swap` transports the result, the same helper arm (1) uses. -/
+private theorem openedUnsatisfying_measure_prod_le_avg
+    (hsmul : ∀ (z : C.ScalarField) (P : C.Point), z • P = z.val • P)
+    (hcast : Function.Injective (fun q : Prechallenge => ((q : ℕ) : C.ScalarField)))
+    (hexp : Function.Injective (expandPre C)) (B : C.Point) :
+    (PMF.uniformOfFintype ((SetupIndex (2 ^ k) → C.ScalarField) ×
+        (Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)))).toOuterMeasure
+        {q | fam.Wins (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 ∧
+          fam.OpenedUnsatisfying
+            (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 q.2.2.toCoins}
+      ≤ ((fam.Q + 1 : ℕ) : ℝ≥0∞)
+        * ((szBudget nc n fam.idx.zkRows : ℝ≥0∞) / (2 ^ 128 : ℕ)) := by
+  refine uniform_prod_assoc_swap
+    (fun (s : SetupIndex (2 ^ k) → C.ScalarField) (O : Coins C nc k)
+        (τ : Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)) =>
+      fam.Wins (augOfSetup (Zcash.Snark.scalarBasis B s)) O ∧
+        fam.OpenedUnsatisfying (augOfSetup (Zcash.Snark.scalarBasis B s)) O τ.toCoins) ?_
+  exact measure_prod_le_of_forall_fibre
+    (fun (s : (SetupIndex (2 ^ k) → C.ScalarField) ×
+        Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)) (O : Coins C nc k) =>
+      fam.Wins (augOfSetup (Zcash.Snark.scalarBasis B s.1)) O ∧
+        fam.OpenedUnsatisfying (augOfSetup (Zcash.Snark.scalarBasis B s.1)) O s.2.toCoins)
+    fun s => fam.openedUnsatisfying_measure_le hsmul hcast hexp
+      (augOfSetup (Zcash.Snark.scalarBasis B s.1)) s.2.toCoins
+
+/-- **Discrete log is hard for this family against `R`-call reductions, on the joint axis** —
+`DiscreteLogRelationHardFor`'s twin, gated by `ReductionEfficientAvg`.
+
+It carries **both** advantage bounds for the same reason the per-tape form does: kimchi's `U` is
+transcript derived, so a `U`-touching break is not a relation among the sampled setup generators
+and cannot be charged to textbook discrete log; `δ` has no upstream counterpart. And as there, `δ`
+is the residual event's own measure — `residual_summand_avg` is the assumption restated, not a
+consequence of it — so only the `ε` component is a genuine reduction to a studied problem.
+
+What is genuinely better here: **the reduction samples its own fork tape as part of its
+randomness**, which is what a real reduction does. The per-tape form instead assumes an advantage
+bound at one externally fixed tape, which is a hypothesis about a tape the reduction did not
+choose. -/
+def DiscreteLogRelationHardForAvg (B : C.Point) (R : ℕ) (ε δ : ℝ≥0∞) : Prop :=
+  fam.ReductionEfficientAvg R →
+    Zcash.Snark.TextbookDLWithCoinsAdvantageLE B fam.relationFinderAvg ε ∧
+      fam.DerivedUDLAdvantageLEAvg B δ
+
+/-- **The joint-axis endpoint, reduced to its two cryptographically-priced arms.** The twin of
+`wins_notExtracts_measure_le_of_arms`, and like it `four_way_cover_avg`, monotonicity and
+subadditivity three times, with nothing else in between.
+
+`hAlgebraic` bounds the arm WITH its win conjunct, matching `four_way_cover_avg`; that is a
+smaller set than bare `OpenedUnsatisfying`, so the hypothesis is weaker and this corollary is
+correspondingly stronger. There is no completeness hypothesis anywhere in the chain. -/
+private theorem wins_notExtracts_measure_le_of_arms_avg (B : C.Point) {R : ℕ}
+    {ε δ bPresence bAlgebraic : ℝ≥0∞}
+    (hHard : fam.DiscreteLogRelationHardForAvg B R ε δ)
+    (hEff : fam.ReductionEfficientAvg R)
+    (hPresence : (PMF.uniformOfFintype ((SetupIndex (2 ^ k) → C.ScalarField) ×
+        (Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)))).toOuterMeasure
+        {q | q.2.1 ∈ fam.acceptExtractionFailure
+          (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.2.toCoins} ≤ bPresence)
+    (hAlgebraic : (PMF.uniformOfFintype ((SetupIndex (2 ^ k) → C.ScalarField) ×
+        (Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)))).toOuterMeasure
+        {q | fam.Wins (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 ∧
+          fam.OpenedUnsatisfying
+            (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 q.2.2.toCoins}
+          ≤ bAlgebraic) :
+    (PMF.uniformOfFintype ((SetupIndex (2 ^ k) → C.ScalarField) ×
+        (Coins C nc k × Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)))).toOuterMeasure
+        {q | fam.Wins (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 ∧
+          ¬ fam.ExtractsWitness (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 q.2.2.toCoins}
+      ≤ bPresence + ((2 ^ k + 1 : ℕ) : ℝ≥0∞) * ε + δ + bAlgebraic := by
+  obtain ⟨hDL, hU⟩ := hHard hEff
+  refine le_trans (MeasureTheory.measure_mono (fam.four_way_cover_avg B)) ?_
+  refine le_trans (MeasureTheory.measure_union_le _ _) (add_le_add ?_ hAlgebraic)
+  refine le_trans (MeasureTheory.measure_union_le _ _)
+    (add_le_add ?_ (fam.residual_summand_avg B hU))
+  exact le_trans (MeasureTheory.measure_union_le _ _)
+    (add_le_add hPresence (fam.relation_summand_avg B hDL))
+
+end KimchiFamily
+
+/-! ### The joint-axis twins: knowledge soundness on the joint axis, per curve
+
+One statement per curve, every curve-specific hypothesis discharged and every constant evaluated,
+standing beside `vesta_kimchi_knowledge_sound` / `pallas_kimchi_knowledge_sound` rather than
+replacing them. The right-hand side is byte-identical to the primaries': same four summands, same
+constants. What differs is the space, the efficiency gate and the absence of `hcoins`. -/
+
+/-- **Vesta: the deployed kimchi verifier is knowledge-sound on the joint (table × tape) axis, in
+the random-oracle model and the algebraic group model.**
+
+For a family of `Q`-query algebraic adversaries against the executable kimchi verifier, over a
+uniformly sampled setup basis, a uniform challenge table **and a uniform fork tape**: the
+probability that the verifier accepts while the extractor fails to hand back a witness table
+satisfying the circuit the verifying key corresponds to is at most
+
+`(Q + k + 1)·3/2¹²⁸  +  (2ᵏ + 1)·ε  +  δ  +  (Q + 1)·szBudget/2¹²⁸`.
+
+Four summands, four sources, exactly as in `vesta_kimchi_knowledge_sound`: the forking extraction
+returns nothing (query loss, unconditional); it returns a relation among the sampled setup
+generators (`ε`, textbook discrete log); it returns a relation touching the transcript-derived base
+(`δ`, the residual — an assumption about a slice of the conclusion, not a reduction); or it returns
+an opening but the run's own Fiat–Shamir challenges land in an exclusion set (`szBudget`).
+
+**What the bound rests on.** One cryptographic assumption, `hHard`, which prices the two
+discrete-log arms; `hEff` fixes which reductions it is taken against. There is **no** `hcoins`.
+Everything else is proved: the presence arm by the claim-adaptive extraction game, and the
+algebraic arm by the Fiat–Shamir-axiom-free run-soundness root together with the adaptive
+Schwartz–Zippel charge.
+
+**The trade against `vesta_kimchi_knowledge_sound`, stated so it cannot be misread.** *Gained*:
+the efficiency gate is `ReductionEfficientAvg`, which
+`KimchiFamily.reductionEfficientAvg_of_forkSpreadFamily` discharges from a fork spread at the
+conditional `(6 · 2¹²⁸ / (σ₀ − 1))^(k+1)` rather than only at the worst-case
+`(2 · 2¹²⁸ + 1)^(k+1)`; and the completeness hypothesis `hcoins` is **gone**, discharged
+structurally by `Zcash.Snark.RecursiveForkTape.toCoins_complete` rather than assumed. *Paid*: the
+measured event lives over a larger space — the fork tape is sampled, so a bad tape is **charged**
+to the failure probability rather than assumed away. **Neither endpoint implies the other**, and
+the per-tape statement is untouched. *Still assumed*: `KimchiFamily.KimchiForkSpreadFamily` has
+**no witness at any layer** — `Bulletproof.Forking.exists_kimchiForkSpread_two_le_of_rounds`
+exhibits `σ₀ = 4` over `Pre = Fin 5` at the abstract layer and instantiates no family whose
+prechallenge alphabet has `2¹²⁸` elements — and the regime caveat travels with the number:
+`(6/δ)^(k+1)` at `k = 15` is about `2⁵⁴` calls at `δ = 1/2` and about `2³³⁹` at `δ = 2⁻²⁰`, worse
+than solving discrete log outright.
+
+**Scope.** Unchanged: "the deployed verifier" means the modeled fragment (see the module
+preamble) — basic gate set, `nc · 2^k = n` (no sub-SRS keys — the deployed o1js/Mina default is
+outside), no lookups, no optional gates, no recursion, no optional-gate/lookup evaluation fields,
+non-empty quotient commitment. Mina/pickles proofs are outside on four axes.
+
+`#print axioms` on this theorem: the three standard axioms plus CompElliptic's certified
+`native_decide` witnesses for the Pasta curve constants — no `sorryAx`, and no Fiat–Shamir axiom
+of any kind. -/
+theorem vesta_kimchi_knowledge_sound_avg {nc k n : ℕ} [NeZero n]
+    (B : IpaVesta.Point) (fam : KimchiFamily IpaVesta.curve nc k n) {R : ℕ} {ε δ : ℝ≥0∞}
+    (hHard : fam.DiscreteLogRelationHardForAvg B R ε δ)
+    (hEff : fam.ReductionEfficientAvg R) :
+    (PMF.uniformOfFintype ((SetupIndex (2 ^ k) → IpaVesta.curve.ScalarField) ×
+        (Coins _ nc k ×
+          Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)))).toOuterMeasure
+        {q | fam.Wins (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 ∧
+          ¬ fam.ExtractsWitness (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 q.2.2.toCoins}
+      ≤ (fam.Q + k + 1) * (3 / (2 ^ 128 : ℕ))
+        + ((2 ^ k + 1 : ℕ) : ℝ≥0∞) * ε + δ
+        + ((fam.Q + 1 : ℕ) : ℝ≥0∞) * ((szBudget nc n fam.idx.zkRows : ℝ≥0∞) / (2 ^ 128 : ℕ)) := by
+  have hpres := fam.acceptExtractionFailure_measure_prod_le_avg Pasta.vesta_smul_val
+    expandPre_vesta_injective expandPre_vesta_ne_zero B
+  rw [card_prechallenge] at hpres
+  exact fam.wins_notExtracts_measure_le_of_arms_avg B hHard hEff hpres
+    (fam.openedUnsatisfying_measure_prod_le_avg Pasta.vesta_smul_val
+      (natCast_prechallenge_injective (by decide)) expandPre_vesta_injective B)
+
+/-- **Pallas: the deployed kimchi verifier is knowledge-sound on the joint (table × tape) axis.**
+The Pallas-side twin of `vesta_kimchi_knowledge_sound_avg`, over `Fq`/`IpaPallas`; same shape,
+same four summands, same axiom footprint, same absence of `hcoins`, same trade against
+`pallas_kimchi_knowledge_sound`, same modeled-fragment scope (see the Vesta twin's docstring and
+the module preamble). Every step of the argument is curve-generic; only the four per-curve facts
+about the expansions and the scalar action are re-discharged. -/
+theorem pallas_kimchi_knowledge_sound_avg {nc k n : ℕ} [NeZero n]
+    (B : IpaPallas.Point) (fam : KimchiFamily IpaPallas.curve nc k n) {R : ℕ} {ε δ : ℝ≥0∞}
+    (hHard : fam.DiscreteLogRelationHardForAvg B R ε δ)
+    (hEff : fam.ReductionEfficientAvg R) :
+    (PMF.uniformOfFintype ((SetupIndex (2 ^ k) → IpaPallas.curve.ScalarField) ×
+        (Coins _ nc k ×
+          Zcash.Snark.RecursiveForkTape Prechallenge (k + 1)))).toOuterMeasure
+        {q | fam.Wins (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 ∧
+          ¬ fam.ExtractsWitness (augOfSetup (Zcash.Snark.scalarBasis B q.1)) q.2.1 q.2.2.toCoins}
+      ≤ (fam.Q + k + 1) * (3 / (2 ^ 128 : ℕ))
+        + ((2 ^ k + 1 : ℕ) : ℝ≥0∞) * ε + δ
+        + ((fam.Q + 1 : ℕ) : ℝ≥0∞) * ((szBudget nc n fam.idx.zkRows : ℝ≥0∞) / (2 ^ 128 : ℕ)) := by
+  have hpres := fam.acceptExtractionFailure_measure_prod_le_avg Pasta.pallas_smul_val
+    expandPre_pallas_injective expandPre_pallas_ne_zero B
+  rw [card_prechallenge] at hpres
+  exact fam.wins_notExtracts_measure_le_of_arms_avg B hHard hEff hpres
+    (fam.openedUnsatisfying_measure_prod_le_avg Pasta.pallas_smul_val
+      (natCast_prechallenge_injective (by decide)) expandPre_pallas_injective B)
+
+end JointAxis
 
 end Kimchi.Verifier.KnowledgeSoundness

--- a/formal/kimchi/roots.txt
+++ b/formal/kimchi/roots.txt
@@ -127,6 +127,29 @@ Kimchi.Verifier.KnowledgeSoundness.KimchiFamily.exists_complete_reductionEfficie
 -- (that is the entry above).
 Kimchi.Verifier.KnowledgeSoundness.KimchiFamily.one_le_of_reductionEfficient
 
+-- The CONDITIONAL AVERAGE axis (upstream's joint table-and-tape coin axis), standing beside the
+-- per-tape entries above and replacing neither. The bridge from a family-level fork spread to an
+-- average call bound over (table, tape) pairs; the walk from it reaches KimchiForkSpreadFamily,
+-- attemptRuns_sum_le_of_forkSpreadFamily and ReductionEfficientAvg, so none of those is rooted
+-- separately. `KimchiForkSpreadFamily` has NO witness at any layer, which is why the two
+-- companions are rooted with it: the gate is reachable unconditionally at the worst-case
+-- (2·2^128 + 1)^(k+1), and no R below 1 satisfies it.
+Kimchi.Verifier.KnowledgeSoundness.KimchiFamily.reductionEfficientAvg_of_forkSpreadFamily
+Kimchi.Verifier.KnowledgeSoundness.KimchiFamily.reductionEfficientAvg_of_worstCase
+Kimchi.Verifier.KnowledgeSoundness.KimchiFamily.one_le_of_reductionEfficientAvg
+
+-- The PROBABILITY half of that same conditional-average axis: the deployed verifier is
+-- knowledge-sound, per curve, over (setup basis) x (challenge table x fork tape) jointly, with
+-- the fork tape SAMPLED rather than fixed. Same four summands and the same constants as the
+-- per-tape endpoints above; the completeness hypothesis is gone, discharged structurally by
+-- RecursiveForkTape.toCoins_complete. NEITHER endpoint implies the other, and the per-tape pair
+-- above is untouched. These two roots are terminal: the walk from them reaches the whole
+-- probability layer (relationFinderAvg, DerivedUDLAdvantageLEAvg, DiscreteLogRelationHardForAvg,
+-- both summands, the cover, both arm measures and the measure transport), so none of those is
+-- rooted separately.
+Kimchi.Verifier.KnowledgeSoundness.vesta_kimchi_knowledge_sound_avg
+Kimchi.Verifier.KnowledgeSoundness.pallas_kimchi_knowledge_sound_avg
+
 -- Faithfulness: the deployed verifier IS the challenge-generic one at the sponge's own
 -- squeezes, stated at named sources rather than as an existential (an existential over the
 -- challenges is satisfied even by a verifier with Fiat-Shamir deleted).
@@ -147,6 +170,12 @@ Kimchi.Verifier.Forking.honestKimchiFamily_failure_set
 -- unconditionally at the deployed instantiations.
 Kimchi.Verifier.Forking.vesta_honest_extraction_failure_measure_le
 Kimchi.Verifier.Forking.pallas_honest_extraction_failure_measure_le
+
+-- and the same two guards against the CONDITIONAL-AVERAGE endpoints, over the joint
+-- (table x tape) space: the honest family's win conjunct does not read the tape, so the
+-- containment is the same, and `hcoins` is gone (structural via `toCoins_complete`).
+Kimchi.Verifier.Forking.vesta_honest_extraction_failure_measure_le_avg
+Kimchi.Verifier.Forking.pallas_honest_extraction_failure_measure_le_avg
 -- and: the sampled basis is maximally non-binding -- `hbind` is refutable at
 -- `augOfSetup (scalarBasis B s)`, which is why no binding hypothesis can appear anywhere
 -- in the endpoints' ancestry (the module preamble's "eval pins would be circular" record).

--- a/formal/kimchi/scripts/check_axioms.lean
+++ b/formal/kimchi/scripts/check_axioms.lean
@@ -10,6 +10,10 @@ what `native_decide` produces on this toolchain. This subsumes the old `sorryAx`
 `sorry` shows up as
 `sorryAx`, which is not in the allowlist, and any *other* stray axiom that slips in is caught too.
 
+The root list is a deletion guard as well as an axiom guard: a name absent from the environment
+fails with `axiom-check root not in environment`, so removing a listed declaration — even
+together with its `roots.txt` line — cannot pass silently.
+
 Run from `formal/kimchi/`:  lake env lean scripts/check_axioms.lean
 (or from `formal/`:         lake env lean kimchi/scripts/check_axioms.lean)
 -/
@@ -59,6 +63,27 @@ def roots : List Name :=
     -- floor under that same hypothesis — no R below 1 satisfies it.
     `Kimchi.Verifier.KnowledgeSoundness.KimchiFamily.exists_complete_reductionEfficient,
     `Kimchi.Verifier.KnowledgeSoundness.KimchiFamily.one_le_of_reductionEfficient,
+    -- The conditional-average counting layer (upstream's joint table-and-tape coin axis),
+    -- standing beside the per-tape entries above and replacing neither. Existence as well as
+    -- axioms: every public declaration of the block is pinned by name, terminals and plumbing
+    -- alike, so neither a deletion sweep nor a `sorry` behind a reachable terminal is silent.
+    `Kimchi.Verifier.KnowledgeSoundness.KimchiFamily.KimchiForkSpreadFamily,
+    `Kimchi.Verifier.KnowledgeSoundness.KimchiFamily.attemptRuns_sum_le_of_forkSpreadFamily,
+    `Kimchi.Verifier.KnowledgeSoundness.KimchiFamily.ReductionEfficientAvg,
+    `Kimchi.Verifier.KnowledgeSoundness.KimchiFamily.reductionEfficientAvg_of_forkSpreadFamily,
+    `Kimchi.Verifier.KnowledgeSoundness.KimchiFamily.reductionEfficientAvg_of_worstCase,
+    `Kimchi.Verifier.KnowledgeSoundness.KimchiFamily.one_le_of_reductionEfficientAvg,
+    -- The conditional-average PROBABILITY layer, and its two twin endpoints: knowledge
+    -- soundness over (setup basis) x (challenge table x fork tape) jointly, with the tape
+    -- sampled and no completeness hypothesis. Pinned on the same terms as the counting layer
+    -- above — every public declaration of the block by name, terminals and plumbing alike.
+    `Kimchi.Verifier.KnowledgeSoundness.KimchiFamily.relationFinderAvg,
+    `Kimchi.Verifier.KnowledgeSoundness.KimchiFamily.DerivedUDLAdvantageLEAvg,
+    `Kimchi.Verifier.KnowledgeSoundness.KimchiFamily.relation_summand_avg,
+    `Kimchi.Verifier.KnowledgeSoundness.KimchiFamily.residual_summand_avg,
+    `Kimchi.Verifier.KnowledgeSoundness.KimchiFamily.DiscreteLogRelationHardForAvg,
+    `Kimchi.Verifier.KnowledgeSoundness.vesta_kimchi_knowledge_sound_avg,
+    `Kimchi.Verifier.KnowledgeSoundness.pallas_kimchi_knowledge_sound_avg,
     `Kimchi.Verifier.Forking.honestKimchiFamily_wins,
     -- The Tier-2/3 surface (external-audit A-2): the faithfulness layer, the named
     -- anti-vacuity exhibits, and the REVISIT AGM lemmas are consumed by nothing, so no
@@ -75,9 +100,12 @@ def roots : List Name :=
     `Kimchi.Verifier.dlRelation_of_chunk_rep_ne,
     `Kimchi.Verifier.dlRelation_of_chunk_rep_masked_ne,
     `Kimchi.Verifier.ft_identity_of_chunks,
-    -- the per-curve honest-family corollaries (external-audit B-4)
+    -- the per-curve honest-family corollaries (external-audit B-4), and the same two guards
+    -- against the conditional-average endpoints over the joint (table x tape) space
     `Kimchi.Verifier.Forking.vesta_honest_extraction_failure_measure_le,
-    `Kimchi.Verifier.Forking.pallas_honest_extraction_failure_measure_le ]
+    `Kimchi.Verifier.Forking.pallas_honest_extraction_failure_measure_le,
+    `Kimchi.Verifier.Forking.vesta_honest_extraction_failure_measure_le_avg,
+    `Kimchi.Verifier.Forking.pallas_honest_extraction_failure_measure_le_avg ]
 
 /-- The only axioms the roots may depend on: the standard logical axioms. The pasta
     package declares NO axioms — the group orders are unconditional (CompElliptic's


### PR DESCRIPTION
…e-soundness twin endpoints (audit O-1b)

The conditional-average half of audit item O-1b, at both layers:

bulletproof-pcs (Forking/Game.lean, Forking/KnowledgeSoundness.lean):
- the spread layer: KimchiForkSpread (diagonal, tape-derived-coins narrowed), good sets, scan candidates, pointwise bounds, and the depth induction up to kimchiExtractRuns_sum_le_of_forkSpread — (sigma0-1)^(k+1)-scaled tape-sum bound at every table, with satisfiability exhibits at every round count
- the joint table-and-tape axis (ironwood's): KimchiForkSpreadFamily, ReductionEfficientAvg, the Fubini bridge, and the twin endpoints ipa{Vesta,Pallas}_knowledge_sound_avg with the fork tape sampled inside the probability space; hcoins discharged structurally by toCoins_complete

kimchi (Verifier/KnowledgeSoundness.lean, Verifier/Forking/Honest.lean):
- the same two layers at the deployed verifier, warm-base indexed, ending in vesta/pallas_kimchi_knowledge_sound_avg (four summands, same constants as the per-tape endpoints), plus the honest-family anti-vacuity guards on the joint axis

The per-tape layer is untouched: the worst-case (2*2^128+1)^(k+1) bound holds for every complete tape, which the average form cannot state; neither endpoint implies the other. KimchiForkSpreadFamily has no witness at any layer — the conditional gate is reachable unconditionally at the worst case (reductionEfficientAvg_of_worstCase), and the (6/delta)^(k+1) regime caveat travels with every quote of the number.