### PR TITLE
snarky-kimchi: the Poseidon gadget and its law pair

### DIFF
--- a/formal/scripts/deadcode.lean
+++ b/formal/scripts/deadcode.lean
@@ -36,6 +36,7 @@ import Kimchi
 import Snarky
 import Snarky.Kimchi.Backend.Compile
 import Snarky.Kimchi.Circuit.AddComplete
+import Snarky.Kimchi.Circuit.Poseidon
 import Snarky.Kimchi.Semantics
 -- The fixture-decoding libraries are not part of any package's main library, so import them
 -- explicitly: their declarations are authored code, and some are declared roots.

--- a/formal/snarky/Snarky/Backend/WP.lean
+++ b/formal/snarky/Snarky/Backend/WP.lean
@@ -468,10 +468,9 @@ open Std.Do in
 /-! ## The witness leaf
 
 One completeness spec serves every witnessed type: the honest encoding is written to
-fresh slots and passes its own checks (`LawfulCheckedType`), and the bundle's fields
-read back as the encoding. The per-type readings (`witnessed_fvar_eval`,
-`witnessed_boolVar_eval`, `witnessed_uncheckedBool_eval`) extract the shaped facts
-call sites consume. -/
+fresh slots and passes its own checks (`LawfulCheckedType`), and the promise arrives
+as the bundle's `WitnessReads.Reads` — already in the type's own vocabulary, so call
+sites consume it directly. -/
 
 /-- The completeness contract of a `CheckedType`: an honest encoding passes its own
 checks. PS discharges this dynamically — the prover runs `check` on the freshly
@@ -627,8 +626,9 @@ class WitnessReads (F val var : Type) [Add F] [Mul F] [CircuitType F val var] wh
 
 open Std.Do in
 /-- A witness computation that succeeds makes the run succeed — the honest encoding
-passes its own checks — and the bundle's fields read back as the encoding on the
-final table (the `witnessed_*` readings above extract the per-type forms). -/
+passes its own checks — and the bundle reads as the computed value on the final table
+(`WitnessReads.Reads`, which at each concrete type computes to its instance's
+shape). -/
 @[spec] theorem witness_complete_spec {F c val var : Type} [Add F] [Mul F]
     [DecidableEq F] [CircuitType F val var] [LawfulCircuitType F val var]
     [CheckedType F (Prover c) var] [Checker F c] [LawfulCheckedType F c val var]

--- a/formal/snarky/Snarky/Backend/WP.lean
+++ b/formal/snarky/Snarky/Backend/WP.lean
@@ -608,6 +608,23 @@ private theorem mapM_eval_range' {F : Type} [Add F] [Mul F]
       (CVar.eval · env') = _
     simp [List.mapM_cons, hx, ih, Bind.bind, Except.bind, Pure.pure, Except.pure]
 
+/-- The decoded reading of a witnessed bundle — what the flat fields grant of the
+witness leaf means, in the type's own vocabulary. Instances mirror the `CircuitType`
+grammar, so a composite bundle's reading computes to its components' readings and no
+per-composite extraction lemmas exist: one instance per leaf encoder is the whole
+per-type surface. -/
+class WitnessReads (F val var : Type) [Add F] [Mul F] [CircuitType F val var] where
+  /-- The bundle's decoded reading on a table: `r` witnesses the value `v`. -/
+  Reads : var → Assignments F → val → Prop
+  /-- The flat fields grant implies the reading. -/
+  reads_of_grant : ∀ {r : var} {env : Assignments F} {v : val},
+    (CircuitType.varToFields (F := F) (val := val) r).toList.mapM (CVar.eval · env)
+      = .ok (CircuitType.valueToFields (F := F) (var := var) v).toList →
+    Reads r env v
+  /-- The reading survives table extension. -/
+  reads_le : ∀ {env env' : Assignments F} {r : var} {v : val},
+    env.Le env' → Reads r env v → Reads r env' v
+
 open Std.Do in
 /-- A witness computation that succeeds makes the run succeed — the honest encoding
 passes its own checks — and the bundle's fields read back as the encoding on the
@@ -615,13 +632,11 @@ final table (the `witnessed_*` readings above extract the per-type forms). -/
 @[spec] theorem witness_complete_spec {F c val var : Type} [Add F] [Mul F]
     [DecidableEq F] [CircuitType F val var] [LawfulCircuitType F val var]
     [CheckedType F (Prover c) var] [Checker F c] [LawfulCheckedType F c val var]
-    (w : AsProver F val)
+    [WitnessReads F val var] (w : AsProver F val)
     (Q : PostCond var (.arg (ProverState F) (.except EvalError .pure))) :
     ⦃Complete (fun env => (w env).isOk)
         (fun env (r : var) env' => ∀ v, w env = .ok v →
-          (CircuitType.varToFields (F := F) (val := val) r).toList.mapM
-              (CVar.eval · env')
-            = .ok (CircuitType.valueToFields (F := F) (var := var) v).toList) Q⦄
+          WitnessReads.Reads (F := F) r env' v) Q⦄
     (witness (val := val) w : CircuitM F (Prover c) var)
     ⦃Q⦄ := by
   intro st hpre
@@ -682,38 +697,7 @@ final table (the `witnessed_*` readings above extract the per-type forms). -/
   rw [hw] at hv'
   injection hv' with hv'
   subst hv'
-  exact hvars st'.env hle'
-
-/-- The witnessed-field reading at `val := F`: the fields fact is the variable's
-evaluation. -/
-theorem witnessed_fvar_eval {F : Type} [Add F] [Mul F]
-    {r : FVar F} {env : Assignments F} {x : F}
-    (h : (CircuitType.varToFields (F := F) (val := F) r).toList.mapM (CVar.eval · env)
-      = .ok (CircuitType.valueToFields (F := F) (var := FVar F) x).toList) :
-    r.eval env = .ok x :=
-  mapM_eval_singleton h
-
-/-- The witnessed-field reading at `val := Bool`: the bit variable evaluates to the
-bit's encoding. -/
-theorem witnessed_boolVar_eval {F : Type} [Add F] [Mul F] [Zero F] [One F]
-    [DecidableEq F] {r : BoolVar F} {env : Assignments F} {b : Bool}
-    (h : (CircuitType.varToFields (F := F) (val := Bool) r).toList.mapM
-        (CVar.eval · env)
-      = .ok (CircuitType.valueToFields (F := F) (var := BoolVar F) b).toList) :
-    (↑r : CVar F).eval env = .ok (bit b) :=
-  mapM_eval_singleton h
-
-/-- The witnessed-field reading at `val := UnChecked Bool`: the wrapped bit variable
-evaluates to the bit's encoding. -/
-theorem witnessed_uncheckedBool_eval {F : Type} [Add F] [Mul F] [Zero F] [One F]
-    [DecidableEq F] {r : UnChecked (BoolVar F)} {env : Assignments F}
-    {u : UnChecked Bool}
-    (h : (CircuitType.varToFields (F := F) (val := UnChecked Bool) r).toList.mapM
-        (CVar.eval · env)
-      = .ok (CircuitType.valueToFields (F := F)
-          (var := UnChecked (BoolVar F)) u).toList) :
-    (↑r.val : CVar F).eval env = .ok (bit u.val) :=
-  mapM_eval_singleton h
+  exact WitnessReads.reads_of_grant (hvars st'.env hle')
 
 /-- Reads survive table extension, listwise. -/
 private theorem mapM_eval_le {F : Type} [Add F] [Mul F] {env env' : Assignments F}
@@ -875,43 +859,72 @@ instance instLawfulCheckedTypeVector {F c : Type} [Add F] [Mul F] {val var : Typ
       exact List.mem_map_of_mem hp
     exact hsplit _ hmem
 
-/-- The witnessed-field reading at a vector type: each element's fields evaluate to
-that element's encoding. -/
-theorem witnessed_vector_eval {F : Type} [Add F] [Mul F] {val var : Type}
-    [CircuitType F val var] {n : Nat} {r : Vector var n} {env : Assignments F}
-    {v : Vector val n}
-    (h : (CircuitType.varToFields (F := F) (val := Vector val n) r).toList.mapM
-        (CVar.eval · env)
-      = .ok (CircuitType.valueToFields (F := F) (var := Vector var n) v).toList)
-    {i : Nat} (hi : i < n) :
-    (CircuitType.varToFields (F := F) (val := val) r[i]).toList.mapM (CVar.eval · env)
-      = .ok (CircuitType.valueToFields (F := F) (var := var) v[i]).toList := by
-  have hsplit := mapM_eval_flatten_ok (env := env)
-    (bs := r.toList.map fun x =>
-      (CircuitType.varToFields (F := F) (val := val) x).toList)
-    (es := v.toList.map fun x =>
-      (CircuitType.valueToFields (F := F) (var := var) x).toList)
-    (by simp) (fun q hq => by
-      rw [List.zip_map] at hq
-      obtain ⟨q₀, -, rfl⟩ := List.mem_map.mp hq
-      simp)
-    (by
-      have h' : ((r.map (CircuitType.varToFields (F := F)
-              (val := val))).flatten).toList.mapM (CVar.eval · env)
-          = .ok ((v.map (CircuitType.valueToFields (F := F)
-              (var := var))).flatten).toList := h
-      simpa [toList_flatten, Vector.toList_map, List.map_map] using h')
-  have hmem : ((CircuitType.varToFields (F := F) (val := val) r[i]).toList,
-      (CircuitType.valueToFields (F := F) (var := var) v[i]).toList)
-      ∈ (r.toList.map fun x =>
-          (CircuitType.varToFields (F := F) (val := val) x).toList).zip
-        (v.toList.map fun x =>
-          (CircuitType.valueToFields (F := F) (var := var) x).toList) := by
-    rw [List.zip_map]
-    refine List.mem_map_of_mem (a := (r[i], v[i])) ?_
-    refine List.mem_iff_getElem.mpr ⟨i, by simp; omega, ?_⟩
-    simp [List.getElem_zip]
-  exact hsplit _ hmem
+instance instWitnessReadsF {F : Type} [Add F] [Mul F] :
+    WitnessReads F F (FVar F) where
+  Reads r env x := r.eval env = .ok x
+  reads_of_grant h := mapM_eval_singleton h
+  reads_le hle h := CVar.eval_le hle h
+
+instance instWitnessReadsBool {F : Type} [Add F] [Mul F] [Zero F] [One F]
+    [DecidableEq F] : WitnessReads F Bool (BoolVar F) where
+  Reads r env b := (↑r : CVar F).eval env = .ok (bit b)
+  reads_of_grant h := mapM_eval_singleton h
+  reads_le hle h := CVar.eval_le hle h
+
+instance instWitnessReadsUnChecked {F val var : Type} [Add F] [Mul F]
+    [CircuitType F val var] [WitnessReads F val var] :
+    WitnessReads F (UnChecked val) (UnChecked var) where
+  Reads r env v := WitnessReads.Reads (F := F) r.val env v.val
+  reads_of_grant h := WitnessReads.reads_of_grant h
+  reads_le hle h := WitnessReads.reads_le hle h
+
+instance instWitnessReadsProd {F a b av bv : Type} [Add F] [Mul F]
+    [A : CircuitType F a av] [B : CircuitType F b bv] [WitnessReads F a av]
+    [WitnessReads F b bv] : WitnessReads F (a × b) (av × bv) where
+  Reads r env v := WitnessReads.Reads (F := F) r.1 env v.1 ∧
+    WitnessReads.Reads (F := F) r.2 env v.2
+  reads_of_grant {r} {env} {v} h := by
+    have h' : (A.varToFields r.1 ++ B.varToFields r.2).toList.mapM (CVar.eval · env)
+        = .ok (A.valueToFields v.1 ++ B.valueToFields v.2).toList := h
+    simp only [Vector.toList_append] at h'
+    obtain ⟨h1, h2⟩ := mapM_eval_append_ok (by simp) h'
+    exact ⟨WitnessReads.reads_of_grant h1, WitnessReads.reads_of_grant h2⟩
+  reads_le hle h := ⟨WitnessReads.reads_le hle h.1, WitnessReads.reads_le hle h.2⟩
+
+instance instWitnessReadsVector {F val var : Type} [Add F] [Mul F]
+    [CircuitType F val var] [WitnessReads F val var] {n : Nat} :
+    WitnessReads F (Vector val n) (Vector var n) where
+  Reads r env v := ∀ (i : ℕ) (hi : i < n), WitnessReads.Reads (F := F) r[i] env v[i]
+  reads_of_grant {r} {env} {v} h := by
+    intro i hi
+    refine WitnessReads.reads_of_grant ?_
+    have hsplit := mapM_eval_flatten_ok (env := env)
+      (bs := r.toList.map fun x =>
+        (CircuitType.varToFields (F := F) (val := val) x).toList)
+      (es := v.toList.map fun x =>
+        (CircuitType.valueToFields (F := F) (var := var) x).toList)
+      (by simp) (fun q hq => by
+        rw [List.zip_map] at hq
+        obtain ⟨q₀, -, rfl⟩ := List.mem_map.mp hq
+        simp)
+      (by
+        have h' : ((r.map (CircuitType.varToFields (F := F)
+                (val := val))).flatten).toList.mapM (CVar.eval · env)
+            = .ok ((v.map (CircuitType.valueToFields (F := F)
+                (var := var))).flatten).toList := h
+        simpa [toList_flatten, Vector.toList_map, List.map_map] using h')
+    have hmem : ((CircuitType.varToFields (F := F) (val := val) r[i]).toList,
+        (CircuitType.valueToFields (F := F) (var := var) v[i]).toList)
+        ∈ (r.toList.map fun x =>
+            (CircuitType.varToFields (F := F) (val := val) x).toList).zip
+          (v.toList.map fun x =>
+            (CircuitType.valueToFields (F := F) (var := var) x).toList) := by
+      rw [List.zip_map]
+      refine List.mem_map_of_mem (a := (r[i], v[i])) ?_
+      refine List.mem_iff_getElem.mpr ⟨i, by simp; omega, ?_⟩
+      simp [List.getElem_zip]
+    exact hsplit _ hmem
+  reads_le hle h := fun i hi => WitnessReads.reads_le hle (h i hi)
 
 /-! ## The vector loop rule
 

--- a/formal/snarky/Snarky/Backend/WP.lean
+++ b/formal/snarky/Snarky/Backend/WP.lean
@@ -539,6 +539,20 @@ instance instLawfulCheckedTypeBool {F c : Type} [Add F] [Mul F] [Zero F] [One F]
       ⟨?_, fun u st' _ hle => hk u st' trivial hle⟩
     exact LawfulChecker.check_boolean _ _ _ hb (by cases b <;> simp [bit])
 
+/-- The check-completeness contract transports across the equivalences: the
+transported grant is the base grant at the mapped bundle and value, definitionally.
+Built with `letI` (see `LawfulCircuitType.ofEquiv`). -/
+theorem LawfulCheckedType.ofEquiv {F c : Type} [Add F] [Mul F] [Checker F c]
+    {val var val' var' : Type} [A : CircuitType F val var]
+    [CheckedType F (Prover c) var] [LawfulCheckedType F c val var]
+    (ev : val' ≃ val) (er : var' ≃ var) :
+    @LawfulCheckedType F c val' var' _ _ (A.ofEquiv ev er)
+      (CheckedType.ofEquiv (c := Prover c) er) _ :=
+  letI : CircuitType F val' var' := A.ofEquiv ev er
+  letI : CheckedType F (Prover c) var' := CheckedType.ofEquiv (c := Prover c) er
+  { check_complete := fun bundle v Q =>
+      LawfulCheckedType.check_complete (c := c) (val := val) (er bundle) (ev v) Q }
+
 /-- `allocRange`'s underlying list is the consecutive range. -/
 private theorem allocRange_toList : ∀ (n nv : Nat),
     (allocRange nv n).toList = List.range' nv n
@@ -623,6 +637,17 @@ class WitnessReads (F val var : Type) [Add F] [Mul F] [CircuitType F val var] wh
   /-- The reading survives table extension. -/
   reads_le : ∀ {env env' : Assignments F} {r : var} {v : val},
     env.Le env' → Reads r env v → Reads r env' v
+
+/-- The decoded reading transports across the equivalences: read the mapped bundle
+as the mapped value. Built with `letI` (see `LawfulCircuitType.ofEquiv`). -/
+@[reducible] def WitnessReads.ofEquiv {F : Type} [Add F] [Mul F]
+    {val var val' var' : Type} [A : CircuitType F val var] [WitnessReads F val var]
+    (ev : val' ≃ val) (er : var' ≃ var) :
+    @WitnessReads F val' var' _ _ (A.ofEquiv ev er) :=
+  letI : CircuitType F val' var' := A.ofEquiv ev er
+  { Reads := fun r env v => WitnessReads.Reads (F := F) (er r) env (ev v)
+    reads_of_grant := fun h => WitnessReads.reads_of_grant h
+    reads_le := fun hle h => WitnessReads.reads_le hle h }
 
 open Std.Do in
 /-- A witness computation that succeeds makes the run succeed — the honest encoding

--- a/formal/snarky/Snarky/Backend/WP.lean
+++ b/formal/snarky/Snarky/Backend/WP.lean
@@ -715,6 +715,204 @@ theorem witnessed_uncheckedBool_eval {F : Type} [Add F] [Mul F] [Zero F] [One F]
     (↑r.val : CVar F).eval env = .ok (bit u.val) :=
   mapM_eval_singleton h
 
+/-- Reads survive table extension, listwise. -/
+private theorem mapM_eval_le {F : Type} [Add F] [Mul F] {env env' : Assignments F}
+    (hle : env.Le env') :
+    ∀ {xs : List (CVar F)} {vs : List F},
+      xs.mapM (CVar.eval · env) = .ok vs → xs.mapM (CVar.eval · env') = .ok vs
+  | [], _, h => h
+  | x :: xs, vs, h => by
+    cases he : x.eval env with
+    | error e => simp [List.mapM_cons, he, Bind.bind, Except.bind] at h
+    | ok y =>
+      cases hr : xs.mapM (CVar.eval · env) with
+      | error e => simp [List.mapM_cons, he, hr, Bind.bind, Except.bind] at h
+      | ok ys =>
+        simp only [List.mapM_cons, he, hr, Bind.bind, Except.bind, Pure.pure,
+          Except.pure] at h
+        simp [List.mapM_cons, CVar.eval_le hle he, mapM_eval_le hle hr, Bind.bind,
+          Except.bind, Pure.pure, Except.pure, h]
+
+/-- Split a successful read at the append boundary. -/
+private theorem mapM_eval_append_ok {F : Type} [Add F] [Mul F] {env : Assignments F} :
+    ∀ {l₁ : List (CVar F)} {e₁ : List F} {l₂ : List (CVar F)} {e₂ : List F},
+      e₁.length = l₁.length →
+      (l₁ ++ l₂).mapM (CVar.eval · env) = .ok (e₁ ++ e₂) →
+      l₁.mapM (CVar.eval · env) = .ok e₁ ∧ l₂.mapM (CVar.eval · env) = .ok e₂
+  | [], e₁, _, _, hlen, h => by
+    have : e₁ = [] := List.eq_nil_of_length_eq_zero (by simpa using hlen)
+    subst this
+    exact ⟨rfl, by simpa using h⟩
+  | x :: xs, y :: e₁, l₂, e₂, hlen, h => by
+    cases he : x.eval env with
+    | error e => simp [List.mapM_cons, he, Bind.bind, Except.bind] at h
+    | ok z =>
+      cases hr : (xs ++ l₂).mapM (CVar.eval · env) with
+      | error e => simp [List.mapM_cons, he, hr, Bind.bind, Except.bind] at h
+      | ok zs =>
+        simp only [List.cons_append, List.mapM_cons, he, hr, Bind.bind, Except.bind,
+          Pure.pure, Except.pure, Except.ok.injEq, List.cons.injEq] at h
+        obtain ⟨hz, hzs⟩ := h
+        obtain ⟨h1, h2⟩ :=
+          mapM_eval_append_ok (by simpa using hlen) (hr.trans (by rw [hzs]))
+        exact ⟨by simp [List.mapM_cons, he, h1, hz, Bind.bind, Except.bind,
+          Pure.pure, Except.pure], h2⟩
+  | x :: xs, [], l₂, e₂, hlen, h => by simp at hlen
+
+/-- Split a successful flattened read into its per-piece reads. -/
+private theorem mapM_eval_flatten_ok {F : Type} [Add F] [Mul F] {env : Assignments F} :
+    ∀ {bs : List (List (CVar F))} {es : List (List F)}, bs.length = es.length →
+      (∀ p ∈ bs.zip es, p.2.length = p.1.length) →
+      bs.flatten.mapM (CVar.eval · env) = .ok es.flatten →
+      ∀ p ∈ bs.zip es, p.1.mapM (CVar.eval · env) = .ok p.2
+  | [], [], _, _, _, _, hp => by simp at hp
+  | [], _ :: _, hlen, _, _, _, _ => by simp at hlen
+  | _ :: _, [], hlen, _, _, _, _ => by simp at hlen
+  | b :: bs, e :: es, hlen, hplen, h, p, hp => by
+    simp only [List.flatten_cons] at h
+    obtain ⟨h1, h2⟩ := mapM_eval_append_ok (hplen (b, e) (by simp)) h
+    rcases List.mem_cons.mp (by simpa using hp) with hhead | htail
+    · rw [hhead]
+      exact h1
+    · exact mapM_eval_flatten_ok (by simpa using hlen)
+        (fun q hq => hplen q (List.mem_cons_of_mem _ hq)) h2 p htail
+
+open Std.Do in
+instance instLawfulCheckedTypeProd {F c : Type} [Add F] [Mul F] {a b av bv : Type}
+    [A : CircuitType F a av] [B : CircuitType F b bv] [CheckedType F (Prover c) av]
+    [CheckedType F (Prover c) bv] [Checker F c] [LawfulCheckedType F c a av]
+    [LawfulCheckedType F c b bv] :
+    LawfulCheckedType F c (a × b) (av × bv) where
+  check_complete bundle v Q := by
+    intro st hpre
+    obtain ⟨hread, hk⟩ := hpre
+    have hread' : (A.varToFields bundle.1 ++ B.varToFields bundle.2).toList.mapM
+          (CVar.eval · st.env)
+        = .ok (A.valueToFields v.1 ++ B.valueToFields v.2).toList := hread
+    simp only [Vector.toList_append] at hread'
+    obtain ⟨hr1, hr2⟩ := mapM_eval_append_ok (by simp) hread'
+    rw [show (CheckedType.check (c := Prover c) bundle : CircuitM F (Prover c) PUnit)
+        = (CheckedType.check (c := Prover c) bundle.1 >>= fun _ =>
+            CheckedType.check (c := Prover c) bundle.2) from rfl]
+    simp only [WPMonad.wp_bind, PredTrans.apply_Bind_bind]
+    refine LawfulCheckedType.check_complete (c := c) (val := a) bundle.1 v.1
+      ⟨fun _ st' => (Std.Do.wp (CheckedType.check (c := Prover c) bundle.2 :
+          CircuitM F (Prover c) PUnit)).apply Q st', Q.2⟩ st
+      ⟨hr1, fun u st' _ hle' => ?_⟩
+    exact LawfulCheckedType.check_complete (c := c) (val := b) bundle.2 v.2 Q st'
+      ⟨mapM_eval_le hle' hr2,
+        fun w st'' _ hle'' => hk w st'' trivial (hle'.trans hle'')⟩
+
+open Std.Do in
+/-- The element checks of a list, run in order: each element's read survives to its
+own check through the table growth of the checks before it. -/
+private theorem forM_check_complete {F c val var : Type} [Add F] [Mul F]
+    [CircuitType F val var] [CheckedType F (Prover c) var] [Checker F c]
+    [LawfulCheckedType F c val var] :
+    ∀ (bs : List var) (vs : List val), bs.length = vs.length →
+      ∀ (Q : PostCond PUnit (.arg (ProverState F) (.except EvalError .pure))),
+      ⦃Complete
+          (fun env => ∀ p ∈ bs.zip vs,
+            (CircuitType.varToFields (F := F) (val := val) p.1).toList.mapM
+                (CVar.eval · env)
+              = .ok (CircuitType.valueToFields (F := F) (var := var) p.2).toList)
+          (fun _ _ _ => True) Q⦄
+      (bs.forM (CheckedType.check (c := Prover c)) : CircuitM F (Prover c) PUnit)
+      ⦃Q⦄
+  | [], _, _, Q => fun st hpre => check_pure_complete (c := c) Q st hpre
+  | b :: bs, [], hlen, Q => by simp at hlen
+  | b :: bs, v :: vs, hlen, Q => by
+    intro st hpre
+    obtain ⟨hreads, hk⟩ := hpre
+    rw [show ((b :: bs).forM (CheckedType.check (c := Prover c))
+          : CircuitM F (Prover c) PUnit)
+        = (CheckedType.check (c := Prover c) b >>= fun _ =>
+            bs.forM (CheckedType.check (c := Prover c))) from rfl]
+    simp only [WPMonad.wp_bind, PredTrans.apply_Bind_bind]
+    refine LawfulCheckedType.check_complete (c := c) (val := val) b v
+      ⟨fun _ st' => (Std.Do.wp (bs.forM (CheckedType.check (c := Prover c))
+          : CircuitM F (Prover c) PUnit)).apply Q st', Q.2⟩ st
+      ⟨hreads (b, v) (by simp), fun u st' _ hle' => ?_⟩
+    refine forM_check_complete bs vs (by simpa using hlen) Q st'
+      ⟨fun p hp => mapM_eval_le hle' (hreads p ?_),
+        fun w st'' _ hle'' => hk w st'' trivial (hle'.trans hle'')⟩
+    rw [List.zip_cons_cons]
+    exact List.mem_cons_of_mem _ hp
+
+open Std.Do in
+instance instLawfulCheckedTypeVector {F c : Type} [Add F] [Mul F] {val var : Type}
+    [A : CircuitType F val var] [CheckedType F (Prover c) var] [Checker F c]
+    [LawfulCheckedType F c val var] {n : Nat} :
+    LawfulCheckedType F c (Vector val n) (Vector var n) where
+  check_complete bundle v Q := by
+    intro st hpre
+    obtain ⟨hread, hk⟩ := hpre
+    refine forM_check_complete bundle.toList v.toList (by simp) Q st
+      ⟨?_, fun u st' _ hle' => hk u st' trivial hle'⟩
+    intro p hp
+    have hsplit := mapM_eval_flatten_ok (env := st.env)
+      (bs := bundle.toList.map fun x =>
+        (CircuitType.varToFields (F := F) (val := val) x).toList)
+      (es := v.toList.map fun x =>
+        (CircuitType.valueToFields (F := F) (var := var) x).toList)
+      (by simp) (fun q hq => by
+        rw [List.zip_map] at hq
+        obtain ⟨q₀, -, rfl⟩ := List.mem_map.mp hq
+        simp)
+      (by
+        have hread' : ((bundle.map (CircuitType.varToFields (F := F)
+                (val := val))).flatten).toList.mapM (CVar.eval · st.env)
+            = .ok ((v.map (CircuitType.valueToFields (F := F)
+                (var := var))).flatten).toList := hread
+        simpa [toList_flatten, Vector.toList_map, List.map_map] using hread')
+    have hmem : ((CircuitType.varToFields (F := F) (val := val) p.1).toList,
+        (CircuitType.valueToFields (F := F) (var := var) p.2).toList)
+        ∈ (bundle.toList.map fun x =>
+            (CircuitType.varToFields (F := F) (val := val) x).toList).zip
+          (v.toList.map fun x =>
+            (CircuitType.valueToFields (F := F) (var := var) x).toList) := by
+      rw [List.zip_map]
+      exact List.mem_map_of_mem hp
+    exact hsplit _ hmem
+
+/-- The witnessed-field reading at a vector type: each element's fields evaluate to
+that element's encoding. -/
+theorem witnessed_vector_eval {F : Type} [Add F] [Mul F] {val var : Type}
+    [CircuitType F val var] {n : Nat} {r : Vector var n} {env : Assignments F}
+    {v : Vector val n}
+    (h : (CircuitType.varToFields (F := F) (val := Vector val n) r).toList.mapM
+        (CVar.eval · env)
+      = .ok (CircuitType.valueToFields (F := F) (var := Vector var n) v).toList)
+    {i : Nat} (hi : i < n) :
+    (CircuitType.varToFields (F := F) (val := val) r[i]).toList.mapM (CVar.eval · env)
+      = .ok (CircuitType.valueToFields (F := F) (var := var) v[i]).toList := by
+  have hsplit := mapM_eval_flatten_ok (env := env)
+    (bs := r.toList.map fun x =>
+      (CircuitType.varToFields (F := F) (val := val) x).toList)
+    (es := v.toList.map fun x =>
+      (CircuitType.valueToFields (F := F) (var := var) x).toList)
+    (by simp) (fun q hq => by
+      rw [List.zip_map] at hq
+      obtain ⟨q₀, -, rfl⟩ := List.mem_map.mp hq
+      simp)
+    (by
+      have h' : ((r.map (CircuitType.varToFields (F := F)
+              (val := val))).flatten).toList.mapM (CVar.eval · env)
+          = .ok ((v.map (CircuitType.valueToFields (F := F)
+              (var := var))).flatten).toList := h
+      simpa [toList_flatten, Vector.toList_map, List.map_map] using h')
+  have hmem : ((CircuitType.varToFields (F := F) (val := val) r[i]).toList,
+      (CircuitType.valueToFields (F := F) (var := var) v[i]).toList)
+      ∈ (r.toList.map fun x =>
+          (CircuitType.varToFields (F := F) (val := val) x).toList).zip
+        (v.toList.map fun x =>
+          (CircuitType.valueToFields (F := F) (var := var) x).toList) := by
+    rw [List.zip_map]
+    refine List.mem_map_of_mem (a := (r[i], v[i])) ?_
+    refine List.mem_iff_getElem.mpr ⟨i, by simp; omega, ?_⟩
+    simp [List.getElem_zip]
+  exact hsplit _ hmem
+
 /-! ## The vector loop rule
 
 The `Sound` and `Complete` laws of `generateVec`, given a spec for each component —

--- a/formal/snarky/Snarky/Circuit/DSL/Bits.lean
+++ b/formal/snarky/Snarky/Circuit/DSL/Bits.lean
@@ -280,7 +280,7 @@ the results are the operand's binary digits. -/
     rw [hv'] at hv''
     injection hv'' with hv''
     subst hv''
-    exact witnessed_boolVar_eval (hr _ hw)
+    exact hr _ hw
   refine generateVec_complete_spec n _ _ _ hcomp
     (fun i env env' hle hok => by
       obtain ⟨vv', hv'⟩ := CVar.evalOk hok

--- a/formal/snarky/Snarky/Circuit/DSL/Monad.lean
+++ b/formal/snarky/Snarky/Circuit/DSL/Monad.lean
@@ -202,6 +202,12 @@ instance {avar bvar : Type u} [CheckedType F c avar] [CheckedType F c bvar] :
     CheckedType.check (c := c) p.1
     CheckedType.check (c := c) p.2
 
+/-- A vector is checked elementwise, in index order (PS `CheckedType` instance for
+`Vector`: `traverse_ check`). -/
+instance {var : Type u} [CheckedType F c var] {n : Nat} :
+    CheckedType F c (Vector var n) where
+  check v := v.toList.forM (CheckedType.check (c := c))
+
 /-! ## The typed combinators -/
 
 variable {val var : Type u}

--- a/formal/snarky/Snarky/Circuit/DSL/Monad.lean
+++ b/formal/snarky/Snarky/Circuit/DSL/Monad.lean
@@ -1,4 +1,5 @@
 import Snarky.Backend.Assignments
+import Mathlib.Logic.Equiv.Defs
 import Snarky.Circuit.Types
 import Snarky.Constraint.Basic
 import Snarky.Vec
@@ -207,6 +208,12 @@ instance {avar bvar : Type u} [CheckedType F c avar] [CheckedType F c bvar] :
 instance {var : Type u} [CheckedType F c var] {n : Nat} :
     CheckedType F c (Vector var n) where
   check v := v.toList.forM (CheckedType.check (c := c))
+
+/-- The checks of `var`, run on an isomorphic `var'` — the leaf a nominal structure
+declares through its field-product equivalence. -/
+@[reducible] def CheckedType.ofEquiv {var var' : Type u} [CheckedType F c var]
+    (er : var' ≃ var) : CheckedType F c var' :=
+  ⟨fun r => CheckedType.check (c := c) (er r)⟩
 
 /-! ## The typed combinators -/
 

--- a/formal/snarky/Snarky/Circuit/Types.lean
+++ b/formal/snarky/Snarky/Circuit/Types.lean
@@ -16,9 +16,10 @@ Deviations from the PS original (ledger: `formal/docs/snarky-ps-alignment.md`):
   dispatches on the plain field type and core `Bool` directly, so `val` is unwrapped. The
   wrapper-lifting instances (`PrimeField (F f)`, `HasEndo (F f)`, `FieldSizeInBits (F f)`)
   therefore have no analogue.
-- Instance coverage is the base pair (`F`, `Bool`), `Prod` (PS `Tuple`), and the
-  size-0 `PUnit` (PS `Unit`); the PS `NoInput`/`NoOutput`, `Const`, `Product`,
-  `Vector`, and `Record` instances are not yet ported. `UnChecked` is here.
+- Instance coverage is the base pair (`F`, `Bool`), `Prod` (PS `Tuple`), sized
+  vectors (PS `Vector`), and the size-0 `PUnit` (PS `Unit`); the PS
+  `NoInput`/`NoOutput`, `Const`, `Product`, and `Record` instances are not yet
+  ported. `UnChecked` is here.
 - The generic/rowlist deriving machinery (`GCircuitType`/`RCircuitType`, the `generic*`
   helpers) is not ported — Lean would grow a `deriving` handler instead.
 - `CheckedType` is not here: its PS home is `Circuit/DSL/Monad.purs`.
@@ -176,6 +177,28 @@ instance : CircuitType F PUnit PUnit where
   varToFields _ := #v[]
   fieldsToVar _ := PUnit.unit
 
+/-- Every element's block starts strictly inside the flattening: the index bound the
+vector instance's decode direction reads through. -/
+private theorem mul_add_lt {i j n sz : Nat} (hi : i < n) (hj : j < sz) :
+    i * sz + j < n * sz :=
+  calc i * sz + j < (i + 1) * sz := by rw [Nat.succ_mul]; omega
+    _ ≤ n * sz := Nat.mul_le_mul_right sz hi
+
+/-- Sized vectors encode as the concatenation of their elements' encodings, in index
+order (PS `CircuitType` instance for `Vector`); decoding reads element `i`'s fields
+back off block `i`. -/
+instance instCircuitTypeVector {val var : Type u} [A : CircuitType F val var]
+    {n : Nat} : CircuitType F (Vector val n) (Vector var n) where
+  size := n * A.size
+  valueToFields v := (v.map A.valueToFields).flatten
+  fieldsToValue fs := Vector.ofFn fun i =>
+    A.fieldsToValue (Vector.ofFn fun j =>
+      fs[i.1 * A.size + j.1]'(mul_add_lt i.isLt j.isLt))
+  varToFields v := (v.map A.varToFields).flatten
+  fieldsToVar fs := Vector.ofFn fun i =>
+    A.fieldsToVar (Vector.ofFn fun j =>
+      fs[i.1 * A.size + j.1]'(mul_add_lt i.isLt j.isLt))
+
 /-! ## Round-trip laws
 
 The PS suite checks these by QuickCheck over a table of types; for the base instances
@@ -244,5 +267,80 @@ instance instLawfulCircuitTypeUnChecked {val var : Type} [CircuitType F val var]
     LawfulCircuitType F (UnChecked val) (UnChecked var) where
   value_roundTrip v := congrArg UnChecked.mk (LawfulCircuitType.value_roundTrip v.val)
   vars_roundTrip cvs := LawfulCircuitType.vars_roundTrip (val := val) cvs
+
+/-- Taking a concatenation's first block gives it back. -/
+private theorem cast_take_append {α : Type u} {m k : Nat} (v : Vector α m)
+    (w : Vector α k) {h : min m (m + k) = m} : ((v ++ w).take m).cast h = v := by
+  ext i hi
+  simp [hi]
+
+/-- Dropping a concatenation's first block leaves the second. -/
+private theorem cast_drop_append {α : Type u} {m k : Nat} (v : Vector α m)
+    (w : Vector α k) {h : m + k - m = k} : ((v ++ w).drop m).cast h = w := by
+  ext i hi
+  simp
+
+/-- A vector is its first `m` entries followed by the rest. -/
+private theorem take_append_drop {α : Type u} {m k : Nat} (fs : Vector α (m + k))
+    {h₁ : min m (m + k) = m} {h₂ : m + k - m = k} :
+    ((fs.take m).cast h₁ ++ (fs.drop m).cast h₂) = fs := by
+  ext i hi
+  simp only [Vector.getElem_append, Vector.getElem_cast, Vector.getElem_take,
+    Vector.getElem_drop]
+  split
+  · rfl
+  · congr 1
+    omega
+
+instance instLawfulCircuitTypeProd {a b av bv : Type} [A : CircuitType F a av]
+    [B : CircuitType F b bv] [LawfulCircuitType F a av] [LawfulCircuitType F b bv] :
+    LawfulCircuitType F (a × b) (av × bv) where
+  value_roundTrip p := by
+    show (A.fieldsToValue
+          (((A.valueToFields p.1 ++ B.valueToFields p.2).take A.size).cast _),
+        B.fieldsToValue
+          (((A.valueToFields p.1 ++ B.valueToFields p.2).drop A.size).cast _)) = p
+    rw [cast_take_append, cast_drop_append, LawfulCircuitType.value_roundTrip,
+      LawfulCircuitType.value_roundTrip]
+  vars_roundTrip cvs := by
+    show A.varToFields (A.fieldsToVar _) ++ B.varToFields (B.fieldsToVar _) = cvs
+    rw [LawfulCircuitType.vars_roundTrip (val := a),
+      LawfulCircuitType.vars_roundTrip (val := b), take_append_drop]
+
+instance instLawfulCircuitTypeVector {val var : Type} [A : CircuitType F val var]
+    [LawfulCircuitType F val var] {n : Nat} :
+    LawfulCircuitType F (Vector val n) (Vector var n) where
+  value_roundTrip v := by
+    ext i hi
+    show (Vector.ofFn fun i' : Fin n =>
+        A.fieldsToValue (Vector.ofFn fun j : Fin A.size =>
+          ((v.map A.valueToFields).flatten)[i'.1 * A.size + j.1]'(
+            mul_add_lt i'.isLt j.isLt)))[i]
+      = v[i]
+    simp only [Vector.getElem_ofFn]
+    have hinner : (Vector.ofFn fun j : Fin A.size =>
+        ((v.map A.valueToFields).flatten)[i * A.size + j.1]'(mul_add_lt hi j.isLt))
+        = A.valueToFields v[i] := by
+      ext j hj
+      have hdiv : (i * A.size + j) / A.size = i := by
+        rw [Nat.mul_comm i A.size, Nat.mul_add_div (by omega), Nat.div_eq_of_lt hj,
+          Nat.add_zero]
+      have hmod : (i * A.size + j) % A.size = j := by
+        rw [Nat.mul_add_mod', Nat.mod_eq_of_lt hj]
+      simp only [Vector.getElem_ofFn, Vector.getElem_flatten, Vector.getElem_map,
+        hdiv, hmod]
+    rw [hinner]
+    exact LawfulCircuitType.value_roundTrip v[i]
+  vars_roundTrip cvs := by
+    ext i hi
+    show ((Vector.ofFn fun i' : Fin n =>
+        A.fieldsToVar (Vector.ofFn fun j : Fin A.size =>
+          cvs[i'.1 * A.size + j.1]'(mul_add_lt i'.isLt j.isLt))).map
+        A.varToFields).flatten[i]
+      = cvs[i]
+    simp only [Vector.getElem_flatten, Vector.getElem_map, Vector.getElem_ofFn]
+    simp only [LawfulCircuitType.vars_roundTrip (val := val), Vector.getElem_ofFn]
+    congr 1
+    exact Nat.div_add_mod' i A.size
 
 end Snarky

--- a/formal/snarky/Snarky/Circuit/Types.lean
+++ b/formal/snarky/Snarky/Circuit/Types.lean
@@ -1,4 +1,5 @@
 import Snarky.Circuit.CVar
+import Mathlib.Logic.Equiv.Defs
 
 /-!
 # Circuit types
@@ -199,6 +200,19 @@ instance instCircuitTypeVector {val var : Type u} [A : CircuitType F val var]
     A.fieldsToVar (Vector.ofFn fun j =>
       fs[i.1 * A.size + j.1]'(mul_add_lt i.isLt j.isLt))
 
+/-- The encoding of `val`, worn by an isomorphic `val'` — the leaf a nominal
+structure declares through its field-product equivalence instead of by hand.
+Reducible, so instance resolution and definitional unfolding see through the
+transport. -/
+@[reducible] def CircuitType.ofEquiv {val var val' var' : Type u}
+    (A : CircuitType F val var) (ev : val' ≃ val) (er : var' ≃ var) :
+    CircuitType F val' var' where
+  size := A.size
+  valueToFields v := A.valueToFields (ev v)
+  fieldsToValue fs := ev.symm (A.fieldsToValue fs)
+  varToFields r := A.varToFields (er r)
+  fieldsToVar fs := er.symm (A.fieldsToVar fs)
+
 /-! ## Round-trip laws
 
 The PS suite checks these by QuickCheck over a table of types; for the base instances
@@ -342,5 +356,23 @@ instance instLawfulCircuitTypeVector {val var : Type} [A : CircuitType F val var
     simp only [LawfulCircuitType.vars_roundTrip (val := val), Vector.getElem_ofFn]
     congr 1
     exact Nat.div_add_mod' i A.size
+
+/-- Lawfulness transports across the equivalences: both round trips factor through
+the base instance's. Built with `letI` — a `where` literal at the ascribed instance
+re-synthesizes the class's instance arguments instead of using it. -/
+theorem LawfulCircuitType.ofEquiv {val var val' var' : Type}
+    [A : CircuitType F val var] [LawfulCircuitType F val var]
+    (ev : val' ≃ val) (er : var' ≃ var) :
+    @LawfulCircuitType F val' var' (A.ofEquiv ev er) :=
+  letI : CircuitType F val' var' := A.ofEquiv ev er
+  { value_roundTrip := fun v => by
+      show ev.symm (CircuitType.fieldsToValue (CircuitType.valueToFields (ev v))) = v
+      rw [LawfulCircuitType.value_roundTrip (F := F) (var := var),
+        Equiv.symm_apply_apply]
+    vars_roundTrip := fun cvs => by
+      show CircuitType.varToFields (F := F) (val := val)
+          (er (er.symm (CircuitType.fieldsToVar (F := F) (val := val) cvs))) = cvs
+      rw [Equiv.apply_symm_apply,
+        LawfulCircuitType.vars_roundTrip (F := F) (val := val)] }
 
 end Snarky

--- a/formal/snarky/Snarky/Circuit/Types.lean
+++ b/formal/snarky/Snarky/Circuit/Types.lean
@@ -177,8 +177,8 @@ instance : CircuitType F PUnit PUnit where
   varToFields _ := #v[]
   fieldsToVar _ := PUnit.unit
 
-/-- Every element's block starts strictly inside the flattening: the index bound the
-vector instance's decode direction reads through. -/
+/-- Element `i`'s block sits inside the flattening: the index bound of the vector
+instance's decode direction. -/
 private theorem mul_add_lt {i j n sz : Nat} (hi : i < n) (hj : j < sz) :
     i * sz + j < n * sz :=
   calc i * sz + j < (i + 1) * sz := by rw [Nat.succ_mul]; omega

--- a/formal/snarky/Snarky/Kimchi/Backend/Compile.lean
+++ b/formal/snarky/Snarky/Kimchi/Backend/Compile.lean
@@ -25,10 +25,10 @@ queue flushed). -/
 private def kimchiCompile [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F]
     [DecidableEq F] [A : CircuitType F a avar]
     [CheckedType F (KimchiConstraint F) avar] [B : CircuitType F b bvar]
-    (rc : ℕ → F × F × F) (main : avar → CircuitM F (KimchiConstraint F) bvar) :
+    (main : avar → CircuitM F (KimchiConstraint F) bvar) :
     BuiltWith (KimchiGate F) (AuxState F) bvar :=
-  finalizeWith (kimchiOps rc)
-    (buildWith (kimchiOps rc) (compileBody (a := a) (b := b) main)
+  finalizeWith kimchiOps
+    (buildWith kimchiOps (compileBody (a := a) (b := b) main)
       (A.size + B.size) initialAuxState)
 
 /-- Solve a circuit at the kimchi backend (the base `solve` at `kimchiOps`): seed the
@@ -36,13 +36,13 @@ input slots, prove, decode the output. -/
 def kimchiSolve [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F]
     [DecidableEq F] [A : CircuitType F a avar]
     [CheckedType F (KimchiConstraint F) avar] [B : CircuitType F b bvar]
-    (rc : ℕ → F × F × F) (main : avar → CircuitM F (KimchiConstraint F) bvar)
+    (main : avar → CircuitM F (KimchiConstraint F) bvar)
     (input : a) : Except EvalError (b × Assignments F) :=
   match Assignments.empty.extendPairs
       ((allocRange 0 A.size).toList.zip (A.valueToFields input).toList) with
   | .error e => .error e
   | .ok env₀ =>
-    match proveWith (kimchiOps rc) (compileBody (a := a) (b := b) main)
+    match proveWith kimchiOps (compileBody (a := a) (b := b) main)
         (A.size + B.size) env₀ with
     | .error e => .error e
     | .ok p =>
@@ -55,9 +55,9 @@ returning the rows (public rows included), the gate table, and the public size. 
 def kimchiGateData [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F]
     [DecidableEq F] [A : CircuitType F a avar]
     [CheckedType F (KimchiConstraint F) avar] [B : CircuitType F b bvar]
-    (rc : ℕ → F × F × F) (main : avar → CircuitM F (KimchiConstraint F) bvar) :
+    (main : avar → CircuitM F (KimchiConstraint F) bvar) :
     List (KimchiRow F) × List (AssembledGate F) × Nat :=
-  let built := kimchiCompile (a := a) (b := b) rc main
+  let built := kimchiCompile (a := a) (b := b) main
   let rows := built.constraints.flatMap (toKimchiRows (F := F))
   makeGateData ((allocRange 0 (A.size + B.size)).toList) rows
     built.aux.wireState.unionFind

--- a/formal/snarky/Snarky/Kimchi/Circuit/AddComplete.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/AddComplete.lean
@@ -485,7 +485,7 @@ private theorem addFastTail_complete_spec [Field F] [DecidableEq F]
       simp [infZWit, AsProver.readCVar, hp1y, hp2y, readVar_bool_of_eval hsx, hy, hx,
         Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
   refine ⟨by rw [hinfZw]; rfl, fun infZ st₁ hr₁ hle₁ => ?_⟩
-  have hinfZ := witnessed_fvar_eval (hr₁ _ hinfZw)
+  have hinfZ : _ = _ := hr₁ _ hinfZw
   mvcgen
   have hx21w : x21InvWit p1 p2 sameX st₁.env
       = .ok (if x1v = x2v then 0 else (x2v - x1v)⁻¹) := by
@@ -494,7 +494,7 @@ private theorem addFastTail_complete_spec [Field F] [DecidableEq F]
         CVar.eval_le hle₁ hp2x, readVar_bool_of_eval (CVar.eval_le hle₁ hsx), hx,
         Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
   refine ⟨by rw [hx21w]; rfl, fun x21Inv st₂ hr₂ hle₂ => ?_⟩
-  have hx21 := witnessed_fvar_eval (hr₂ _ hx21w)
+  have hx21 : _ = _ := hr₂ _ hx21w
   have hle02 := hle₁.trans hle₂
   mvcgen
   have hsw : slopeWit p1 p2 sameX st₂.env
@@ -506,7 +506,7 @@ private theorem addFastTail_complete_spec [Field F] [DecidableEq F]
         readVar_bool_of_eval (CVar.eval_le hle02 hsx), hx,
         Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
   refine ⟨by rw [hsw]; rfl, fun s st₃ hr₃ hle₃ => ?_⟩
-  have hs := witnessed_fvar_eval (hr₃ _ hsw)
+  have hs : _ = _ := hr₃ _ hsw
   have hle03 := hle02.trans hle₃
   mvcgen
   have hx3w : x3Wit p1 p2 s st₃.env
@@ -518,7 +518,7 @@ private theorem addFastTail_complete_spec [Field F] [DecidableEq F]
       CVar.eval_le hle03 hp2x,
       Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
   refine ⟨by rw [hx3w]; rfl, fun x3 st₄ hr₄ hle₄ => ?_⟩
-  have hx3 := witnessed_fvar_eval (hr₄ _ hx3w)
+  have hx3 : _ = _ := hr₄ _ hx3w
   have hle04 := hle03.trans hle₄
   mvcgen
   have hy3w : y3Wit p1 s x3 st₄.env
@@ -533,7 +533,7 @@ private theorem addFastTail_complete_spec [Field F] [DecidableEq F]
       CVar.eval_le hle04 hp1x, CVar.eval_le hle04 hp1y,
       Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
   refine ⟨by rw [hy3w]; rfl, fun y3 st₅ hr₅ hle₅ => ?_⟩
-  have hy3 := witnessed_fvar_eval (hr₅ _ hy3w)
+  have hy3 : _ = _ := hr₅ _ hy3w
   have hle05 := hle04.trans hle₅
   have hle25 := hle₃.trans (hle₄.trans hle₅)
   mvcgen
@@ -606,7 +606,7 @@ theorem addFast_complete_spec [Field F] [DecidableEq F]
       Functor.map, Bind.bind, ReaderT.bind, Except.bind, Except.map,
       Pure.pure, ReaderT.pure, Except.pure]
   refine ⟨by rw [hsw]; rfl, fun sameXU st₃ hsxr hle₃ => ?_⟩
-  have hsx := witnessed_uncheckedBool_eval (hsxr _ hsw)
+  have hsx : _ = _ := hsxr _ hsw
   cases fin with
   | checkFinite =>
     mvcgen
@@ -626,7 +626,7 @@ theorem addFast_complete_spec [Field F] [DecidableEq F]
         Functor.map, Bind.bind, ReaderT.bind, Except.bind, Except.map,
         Pure.pure, ReaderT.pure, Except.pure]
     refine ⟨by rw [hiw]; rfl, fun infU st₄ hinfr hle₄ => ?_⟩
-    have hinfb := witnessed_uncheckedBool_eval (hinfr _ hiw)
+    have hinfb : _ = _ := hinfr _ hiw
     mvcgen
     refine addFastTail_complete_spec p1 p2 sameXU.val infU.val x1v y1v x2v y2v
       (decide (x1v = x2v) && !decide (y1v = y2v))

--- a/formal/snarky/Snarky/Kimchi/Circuit/Poseidon.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/Poseidon.lean
@@ -1,0 +1,63 @@
+import Snarky.Circuit.DSL.Monad
+import Snarky.Kimchi.Semantics
+import Poseidon.Basic
+
+/-!
+# The Poseidon gadget
+
+Port of `Snarky.Circuit.Kimchi.Poseidon`
+(packages/snarky-kimchi/src/Snarky/Circuit/Kimchi/Poseidon.purs): witness the 55 round
+outputs of the permutation in ONE bulk `exists` — the traversal lives inside the
+witness computation, so the circuit itself is three binds — emit the block constraint
+over the 56 chained states, and return the output state.
+
+Name map: `poseidon` keeps its name; the `exists` body's `scanl` renders as the
+indexed prefix map `roundsUpTo` (same values, and output `i` is the `(i + 1)`-round
+prefix by definition).
+
+Deviations from the PS original (per `formal/docs/snarky-kimchi-alignment.md`):
+- PS's ambient `PoseidonField` class arrives as the explicit parameter
+  `p : Poseidon.Params F`, whose data the emitted payload carries (the payload-data
+  deviation in `Constraint/Poseidon.lean`).
+- PS's width-3 `Vector` states render as triples, matching the payload.
+- The PS `label "poseidon"` wrapper is dropped (labels are not threaded —
+  `Kimchi/Constraint.lean`'s deviation ledger).
+-/
+
+namespace Snarky.Kimchi
+
+open Snarky
+
+variable {F c : Type}
+
+/-- The state after rounds `0 … k − 1` (the `k`-prefix of the `blockCipher` fold;
+`getD` never fires at the deployed 55-entry table). -/
+private def roundsUpTo [Field F] (p : Poseidon.Params F) :
+    ℕ → F × F × F → F × F × F
+  | 0, s => s
+  | k + 1, s =>
+    Poseidon.fullRound p.mds (p.roundConstants.getD k (0, 0, 0)) (roundsUpTo p k s)
+
+/-- The bulk witness: read the input state, return all 55 round outputs, oldest
+first (the PS `exists` body's `scanl`). -/
+private def roundOutputsWit [Field F] (p : Poseidon.Params F)
+    (s : FVar F × FVar F × FVar F) : AsProver F (Vector (F × F × F) 55) := do
+  let s0 ← AsProver.readCVar s.1
+  let s1 ← AsProver.readCVar s.2.1
+  let s2 ← AsProver.readCVar s.2.2
+  pure (Vector.ofFn fun i => roundsUpTo p (i.1 + 1) (s0, s1, s2))
+
+/-- The Poseidon permutation gadget (PS `poseidon`): one bulk witness of the round
+outputs, one block constraint over the 56 chained states at `p`'s data, the last
+state returned. -/
+def poseidon [Field F] [KimchiSystem F c] (p : Poseidon.Params F)
+    (initialState : FVar F × FVar F × FVar F) :
+    CircuitM F c (FVar F × FVar F × FVar F) := do
+  let roundOutputs ← witness (val := Vector (F × F × F) 55)
+    (roundOutputsWit p initialState)
+  addConstraint (KimchiSystem.poseidon
+    { mds := p.mds, rc := p.roundConstants.toList,
+      state := initialState :: roundOutputs.toList })
+  pure roundOutputs[54]
+
+end Snarky.Kimchi

--- a/formal/snarky/Snarky/Kimchi/Circuit/Poseidon.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/Poseidon.lean
@@ -165,4 +165,237 @@ theorem poseidon_spec [Field F] [DecidableEq F] (p : Poseidon.Params F)
 
 end Poseidon
 
+/-! ## Completeness
+
+`Poseidon.poseidon_complete_spec`: the honest `KimchiProverC` run accepts on any
+readable input state — no domain conditions — and the output reads back as
+`Poseidon.blockCipher` of the inputs. The witness values are `roundsUpTo` prefixes,
+so each window's five equations hold by the recursion itself, read through
+`round_eq_fullRound`. -/
+
+/-- Reading a triple bundle's fields is reading its three components. -/
+private theorem mapM_eval_triple [Add F] [Mul F] {env : Assignments F}
+    {t : FVar F × FVar F × FVar F} {v : F × F × F}
+    (h : (CircuitType.varToFields (F := F) (val := F × F × F) t).toList.mapM
+        (CVar.eval · env)
+      = .ok (CircuitType.valueToFields (F := F)
+          (var := FVar F × FVar F × FVar F) v).toList) :
+    t.1.eval env = .ok v.1 ∧ t.2.1.eval env = .ok v.2.1 ∧ t.2.2.eval env = .ok v.2.2 := by
+  have h' : [t.1, t.2.1, t.2.2].mapM (CVar.eval · env) = .ok [v.1, v.2.1, v.2.2] := by
+    simpa [Vector.toList_append] using h
+  cases h1 : t.1.eval env with
+  | error e => simp [List.mapM_cons, h1, Bind.bind, Except.bind] at h'
+  | ok a =>
+    cases h2 : t.2.1.eval env with
+    | error e => simp [List.mapM_cons, h1, h2, Bind.bind, Except.bind] at h'
+    | ok b =>
+      cases h3 : t.2.2.eval env with
+      | error e => simp [List.mapM_cons, h1, h2, h3, Bind.bind, Except.bind] at h'
+      | ok c =>
+        simp only [List.mapM_cons, List.mapM_nil, h1, h2, h3, Bind.bind, Except.bind,
+          Pure.pure, Except.pure, Except.ok.injEq, List.cons.injEq, and_true] at h'
+        obtain ⟨ha, hb, hc⟩ := h'
+        refine ⟨?_, ?_, ?_⟩ <;> simp [ha, hb, hc]
+
+namespace Poseidon
+
+/-- The prefix map is the gate tower's iterate at the parameter family. -/
+private theorem roundsUpTo_eq_rounds [Field F] (p : Poseidon.Params F) :
+    ∀ (k : ℕ) (s : F × F × F),
+      roundsUpTo p k s
+        = Kimchi.Gate.Poseidon.rounds (Kimchi.Gate.Poseidon.mdsOfParams p)
+            (Kimchi.Gate.Poseidon.paramsRc p) k s
+  | 0, _ => rfl
+  | k + 1, s => by
+    rw [show roundsUpTo p (k + 1) s
+        = Poseidon.fullRound p.mds (p.roundConstants.getD k (0, 0, 0))
+            (roundsUpTo p k s) from rfl,
+      Kimchi.Gate.Poseidon.rounds, roundsUpTo_eq_rounds p k s,
+      Kimchi.Gate.Poseidon.round_eq_fullRound]
+    rfl
+
+/-- The decidable chain check reflects the chain reading (the gate's `ok_iff`,
+windowed). -/
+private theorem chainOk_iff [CommRing F] [DecidableEq F]
+    {M : Kimchi.Gate.Poseidon.Mds F} {rc : List (F × F × F)} :
+    ∀ (k : ℕ) (l : List (F × F × F)), chainOk M rc k l = true ↔ chainHolds M rc k l
+  | k, [] => by simp [chainOk, chainHolds]
+  | k, [_] => by simp [chainOk, chainHolds]
+  | k, [_, _] => by simp [chainOk, chainHolds]
+  | k, [_, _, _] => by simp [chainOk, chainHolds]
+  | k, [_, _, _, _] => by simp [chainOk, chainHolds]
+  | k, s0 :: s1 :: s2 :: s3 :: s4 :: [] => by simp [chainOk, chainHolds]
+  | k, s0 :: s1 :: s2 :: s3 :: s4 :: s5 :: rest => by
+    simp only [chainOk, chainHolds, Bool.and_eq_true,
+      Kimchi.Gate.Poseidon.ok_iff, chainOk_iff (k + 1) (s5 :: rest)]
+
+/-- A list whose successive entries are the gate's round images satisfies the chain
+reading: each window's fifteen constraint expressions vanish by the adjacency
+equations alone. -/
+private theorem chainHolds_of_succ [CommRing F] {M : Kimchi.Gate.Poseidon.Mds F}
+    {rc : List (F × F × F)} :
+    ∀ (k : ℕ) (l : List (F × F × F)),
+      (∀ j (hj1 : j + 1 < l.length) (hj0 : j < l.length),
+        l[j + 1] = Kimchi.Gate.Poseidon.round M l[j]
+          (rc.getD (5 * k + j) (0, 0, 0))) →
+      chainHolds M rc k l
+  | k, s0 :: s1 :: s2 :: s3 :: s4 :: s5 :: rest, hsucc => by
+    simp only [chainHolds]
+    refine ⟨?_, ?_⟩
+    · have e0 := hsucc 0 (by simp) (by simp)
+      have e1 := hsucc 1 (by simp) (by simp)
+      have e2 := hsucc 2 (by simp) (by simp)
+      have e3 := hsucc 3 (by simp) (by simp)
+      have e4 := hsucc 4 (by simp) (by simp)
+      simp only [List.getElem_cons_zero, List.getElem_cons_succ] at e0 e1 e2 e3 e4
+      intro e he
+      simp only [Kimchi.Gate.Poseidon.constraints, rcRow, List.mem_cons,
+        List.not_mem_nil, or_false] at he
+      rcases he with h | h | h | h | h | h | h | h | h | h | h | h | h | h | h <;>
+        (subst h; simp [e0, e1, e2, e3, e4])
+    · refine chainHolds_of_succ (k + 1) (s5 :: rest) ?_
+      intro j hj1 hj0
+      have hs := hsucc (j + 5) (by simp at hj1 ⊢; omega) (by simp at hj1 ⊢; omega)
+      simp only [List.getElem_cons_succ] at hs ⊢
+      rw [show 5 * (k + 1) + j = 5 * k + (j + 5) by omega]
+      exact hs
+  | k, [], _ => by simp [chainHolds]
+  | k, [_], _ => by simp [chainHolds]
+  | k, [_, _], _ => by simp [chainHolds]
+  | k, [_, _, _], _ => by simp [chainHolds]
+  | k, [_, _, _, _], _ => by simp [chainHolds]
+  | k, [_, _, _, _, _], _ => by simp [chainHolds]
+
+/-- Element reads assemble into the state-list evaluation. -/
+private theorem evalStates_ok [CommRing F] [DecidableEq F] {env : Assignments F} :
+    ∀ (ts : List (FVar F × FVar F × FVar F)) (vs : List (F × F × F)),
+      (∀ j (hj : j < ts.length) (hj' : j < vs.length),
+        ts[j].1.eval env = .ok vs[j].1 ∧
+        ts[j].2.1.eval env = .ok vs[j].2.1 ∧
+        ts[j].2.2.eval env = .ok vs[j].2.2) →
+      ts.length = vs.length →
+      evalStates env ts = .ok vs
+  | [], [], _, _ => rfl
+  | [], _ :: _, _, hlen => by simp at hlen
+  | _ :: _, [], _, hlen => by simp at hlen
+  | t :: ts, v :: vs, hread, hlen => by
+    obtain ⟨h1, h2, h3⟩ := hread 0 (by simp) (by simp)
+    simp only [List.getElem_cons_zero] at h1 h2 h3
+    have ih := evalStates_ok ts vs
+      (fun j hj hj' => by
+        have := hread (j + 1) (by simpa using hj) (by simpa using hj')
+        simpa only [List.getElem_cons_succ] using this)
+      (by simpa using hlen)
+    simp [evalStates, h1, h2, h3, ih, Bind.bind, Except.bind, Pure.pure, Except.pure]
+
+open Std.Do in
+/-- The gadget is complete: the honest prover run accepts on any readable input
+state — no domain conditions — and the output state reads back as
+`Poseidon.blockCipher` of the input values. -/
+theorem poseidon_complete_spec [Field F] [DecidableEq F] (p : Poseidon.Params F)
+    (hsize : p.roundConstants.size = 5 * 11) (s : FVar F × FVar F × FVar F)
+    (Q : PostCond (FVar F × FVar F × FVar F)
+      (.arg (ProverState F) (.except EvalError .pure))) :
+    ⦃Complete
+        (fun env =>
+          (s.1.eval env).isOk ∧ (s.2.1.eval env).isOk ∧ (s.2.2.eval env).isOk)
+        (fun env (r : FVar F × FVar F × FVar F) env' =>
+          ∀ a b c, s.1.eval env = .ok a → s.2.1.eval env = .ok b →
+            s.2.2.eval env = .ok c →
+            r.1.eval env' = .ok (Poseidon.blockCipher p (a, b, c)).1 ∧
+            r.2.1.eval env' = .ok (Poseidon.blockCipher p (a, b, c)).2.1 ∧
+            r.2.2.eval env' = .ok (Poseidon.blockCipher p (a, b, c)).2.2)
+        Q⦄
+    (poseidon (c := KimchiProverC F) p s)
+    ⦃Q⦄ := by
+  simp only [poseidon]
+  mvcgen
+  rename_i st hpre
+  obtain ⟨⟨haok, hbok, hcok⟩, hk⟩ := hpre
+  obtain ⟨av, ha⟩ := CVar.evalOk haok
+  obtain ⟨bv, hb⟩ := CVar.evalOk hbok
+  obtain ⟨cv, hc⟩ := CVar.evalOk hcok
+  have hwit : roundOutputsWit p s st.env
+      = .ok (Vector.ofFn fun i => roundsUpTo p (i.1 + 1) (av, bv, cv)) := by
+    simp [roundOutputsWit, AsProver.readCVar, ha, hb, hc, Bind.bind, ReaderT.bind,
+      Except.bind, Pure.pure, ReaderT.pure, Except.pure]
+  refine ⟨by rw [hwit]; rfl, fun outs st₁ hgrant hle₁ => ?_⟩
+  have hread := hgrant _ hwit
+  have helem : ∀ (i : ℕ) (hi : i < 55),
+      outs[i].1.eval st₁.env = .ok (roundsUpTo p (i + 1) (av, bv, cv)).1 ∧
+      outs[i].2.1.eval st₁.env = .ok (roundsUpTo p (i + 1) (av, bv, cv)).2.1 ∧
+      outs[i].2.2.eval st₁.env = .ok (roundsUpTo p (i + 1) (av, bv, cv)).2.2 := by
+    intro i hi
+    have h := witnessed_vector_eval hread hi
+    simp only [Vector.getElem_ofFn] at h
+    exact mapM_eval_triple h
+  mvcgen
+  refine addConstraint_complete_spec (c := KimchiConstraint F)
+    (KimchiSystem.poseidon ⟨p.mds, p.roundConstants.toList, s :: outs.toList⟩)
+    (fun a => wp⟦pure outs[54]⟧ Q, Q.2) st₁ ⟨?_, fun u st₂ _ hle₂ => ?_⟩
+  · show KimchiConstraint.check
+      (.poseidon ⟨p.mds, p.roundConstants.toList, s :: outs.toList⟩) st₁.env = true
+    have hstates : evalStates st₁.env (s :: outs.toList)
+        = .ok ((av, bv, cv) ::
+            (List.ofFn fun i : Fin 55 => roundsUpTo p (i.1 + 1) (av, bv, cv))) := by
+      refine evalStates_ok _ _ ?_ (by simp)
+      intro j hj hj'
+      cases j with
+      | zero =>
+        exact ⟨CVar.eval_le hle₁ ha, CVar.eval_le hle₁ hb, CVar.eval_le hle₁ hc⟩
+      | succ i =>
+        simp only [List.length_cons, Vector.length_toList] at hj
+        have h := helem i (by omega)
+        simp only [List.getElem_cons_succ, Vector.getElem_toList, List.getElem_ofFn]
+        exact h
+    have hchain : chainHolds (mdsOf p.mds) p.roundConstants.toList 0
+        ((av, bv, cv) ::
+          (List.ofFn fun i : Fin 55 => roundsUpTo p (i.1 + 1) (av, bv, cv))) := by
+      refine chainHolds_of_succ 0 _ ?_
+      intro j hj1 hj0
+      have hgetD : ∀ (m : ℕ) (hm : m < 56),
+          ((av, bv, cv) ::
+            (List.ofFn fun i : Fin 55 => roundsUpTo p (i.1 + 1) (av, bv, cv)))[m]'(
+              by simp; omega)
+            = roundsUpTo p m (av, bv, cv) := by
+        intro m hm
+        cases m with
+        | zero => rfl
+        | succ i => simp only [List.getElem_cons_succ, List.getElem_ofFn]
+      simp only [List.length_cons, List.length_ofFn] at hj1
+      rw [hgetD (j + 1) (by omega), hgetD j (by omega)]
+      rw [show (5 * 0 + j) = j by omega]
+      rw [show roundsUpTo p (j + 1) (av, bv, cv)
+          = Poseidon.fullRound p.mds (p.roundConstants.getD j (0, 0, 0))
+              (roundsUpTo p j (av, bv, cv)) from rfl,
+        ← Kimchi.Gate.Poseidon.round_eq_fullRound]
+      have hgd : p.roundConstants.toList.getD j (0, 0, 0)
+          = p.roundConstants.getD j (0, 0, 0) := by
+        simp [List.getD_eq_getElem?_getD, Array.getD_eq_getD_getElem?]
+      rw [hgd]
+      rfl
+    simp only [KimchiConstraint.check, hstates]
+    exact (chainOk_iff 0 _).mpr hchain
+  · simp only [wp, PredTrans.apply, prove]
+    intro hf
+    refine hk _ ⟨st₂.nv, st₂.env, hf⟩ (fun a b c ha' hb' hc' => ?_) (hle₁.trans hle₂)
+    rw [ha] at ha'
+    rw [hb] at hb'
+    rw [hc] at hc'
+    injection ha' with ha'
+    injection hb' with hb'
+    injection hc' with hc'
+    subst ha' hb' hc'
+    have h54 := helem 54 (by omega)
+    have hbc : Poseidon.blockCipher p (av, bv, cv)
+        = roundsUpTo p 55 (av, bv, cv) := by
+      rw [roundsUpTo_eq_rounds,
+        show (55 : ℕ) = p.roundConstants.size by rw [hsize]]
+      exact Kimchi.Gate.Poseidon.blockCipher_eq_rounds p (av, bv, cv)
+    rw [hbc]
+    exact ⟨CVar.eval_le hle₂ h54.1, CVar.eval_le hle₂ h54.2.1,
+      CVar.eval_le hle₂ h54.2.2⟩
+
+end Poseidon
+
 end Snarky.Kimchi

--- a/formal/snarky/Snarky/Kimchi/Circuit/Poseidon.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/Poseidon.lean
@@ -173,30 +173,6 @@ readable input state — no domain conditions — and the output reads back as
 so each window's five equations hold by the recursion itself, read through
 `round_eq_fullRound`. -/
 
-/-- Reading a triple bundle's fields is reading its three components. -/
-private theorem mapM_eval_triple [Add F] [Mul F] {env : Assignments F}
-    {t : FVar F × FVar F × FVar F} {v : F × F × F}
-    (h : (CircuitType.varToFields (F := F) (val := F × F × F) t).toList.mapM
-        (CVar.eval · env)
-      = .ok (CircuitType.valueToFields (F := F)
-          (var := FVar F × FVar F × FVar F) v).toList) :
-    t.1.eval env = .ok v.1 ∧ t.2.1.eval env = .ok v.2.1 ∧ t.2.2.eval env = .ok v.2.2 := by
-  have h' : [t.1, t.2.1, t.2.2].mapM (CVar.eval · env) = .ok [v.1, v.2.1, v.2.2] := by
-    simpa [Vector.toList_append] using h
-  cases h1 : t.1.eval env with
-  | error e => simp [List.mapM_cons, h1, Bind.bind, Except.bind] at h'
-  | ok a =>
-    cases h2 : t.2.1.eval env with
-    | error e => simp [List.mapM_cons, h1, h2, Bind.bind, Except.bind] at h'
-    | ok b =>
-      cases h3 : t.2.2.eval env with
-      | error e => simp [List.mapM_cons, h1, h2, h3, Bind.bind, Except.bind] at h'
-      | ok c =>
-        simp only [List.mapM_cons, List.mapM_nil, h1, h2, h3, Bind.bind, Except.bind,
-          Pure.pure, Except.pure, Except.ok.injEq, List.cons.injEq, and_true] at h'
-        obtain ⟨ha, hb, hc⟩ := h'
-        refine ⟨?_, ?_, ?_⟩ <;> simp [ha, hb, hc]
-
 namespace Poseidon
 
 /-- The prefix map is the gate tower's iterate at the parameter family. -/
@@ -326,9 +302,8 @@ theorem poseidon_complete_spec [Field F] [DecidableEq F] (p : Poseidon.Params F)
       outs[i].2.1.eval st₁.env = .ok (roundsUpTo p (i + 1) (av, bv, cv)).2.1 ∧
       outs[i].2.2.eval st₁.env = .ok (roundsUpTo p (i + 1) (av, bv, cv)).2.2 := by
     intro i hi
-    have h := witnessed_vector_eval hread hi
-    simp only [Vector.getElem_ofFn] at h
-    exact mapM_eval_triple h
+    have h := hread i hi
+    simpa only [Vector.getElem_ofFn] using h
   mvcgen
   refine addConstraint_complete_spec (c := KimchiConstraint F)
     (KimchiSystem.poseidon ⟨p.mds, p.roundConstants.toList, s :: outs.toList⟩)

--- a/formal/snarky/Snarky/Kimchi/Circuit/Poseidon.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/Poseidon.lean
@@ -1,6 +1,7 @@
 import Snarky.Circuit.DSL.Monad
 import Snarky.Kimchi.Semantics
 import Poseidon.Basic
+import Kimchi.Gate.Semantics.Poseidon
 
 /-!
 # The Poseidon gadget
@@ -59,5 +60,109 @@ def poseidon [Field F] [KimchiSystem F c] (p : Poseidon.Params F)
     { mds := p.mds, rc := p.roundConstants.toList,
       state := initialState :: roundOutputs.toList })
   pure roundOutputs[54]
+
+/-! ## Soundness
+
+`Poseidon.poseidon_spec`: any satisfying valuation reads the returned state as
+`Poseidon.blockCipher` of the input state — the fixture-validated production
+permutation. The walk is three nodes (the bulk witness promises nothing, the
+constraint carries the whole chain), and the finish assembles the payload's
+`chainHolds` windows into the gate tower's `Chain` and applies
+`chain_blockCipher`. -/
+
+namespace Poseidon
+
+open Std.Do
+
+/-- Window `i` of a satisfied chain, read off the list by index: `chainHolds` from
+position `k0` puts the gate's `Holds` on every five-apart window, at the constant
+table's row `k0 + i`. -/
+private theorem chainHolds_window [CommRing F] {M : Kimchi.Gate.Poseidon.Mds F}
+    {rc : List (F × F × F)} :
+    ∀ (i k0 : ℕ) (l : List (F × F × F)), chainHolds M rc k0 l →
+      5 * i + 5 < l.length →
+      Kimchi.Gate.Poseidon.Holds M (rcRow rc (k0 + i))
+        ⟨l.getD (5 * i) (0, 0, 0), l.getD (5 * i + 1) (0, 0, 0),
+         l.getD (5 * i + 2) (0, 0, 0), l.getD (5 * i + 3) (0, 0, 0),
+         l.getD (5 * i + 4) (0, 0, 0), l.getD (5 * i + 5) (0, 0, 0)⟩
+  | 0, k0, s0 :: s1 :: s2 :: s3 :: s4 :: s5 :: rest, h, _ => by
+    simp only [chainHolds] at h
+    simpa using h.1
+  | i + 1, k0, s0 :: s1 :: s2 :: s3 :: s4 :: s5 :: rest, h, hlen => by
+    simp only [chainHolds] at h
+    have ih := chainHolds_window i (k0 + 1) (s5 :: rest) h.2
+      (by simp at hlen ⊢; omega)
+    rw [show k0 + 1 + i = k0 + (i + 1) by omega] at ih
+    simpa [show ∀ j, 5 * (i + 1) + j = (5 * i + j) + 5 from fun j => by omega,
+      List.getD] using ih
+  | _, _, [], h, hlen => by simp at hlen
+  | _, _, [_], h, hlen => by
+    simp only [List.length_cons, List.length_nil] at hlen
+    omega
+  | _, _, [_, _], h, hlen => by
+    simp only [List.length_cons, List.length_nil] at hlen
+    omega
+  | _, _, [_, _, _], h, hlen => by
+    simp only [List.length_cons, List.length_nil] at hlen
+    omega
+  | _, _, [_, _, _, _], h, hlen => by
+    simp only [List.length_cons, List.length_nil] at hlen
+    omega
+  | _, _, [_, _, _, _, _], h, hlen => by
+    simp only [List.length_cons, List.length_nil] at hlen
+    omega
+
+/-- The gadget is sound: under any satisfying valuation, at a full-size constant
+table, the returned state's values are `Poseidon.blockCipher` of the input state's
+values. -/
+theorem poseidon_spec [Field F] [DecidableEq F] (p : Poseidon.Params F)
+    (hsize : p.roundConstants.size = 5 * 11) (s : FVar F × FVar F × FVar F)
+    (Q : PostCond (FVar F × FVar F × FVar F) (.arg (BuilderState F) .pure)) :
+    ⦃Sound (fun V (r : FVar F × FVar F × FVar F) =>
+        (r.1.val V, r.2.1.val V, r.2.2.val V)
+          = Poseidon.blockCipher p (s.1.val V, s.2.1.val V, s.2.2.val V)) Q⦄
+    (poseidon (c := KimchiConstraint F) p s)
+    ⦃Q⦄ := by
+  simp only [poseidon]
+  mvcgen
+  rename_i st hpre
+  intro outs _
+  mvcgen
+  intro u _ hpay
+  mvcgen
+  refine hpre _ _ ?_
+  have hchain : chainHolds (mdsOf p.mds) p.roundConstants.toList 0
+      (read st.V ⟨p.mds, p.roundConstants.toList, s :: outs.toList⟩) := hpay
+  let vs : List (F × F × F) :=
+    read st.V ⟨p.mds, p.roundConstants.toList, s :: outs.toList⟩
+  have hlen : vs.length = 56 := by
+    simp [vs, read]
+  let w : ℕ → Kimchi.Gate.Poseidon.Witness F := fun k =>
+    ⟨vs.getD (5 * k) (0, 0, 0), vs.getD (5 * k + 1) (0, 0, 0),
+     vs.getD (5 * k + 2) (0, 0, 0), vs.getD (5 * k + 3) (0, 0, 0),
+     vs.getD (5 * k + 4) (0, 0, 0), vs.getD (5 * k + 5) (0, 0, 0)⟩
+  have hch : Kimchi.Gate.Poseidon.Chain (Kimchi.Gate.Poseidon.mdsOfParams p)
+      (fun i => p.roundConstants.toList.getD i (0, 0, 0)) w 11 := by
+    refine ⟨fun i hi => ?_, fun i _ => rfl⟩
+    have hw := chainHolds_window i 0 vs hchain (by omega)
+    rw [Nat.zero_add] at hw
+    exact hw
+  have hrc : ∀ i < 5 * 11, (fun i => p.roundConstants.toList.getD i (0, 0, 0)) i
+      = Kimchi.Gate.Poseidon.paramsRc p i := by
+    intro i _
+    simp [Kimchi.Gate.Poseidon.paramsRc, List.getD_eq_getElem?_getD,
+      Array.getD_eq_getD_getElem?]
+  have hbc := Kimchi.Gate.Poseidon.chain_blockCipher p
+    (fun i => p.roundConstants.toList.getD i (0, 0, 0)) w 11 hch (by omega) hsize hrc
+  have h0 : (w 0).s0 = (s.1.val st.V, s.2.1.val st.V, s.2.2.val st.V) := rfl
+  have h55 : (w 10).s5
+      = (outs[54].1.val st.V, outs[54].2.1.val st.V, outs[54].2.2.val st.V) := by
+    show vs.getD 55 (0, 0, 0) = _
+    rw [List.getD_eq_getElem vs (0, 0, 0) (by omega)]
+    simp [vs, read, Vector.getElem_toList]
+  rw [h0, h55] at hbc
+  exact hbc
+
+end Poseidon
 
 end Snarky.Kimchi

--- a/formal/snarky/Snarky/Kimchi/Constraint.lean
+++ b/formal/snarky/Snarky/Kimchi/Constraint.lean
@@ -30,10 +30,10 @@ of it — the PS instances inline the same dispatch twice); `finalize` is the op
 record's field.
 
 Deviations from the PS original (per `formal/docs/snarky-kimchi-alignment.md`):
-- The Poseidon round constants thread as the explicit `rc` parameter (PS
-  `PoseidonField`), as in the Poseidon step. The `KimchiVerify` marker class is not
-  ported: it bundles per-curve endo/Poseidon data for PS instance resolution, and the
-  Lean side passes that data explicitly.
+- The Poseidon parameters ride in the payload (the payload-data deviation in
+  `Constraint/Poseidon.lean`), so the reduction seam takes no parameter for them.
+  The `KimchiVerify` marker class is not ported: it bundles per-curve endo/Poseidon
+  data for PS instance resolution, and the Lean side passes that data explicitly.
 - `eval` is not ported (PS keeps it as a vacuous `pure true` stub of the deleted
   Rust cross-check); `postCondition` is not ported (a test-harness check that wired
   classes carry consistent values; no analogue is stated here). The PS prover's
@@ -139,13 +139,13 @@ private def reducePad [Add F] [Mul F] [Zero F] [One F] [Neg F] [DecidableEq F]
 a constraint through its gate's reducer and wrap the rows. `Basic` constraints emit
 into the batching queue and wrap as `noOp`. -/
 def KimchiConstraint.reduce [Add F] [Mul F] [Sub F] [Zero F] [One F] [Neg F]
-    [DecidableEq F] [Monad m] [PlonkReductionM F m] (rc : ℕ → F × F × F) :
+    [DecidableEq F] [Monad m] [PlonkReductionM F m] :
     KimchiConstraint F → m (KimchiGate F)
   | .basic c => do
     Snarky.Kimchi.reduce c
     pure .noOp
   | .addComplete c => .addComplete <$> c.reduce
-  | .poseidon c => .poseidon <$> c.reduce rc
+  | .poseidon c => .poseidon <$> c.reduce
   | .varBaseMul c => .varBaseMul <$> VarBaseMul.reduce c
   | .endoScalar c => .endoScalar <$> EndoScalar.reduce c
   | .endoMul c => .endoMul <$> c.reduce
@@ -160,13 +160,13 @@ gate), in the prover for `proveConstraint` (extending the table, checking nothin
 the PS production semantics; see the module docstring) — and `finalize` flushes the
 odd queued constraint into one more packed row. -/
 def kimchiOps [Add F] [Mul F] [Sub F] [Zero F] [One F] [Neg F] [Div F]
-    [DecidableEq F] (rc : ℕ → F × F × F) :
+    [DecidableEq F] :
     BackendOps F (KimchiGate F) (KimchiConstraint F) (AuxState F) where
   appendConstraint con n aux :=
-    let red := reduceAsBuilder n aux (KimchiConstraint.reduce rc con)
+    let red := reduceAsBuilder n aux (KimchiConstraint.reduce con)
     (red.2.1.map .plonk ++ [red.1], red.2.2.1, red.2.2.2)
   proveConstraint con nv env :=
-    match reduceAsProver ⟨nv, env⟩ (KimchiConstraint.reduce rc con) with
+    match reduceAsProver ⟨nv, env⟩ (KimchiConstraint.reduce con) with
     | .error e => .error e
     | .ok (_, s') => .ok (s'.nextVariable, s'.assignments)
   finalize aux :=

--- a/formal/snarky/Snarky/Kimchi/Constraint/Poseidon.lean
+++ b/formal/snarky/Snarky/Kimchi/Constraint/Poseidon.lean
@@ -13,11 +13,15 @@ a trailing `zero` row carrying the output state. The reduction ORDER is the byte
 contract: the states in index order, each triple left to right.
 
 Name map: `PoseidonConstraint` and `reduce` keep their names; `addRoundState`
-and the final row stay named helpers. PS's `PoseidonField` class supplies
-`getRoundConstants`; that renders as the explicit parameter `rc : ℕ → F × F × F`,
-a caller-supplied constant table.
+and the final row stay named helpers.
 
 Deviations from the PS original (per `formal/docs/snarky-kimchi-alignment.md`):
+- PS reads the round constants off the ambient `PoseidonField` class at reduction
+  time; a deep embedding has no ambient dictionary, so the payload carries the
+  permutation's parameter set — the MDS matrix rows and the constant table — as
+  data, and `reduce` reads the coefficient rows off the payload. The constants are
+  the coefficient content of the emitted rows; the matrix is the rest of the same
+  parameter record and travels with them.
 - `Vector 56 (Vector 3 _)` renders as a TRIPLE LIST (the width is an emitter
   invariant, not a type index): at 168 operands the per-operand law template of
   steps 4–7 cannot fit the heartbeat budget, and the list shape is what the
@@ -36,8 +40,16 @@ namespace Snarky.Kimchi
 open Snarky
 
 /-- The Poseidon block constraint (PS `PoseidonConstraint`): the 56 chained
-three-element sponge states, input first, permutation output last. -/
+three-element sponge states, input first, permutation output last, together with
+the permutation's parameter set (the payload-data deviation in the module
+docstring). -/
 structure PoseidonConstraint (F : Type u) where
+  /-- The rows of the round function's 3×3 MDS matrix, top to bottom. -/
+  mds : (F × F × F) × (F × F × F) × (F × F × F)
+  /-- The round constants in round order, one width-3 triple per round
+  (55 deployed); `reduce` writes rounds `5k … 5k+4` into row `k`'s
+  coefficient cells. -/
+  rc : List (F × F × F)
   /-- The states in round order, each a width-3 triple. -/
   state : List (FVar F × FVar F × FVar F)
   deriving Repr, DecidableEq
@@ -101,11 +113,12 @@ private def rowsFromStates (rc : ℕ → F × F × F) :
   | _, _ => []
 
 /-- Reduce a Poseidon block (PS `reduce`): pin every state, then lay out the eleven
-rows and the trailing `zero` row. -/
+rows and the trailing `zero` row, with the payload's constant table as the
+coefficient source. -/
 def PoseidonConstraint.reduce [Add F] [Mul F] [Zero F] [One F] [Neg F] [DecidableEq F]
-    [Monad m] [PlonkReductionM F m] (rc : ℕ → F × F × F) (c : PoseidonConstraint F) :
+    [Monad m] [PlonkReductionM F m] (c : PoseidonConstraint F) :
     m (List (KimchiRow F)) := do
   let vs ← reduceStates c.state
-  pure (rowsFromStates rc 0 vs)
+  pure (rowsFromStates (fun i => c.rc.getD i (0, 0, 0)) 0 vs)
 
 end Snarky.Kimchi

--- a/formal/snarky/Snarky/Kimchi/Semantics.lean
+++ b/formal/snarky/Snarky/Kimchi/Semantics.lean
@@ -127,8 +127,10 @@ method per landed gadget law. -/
 class KimchiSystem (F c : Type) where
   /-- Embed a complete-addition payload. -/
   addComplete : AddComplete F → c
+  /-- Embed a Poseidon block payload. -/
+  poseidon : PoseidonConstraint F → c
 
-instance : KimchiSystem F (KimchiConstraint F) := ⟨.addComplete⟩
+instance : KimchiSystem F (KimchiConstraint F) := ⟨.addComplete, .poseidon⟩
 
 instance [inst : KimchiSystem F c] : KimchiSystem F (Prover c) := inst
 

--- a/formal/snarky/Snarky/Kimchi/Semantics.lean
+++ b/formal/snarky/Snarky/Kimchi/Semantics.lean
@@ -1,6 +1,7 @@
 import Snarky.Kimchi.Constraint
 import Snarky.Backend.WP
 import Kimchi.Gate.AddComplete
+import Kimchi.Gate.Poseidon
 
 /-!
 # The kimchi constraint semantics
@@ -10,9 +11,11 @@ with no rows, reduction, or wiring in sight. The soundness side reads a constrai
 a total valuation (`Holds`); the prover side checks it on the prover's partial table
 (`check`). In both, `.basic` is the reference `Basic` reading — so the
 `LawfulBasicSystem` and `LawfulChecker` instances below transfer every backend-generic
-base gadget law, sound and complete, to this backend — and `.addComplete` is the
-verified gate's own predicate/`ok` at the payload's operand values (`read`/`eval`, one
-field per gate column; a value missing from the table rejects). `.pad` reads
+base gadget law, sound and complete, to this backend — and the landed gate payloads
+read as the verified gates' own predicates/`ok` at the payload's operand values: one
+witness record for `.addComplete` (`read`/`eval`, one field per gate column), a chain
+of five-round windows over the state list for `.poseidon` (`chainHolds`/`chainOk` at
+the payload's parameter data; a value missing from the table rejects). `.pad` reads
 vacuously (a padding row asserts nothing), as do the gate payloads with no landed
 gadget: the reading is deliberately per-constructor, and a vacuous case marks a
 constructor outside the landed gadget surface.
@@ -40,13 +43,44 @@ def AddComplete.read (V : Valuation F) (c : AddComplete F) :
   infZ := c.infZ.val V
   x21Inv := c.x21Inv.val V
 
-/-- The constraint-level semantics: `.basic` is the reference reading, `.addComplete`
-the verified gate's predicate at the operand values, and the rest vacuous (module
-docstring). -/
+/-- The payload's MDS rows as the gate's matrix record. -/
+def Poseidon.mdsOf (m : (F × F × F) × (F × F × F) × (F × F × F)) :
+    Kimchi.Gate.Poseidon.Mds F :=
+  { m00 := m.1.1, m01 := m.1.2.1, m02 := m.1.2.2,
+    m10 := m.2.1.1, m11 := m.2.1.2.1, m12 := m.2.1.2.2,
+    m20 := m.2.2.1, m21 := m.2.2.2.1, m22 := m.2.2.2.2 }
+
+/-- Window `k`'s five constant triples off the payload's table (rounds `5k … 5k+4`,
+the offsets the reducer writes into row `k`'s coefficient cells). -/
+def Poseidon.rcRow (rc : List (F × F × F)) (k : ℕ) : Fin 5 → F × F × F :=
+  fun j => rc.getD (5 * k + j.1) (0, 0, 0)
+
+/-- The payload's state values under a valuation, in round order. -/
+def Poseidon.read (V : Valuation F) (c : PoseidonConstraint F) : List (F × F × F) :=
+  c.state.map fun t => (t.1.val V, t.2.1.val V, t.2.2.val V)
+
+/-- The chain reading of a state list: one gate window per five states from position
+`5k`, each window's sixth state opening the next — the wire layout's next-row read,
+value-level, so the chain's links are shared list elements. Off the deployed
+`11·5 + 1` shape, partial tails assert nothing, matching the reducer's row
+fallbacks. -/
+def Poseidon.chainHolds (M : Kimchi.Gate.Poseidon.Mds F) (rc : List (F × F × F)) :
+    ℕ → List (F × F × F) → Prop
+  | k, s0 :: s1 :: s2 :: s3 :: s4 :: rest =>
+    match rest with
+    | s5 :: _ =>
+      Kimchi.Gate.Poseidon.Holds M (rcRow rc k) ⟨s0, s1, s2, s3, s4, s5⟩ ∧
+        chainHolds M rc (k + 1) rest
+    | [] => True
+  | _, _ => True
+
+/-- The constraint-level semantics: `.basic` is the reference reading, the landed gate
+payloads the verified gates' predicates at the operand values, and the rest vacuous
+(module docstring). -/
 def KimchiConstraint.Holds (V : Valuation F) : KimchiConstraint F → Prop
   | .basic con => ConstraintHolds.Holds V con
   | .addComplete c => Kimchi.Gate.AddComplete.Holds (AddComplete.read V c)
-  | .poseidon _ => True
+  | .poseidon c => Poseidon.chainHolds (Poseidon.mdsOf c.mds) c.rc 0 (Poseidon.read V c)
   | .varBaseMul _ => True
   | .endoScalar _ => True
   | .endoMul _ => True
@@ -83,8 +117,31 @@ def AddComplete.eval (env : Assignments F) (c : AddComplete F) :
   let x21Inv ← c.x21Inv.eval env
   return { x1, y1, x2, y2, x3, y3, inf, sameX, s, infZ, x21Inv }
 
-/-- The prover-side check: `.basic` is the reference check, `.addComplete` the gate's
-`ok` at the evaluated payload, and the rest vacuous (module docstring). -/
+/-- The payload's state values on the prover's partial table, failing where a value
+is missing. -/
+def Poseidon.evalStates (env : Assignments F) :
+    List (FVar F × FVar F × FVar F) → Except EvalError (List (F × F × F))
+  | [] => .ok []
+  | t :: ts => do
+    let a ← t.1.eval env
+    let b ← t.2.1.eval env
+    let c ← t.2.2.eval env
+    let rest ← evalStates env ts
+    return (a, b, c) :: rest
+
+/-- The decidable mirror of `chainHolds`: the gate's `ok` per window. -/
+def Poseidon.chainOk (M : Kimchi.Gate.Poseidon.Mds F) (rc : List (F × F × F)) :
+    ℕ → List (F × F × F) → Bool
+  | k, s0 :: s1 :: s2 :: s3 :: s4 :: rest =>
+    match rest with
+    | s5 :: _ =>
+      Kimchi.Gate.Poseidon.ok M (rcRow rc k) ⟨s0, s1, s2, s3, s4, s5⟩ &&
+        chainOk M rc (k + 1) rest
+    | [] => true
+  | _, _ => true
+
+/-- The prover-side check: `.basic` is the reference check, the landed gate payloads
+the gates' `ok` at the evaluated values, and the rest vacuous (module docstring). -/
 def KimchiConstraint.check (con : KimchiConstraint F) (env : Assignments F) : Bool :=
   match con with
   | .basic b => Basic.holds b env
@@ -92,7 +149,10 @@ def KimchiConstraint.check (con : KimchiConstraint F) (env : Assignments F) : Bo
     match AddComplete.eval env c with
     | .ok w => Kimchi.Gate.AddComplete.ok w
     | .error _ => false
-  | .poseidon _ => true
+  | .poseidon c =>
+    match Poseidon.evalStates env c.state with
+    | .ok vs => Poseidon.chainOk (Poseidon.mdsOf c.mds) c.rc 0 vs
+    | .error _ => false
   | .varBaseMul _ => true
   | .endoScalar _ => true
   | .endoMul _ => true

--- a/formal/snarky/Snarky/Vec.lean
+++ b/formal/snarky/Snarky/Vec.lean
@@ -18,6 +18,14 @@ opaque to the kernel; `List.map` is structural, so this version reduces under `d
 def mapVec (f : α → β) (v : Vector α n) : Vector β n :=
   ⟨⟨v.toList.map f⟩, by simp⟩
 
+/-- A flattening reads as the flattening of the element lists (the `toList` bridge core
+provides for `map` but not `flatten`). -/
+theorem toList_flatten {α : Type u} {m n : Nat} (xss : Vector (Vector α m) n) :
+    xss.flatten.toList = (xss.toList.map Vector.toList).flatten := by
+  rcases xss with ⟨⟨l⟩, h⟩
+  simp [Vector.flatten_mk, List.map_map]
+  rfl
+
 /-- Collect `n` indexed effectful computations into a sized vector, in index order —
 PS `Vector.generateA`, monad-generic. Structural on `n`, so it kernel-reduces at any
 concrete monad. -/

--- a/formal/snarky/roots.txt
+++ b/formal/snarky/roots.txt
@@ -76,6 +76,11 @@ Snarky.witness_complete_spec
 Snarky.witnessed_fvar_eval
 Snarky.witnessed_boolVar_eval
 Snarky.witnessed_uncheckedBool_eval
+Snarky.witnessed_vector_eval
+Snarky.instLawfulCircuitTypeProd
+Snarky.instLawfulCircuitTypeVector
+Snarky.instLawfulCheckedTypeProd
+Snarky.instLawfulCheckedTypeVector
 Snarky.generateVec_spec
 Snarky.generateVec_complete_spec
 Snarky.CVar.evalOk

--- a/formal/snarky/roots.txt
+++ b/formal/snarky/roots.txt
@@ -78,6 +78,11 @@ Snarky.instWitnessReadsBool
 Snarky.instWitnessReadsUnChecked
 Snarky.instWitnessReadsProd
 Snarky.instWitnessReadsVector
+Snarky.CircuitType.ofEquiv
+Snarky.LawfulCircuitType.ofEquiv
+Snarky.CheckedType.ofEquiv
+Snarky.LawfulCheckedType.ofEquiv
+Snarky.WitnessReads.ofEquiv
 Snarky.instLawfulCircuitTypeProd
 Snarky.instLawfulCircuitTypeVector
 Snarky.instLawfulCheckedTypeProd

--- a/formal/snarky/roots.txt
+++ b/formal/snarky/roots.txt
@@ -368,6 +368,7 @@ Snarky.Kimchi.addFast
 Snarky.Kimchi.AddFast.addFast_spec
 Snarky.Kimchi.AddFast.addFast_complete_spec
 Snarky.Kimchi.addComplete
+Snarky.Kimchi.poseidon
 Snarky.Kimchi.instCircuitTypeAffinePointFVar
 Snarky.Kimchi.instCheckedTypeAffinePointFVar
 

--- a/formal/snarky/roots.txt
+++ b/formal/snarky/roots.txt
@@ -369,6 +369,7 @@ Snarky.Kimchi.AddFast.addFast_spec
 Snarky.Kimchi.AddFast.addFast_complete_spec
 Snarky.Kimchi.addComplete
 Snarky.Kimchi.poseidon
+Snarky.Kimchi.Poseidon.poseidon_spec
 Snarky.Kimchi.instCircuitTypeAffinePointFVar
 Snarky.Kimchi.instCheckedTypeAffinePointFVar
 

--- a/formal/snarky/roots.txt
+++ b/formal/snarky/roots.txt
@@ -370,6 +370,7 @@ Snarky.Kimchi.AddFast.addFast_complete_spec
 Snarky.Kimchi.addComplete
 Snarky.Kimchi.poseidon
 Snarky.Kimchi.Poseidon.poseidon_spec
+Snarky.Kimchi.Poseidon.poseidon_complete_spec
 Snarky.Kimchi.instCircuitTypeAffinePointFVar
 Snarky.Kimchi.instCheckedTypeAffinePointFVar
 

--- a/formal/snarky/roots.txt
+++ b/formal/snarky/roots.txt
@@ -73,10 +73,11 @@ Snarky.addConstraint_spec
 Snarky.addConstraint_complete_spec
 Snarky.witnessBool_spec
 Snarky.witness_complete_spec
-Snarky.witnessed_fvar_eval
-Snarky.witnessed_boolVar_eval
-Snarky.witnessed_uncheckedBool_eval
-Snarky.witnessed_vector_eval
+Snarky.instWitnessReadsF
+Snarky.instWitnessReadsBool
+Snarky.instWitnessReadsUnChecked
+Snarky.instWitnessReadsProd
+Snarky.instWitnessReadsVector
 Snarky.instLawfulCircuitTypeProd
 Snarky.instLawfulCircuitTypeVector
 Snarky.instLawfulCheckedTypeProd

--- a/formal/snarky/scripts/check_axioms.lean
+++ b/formal/snarky/scripts/check_axioms.lean
@@ -11,6 +11,7 @@ Run from `formal/snarky/`:  lake env lean scripts/check_axioms.lean
 -/
 import Snarky
 import Snarky.Kimchi.Circuit.AddComplete
+import Snarky.Kimchi.Circuit.Poseidon
 import Lean.Elab.Command
 
 open Lean Lean.Elab.Command
@@ -81,6 +82,7 @@ def roots : List Name :=
     `Snarky.sealVar_spec,
     `Snarky.sealVar_complete_spec,
     `Snarky.Kimchi.AddFast.addFast_spec,
+    `Snarky.Kimchi.Poseidon.poseidon_spec,
     `Snarky.Kimchi.AddFast.addFast_complete_spec,
     `Snarky.post_of_prove,
 

--- a/formal/snarky/scripts/check_axioms.lean
+++ b/formal/snarky/scripts/check_axioms.lean
@@ -126,7 +126,12 @@ def roots : List Name :=
     `Snarky.instWitnessReadsBool,
     `Snarky.instWitnessReadsUnChecked,
     `Snarky.instWitnessReadsProd,
-    `Snarky.instWitnessReadsVector ]
+    `Snarky.instWitnessReadsVector,
+    `Snarky.CircuitType.ofEquiv,
+    `Snarky.LawfulCircuitType.ofEquiv,
+    `Snarky.CheckedType.ofEquiv,
+    `Snarky.LawfulCheckedType.ofEquiv,
+    `Snarky.WitnessReads.ofEquiv ]
 
 /-- Pure core Lean: only the three standard logical axioms are permitted. -/
 def allowed : List Name := [`propext, `Classical.choice, `Quot.sound]

--- a/formal/snarky/scripts/check_axioms.lean
+++ b/formal/snarky/scripts/check_axioms.lean
@@ -122,7 +122,11 @@ def roots : List Name :=
     `Snarky.instLawfulCheckedTypeBool,
     `Snarky.instLawfulCheckedTypeProd,
     `Snarky.instLawfulCheckedTypeVector,
-    `Snarky.witnessed_vector_eval ]
+    `Snarky.instWitnessReadsF,
+    `Snarky.instWitnessReadsBool,
+    `Snarky.instWitnessReadsUnChecked,
+    `Snarky.instWitnessReadsProd,
+    `Snarky.instWitnessReadsVector ]
 
 /-- Pure core Lean: only the three standard logical axioms are permitted. -/
 def allowed : List Name := [`propext, `Classical.choice, `Quot.sound]

--- a/formal/snarky/scripts/check_axioms.lean
+++ b/formal/snarky/scripts/check_axioms.lean
@@ -112,9 +112,14 @@ def roots : List Name :=
     `Snarky.instLawfulCircuitTypeF,
     `Snarky.instLawfulCircuitTypeBool,
     `Snarky.instLawfulCircuitTypeUnChecked,
+    `Snarky.instLawfulCircuitTypeProd,
+    `Snarky.instLawfulCircuitTypeVector,
     `Snarky.instLawfulCheckedTypeF,
     `Snarky.instLawfulCheckedTypeUnChecked,
-    `Snarky.instLawfulCheckedTypeBool ]
+    `Snarky.instLawfulCheckedTypeBool,
+    `Snarky.instLawfulCheckedTypeProd,
+    `Snarky.instLawfulCheckedTypeVector,
+    `Snarky.witnessed_vector_eval ]
 
 /-- Pure core Lean: only the three standard logical axioms are permitted. -/
 def allowed : List Name := [`propext, `Classical.choice, `Quot.sound]

--- a/formal/snarky/scripts/check_axioms.lean
+++ b/formal/snarky/scripts/check_axioms.lean
@@ -83,6 +83,7 @@ def roots : List Name :=
     `Snarky.sealVar_complete_spec,
     `Snarky.Kimchi.AddFast.addFast_spec,
     `Snarky.Kimchi.Poseidon.poseidon_spec,
+    `Snarky.Kimchi.Poseidon.poseidon_complete_spec,
     `Snarky.Kimchi.AddFast.addFast_complete_spec,
     `Snarky.post_of_prove,
 

--- a/formal/snarky/scripts/check_cs_equality.lean
+++ b/formal/snarky/scripts/check_cs_equality.lean
@@ -48,9 +48,6 @@ def kindType : GateKind → GateType
   | .endoScalar => .endoScalar
   | .zero => .zero
 
-/-- Round constants are inert for the Poseidon-free gadget circuits. -/
-def rc0 : ℕ → Fp × Fp × Fp := fun _ => (0, 0, 0)
-
 /-- `unpack`'s bit reads go through the canonical representative. -/
 instance : ToNat Fp := ⟨ZMod.val⟩
 
@@ -197,7 +194,7 @@ witness re-solve seeds the fixture's recorded public inputs. -/
 def compareWith {a b avar bvar : Type} [A : CircuitType Fp a avar]
     [CheckedType Fp C avar] [B : CircuitType Fp b bvar]
     (main : avar → CircuitM Fp C bvar) (raw : Raw) : List (String × Bool) :=
-  let (rows, gates, pubSize) := kimchiGateData (a := a) (b := b) rc0 main
+  let (rows, gates, pubSize) := kimchiGateData (a := a) (b := b) main
   let csChecks :=
     [ ("publicInputSize", pubSize == raw.publicInputSize),
       ("gate count", gates.length == raw.typs.size),
@@ -211,7 +208,7 @@ def compareWith {a b avar bvar : Type} [A : CircuitType Fp a avar]
         (rows.map fun r => r.vars.toList.toArray).toArray == raw.vars) ]
   let input : a := A.fieldsToValue (Vector.ofFn fun i => raw.pub.getD i 0)
   let witChecks := if raw.witness.isEmpty then [] else
-    match kimchiSolve (a := a) (b := b) rc0 main input with
+    match kimchiSolve (a := a) (b := b) main input with
     | .error _ => [("solve", false)]
     | .ok (_, env) =>
       let (wit, pubs) := makeWitness env rows ((allocRange 0 pubSize).toList)

--- a/formal/snarky/scripts/check_cs_equality.lean
+++ b/formal/snarky/scripts/check_cs_equality.lean
@@ -11,10 +11,11 @@ ids pin the shared counter's numbering.
 
 The circuits transcribe `Test.Pickles.CircuitDiffs.Main`
 (packages/pickles-circuit-diffs/test/): every witness-carrying circuit built from the
-`Basic` gadget vocabulary. The export also carries witness dumps for the four kimchi
-gate circuits (poseidon, endo_scalar, endo_mul, var_base_mul); those are DELIBERATELY
-not in the corpus — each joins with its gadget slice, so the Poseidon, EndoScalar,
-EndoMul, and VarBaseMul reducers are uncovered by this oracle until then.
+`Basic` gadget vocabulary, plus the landed gate gadgets (poseidon). The export also
+carries witness dumps for the remaining gate circuits (endo_scalar, endo_mul,
+var_base_mul); those are DELIBERATELY not in the corpus — each joins with its gadget
+slice, so the EndoScalar, EndoMul, and VarBaseMul reducers are uncovered by this
+oracle until then.
 
 The dumps are the PS suite's gitignored export: generate with
 `CIRCUIT_DIFFS_WITNESS_EXPORT=1 npx spago test -p pickles-circuit-diffs`. CI runs
@@ -27,6 +28,8 @@ import KimchiFixture.PS
 import Snarky.DSL
 import Snarky.Kimchi.Backend.Compile
 import Snarky.Kimchi.Circuit.AddComplete
+import Snarky.Kimchi.Circuit.Poseidon
+import Poseidon.Basic
 
 open Lean Snarky Snarky.Kimchi Kimchi Kimchi.Index Kimchi.Fixture.PS CompElliptic.Fields.Pasta
 
@@ -160,6 +163,13 @@ def addCompleteCircuit (p : AffinePoint (FVar Fp) × AffinePoint (FVar Fp)) :
     CircuitM Fp C (AffinePoint (FVar Fp)) :=
   (·.p) <$> addFast .dontCheckFinite p.1 p.2
 
+/-- `poseidon_step_circuit` (the PS gadget `Snarky.Circuit.Kimchi.Poseidon.poseidon`
+at the step field's parameters; the PS `Vector 3` interface renders as the gadget's
+triples at the boundary). -/
+def poseidonCircuit (s : Vector (FVar Fp) 3) : CircuitM Fp C (Vector (FVar Fp) 3) := do
+  let (a, b, c) ← poseidon Poseidon.fpParams (s[0], s[1], s[2])
+  pure #v[a, b, c]
+
 /-! ## The comparison -/
 
 /-- An assembled circuit in the fixture's `Raw` shape (witness transposed to the
@@ -247,7 +257,9 @@ def targets : List (String × (Raw → List (String × Bool))) :=
     ("bool_assert_step_circuit", compareWith (a := Bool) (b := PUnit) boolAssertCircuit),
     ("add_complete_step_circuit",
       compareWith (a := AffinePoint Fp × AffinePoint Fp) (b := AffinePoint Fp)
-        addCompleteCircuit) ]
+        addCompleteCircuit),
+    ("poseidon_step_circuit",
+      compareWith (a := Vector Fp 3) (b := Vector Fp 3) poseidonCircuit) ]
 
 def main : IO Unit := do
   let dir ← resultsDir


### PR DESCRIPTION
The Poseidon gadget slice: the second kimchi gate joins the gadget layer with its full law pair, ending at `Poseidon.blockCipher` — the fixture-validated production permutation — on both the soundness and completeness sides.

## What lands

**The seam retrofit.** `PoseidonConstraint` now carries the permutation's parameter set (MDS rows + round-constant table) as payload data, and `reduce` writes its coefficient rows off the payload. The `rc` parameter disappears from the whole reduction seam (`KimchiConstraint.reduce`, `kimchiOps`, the `Compile` entry points, the corpus script's inert `rc0`), making `reduce` a pure function of the constraint again. PS reads the constants off the ambient `PoseidonField` class; a deep embedding has no ambient dictionary, so the payload carries them — the deviation is recorded in the module docstring.

**The elementwise witness leaf.** `CircuitType` gains the sized-vector instance (the port of PS `Types.purs`' `Vector` instance: encode = `flatten` of element encodings, decode = per-block reads), `CheckedType` the elementwise `Vector` instance (PS `traverse_ check`), and the law layer their `LawfulCircuitType`/`LawfulCheckedType` instances plus the previously missing `Prod` pair — so the generic `witness_complete_spec` fires on any bulk vector `exists`, with `witnessed_vector_eval` extracting per-element reads. Built on core's `flatten`/`ofFn`/`getElem` API; the bespoke remainder is one `Nat` bound, a `toList_flatten` bridge, and the Except-`ok` inversions no library states (reads splitting at append/flatten boundaries and surviving table extension).

**The gadget.** `Circuit/Kimchi/Poseidon.lean` mirrors the PS gadget's shape exactly: the 55-round traversal lives inside the witness computation, so the circuit is three binds — one bulk `exists` of the round outputs, one block constraint over the 56 chained states, the output state returned. `poseidon_step_circuit` joins the byte-equality corpus through the real gadget at `fpParams`: **22/22, byte-equal including the raw per-cell variable ids, on the first run**.

**The semantics.** `.poseidon` sheds its vacuous reading: `chainHolds`/`chainOk` window the payload's state list five states at a time against the verified gate's `Holds`/`ok` at the payload's parameter data, each window's sixth state opening the next — the wire layout's next-row read made value-level, so the chain links are shared list elements. Off-emitter shapes assert nothing, matching the reducer's row fallbacks.

**The law pair.**
- `Poseidon.poseidon_spec` — any satisfying valuation reads the returned state as `Poseidon.blockCipher` of the input state. The walk is three nodes; the finish assembles the payload's windows into the gate tower's `Chain` (the links are definitional) and applies `chain_blockCipher`. The one statement hypothesis is the table size, discharged at Fq/Fp by `fqParams_size`/`fpParams_size`.
- `Poseidon.poseidon_complete_spec` — the honest `KimchiProverC` run accepts on any readable input state, with **no domain preconditions**, and the output reads back as `blockCipher` of the inputs. Every window's fifteen constraint expressions vanish on the witness recursion itself, read through `round_eq_fullRound`.

## Gates

All green on every commit: build, style, axiom gate (102 roots, three standard axioms only), dead-code 0/2250, lint, shake, and the fresh-export byte-equality corpus (22 circuits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
