### PR TITLE
snarky-kimchi: the EndoScalar gadget and its law quartet

### DIFF
--- a/formal/kimchi/Kimchi/Gate/Semantics/EndoScalar.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/EndoScalar.lean
@@ -76,6 +76,33 @@ private theorem dPoly_eq_dFunc (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) {x : F}
   · rw [d2, dFunc, if_neg h2, if_neg e21]
   · rw [d3, dFunc, if_neg h3, if_neg e31]
 
+/-- The satisfying row built with the bare `cFunc`/`dFunc` tables in place of the
+    interpolating cubics — the row every deployed prover actually fills. On valid crumbs
+    it is `build` itself (`buildTable_eq_build`). -/
+def buildTable (a0 b0 n0 : F) (crumbs : List F) : Witness F :=
+  { a0, b0, n0
+  , n8 := crumbs.foldl (fun acc x => 4 * acc + x) n0
+  , a8 := crumbs.foldl (fun acc x => 2 * acc + cFunc x) a0
+  , b8 := crumbs.foldl (fun acc x => 2 * acc + dFunc x) b0
+  , crumbs }
+
+/-- On valid crumbs the bare-table row is the canonical build: the tables agree with the
+    cubics crumb by crumb. -/
+theorem buildTable_eq_build (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) (a0 b0 n0 : F)
+    (crumbs : List F) (hvalid : ∀ x ∈ crumbs, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) :
+    buildTable a0 b0 n0 crumbs = build a0 b0 n0 crumbs := by
+  unfold buildTable build
+  rw [foldl_table crumbs a0 (fun x hx => (cPoly_eq_cFunc h2 h3 (hvalid x hx)).symm),
+    foldl_table crumbs b0 (fun x hx => (dPoly_eq_dFunc h2 h3 (hvalid x hx)).symm)]
+
+/-- **Completeness at the deployed tables**: the bare-table row satisfies the gate — the
+    row the deployed provers fill. -/
+theorem complete_table (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) (a0 b0 n0 : F)
+    (crumbs : List F) (hvalid : ∀ x ∈ crumbs, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) :
+    Holds (buildTable a0 b0 n0 crumbs) := by
+  rw [buildTable_eq_build h2 h3 a0 b0 n0 crumbs hvalid]
+  exact complete a0 b0 n0 crumbs hvalid
+
 /-- **Soundness.** A satisfying row genuinely runs Halo's Algorithm 2: the crumbs are valid 2-bit
     values, and the `a`/`b`/`n` accumulators are the Algorithm-2 folds — with the `a`/`b` folds
     using the *literal* `c_func`/`d_func` lookup tables (the cubics in `Holds` interpolate them, so

--- a/formal/kimchi/Kimchi/Gate/Semantics/EndoScalar.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/EndoScalar.lean
@@ -41,11 +41,13 @@ private theorem foldl_table {φ ψ : F → F} :
 
 variable [DecidableEq F]
 
-/-- `c_func` as the bare `(0,0,−1,1)` table. -/
-private def cFunc (x : F) : F := if x = 2 then -1 else if x = 3 then 1 else 0
+/-- `c_func` as the bare `(0,0,−1,1)` table — public, as the `a`-fold every deployed
+prover runs (OCaml `Pickles.Scalar_challenge` and its PS port). -/
+def cFunc (x : F) : F := if x = 2 then -1 else if x = 3 then 1 else 0
 
-/-- `d_func` as the bare `(−1,1,0,0)` table. -/
-private def dFunc (x : F) : F := if x = 0 then -1 else if x = 1 then 1 else 0
+/-- `d_func` as the bare `(−1,1,0,0)` table — public, as the `b`-fold every deployed
+prover runs. -/
+def dFunc (x : F) : F := if x = 0 then -1 else if x = 1 then 1 else 0
 
 /-- On a valid crumb the interpolating cubic `cPoly` equals the bare table `cFunc`. -/
 private theorem cPoly_eq_cFunc (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) {x : F}
@@ -114,6 +116,8 @@ arithmetic.
 
 * `decomposeA`, `decomposeB`, `nReconstruct`, `toField` — the Algorithm-2 accumulators and the
   effective scalar, as field-valued folds over the crumb stream.
+* `decomposeA_eq_table`, `decomposeB_eq_table` — on valid crumbs the interpolating folds are the
+  bare `cFunc`/`dFunc` table folds.
 * `decomposeA_append`, `decomposeB_append`, `nReconstruct_append` — each fold resumes across a
   row boundary from the partial value of the earlier rows.
 * `nReconstruct_append_pos` — the same boundary read *positionally* instead: the earlier rows'
@@ -175,13 +179,27 @@ def decomposeA (crumbs : List F) : F := crumbs.foldl (fun a x => 2 * a + cPoly x
 def decomposeB (crumbs : List F) : F := crumbs.foldl (fun b x => 2 * b + dPoly x) 2
 
 /-- The raw challenge reconstructed from its base-4 crumbs (`n := 4n + x`), the
-    gate's `n` register. -/
-private def nReconstruct (crumbs : List F) : F := crumbs.foldl (fun n x => 4 * n + x) 0
+    gate's `n` register — public, as the reconstruction the wrapper pins to the
+    input challenge. -/
+def nReconstruct (crumbs : List F) : F := crumbs.foldl (fun n x => 4 * n + x) 0
 
 /-- The effective scalar the gate outputs: `a·λ + b` (`λ` the endomorphism
     eigenvalue). This is the pure `to_field` of the challenge. -/
 def toField (crumbs : List F) (lam : F) : F :=
   decomposeA crumbs * lam + decomposeB crumbs
+
+/-- On valid crumbs the `a`-accumulator is the bare-table fold: `cPoly` agrees with
+    `cFunc` there, so the interpolating fold and the table fold coincide. -/
+theorem decomposeA_eq_table [DecidableEq F] (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
+    {crumbs : List F} (hv : ∀ x ∈ crumbs, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) :
+    decomposeA crumbs = crumbs.foldl (fun a x => 2 * a + cFunc x) 2 :=
+  foldl_table crumbs 2 fun x hx => cPoly_eq_cFunc h2 h3 (hv x hx)
+
+/-- The `b`-accumulator's bare-table fold, likewise. -/
+theorem decomposeB_eq_table [DecidableEq F] (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
+    {crumbs : List F} (hv : ∀ x ∈ crumbs, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) :
+    decomposeB crumbs = crumbs.foldl (fun b x => 2 * b + dFunc x) 2 :=
+  foldl_table crumbs 2 fun x hx => dPoly_eq_dFunc h2 h3 (hv x hx)
 
 /-! ## Multi-row composition: threading rows is folding the concatenated crumbs.
 

--- a/formal/kimchi/Kimchi/Gate/Semantics/EndoScalar.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/EndoScalar.lean
@@ -88,7 +88,7 @@ def buildTable (a0 b0 n0 : F) (crumbs : List F) : Witness F :=
 
 /-- On valid crumbs the bare-table row is the canonical build: the tables agree with the
     cubics crumb by crumb. -/
-theorem buildTable_eq_build (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) (a0 b0 n0 : F)
+private theorem buildTable_eq_build (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) (a0 b0 n0 : F)
     (crumbs : List F) (hvalid : ∀ x ∈ crumbs, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) :
     buildTable a0 b0 n0 crumbs = build a0 b0 n0 crumbs := by
   unfold buildTable build

--- a/formal/kimchi/Kimchi/Gate/Semantics/EndoScalar.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/EndoScalar.lean
@@ -49,32 +49,48 @@ def cFunc (x : F) : F := if x = 2 then -1 else if x = 3 then 1 else 0
 prover runs. -/
 def dFunc (x : F) : F := if x = 0 then -1 else if x = 1 then 1 else 0
 
-/-- On a valid crumb the interpolating cubic `cPoly` equals the bare table `cFunc`. -/
-private theorem cPoly_eq_cFunc (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) {x : F}
-    (hx : x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) : cPoly x = cFunc x := by
-  obtain ⟨c0, c1, c2, c3⟩ := cPoly_table h2 h3
+/-- The `a`-table's value at each crumb; the characteristic hypotheses separate the
+four crumb values. -/
+theorem cFunc_table (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) :
+    cFunc (0 : F) = 0 ∧ cFunc (1 : F) = 0 ∧ cFunc (2 : F) = -1 ∧ cFunc (3 : F) = 1 := by
   have e02 : (0 : F) ≠ 2 := fun h => h2 h.symm
   have e03 : (0 : F) ≠ 3 := fun h => h3 h.symm
   have e12 : (1 : F) ≠ 2 := fun h => (one_ne_zero : (1 : F) ≠ 0) (by linear_combination -h)
   have e13 : (1 : F) ≠ 3 := fun h => h2 (by linear_combination -h)
   have e32 : (3 : F) ≠ 2 := fun h => (one_ne_zero : (1 : F) ≠ 0) (by linear_combination h)
+  exact ⟨by rw [cFunc, if_neg e02, if_neg e03], by rw [cFunc, if_neg e12, if_neg e13],
+    by rw [cFunc, if_pos rfl], by rw [cFunc, if_neg e32, if_pos rfl]⟩
+
+/-- The `b`-table's value at each crumb. -/
+theorem dFunc_table (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) :
+    dFunc (0 : F) = -1 ∧ dFunc (1 : F) = 1 ∧ dFunc (2 : F) = 0 ∧ dFunc (3 : F) = 0 := by
+  have e21 : (2 : F) ≠ 1 := fun h => (one_ne_zero : (1 : F) ≠ 0) (by linear_combination h)
+  have e31 : (3 : F) ≠ 1 := fun h => h2 (by linear_combination h)
+  exact ⟨by rw [dFunc, if_pos rfl],
+    by rw [dFunc, if_neg ((one_ne_zero : (1 : F) ≠ 0)), if_pos rfl],
+    by rw [dFunc, if_neg h2, if_neg e21], by rw [dFunc, if_neg h3, if_neg e31]⟩
+
+/-- On a valid crumb the interpolating cubic `cPoly` equals the bare table `cFunc`. -/
+private theorem cPoly_eq_cFunc (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) {x : F}
+    (hx : x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) : cPoly x = cFunc x := by
+  obtain ⟨c0, c1, c2, c3⟩ := cPoly_table h2 h3
+  obtain ⟨f0, f1, f2, f3⟩ := cFunc_table h2 h3
   rcases hx with rfl | rfl | rfl | rfl
-  · rw [c0, cFunc, if_neg e02, if_neg e03]
-  · rw [c1, cFunc, if_neg e12, if_neg e13]
-  · rw [c2, cFunc, if_pos rfl]
-  · rw [c3, cFunc, if_neg e32, if_pos rfl]
+  · rw [c0, f0]
+  · rw [c1, f1]
+  · rw [c2, f2]
+  · rw [c3, f3]
 
 /-- On a valid crumb the interpolating cubic `dPoly` equals the bare table `dFunc`. -/
 private theorem dPoly_eq_dFunc (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) {x : F}
     (hx : x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) : dPoly x = dFunc x := by
   obtain ⟨d0, d1, d2, d3⟩ := dPoly_table h2 h3
-  have e21 : (2 : F) ≠ 1 := fun h => (one_ne_zero : (1 : F) ≠ 0) (by linear_combination h)
-  have e31 : (3 : F) ≠ 1 := fun h => h2 (by linear_combination h)
+  obtain ⟨g0, g1, g2, g3⟩ := dFunc_table h2 h3
   rcases hx with rfl | rfl | rfl | rfl
-  · rw [d0, dFunc, if_pos rfl]
-  · rw [d1, dFunc, if_neg ((one_ne_zero : (1 : F) ≠ 0)), if_pos rfl]
-  · rw [d2, dFunc, if_neg h2, if_neg e21]
-  · rw [d3, dFunc, if_neg h3, if_neg e31]
+  · rw [d0, g0]
+  · rw [d1, g1]
+  · rw [d2, g2]
+  · rw [d3, g3]
 
 /-- The satisfying row built with the bare `cFunc`/`dFunc` tables in place of the
     interpolating cubics — the row every deployed prover actually fills. On valid crumbs
@@ -370,13 +386,13 @@ private theorem chainCrumbs_chainBuild (rows : ℕ → List F) (m : ℕ) :
     recurse on `k / 4`. High crumbs are padded with `0`, and whatever of `k` sits at or above
     `4 ^ c` is discarded. Mathlib's `Nat.digits` will not do here: it is least-significant-first
     and unpadded, so pinning the width back to `c` costs more than this peel. -/
-private def crumbsOf : ℕ → ℕ → List F
+def crumbsOf : ℕ → ℕ → List F
   | 0, _ => []
   | c + 1, k => crumbsOf c (k / 4) ++ [((k % 4 : ℕ) : F)]
 
 /-- `crumbsOf` has exactly the width asked for, which is what lets it fill whole
     `EndoScalar` rows. -/
-private theorem crumbsOf_length (c k : ℕ) : (crumbsOf (F := F) c k).length = c := by
+theorem crumbsOf_length (c k : ℕ) : (crumbsOf (F := F) c k).length = c := by
   induction c generalizing k with
   | zero => rfl
   | succ c ih =>
@@ -386,7 +402,7 @@ private theorem crumbsOf_length (c k : ℕ) : (crumbsOf (F := F) c k).length = c
 
 /-- Every entry of `crumbsOf` is a 2-bit crumb, the tail one because `k % 4 < 4`. This is
     `complete`'s precondition, so the expansion feeds `build` directly. -/
-private theorem crumbsOf_valid (c k : ℕ) :
+theorem crumbsOf_valid (c k : ℕ) :
     ∀ x ∈ crumbsOf (F := F) c k, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3 := by
   induction c generalizing k with
   | zero => intro x hx; simp only [crumbsOf, List.not_mem_nil] at hx
@@ -402,7 +418,7 @@ private theorem crumbsOf_valid (c k : ℕ) :
 /-- The expansion inverts the register fold: reconstructing `crumbsOf c k` recovers `k` modulo the
     width budget `4 ^ c`, hence `k` itself below the budget. The Horner step is core's
     `Nat.mod_mul` at `a = 4`, `b = 4 ^ c`, carried into `F` by `nReconstruct_append`. -/
-private theorem nReconstruct_crumbsOf (c k : ℕ) :
+theorem nReconstruct_crumbsOf (c k : ℕ) :
     nReconstruct (crumbsOf (F := F) c k) = ((k % 4 ^ c : ℕ) : F) := by
   induction c generalizing k with
   | zero => simp only [crumbsOf, nReconstruct, pow_zero, Nat.mod_one, List.foldl_nil,

--- a/formal/scripts/deadcode.lean
+++ b/formal/scripts/deadcode.lean
@@ -37,6 +37,7 @@ import Snarky
 import Snarky.Kimchi.Backend.Compile
 import Snarky.Kimchi.Circuit.AddComplete
 import Snarky.Kimchi.Circuit.Poseidon
+import Snarky.Kimchi.Circuit.Utils
 import Snarky.Kimchi.Semantics
 -- The fixture-decoding libraries are not part of any package's main library, so import them
 -- explicitly: their declarations are authored code, and some are declared roots.

--- a/formal/scripts/deadcode.lean
+++ b/formal/scripts/deadcode.lean
@@ -38,6 +38,7 @@ import Snarky.Kimchi.Backend.Compile
 import Snarky.Kimchi.Circuit.AddComplete
 import Snarky.Kimchi.Circuit.Poseidon
 import Snarky.Kimchi.Circuit.Utils
+import Snarky.Kimchi.Circuit.EndoScalar
 import Snarky.Kimchi.Semantics
 -- The fixture-decoding libraries are not part of any package's main library, so import them
 -- explicitly: their declarations are authored code, and some are declared roots.

--- a/formal/snarky/Snarky/Backend/Assignments.lean
+++ b/formal/snarky/Snarky/Backend/Assignments.lean
@@ -219,4 +219,23 @@ through the bridge to the total reading. -/
 
 end CVar
 
+/-- Successful `mapM`-evaluation is stable under assignment extension — the list form
+of `CVar.eval_le`. -/
+theorem mapM_eval_le [Add F] [Mul F] {env env' : Assignments F}
+    (hle : env.Le env') :
+    ∀ {xs : List (CVar F)} {vs : List F},
+      xs.mapM (CVar.eval · env) = .ok vs → xs.mapM (CVar.eval · env') = .ok vs
+  | [], _, h => h
+  | x :: xs, vs, h => by
+    cases he : x.eval env with
+    | error e => simp [List.mapM_cons, he, Bind.bind, Except.bind] at h
+    | ok y =>
+      cases hr : xs.mapM (CVar.eval · env) with
+      | error e => simp [List.mapM_cons, he, hr, Bind.bind, Except.bind] at h
+      | ok ys =>
+        simp only [List.mapM_cons, he, hr, Bind.bind, Except.bind, Pure.pure,
+          Except.pure] at h
+        simp [List.mapM_cons, CVar.eval_le hle he, mapM_eval_le hle hr, Bind.bind,
+          Except.bind, Pure.pure, Except.pure, h]
+
 end Snarky

--- a/formal/snarky/Snarky/Backend/Compile.lean
+++ b/formal/snarky/Snarky/Backend/Compile.lean
@@ -95,14 +95,6 @@ def solve [Add F] [Mul F] [DecidableEq F] [BasicSystem F c]
 
 /-! ## The payoff theorem -/
 
-/-- Splitter for successful `Except.bind`s: recover the intermediate value. -/
-private theorem bind_ok {α β : Type u} {x : Except EvalError α}
-    {f : α → Except EvalError β} {r : β} (h : x.bind f = .ok r) :
-    ∃ m, x = .ok m ∧ f m = .ok r := by
-  cases x with
-  | error e => simp only [Except.bind] at h; cases h
-  | ok m => exact ⟨m, rfl, h⟩
-
 /-- `allocRange` is the vector form of `List.range'`. -/
 private theorem allocRange_toList (s k : Nat) :
     (allocRange s k).toList = List.range' s k := by

--- a/formal/snarky/Snarky/Backend/WP.lean
+++ b/formal/snarky/Snarky/Backend/WP.lean
@@ -724,24 +724,6 @@ shape). -/
   subst hv'
   exact WitnessReads.reads_of_grant (hvars st'.env hle')
 
-/-- Reads survive table extension, listwise. -/
-theorem mapM_eval_le {F : Type} [Add F] [Mul F] {env env' : Assignments F}
-    (hle : env.Le env') :
-    ∀ {xs : List (CVar F)} {vs : List F},
-      xs.mapM (CVar.eval · env) = .ok vs → xs.mapM (CVar.eval · env') = .ok vs
-  | [], _, h => h
-  | x :: xs, vs, h => by
-    cases he : x.eval env with
-    | error e => simp [List.mapM_cons, he, Bind.bind, Except.bind] at h
-    | ok y =>
-      cases hr : xs.mapM (CVar.eval · env) with
-      | error e => simp [List.mapM_cons, he, hr, Bind.bind, Except.bind] at h
-      | ok ys =>
-        simp only [List.mapM_cons, he, hr, Bind.bind, Except.bind, Pure.pure,
-          Except.pure] at h
-        simp [List.mapM_cons, CVar.eval_le hle he, mapM_eval_le hle hr, Bind.bind,
-          Except.bind, Pure.pure, Except.pure, h]
-
 /-- Split a successful read at the append boundary. -/
 private theorem mapM_eval_append_ok {F : Type} [Add F] [Mul F] {env : Assignments F} :
     ∀ {l₁ : List (CVar F)} {e₁ : List F} {l₂ : List (CVar F)} {e₂ : List F},

--- a/formal/snarky/Snarky/Backend/WP.lean
+++ b/formal/snarky/Snarky/Backend/WP.lean
@@ -725,7 +725,7 @@ shape). -/
   exact WitnessReads.reads_of_grant (hvars st'.env hle')
 
 /-- Reads survive table extension, listwise. -/
-private theorem mapM_eval_le {F : Type} [Add F] [Mul F] {env env' : Assignments F}
+theorem mapM_eval_le {F : Type} [Add F] [Mul F] {env env' : Assignments F}
     (hle : env.Le env') :
     ∀ {xs : List (CVar F)} {vs : List F},
       xs.mapM (CVar.eval · env) = .ok vs → xs.mapM (CVar.eval · env') = .ok vs

--- a/formal/snarky/Snarky/Circuit/CVar.lean
+++ b/formal/snarky/Snarky/Circuit/CVar.lean
@@ -54,6 +54,14 @@ inductive EvalError where
   | custom (msg : String)
   deriving Repr
 
+/-- Splitter for successful `Except` binds: recover the intermediate value. -/
+theorem bind_ok {α β : Type u} {x : Except EvalError α}
+    {f : α → Except EvalError β} {r : β} (h : (x >>= f) = .ok r) :
+    ∃ m, x = .ok m ∧ f m = .ok r := by
+  cases x with
+  | error e => simp only [Bind.bind, Except.bind] at h; cases h
+  | ok m => exact ⟨m, rfl, h⟩
+
 /-! ## Affine expressions -/
 
 /-- Affine expressions over circuit variables (PS `CVar`): variables, constants, sums and

--- a/formal/snarky/Snarky/Circuit/DSL/Monad.lean
+++ b/formal/snarky/Snarky/Circuit/DSL/Monad.lean
@@ -243,29 +243,6 @@ def readVar [Add F] [Mul F] [inst : CircuitType F val var] (v : var) : AsProver 
     else
       .error (.custom "readVar: size mismatch")
 
-/-- Successful `mapM`-evaluation is stable under assignment extension — the list form
-of `CVar.eval_le`. -/
-private theorem mapM_eval_le [Add F] [Mul F] {env env' : Assignments F} (hle : env.Le env') :
-    ∀ {l : List (CVar F)} {res : List F},
-      l.mapM (CVar.eval · env) = .ok res → l.mapM (CVar.eval · env') = .ok res := by
-  intro l
-  induction l with
-  | nil => intro res h; exact h
-  | cons x l ih =>
-    intro res h
-    rw [List.mapM_cons] at h ⊢
-    cases hx : CVar.eval x env with
-    | error e => rw [hx] at h; cases h
-    | ok v =>
-      rw [hx] at h
-      rw [CVar.eval_le hle hx]
-      cases hrest : l.mapM (CVar.eval · env) with
-      | error e => rw [hrest] at h; cases h
-      | ok vs =>
-        rw [hrest] at h
-        rw [ih hrest]
-        exact h
-
 /-- Successful `readVar`s are stable under assignment extension — the bundle form of
 `CVar.eval_le`. -/
 theorem readVar_le [Add F] [Mul F] [inst : CircuitType F val var] {v : var}

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
@@ -1,4 +1,5 @@
 import Snarky.Circuit.DSL.Field
+import Kimchi.Gate.Semantics.EndoScalar
 import Snarky.Circuit.DSL.Assert
 import Snarky.Circuit.DSL.Bits
 import Snarky.Kimchi.Semantics
@@ -108,5 +109,178 @@ def toFieldPure [Field F] [ToNat F] (rows : ℕ) (scalar endo : F) : F :=
       else (2 * st.1, 2 * st.2 + s))
     (2, 2)
   acc.1 * endo + acc.2
+
+/-! ## Soundness
+
+`toFieldChecked'_spec`: any satisfying valuation exhibits a valid crumb list whose
+gate-model decompositions (`Kimchi.Gate.EndoScalar.decomposeA`/`decomposeB`/
+`nReconstruct` — the emitter's seeds `(2, 2, 0)` are theirs) carry the three
+returned accumulators. The loop's invariant is structural only — the witnesses
+promise nothing; the content arrives at the constraint after the loop. -/
+
+/-- The loop's structural view: the collected rounds are the chain-threaded records
+over the traversed chunks — each round's inputs are the previous round's output
+variables, from `st` to `fin`. Valuation-free: the soundness invariant carries shape
+only; the values arrive with the constraint after the loop. -/
+private def Threaded : (FVar F × FVar F × FVar F) → List (Vector (FVar F) 8) →
+    List (EndoScalarRound F) → (FVar F × FVar F × FVar F) → Prop
+  | st, [], rounds, fin => rounds = [] ∧ fin = st
+  | st, xs :: rest, rounds, fin =>
+    ∃ w tail,
+      rounds = ({ n0 := st.2.2, n8 := w.2.2, a0 := st.1, a8 := w.1,
+                  b0 := st.2.1, b8 := w.2.1, xs } : EndoScalarRound F) :: tail ∧
+      Threaded w rest tail fin
+
+/-- One more chunk extends a threading at the tail. -/
+private theorem Threaded.snoc :
+    ∀ {st fin : FVar F × FVar F × FVar F} {pref : List (Vector (FVar F) 8)}
+      {rounds : List (EndoScalarRound F)},
+      Threaded st pref rounds fin →
+      ∀ (xs : Vector (FVar F) 8) (w : FVar F × FVar F × FVar F),
+      Threaded st (pref ++ [xs])
+        (rounds ++ [{ n0 := fin.2.2, n8 := w.2.2, a0 := fin.1, a8 := w.1,
+                      b0 := fin.2.1, b8 := w.2.1, xs }]) w
+  | st, fin, [], rounds, h, xs, w => by
+    obtain ⟨hr, hfin⟩ := h
+    subst hr hfin
+    exact ⟨w, [], rfl, rfl, rfl⟩
+  | st, fin, chunk :: rest, rounds, h, xs, w => by
+    obtain ⟨w', tail, hr, hrest⟩ := h
+    subst hr
+    exact ⟨w', tail ++ [_], rfl, hrest.snoc xs w⟩
+
+/-- A satisfied threading folds: every round's gate law chains through the shared
+accumulator variables, so `fin` reads as the bare-table folds of the concatenated
+crumb values from `st`'s values. -/
+private theorem threaded_sound [Field F] [DecidableEq F]
+    (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) (V : Valuation F) :
+    ∀ (pref : List (Vector (FVar F) 8)) (st fin : FVar F × FVar F × FVar F)
+      (rounds : List (EndoScalarRound F)),
+      Threaded st pref rounds fin →
+      (∀ r ∈ rounds, Kimchi.Gate.EndoScalar.Holds (EndoScalarRound.read V r)) →
+      ∃ crumbs : List F,
+        (∀ x ∈ crumbs, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) ∧
+        crumbs.length = 8 * pref.length ∧
+        fin.1.val V = crumbs.foldl
+          (fun a x => 2 * a + Kimchi.Gate.EndoScalar.cFunc x) (st.1.val V) ∧
+        fin.2.1.val V = crumbs.foldl
+          (fun b x => 2 * b + Kimchi.Gate.EndoScalar.dFunc x) (st.2.1.val V) ∧
+        fin.2.2.val V = crumbs.foldl (fun n x => 4 * n + x) (st.2.2.val V)
+  | [], st, fin, rounds, h, _ => by
+    obtain ⟨hr, hfin⟩ := h
+    subst hr hfin
+    exact ⟨[], by simp, by simp, rfl, rfl, rfl⟩
+  | chunk :: rest, st, fin, rounds, h, hHolds => by
+    obtain ⟨w, tail, hr, hrest⟩ := h
+    subst hr
+    have hs := Kimchi.Gate.EndoScalar.sound h2 h3 _ (hHolds _ (List.mem_cons_self ..))
+    obtain ⟨hvalid, hn, ha, hb⟩ := hs
+    simp only [EndoScalarRound.read] at hvalid hn ha hb
+    obtain ⟨crumbs', hvalid', hlen', ha', hb', hn'⟩ :=
+      threaded_sound h2 h3 V rest w fin tail hrest
+        (fun r hr => hHolds r (List.mem_cons_of_mem _ hr))
+    refine ⟨chunk.toList.map (·.val V) ++ crumbs', ?_, ?_, ?_, ?_, ?_⟩
+    · intro x hx
+      rcases List.mem_append.mp hx with hx | hx
+      · exact hvalid x hx
+      · exact hvalid' x hx
+    · simp only [List.length_append, List.length_map, Vector.length_toList,
+        List.length_cons, hlen']
+      omega
+    · rw [List.foldl_append, ← ha, ha']
+    · rw [List.foldl_append, ← hb, hb']
+    · rw [List.foldl_append, ← hn, hn']
+
+open Std.Do in
+/-- The gate emitter is sound: some valid crumb list of length `8·rows` carries the
+returned `(a, b, n)` as its gate-model decompositions — the emitter's seeds
+`(2, 2, 0)` are theirs. The characteristic hypotheses are the gate's own (`sound`
+interpolates the tables from the cubics). -/
+theorem toFieldChecked'_spec [Field F] [DecidableEq F] [ToNat F]
+    (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) (rows : ℕ) (scalar : FVar F)
+    (Q : PostCond (FVar F × FVar F × FVar F) (.arg (BuilderState F) .pure)) :
+    ⦃Sound (fun V (r : FVar F × FVar F × FVar F) =>
+        ∃ crumbs : List F,
+          (∀ x ∈ crumbs, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) ∧
+          crumbs.length = 8 * rows ∧
+          r.1.val V = Kimchi.Gate.EndoScalar.decomposeA crumbs ∧
+          r.2.1.val V = Kimchi.Gate.EndoScalar.decomposeB crumbs ∧
+          r.2.2.val V = Kimchi.Gate.EndoScalar.nReconstruct crumbs) Q⦄
+    (toFieldChecked' (c := KimchiConstraint F) rows scalar)
+    ⦃Q⦄ := by
+  simp only [toFieldChecked', mapAccumM]
+  mvcgen
+  rename_i s hpre
+  intro crumbVars _
+  mvcgen
+  case inv1 =>
+    exact ⇓ p s' => ⌜s'.V = s.V ∧
+      Threaded (.const 2, .const 2, .const 0) p.1.prefix p.2.snd p.2.fst⌝
+  case vc2.vc1.pre =>
+    exact ⟨rfl, rfl, rfl⟩
+  case vc1.step =>
+    rename_i pref cur suff hsplit b st' hinv
+    intro r nv'
+    mvcgen
+    obtain ⟨hV, hthr⟩ := hinv
+    exact ⟨hV, hthr.snoc cur r⟩
+  case vc3.vc1.post.success =>
+    rename_i fin st' hinv
+    obtain ⟨hV, hthr⟩ := hinv
+    intro _ nv' hpay _
+    rw [hV]
+    refine hpre fin.fst nv' ?_
+    have hHolds : ∀ r ∈ fin.snd,
+        Kimchi.Gate.EndoScalar.Holds (EndoScalarRound.read s.V r) := by
+      have h := hpay
+      rw [hV] at h
+      exact h
+    obtain ⟨crumbs, hvalid, hlen, ha, hb, hn⟩ :=
+      threaded_sound h2 h3 s.V crumbVars.toList _ fin.fst fin.snd hthr hHolds
+    refine ⟨crumbs, hvalid, by simpa using hlen, ?_, ?_, ?_⟩
+    · rw [Kimchi.Gate.EndoScalar.decomposeA_eq_table h2 h3 hvalid]
+      simpa [CVar.val] using ha
+    · rw [Kimchi.Gate.EndoScalar.decomposeB_eq_table h2 h3 hvalid]
+      simpa [CVar.val] using hb
+    · simpa [Kimchi.Gate.EndoScalar.nReconstruct, CVar.val] using hn
+
+open Std.Do in
+/-- The checked decomposition is sound: the result reads as the gate model's
+`toField` — `a·endo + b` — over some valid crumb list of length `8·rows` whose
+`nReconstruct` is the scalar. -/
+theorem toField_spec [Field F] [DecidableEq F] [ToNat F]
+    (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) (rows : ℕ) (scalar endo : FVar F)
+    (Q : PostCond (FVar F) (.arg (BuilderState F) .pure)) :
+    ⦃Sound (fun V (r : FVar F) =>
+        ∃ crumbs : List F,
+          (∀ x ∈ crumbs, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) ∧
+          crumbs.length = 8 * rows ∧
+          r.val V = Kimchi.Gate.EndoScalar.toField crumbs (endo.val V) ∧
+          scalar.val V = Kimchi.Gate.EndoScalar.nReconstruct crumbs) Q⦄
+    (toField (c := KimchiConstraint F) rows scalar endo)
+    ⦃Q⦄ := by
+  simp only [toField]
+  mvcgen
+  rename_i s hpre
+  refine toFieldChecked'_spec h2 h3 rows scalar _ _ ?_
+  intro abn nv1 ⟨crumbs, hvalid, hlen, ha, hb, hn⟩
+  mvcgen
+  intro _ nv2 heq
+  split
+  · rename_i e
+    mvcgen
+    refine hpre _ _ ?_
+    refine ⟨crumbs, hvalid, hlen, ?_, by rw [← heq, hn]⟩
+    simp only [Kimchi.Gate.EndoScalar.toField, CVar.val_add_, CVar.val_scale_,
+      ha, hb, CVar.val]
+    ring
+  · mvcgen
+    intro p nv3 hp
+    mvcgen
+    refine hpre _ _ ?_
+    refine ⟨crumbs, hvalid, hlen, ?_, by rw [← heq, hn]⟩
+    simp only [Kimchi.Gate.EndoScalar.toField]
+    rw [CVar.val_add_, hp, ha, hb]
+    ring
 
 end Snarky.Kimchi.EndoScalar

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
@@ -98,7 +98,9 @@ def toField [Field F] [DecidableEq F] [ToNat F] [BasicSystem F c] [KimchiSystem 
     pure (CVar.add_ b p)
 
 /-- The pure model (PS `toFieldPure`): the same MSB-first bit-pair fold on values,
-from the accumulator seeds `(2, 2)`. -/
+from the accumulator seeds `(2, 2)`. The definition transcribes the PS fold;
+`toFieldPure_eq_toField` reads it as the gate model's `toField` at the scalar's
+crumbs. -/
 def toFieldPure [Field F] [ToNat F] (rows : ℕ) (scalar endo : F) : F :=
   let n := ToNat.toNat scalar
   let acc := (List.range (8 * rows)).foldl

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
@@ -25,8 +25,8 @@ Deviations from the PS original (per `formal/docs/snarky-kimchi-alignment.md`):
   with `16 · rows` bits, and the bit reads go through `[ToNat F]`.
 - PS's record `exists` allocates its fields alphabetically; the per-row witness is
   the ordered triple `(a8, b8, n8)`, the same allocation spelled explicitly.
-- PS's `aF`/`bF` throw on impossible crumbs; `aDigit`/`bDigit` render the dead
-  branches as `0`.
+- PS's `aF`/`bF` are the gate's own `cFunc`/`dFunc` tables (their throwing branches
+  rendered as the tables' `0`), so the witness folds are stated with them directly.
 - `toFieldPure` is generalized from PS's pinned 128 bits to `16 · rows`.
 -/
 
@@ -36,35 +36,39 @@ open Snarky
 
 variable {F c : Type}
 
-/-- The crumb-to-`a`-digit map (PS `aF`). -/
-private def aDigit [Field F] [DecidableEq F] (x : F) : F :=
-  if x = 2 then -1 else if x = 3 then 1 else 0
+/-- Crumb `j` (MSB-first) of a `2·count`-bit natural: bits `2(count−j)−1` (high) and
+`2(count−j)−2` (low) — the PS `toBits` reversed and paired. -/
+private def crumbOfNat (count j k : ℕ) : ℕ :=
+  2 * (if k.testBit (2 * (count - j) - 1) then 1 else 0)
+    + (if k.testBit (2 * (count - j) - 2) then 1 else 0)
 
-/-- The crumb-to-`b`-digit map (PS `bF`). -/
-private def bDigit [Field F] [DecidableEq F] (x : F) : F :=
-  if x = 0 then -1 else if x = 1 then 1 else 0
+/-- The scalar's crumbs, MSB-first (PS `chunks @2` of the reversed bits) — the honest
+crumb list the completeness laws read the gate model at. -/
+def crumbsOfNat [NatCast F] (count k : ℕ) : List F :=
+  (List.range count).map fun j => (crumbOfNat count j k : F)
 
-/-- The scalar's MSB-first 2-bit crumbs, eight per row (PS `toBits` reversed and
-paired): crumb `i` is `2·bit(16·rows − 1 − 2i) + bit(16·rows − 2 − 2i)`. -/
+/-- The crumb table the bulk witness writes: row `r`'s entry `j` is crumb `8r + j`. -/
+private def crumbVals [NatCast F] (rows k : ℕ) : Vector (Vector F 8) rows :=
+  Vector.ofFn fun r => Vector.ofFn fun j =>
+    (crumbOfNat (8 * rows) (8 * r.1 + j.1) k : F)
+
+/-- The scalar's MSB-first 2-bit crumbs, eight per row. -/
 private def crumbsWit [Field F] [ToNat F] (rows : ℕ) (scalar : FVar F) :
     AsProver F (Vector (Vector F 8) rows) := do
   let v ← AsProver.readCVar scalar
-  let n := ToNat.toNat v
-  pure (Vector.ofFn fun r => Vector.ofFn fun j =>
-    let i := 8 * r.1 + j.1
-    ((2 * (if n.testBit (16 * rows - 1 - 2 * i) then 1 else 0)
-      + (if n.testBit (16 * rows - 2 - 2 * i) then 1 else 0) : F)))
+  pure (crumbVals rows (ToNat.toNat v))
 
 /-- One row's accumulator witness: fold the row's eight crumbs into the three
-accumulators, returned in the allocation order `(a8, b8, n8)`. -/
+accumulators over the gate's bare tables, returned in the allocation order
+`(a8, b8, n8)`. -/
 private def rowWit [Field F] [DecidableEq F] (xs : Vector (FVar F) 8)
     (st : FVar F × FVar F × FVar F) : AsProver F (F × F × F) := do
   let a0 ← AsProver.readCVar st.1
   let b0 ← AsProver.readCVar st.2.1
   let n0 ← AsProver.readCVar st.2.2
   let vals ← xs.toList.mapM AsProver.readCVar
-  pure (vals.foldl (fun acc x => 2 * acc + aDigit x) a0,
-        vals.foldl (fun acc x => 2 * acc + bDigit x) b0,
+  pure (vals.foldl (fun acc x => 2 * acc + Kimchi.Gate.EndoScalar.cFunc x) a0,
+        vals.foldl (fun acc x => 2 * acc + Kimchi.Gate.EndoScalar.dFunc x) b0,
         vals.foldl (fun acc x => 4 * acc + x) n0)
 
 /-- The gate emitter (PS `toFieldChecked'`; OCaml
@@ -283,4 +287,483 @@ theorem toField_spec [Field F] [DecidableEq F] [ToNat F]
     rw [CVar.val_add_, hp, ha, hb]
     ring
 
-end Snarky.Kimchi.EndoScalar
+/-! ## Completeness
+
+The honest prover run accepts, and the results read as the gate model at the
+scalar's own crumbs (`crumbsOfNat`). The emitter needs only a readable scalar; the
+checked decomposition's `n = scalar` pin adds the boundary conditions of the
+representative — faithfulness and the `4 ^ (8·rows)` range. The crumb lemmas below
+are ℕ-side positional arithmetic; the loop's invariant carries the accumulator
+reads and the collected rounds' checks across table growth. -/
+
+/-- Every crumb is a valid 2-bit value. -/
+private theorem crumbOfNat_cast_valid [Field F] (count j k : ℕ) :
+    ((crumbOfNat count j k : ℕ) : F) = 0 ∨ ((crumbOfNat count j k : ℕ) : F) = 1
+      ∨ ((crumbOfNat count j k : ℕ) : F) = 2 ∨ ((crumbOfNat count j k : ℕ) : F) = 3 := by
+  unfold crumbOfNat
+  by_cases h1 : k.testBit (2 * (count - j) - 1) <;>
+    by_cases h0 : k.testBit (2 * (count - j) - 2) <;> simp [h1, h0]
+
+/-- Every extracted crumb is a valid 2-bit value — what the gate's completeness
+consumes. -/
+private theorem crumbsOfNat_valid [Field F] (count k : ℕ) :
+    ∀ x ∈ crumbsOfNat (F := F) count k, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3 := by
+  intro x hx
+  simp only [crumbsOfNat, List.mem_map, List.mem_range] at hx
+  obtain ⟨j, -, rfl⟩ := hx
+  exact crumbOfNat_cast_valid count j k
+
+/-- A crumb is a base-4 digit read from the top: crumb `j` of a `count`-crumb
+challenge is digit `count−1−j` of its value. -/
+private theorem crumbOfNat_eq_digit (count j k : ℕ) (hj : j < count) :
+    crumbOfNat count j k = k / 4 ^ (count - 1 - j) % 4 := by
+  have hm1 : 2 * (count - j) - 1 = 1 + 2 * (count - 1 - j) := by omega
+  have hm2 : 2 * (count - j) - 2 = 0 + 2 * (count - 1 - j) := by omega
+  rw [crumbOfNat, hm1, hm2]
+  set m := count - 1 - j
+  have h4 : (4 : ℕ) ^ m = 2 ^ (2 * m) := by
+    rw [show (4 : ℕ) = 2 ^ 2 by norm_num, ← pow_mul]
+  rw [h4, ← Nat.testBit_div_two_pow, ← Nat.testBit_div_two_pow,
+    Nat.testBit_add_one, Nat.testBit_zero, Nat.testBit_zero]
+  set q := k / 2 ^ (2 * m)
+  rcases Nat.mod_two_eq_zero_or_one (q / 2) with h1 | h1 <;>
+    rcases Nat.mod_two_eq_zero_or_one q with h0 | h0 <;>
+      simp [h1, h0] <;> omega
+
+/-- Casting a base-4 Horner fold out of `ℕ`. -/
+private theorem foldl_horner_cast [Semiring F] :
+    ∀ (l : List ℕ) (a : ℕ),
+      (l.map (Nat.cast (R := F))).foldl (fun n x => 4 * n + x) (a : F)
+        = ((l.foldl (fun n x => 4 * n + x) a : ℕ) : F)
+  | [], _ => rfl
+  | x :: xs, a => by
+    simp only [List.map_cons, List.foldl_cons]
+    rw [show ((4 : F) * a + x) = ((4 * a + x : ℕ) : F) by push_cast; ring_nf]
+    exact foldl_horner_cast xs (4 * a + x)
+
+/-- The Horner reconstruction at `ℕ`: the MSB-first crumbs fold back to the value
+modulo `4^count`. -/
+private theorem crumbsOfNat_foldl_nat (count k : ℕ) :
+    ((List.range count).map fun j => crumbOfNat count j k).foldl
+      (fun n x => 4 * n + x) 0 = k % 4 ^ count := by
+  induction count generalizing k with
+  | zero => simp [Nat.mod_one]
+  | succ c ih =>
+    rw [List.range_succ, List.map_append, List.foldl_append]
+    have hmap : (List.range c).map (fun j => crumbOfNat (c + 1) j k)
+        = (List.range c).map (fun j => crumbOfNat c j (k / 4)) := by
+      apply List.map_congr_left
+      intro j hj
+      rw [List.mem_range] at hj
+      rw [crumbOfNat_eq_digit (c + 1) j k (by omega),
+        crumbOfNat_eq_digit c j (k / 4) hj,
+        show c + 1 - 1 - j = (c - 1 - j) + 1 by omega, pow_succ,
+        mul_comm ((4 : ℕ) ^ (c - 1 - j)) 4, ← Nat.div_div_eq_div_mul]
+    have hlast : crumbOfNat (c + 1) c k = k % 4 := by
+      rw [crumbOfNat_eq_digit (c + 1) c k (by omega)]
+      simp
+    rw [hmap, ih]
+    simp only [List.map_cons, List.map_nil, List.foldl_cons, List.foldl_nil]
+    rw [hlast]
+    have hM : (0 : ℕ) < 4 ^ c := pow_pos (by norm_num) c
+    have hkdecomp : k = 4 * (k / 4 % 4 ^ c) + k % 4 + 4 ^ (c + 1) * (k / 4 / 4 ^ c) := by
+      have h1 := Nat.div_add_mod k 4
+      have h2 := Nat.div_add_mod (k / 4) (4 ^ c)
+      calc k = 4 * (k / 4) + k % 4 := h1.symm
+        _ = 4 * (4 ^ c * (k / 4 / 4 ^ c) + k / 4 % 4 ^ c) + k % 4 := by rw [h2]
+        _ = 4 * (k / 4 % 4 ^ c) + k % 4 + 4 ^ (c + 1) * (k / 4 / 4 ^ c) := by ring
+    have hlt : 4 * (k / 4 % 4 ^ c) + k % 4 < 4 ^ (c + 1) := by
+      have hr := Nat.mod_lt (k / 4) hM
+      have hs := Nat.mod_lt k (show 0 < 4 by norm_num)
+      have h41 : (4 : ℕ) ^ (c + 1) = 4 * 4 ^ c := by ring
+      omega
+    conv_rhs => rw [hkdecomp]
+    rw [Nat.add_mul_mod_self_left]
+    exact (Nat.mod_eq_of_lt hlt).symm
+
+/-- The register reconstruction recovers the challenge: the gate's `n` fold over the
+extracted crumbs is the value itself, for values in range — what `toField`'s
+`n = scalar` pin consumes. -/
+private theorem crumbsOfNat_reconstruct [Field F] (count k : ℕ) (hk : k < 4 ^ count) :
+    Kimchi.Gate.EndoScalar.nReconstruct (crumbsOfNat (F := F) count k) = (k : F) := by
+  unfold Kimchi.Gate.EndoScalar.nReconstruct crumbsOfNat
+  rw [show ((List.range count).map fun j => ((crumbOfNat count j k : ℕ) : F))
+      = ((List.range count).map fun j => crumbOfNat count j k).map Nat.cast by
+    rw [List.map_map]; rfl]
+  rw [show (0 : F) = ((0 : ℕ) : F) by norm_num, foldl_horner_cast,
+    crumbsOfNat_foldl_nat, Nat.mod_eq_of_lt hk]
+
+/-- Flattening the row-chunked table recovers the flat MSB-first stream. -/
+private theorem flatten_ofFn_rows {F : Type} (g : ℕ → F) :
+    ∀ m : ℕ,
+      (List.ofFn fun r : Fin m => List.ofFn fun j : Fin 8 => g (8 * r.1 + j.1)).flatten
+        = (List.range (8 * m)).map g
+  | 0 => by simp
+  | m + 1 => by
+    rw [List.ofFn_succ', List.concat_eq_append, List.flatten_append]
+    simp only [Fin.val_castSucc]
+    rw [flatten_ofFn_rows g m, show 8 * (m + 1) = 8 * m + 8 by ring, List.range_add,
+      List.map_append, List.map_map]
+    congr 1
+
+/-- The bulk witness's table, flattened, is the crumb stream. -/
+private theorem crumbVals_flatten [NatCast F] (rows k : ℕ) :
+    ((crumbVals (F := F) rows k).toList.map Vector.toList).flatten
+      = crumbsOfNat (8 * rows) k := by
+  show ((Vector.ofFn _).toList.map Vector.toList).flatten = _
+  rw [Vector.toList_ofFn, List.map_ofFn]
+  exact flatten_ofFn_rows (fun i => (crumbOfNat (8 * rows) i k : F)) rows
+
+/-- The value-level row step: the three accumulator folds of one row. -/
+private def accStep [Field F] [DecidableEq F] (st : F × F × F) (xs : List F) :
+    F × F × F :=
+  (xs.foldl (fun a x => 2 * a + Kimchi.Gate.EndoScalar.cFunc x) st.1,
+   xs.foldl (fun b x => 2 * b + Kimchi.Gate.EndoScalar.dFunc x) st.2.1,
+   xs.foldl (fun n x => 4 * n + x) st.2.2)
+
+/-- Row-stepping is folding the concatenated crumbs. -/
+private theorem accStep_foldl [Field F] [DecidableEq F] :
+    ∀ (rs : List (List F)) (st : F × F × F),
+      rs.foldl accStep st
+        = (rs.flatten.foldl (fun a x => 2 * a + Kimchi.Gate.EndoScalar.cFunc x) st.1,
+           rs.flatten.foldl (fun b x => 2 * b + Kimchi.Gate.EndoScalar.dFunc x) st.2.1,
+           rs.flatten.foldl (fun n x => 4 * n + x) st.2.2)
+  | [], st => rfl
+  | r :: rs, st => by
+    simp only [List.foldl_cons, List.flatten_cons, List.foldl_append]
+    exact accStep_foldl rs _
+
+/-- Element reads assemble into the list read. -/
+private theorem mapM_eval_ok [Add F] [Mul F] {env : Assignments F} :
+    ∀ {xs : List (FVar F)} {vs : List F}, xs.length = vs.length →
+      (∀ j (hj : j < xs.length) (hj' : j < vs.length), xs[j].eval env = .ok vs[j]) →
+      xs.mapM (CVar.eval · env) = .ok vs
+  | [], [], _, _ => rfl
+  | [], _ :: _, hlen, _ => by simp at hlen
+  | _ :: _, [], hlen, _ => by simp at hlen
+  | x :: xs, v :: vs, hlen, hj => by
+    have h0 := hj 0 (by simp) (by simp)
+    simp only [List.getElem_cons_zero] at h0
+    have ih := mapM_eval_ok (env := env) (xs := xs) (vs := vs) (by simpa using hlen)
+      (fun j hj1 hj2 => by
+        have := hj (j + 1) (by simpa using hj1) (by simpa using hj2)
+        simpa only [List.getElem_cons_succ] using this)
+    simp [List.mapM_cons, h0, ih, Bind.bind, Except.bind, Pure.pure, Except.pure]
+
+/-- List reads survive table extension. -/
+private theorem mapM_eval_le [Add F] [Mul F] {env env' : Assignments F}
+    (hle : env.Le env') :
+    ∀ {xs : List (FVar F)} {vs : List F},
+      xs.mapM (CVar.eval · env) = .ok vs → xs.mapM (CVar.eval · env') = .ok vs
+  | [], _, h => h
+  | x :: xs, vs, h => by
+    cases he : x.eval env with
+    | error e => simp [List.mapM_cons, he, Bind.bind, Except.bind] at h
+    | ok y =>
+      cases hr : xs.mapM (CVar.eval · env) with
+      | error e => simp [List.mapM_cons, he, hr, Bind.bind, Except.bind] at h
+      | ok ys =>
+        simp only [List.mapM_cons, he, hr, Bind.bind, Except.bind, Pure.pure,
+          Except.pure] at h
+        simp [List.mapM_cons, CVar.eval_le hle he, mapM_eval_le hle hr, Bind.bind,
+          Except.bind, Pure.pure, Except.pure, h]
+
+/-- The prover-side list read is the elementwise read. -/
+private theorem readAll_ok [Add F] [Mul F] {env : Assignments F} :
+    ∀ {xs : List (FVar F)} {vs : List F},
+      xs.mapM (CVar.eval · env) = .ok vs →
+      (xs.mapM AsProver.readCVar) env = .ok vs
+  | [], vs, h => h
+  | x :: xs, vs, h => by
+    cases he : x.eval env with
+    | error e => simp [List.mapM_cons, he, Bind.bind, Except.bind] at h
+    | ok y =>
+      cases hr : xs.mapM (CVar.eval · env) with
+      | error e => simp [List.mapM_cons, he, hr, Bind.bind, Except.bind] at h
+      | ok ys =>
+        simp only [List.mapM_cons, he, hr, Bind.bind, Except.bind, Pure.pure,
+          Except.pure] at h
+        simp [List.mapM_cons, AsProver.readCVar, he, readAll_ok hr, Bind.bind,
+          ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure, h]
+
+/-- Invert one `Except` bind of a successful run. -/
+private theorem bind_ok {α β : Type} {x : Except EvalError α}
+    {f : α → Except EvalError β} {b : β} (h : (x >>= f) = .ok b) :
+    ∃ a, x = .ok a ∧ f a = .ok b := by
+  cases x with
+  | error e => simp [Bind.bind, Except.bind] at h
+  | ok a => exact ⟨a, rfl, by simpa [Bind.bind, Except.bind] using h⟩
+
+/-- A round evaluates to a witness exactly when each register and the crumb list
+read as its fields. -/
+private theorem round_eval_ok_iff [Field F] [DecidableEq F] {env : Assignments F}
+    {r : EndoScalarRound F} {w : Kimchi.Gate.EndoScalar.Witness F} :
+    EndoScalarRound.eval env r = .ok w ↔
+      r.a0.eval env = .ok w.a0 ∧ r.b0.eval env = .ok w.b0 ∧
+      r.n0.eval env = .ok w.n0 ∧ r.a8.eval env = .ok w.a8 ∧
+      r.b8.eval env = .ok w.b8 ∧ r.n8.eval env = .ok w.n8 ∧
+      r.xs.toList.mapM (CVar.eval · env) = .ok w.crumbs := by
+  constructor
+  · intro h
+    unfold EndoScalarRound.eval at h
+    obtain ⟨a0, ha0, h⟩ := bind_ok h
+    obtain ⟨b0, hb0, h⟩ := bind_ok h
+    obtain ⟨n0, hn0, h⟩ := bind_ok h
+    obtain ⟨a8, ha8, h⟩ := bind_ok h
+    obtain ⟨b8, hb8, h⟩ := bind_ok h
+    obtain ⟨n8, hn8, h⟩ := bind_ok h
+    obtain ⟨vs, hxs, h⟩ := bind_ok h
+    simp only [Pure.pure, Except.pure, Except.ok.injEq] at h
+    subst h
+    exact ⟨ha0, hb0, hn0, ha8, hb8, hn8, hxs⟩
+  · intro ⟨ha0, hb0, hn0, ha8, hb8, hn8, hxs⟩
+    unfold EndoScalarRound.eval
+    rw [ha0, hb0, hn0, ha8, hb8, hn8, hxs]
+    simp [Bind.bind, Except.bind, Pure.pure, Except.pure]
+
+/-- A round's read survives table extension. -/
+private theorem round_eval_le [Field F] [DecidableEq F] {env env' : Assignments F}
+    (hle : env.Le env') {r : EndoScalarRound F} {w : Kimchi.Gate.EndoScalar.Witness F}
+    (h : EndoScalarRound.eval env r = .ok w) :
+    EndoScalarRound.eval env' r = .ok w := by
+  obtain ⟨ha0, hb0, hn0, ha8, hb8, hn8, hxs⟩ := round_eval_ok_iff.mp h
+  exact round_eval_ok_iff.mpr ⟨CVar.eval_le hle ha0, CVar.eval_le hle hb0,
+    CVar.eval_le hle hn0, CVar.eval_le hle ha8, CVar.eval_le hle hb8,
+    CVar.eval_le hle hn8, mapM_eval_le hle hxs⟩
+
+/-- The collected rounds' check survives table extension. -/
+private theorem check_rounds_le [Field F] [DecidableEq F] {env env' : Assignments F}
+    (hle : env.Le env') {rounds : List (EndoScalarRound F)}
+    (h : KimchiConstraint.check (.endoScalar rounds) env = true) :
+    KimchiConstraint.check (.endoScalar rounds) env' = true := by
+  simp only [KimchiConstraint.check, List.all_eq_true] at h ⊢
+  intro r hr
+  have hh := h r hr
+  cases he : EndoScalarRound.eval env r with
+  | error e => rw [he] at hh; simp at hh
+  | ok w =>
+    rw [he] at hh
+    rw [round_eval_le hle he]
+    exact hh
+
+/-- One more element folds onto the prefix. -/
+private theorem take_succ_foldl {α β : Type} (f : β → α → β) {l : List α} {k : ℕ}
+    (hk : k < l.length) (init : β) :
+    (l.take (k + 1)).foldl f init = f ((l.take k).foldl f init) l[k] := by
+  rw [List.take_add, List.take_one_drop_eq_of_lt_length hk]
+  simp only [List.foldl_append, List.foldl_cons, List.foldl_nil, List.get_eq_getElem]
+
+/-- Every entry of one witness row is a valid crumb. -/
+private theorem crumbVals_row_valid [Field F] (rows n k : ℕ) (hk : k < rows) :
+    ∀ x ∈ ((crumbVals (F := F) rows n)[k]'hk).toList,
+      x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3 := by
+  intro x hx
+  simp only [crumbVals, Vector.getElem_ofFn, Vector.toList_ofFn, List.mem_ofFn] at hx
+  obtain ⟨j, rfl⟩ := hx
+  exact crumbOfNat_cast_valid _ _ _
+
+/-- One row's accumulator witness computes the row step. -/
+private theorem rowWit_ok [Field F] [DecidableEq F] {env : Assignments F}
+    {xs : Vector (FVar F) 8} {st : FVar F × FVar F × FVar F} {a b n : F} {vs : List F}
+    (ha : st.1.eval env = .ok a) (hb : st.2.1.eval env = .ok b)
+    (hn : st.2.2.eval env = .ok n)
+    (hxs : xs.toList.mapM (CVar.eval · env) = .ok vs) :
+    rowWit xs st env
+      = .ok (vs.foldl (fun acc x => 2 * acc + Kimchi.Gate.EndoScalar.cFunc x) a,
+             vs.foldl (fun acc x => 2 * acc + Kimchi.Gate.EndoScalar.dFunc x) b,
+             vs.foldl (fun acc x => 4 * acc + x) n) := by
+  simp [rowWit, AsProver.readCVar, ha, hb, hn, readAll_ok hxs, Bind.bind, ReaderT.bind,
+    Except.bind, Pure.pure, ReaderT.pure, Except.pure]
+
+open Std.Do in
+/-- The gate emitter is complete: the honest prover run accepts on any readable
+scalar — no range condition — and the returned accumulators read as the gate model's
+decompositions of the scalar's crumbs. -/
+theorem toFieldChecked'_complete_spec [Field F] [DecidableEq F] [ToNat F]
+    (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) (rows : ℕ) (scalar : FVar F)
+    (Q : PostCond (FVar F × FVar F × FVar F)
+      (.arg (ProverState F) (.except EvalError .pure))) :
+    ⦃Complete (fun env => (scalar.eval env).isOk)
+        (fun env r env' => ∀ vv, scalar.eval env = .ok vv →
+          r.1.eval env' = .ok (Kimchi.Gate.EndoScalar.decomposeA
+            (crumbsOfNat (8 * rows) (ToNat.toNat vv))) ∧
+          r.2.1.eval env' = .ok (Kimchi.Gate.EndoScalar.decomposeB
+            (crumbsOfNat (8 * rows) (ToNat.toNat vv))) ∧
+          r.2.2.eval env' = .ok (Kimchi.Gate.EndoScalar.nReconstruct
+            (crumbsOfNat (8 * rows) (ToNat.toNat vv)))) Q⦄
+    (toFieldChecked' (c := KimchiProverC F) rows scalar)
+    ⦃Q⦄ := by
+  simp only [toFieldChecked', mapAccumM]
+  mvcgen
+  rename_i st₀ hpre
+  obtain ⟨hoks, hk⟩ := hpre
+  obtain ⟨vv, hv⟩ := CVar.evalOk hoks
+  have hwit : crumbsWit rows scalar st₀.env
+      = .ok (crumbVals rows (ToNat.toNat vv)) := by
+    simp [crumbsWit, AsProver.readCVar, hv, Bind.bind, ReaderT.bind, Except.bind,
+      Pure.pure, ReaderT.pure, Except.pure]
+  refine ⟨by rw [hwit]; rfl, fun crumbVars st₁ hgrant hle₁ => ?_⟩
+  have hread := hgrant _ hwit
+  mvcgen
+  case inv1 =>
+    exact ⇓ p s' => ⌜st₁.env.Le s'.env ∧
+      (let stv := (((crumbVals (F := F) rows (ToNat.toNat vv)).toList.map
+          Vector.toList).take p.1.prefix.length).foldl accStep (2, 2, 0)
+       p.2.fst.1.eval s'.env = .ok stv.1 ∧
+       p.2.fst.2.1.eval s'.env = .ok stv.2.1 ∧
+       p.2.fst.2.2.eval s'.env = .ok stv.2.2) ∧
+      KimchiConstraint.check (.endoScalar p.2.snd) s'.env = true⌝
+  case vc1.step =>
+    rename_i pref cur suff hsplit b s' hinv
+    obtain ⟨hLe, hacc, hcheck⟩ := hinv
+    obtain ⟨hA, hB, hN⟩ := hacc
+    have hkrows : pref.length < rows := by
+      have hlen := congrArg List.length hsplit
+      simp only [Vector.length_toList, List.length_append, List.length_cons] at hlen
+      omega
+    have hcur : cur = crumbVars[pref.length]'hkrows := by
+      have h1 : crumbVars.toList[pref.length]'(by
+          simp only [Vector.length_toList]; omega) = cur := by
+        simp only [hsplit]
+        rw [List.getElem_append_right (Nat.le_refl _)]
+        simp
+      rw [← h1, Vector.getElem_toList]
+    subst hcur
+    have hxs : (crumbVars[pref.length]'hkrows).toList.mapM (CVar.eval · s'.env)
+        = .ok ((crumbVals (F := F) rows (ToNat.toNat vv))[pref.length]'hkrows).toList := by
+      refine mapM_eval_ok (by simp) ?_
+      intro j hj hj'
+      simp only [Vector.length_toList] at hj
+      simp only [Vector.getElem_toList]
+      exact CVar.eval_le hLe (hread pref.length hkrows j hj)
+    have hrow := rowWit_ok (env := s'.env) hA hB hN hxs
+    refine ⟨by rw [hrow]; rfl, fun r st' hgrant' hle' => ?_⟩
+    have hw := hgrant' _ hrow
+    have heval : EndoScalarRound.eval st'.env
+        { n0 := b.fst.2.2, n8 := r.2.2, a0 := b.fst.1, a8 := r.1,
+          b0 := b.fst.2.1, b8 := r.2.1, xs := crumbVars[pref.length]'hkrows }
+        = .ok (Kimchi.Gate.EndoScalar.buildTable _ _ _
+            ((crumbVals (F := F) rows (ToNat.toNat vv))[pref.length]'hkrows).toList) :=
+      round_eval_ok_iff.mpr ⟨CVar.eval_le hle' hA, CVar.eval_le hle' hB,
+        CVar.eval_le hle' hN, hw.1, hw.2.1, hw.2.2, mapM_eval_le hle' hxs⟩
+    mvcgen
+    refine ⟨hLe.trans hle', ?_, ?_⟩
+    · simp only [List.length_append, List.length_cons, List.length_nil]
+      rw [take_succ_foldl accStep (by simp [hkrows]) (2, 2, 0)]
+      simp only [List.getElem_map, Vector.getElem_toList]
+      exact ⟨hw.1, hw.2.1, hw.2.2⟩
+    · simp only [KimchiConstraint.check, List.all_append, List.all_cons, List.all_nil,
+        Bool.and_eq_true, and_true]
+      refine ⟨?_, ?_⟩
+      · simpa only [KimchiConstraint.check] using check_rounds_le hle' hcheck
+      · simp only [heval]
+        exact (Kimchi.Gate.EndoScalar.ok_iff _).mpr
+          (Kimchi.Gate.EndoScalar.complete_table h2 h3 _ _ _ _
+            (crumbVals_row_valid rows (ToNat.toNat vv) pref.length hkrows))
+  case vc2.vc1.pre =>
+    refine ⟨Assignments.Le.refl st₁.env, ⟨?_, ?_, ?_⟩,
+        by simp [KimchiConstraint.check]⟩ <;>
+      simp [CVar.eval]
+  case vc3.vc1.post.success =>
+    rename_i fin s' hinv
+    obtain ⟨hLe, hacc, hcheck⟩ := hinv
+    obtain ⟨hA, hB, hN⟩ := hacc
+    rw [List.take_of_length_le (by simp)] at hA hB hN
+    rw [accStep_foldl, crumbVals_flatten] at hA hB hN
+    refine addConstraint_complete_spec (c := KimchiConstraint F)
+      (KimchiSystem.endoScalar fin.snd) (fun a => wp⟦pure fin.fst⟧ Q, Q.2) s'
+      ⟨hcheck, fun u st₂ _ hle₂ => ?_⟩
+    simp only [wp, PredTrans.apply, prove]
+    intro hf
+    refine hk fin.fst ⟨st₂.nv, st₂.env, hf⟩ (fun vv' hv' => ?_)
+      (hle₁.trans (hLe.trans hle₂))
+    rw [hv] at hv'
+    injection hv' with hv'
+    subst hv'
+    have hvalid := crumbsOfNat_valid (F := F) (8 * rows) (ToNat.toNat vv)
+    refine ⟨?_, ?_, ?_⟩
+    · rw [Kimchi.Gate.EndoScalar.decomposeA_eq_table h2 h3 hvalid]
+      exact CVar.eval_le hle₂ hA
+    · rw [Kimchi.Gate.EndoScalar.decomposeB_eq_table h2 h3 hvalid]
+      exact CVar.eval_le hle₂ hB
+    · exact CVar.eval_le hle₂ hN
+  case vc4.vc1.post.except =>
+    exact ExceptConds.entails_false
+
+open Std.Do in
+/-- The checked decomposition is complete: the honest prover run accepts on a
+readable scalar whose representative is faithful and fits the crumb budget, and the
+result reads as the gate model's `toField` at the scalar's crumbs. -/
+theorem toField_complete_spec [Field F] [DecidableEq F] [ToNat F]
+    (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) (rows : ℕ) (scalar endo : FVar F)
+    (Q : PostCond (FVar F) (.arg (ProverState F) (.except EvalError .pure))) :
+    ⦃Complete
+        (fun env => (scalar.eval env).isOk ∧ (endo.eval env).isOk ∧
+          ∀ vv, scalar.eval env = .ok vv →
+            ((ToNat.toNat vv : ℕ) : F) = vv ∧ ToNat.toNat vv < 4 ^ (8 * rows))
+        (fun env r env' => ∀ vv ev, scalar.eval env = .ok vv →
+          endo.eval env = .ok ev →
+          r.eval env' = .ok (Kimchi.Gate.EndoScalar.toField
+            (crumbsOfNat (8 * rows) (ToNat.toNat vv)) ev)) Q⦄
+    (toField (c := KimchiProverC F) rows scalar endo)
+    ⦃Q⦄ := by
+  simp only [toField]
+  mvcgen
+  rename_i st₀ hpre
+  obtain ⟨⟨hoks, hoke, hbound⟩, hk⟩ := hpre
+  obtain ⟨vv, hv⟩ := CVar.evalOk hoks
+  obtain ⟨ev, he⟩ := CVar.evalOk hoke
+  obtain ⟨hfaith, hlt⟩ := hbound vv hv
+  refine toFieldChecked'_complete_spec h2 h3 rows scalar _ _
+    ⟨hoks, fun abn st₁ hpost₁ hle₁ => ?_⟩
+  obtain ⟨hA, hB, hN⟩ := hpost₁ vv hv
+  mvcgen
+  refine ⟨⟨by rw [hN]; rfl, by rw [CVar.eval_le hle₁ hv]; rfl,
+      fun nv sv hnv hsv => ?_⟩, fun u st₂ hle₂ => ?_⟩
+  · rw [hN] at hnv
+    injection hnv with hnv
+    rw [CVar.eval_le hle₁ hv] at hsv
+    injection hsv with hsv
+    subst hnv hsv
+    rw [crumbsOfNat_reconstruct (8 * rows) (ToNat.toNat vv) hlt, hfaith]
+  · split
+    · rename_i e
+      simp only [wp, PredTrans.apply, prove]
+      intro hf
+      refine hk _ ⟨st₂.nv, st₂.env, hf⟩ (fun vv' ev' hv' he' => ?_)
+        (hle₁.trans hle₂)
+      rw [hv] at hv'
+      injection hv' with hv'
+      subst hv'
+      rw [he] at he'
+      injection he' with he'
+      subst he'
+      have hA2 := CVar.eval_le hle₂ hA
+      have hB2 := CVar.eval_le hle₂ hB
+      have hev : ev = e := by
+        simp only [CVar.eval] at he
+        exact (Except.ok.inj he).symm
+      rw [CVar.eval_add_]
+      simp only [CVar.eval, CVar.eval_scale_ hA2 e, hB2, Except.ok.injEq,
+        Kimchi.Gate.EndoScalar.toField, hev]
+      ring
+    · mvcgen
+      refine ⟨⟨by rw [CVar.eval_le hle₂ hA]; rfl,
+          by rw [CVar.eval_le (hle₁.trans hle₂) he]; rfl⟩,
+        fun p st₃ hp hle₃ => ?_⟩
+      have hpv := hp _ _ (CVar.eval_le hle₂ hA) (CVar.eval_le (hle₁.trans hle₂) he)
+      simp only [wp, PredTrans.apply, prove]
+      intro hf
+      refine hk _ ⟨st₃.nv, st₃.env, hf⟩ (fun vv' ev' hv' he' => ?_)
+        (hle₁.trans (hle₂.trans hle₃))
+      rw [hv] at hv'
+      injection hv' with hv'
+      subst hv'
+      rw [he] at he'
+      injection he' with he'
+      subst he'
+      have hB3 := CVar.eval_le (hle₂.trans hle₃) hB
+      rw [CVar.eval_add_]
+      simp only [CVar.eval, hB3, hpv, Except.ok.injEq,
+        Kimchi.Gate.EndoScalar.toField]
+      ring

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
@@ -1,0 +1,112 @@
+import Snarky.Circuit.DSL.Field
+import Snarky.Circuit.DSL.Assert
+import Snarky.Circuit.DSL.Bits
+import Snarky.Kimchi.Semantics
+import Snarky.Kimchi.Circuit.Utils
+
+/-!
+# The EndoScalar gadget
+
+Port of `Snarky.Circuit.Kimchi.EndoScalar`
+(packages/snarky-kimchi/src/Snarky/Circuit/Kimchi/EndoScalar.purs): the GLV challenge
+decomposition. `toFieldChecked'` witnesses the scalar's 2-bit crumbs in ONE bulk
+`exists` — eight per row, MSB-first — then threads the three accumulators through
+`mapAccumM`, one `(a8, b8, n8)` witness per row, and emits the `endoScalar` round
+list; `toField` pins the reconstruction `n` to the scalar and returns the affine
+`a·endo + b`. `toFieldPure` is the constant-space model of the same fold.
+
+Name map: `toField`, `toFieldChecked'`, `toFieldPure` keep their names, namespaced
+`EndoScalar` after the PS module's qualified use. `expandToEndoScalar` is
+pickles-layer (cross-field transport) and is not ported.
+
+Deviations from the PS original (per `formal/docs/snarky-kimchi-alignment.md`):
+- PS's type-level `SizedF nBits` sizing renders as the explicit `rows` parameter
+  with `16 · rows` bits, and the bit reads go through `[ToNat F]`.
+- PS's record `exists` allocates its fields alphabetically; the per-row witness is
+  the ordered triple `(a8, b8, n8)`, the same allocation spelled explicitly.
+- PS's `aF`/`bF` throw on impossible crumbs; `aDigit`/`bDigit` render the dead
+  branches as `0`.
+- `toFieldPure` is generalized from PS's pinned 128 bits to `16 · rows`.
+-/
+
+namespace Snarky.Kimchi.EndoScalar
+
+open Snarky
+
+variable {F c : Type}
+
+/-- The crumb-to-`a`-digit map (PS `aF`). -/
+private def aDigit [Field F] [DecidableEq F] (x : F) : F :=
+  if x = 2 then -1 else if x = 3 then 1 else 0
+
+/-- The crumb-to-`b`-digit map (PS `bF`). -/
+private def bDigit [Field F] [DecidableEq F] (x : F) : F :=
+  if x = 0 then -1 else if x = 1 then 1 else 0
+
+/-- The scalar's MSB-first 2-bit crumbs, eight per row (PS `toBits` reversed and
+paired): crumb `i` is `2·bit(16·rows − 1 − 2i) + bit(16·rows − 2 − 2i)`. -/
+private def crumbsWit [Field F] [ToNat F] (rows : ℕ) (scalar : FVar F) :
+    AsProver F (Vector (Vector F 8) rows) := do
+  let v ← AsProver.readCVar scalar
+  let n := ToNat.toNat v
+  pure (Vector.ofFn fun r => Vector.ofFn fun j =>
+    let i := 8 * r.1 + j.1
+    ((2 * (if n.testBit (16 * rows - 1 - 2 * i) then 1 else 0)
+      + (if n.testBit (16 * rows - 2 - 2 * i) then 1 else 0) : F)))
+
+/-- One row's accumulator witness: fold the row's eight crumbs into the three
+accumulators, returned in the allocation order `(a8, b8, n8)`. -/
+private def rowWit [Field F] [DecidableEq F] (xs : Vector (FVar F) 8)
+    (st : FVar F × FVar F × FVar F) : AsProver F (F × F × F) := do
+  let a0 ← AsProver.readCVar st.1
+  let b0 ← AsProver.readCVar st.2.1
+  let n0 ← AsProver.readCVar st.2.2
+  let vals ← xs.toList.mapM AsProver.readCVar
+  pure (vals.foldl (fun acc x => 2 * acc + aDigit x) a0,
+        vals.foldl (fun acc x => 2 * acc + bDigit x) b0,
+        vals.foldl (fun acc x => 4 * acc + x) n0)
+
+/-- The gate emitter (PS `toFieldChecked'`; OCaml
+`Pickles.Scalar_challenge.to_field_checked'`): the bulk crumb witness, the
+accumulator rounds, one `endoScalar` constraint — returning the raw `(a, b, n)`
+accumulators with no wrapper constraints. -/
+def toFieldChecked' [Field F] [DecidableEq F] [ToNat F] [KimchiSystem F c]
+    (rows : ℕ) (scalar : FVar F) :
+    CircuitM F c (FVar F × FVar F × FVar F) := do
+  let crumbs ← witness (val := Vector (Vector F 8) rows) (crumbsWit rows scalar)
+  let (rounds, fin) ← mapAccumM
+    (fun (st : FVar F × FVar F × FVar F) (xs : Vector (FVar F) 8) => do
+      let w ← witness (val := F × F × F) (rowWit xs st)
+      pure (({ n0 := st.2.2, n8 := w.2.2, a0 := st.1, a8 := w.1,
+               b0 := st.2.1, b8 := w.2.1, xs } : EndoScalarRound F),
+            (w.1, w.2.1, w.2.2)))
+    (.const 2, .const 2, .const 0) crumbs.toList
+  addConstraint (KimchiSystem.endoScalar rounds)
+  pure fin
+
+/-- The checked decomposition (PS `toField`; OCaml `to_field_checked`): the gate,
+the pin `n = scalar`, and the affine reconstruction `a·endo + b` — folded
+constraint-free when the endo coefficient is a constant. -/
+def toField [Field F] [DecidableEq F] [ToNat F] [BasicSystem F c] [KimchiSystem F c]
+    (rows : ℕ) (scalar endo : FVar F) : CircuitM F c (FVar F) := do
+  let (a, b, n) ← toFieldChecked' (c := c) rows scalar
+  assertEqual n scalar
+  match endo with
+  | .const e => pure (CVar.add_ (CVar.scale_ e a) b)
+  | _ => do
+    let p ← mul a endo
+    pure (CVar.add_ b p)
+
+/-- The pure model (PS `toFieldPure`): the same MSB-first bit-pair fold on values,
+from the accumulator seeds `(2, 2)`. -/
+def toFieldPure [Field F] [ToNat F] (rows : ℕ) (scalar endo : F) : F :=
+  let n := ToNat.toNat scalar
+  let acc := (List.range (8 * rows)).foldl
+    (fun (st : F × F) i =>
+      let s : F := if n.testBit (16 * rows - 2 - 2 * i) then 1 else -1
+      if n.testBit (16 * rows - 1 - 2 * i) then (2 * st.1 + s, 2 * st.2)
+      else (2 * st.1, 2 * st.2 + s))
+    (2, 2)
+  acc.1 * endo + acc.2
+
+end Snarky.Kimchi.EndoScalar

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
@@ -767,3 +767,62 @@ theorem toField_complete_spec [Field F] [DecidableEq F] [ToNat F]
       simp only [CVar.eval, hB3, hpv, Except.ok.injEq,
         Kimchi.Gate.EndoScalar.toField]
       ring
+
+/-! ## The pure model is the gate model -/
+
+/-- A pair fold with componentwise steps splits into its component folds. -/
+private theorem foldl_pair {α : Type} (f g : F → α → F) :
+    ∀ (l : List α) (a b : F),
+      l.foldl (fun (st : F × F) x => (f st.1 x, g st.2 x)) (a, b)
+        = (l.foldl f a, l.foldl g b)
+  | [], _, _ => rfl
+  | x :: xs, a, b => foldl_pair f g xs (f a x) (g b x)
+
+/-- PS parity: `toFieldPure` computes the gate model's `toField` at the scalar's
+crumbs — the bit-pair `±1` fold is the `cFunc`/`dFunc` table fold, crumb by
+crumb. -/
+theorem toFieldPure_eq_toField [Field F] [DecidableEq F] [ToNat F]
+    (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) (rows : ℕ) (scalar endo : F) :
+    toFieldPure rows scalar endo
+      = Kimchi.Gate.EndoScalar.toField
+          (crumbsOfNat (8 * rows) (ToNat.toNat scalar)) endo := by
+  have hvalid := crumbsOfNat_valid (F := F) (8 * rows) (ToNat.toNat scalar)
+  have hstep : (fun (st : F × F) (i : ℕ) =>
+        let s : F :=
+          if (ToNat.toNat scalar).testBit (16 * rows - 2 - 2 * i) then 1 else -1
+        if (ToNat.toNat scalar).testBit (16 * rows - 1 - 2 * i) then
+          (2 * st.1 + s, 2 * st.2)
+        else (2 * st.1, 2 * st.2 + s))
+      = fun st i =>
+        (2 * st.1 + Kimchi.Gate.EndoScalar.cFunc
+          ((crumbOfNat (8 * rows) i (ToNat.toNat scalar) : ℕ) : F),
+         2 * st.2 + Kimchi.Gate.EndoScalar.dFunc
+          ((crumbOfNat (8 * rows) i (ToNat.toNat scalar) : ℕ) : F)) := by
+    funext st i
+    have hb1 : 2 * (8 * rows - i) - 1 = 16 * rows - 1 - 2 * i := by omega
+    have hb2 : 2 * (8 * rows - i) - 2 = 16 * rows - 2 - 2 * i := by omega
+    have e02 : (0 : F) ≠ 2 := fun h => h2 h.symm
+    have e03 : (0 : F) ≠ 3 := fun h => h3 h.symm
+    have e12 : (1 : F) ≠ 2 := fun h => (one_ne_zero : (1 : F) ≠ 0) (by linear_combination -h)
+    have e13 : (1 : F) ≠ 3 := fun h => h2 (by linear_combination -h)
+    have e32 : (3 : F) ≠ 2 := fun h => (one_ne_zero : (1 : F) ≠ 0) (by linear_combination h)
+    have e21 : (2 : F) ≠ 1 := fun h => (one_ne_zero : (1 : F) ≠ 0) (by linear_combination h)
+    have e31 : (3 : F) ≠ 1 := fun h => h2 (by linear_combination h)
+    simp only [crumbOfNat, hb1, hb2]
+    rcases hhi : (ToNat.toNat scalar).testBit (16 * rows - 1 - 2 * i) <;>
+      rcases hlo : (ToNat.toNat scalar).testBit (16 * rows - 2 - 2 * i) <;>
+        simp [Kimchi.Gate.EndoScalar.cFunc, Kimchi.Gate.EndoScalar.dFunc,
+          e02, e03, e12, e13, e32, e21, e31, h2, h3]
+  have hpair := foldl_pair (F := F)
+    (fun a i => 2 * a + Kimchi.Gate.EndoScalar.cFunc
+      ((crumbOfNat (8 * rows) i (ToNat.toNat scalar) : ℕ) : F))
+    (fun b i => 2 * b + Kimchi.Gate.EndoScalar.dFunc
+      ((crumbOfNat (8 * rows) i (ToNat.toNat scalar) : ℕ) : F))
+    (List.range (8 * rows)) 2 2
+  dsimp only [toFieldPure, Kimchi.Gate.EndoScalar.toField]
+  rw [Kimchi.Gate.EndoScalar.decomposeA_eq_table h2 h3 hvalid,
+    Kimchi.Gate.EndoScalar.decomposeB_eq_table h2 h3 hvalid]
+  unfold crumbsOfNat
+  rw [List.foldl_map, List.foldl_map, hstep, hpair]
+
+end Snarky.Kimchi.EndoScalar

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
@@ -330,17 +330,6 @@ private theorem crumbOfNat_eq_digit (count j k : ℕ) (hj : j < count) :
     rcases Nat.mod_two_eq_zero_or_one q with h0 | h0 <;>
       simp [h1, h0] <;> omega
 
-/-- Casting a base-4 Horner fold out of `ℕ`. -/
-private theorem foldl_horner_cast [Semiring F] :
-    ∀ (l : List ℕ) (a : ℕ),
-      (l.map (Nat.cast (R := F))).foldl (fun n x => 4 * n + x) (a : F)
-        = ((l.foldl (fun n x => 4 * n + x) a : ℕ) : F)
-  | [], _ => rfl
-  | x :: xs, a => by
-    simp only [List.map_cons, List.foldl_cons]
-    rw [show ((4 : F) * a + x) = ((4 * a + x : ℕ) : F) by push_cast; ring_nf]
-    exact foldl_horner_cast xs (4 * a + x)
-
 /-- The Horner reconstruction at `ℕ`: the MSB-first crumbs fold back to the value
 modulo `4^count`. -/
 private theorem crumbsOfNat_foldl_nat (count k : ℕ) :
@@ -390,7 +379,9 @@ private theorem crumbsOfNat_reconstruct [Field F] (count k : ℕ) (hk : k < 4 ^ 
   rw [show ((List.range count).map fun j => ((crumbOfNat count j k : ℕ) : F))
       = ((List.range count).map fun j => crumbOfNat count j k).map Nat.cast by
     rw [List.map_map]; rfl]
-  rw [show (0 : F) = ((0 : ℕ) : F) by norm_num, foldl_horner_cast,
+  rw [List.foldl_map, show (0 : F) = ((0 : ℕ) : F) by norm_num,
+    List.foldl_hom (g₁ := fun n x => 4 * n + x) (Nat.cast (R := F))
+      (fun x y => by push_cast; ring),
     crumbsOfNat_foldl_nat, Nat.mod_eq_of_lt hk]
 
 /-- Flattening the row-chunked table recovers the flat MSB-first stream. -/
@@ -450,24 +441,6 @@ private theorem mapM_eval_ok [Add F] [Mul F] {env : Assignments F} :
         simpa only [List.getElem_cons_succ] using this)
     simp [List.mapM_cons, h0, ih, Bind.bind, Except.bind, Pure.pure, Except.pure]
 
-/-- List reads survive table extension. -/
-private theorem mapM_eval_le [Add F] [Mul F] {env env' : Assignments F}
-    (hle : env.Le env') :
-    ∀ {xs : List (FVar F)} {vs : List F},
-      xs.mapM (CVar.eval · env) = .ok vs → xs.mapM (CVar.eval · env') = .ok vs
-  | [], _, h => h
-  | x :: xs, vs, h => by
-    cases he : x.eval env with
-    | error e => simp [List.mapM_cons, he, Bind.bind, Except.bind] at h
-    | ok y =>
-      cases hr : xs.mapM (CVar.eval · env) with
-      | error e => simp [List.mapM_cons, he, hr, Bind.bind, Except.bind] at h
-      | ok ys =>
-        simp only [List.mapM_cons, he, hr, Bind.bind, Except.bind, Pure.pure,
-          Except.pure] at h
-        simp [List.mapM_cons, CVar.eval_le hle he, mapM_eval_le hle hr, Bind.bind,
-          Except.bind, Pure.pure, Except.pure, h]
-
 /-- The prover-side list read is the elementwise read. -/
 private theorem readAll_ok [Add F] [Mul F] {env : Assignments F} :
     ∀ {xs : List (FVar F)} {vs : List F},
@@ -485,14 +458,6 @@ private theorem readAll_ok [Add F] [Mul F] {env : Assignments F} :
           Except.pure] at h
         simp [List.mapM_cons, AsProver.readCVar, he, readAll_ok hr, Bind.bind,
           ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure, h]
-
-/-- Invert one `Except` bind of a successful run. -/
-private theorem bind_ok {α β : Type} {x : Except EvalError α}
-    {f : α → Except EvalError β} {b : β} (h : (x >>= f) = .ok b) :
-    ∃ a, x = .ok a ∧ f a = .ok b := by
-  cases x with
-  | error e => simp [Bind.bind, Except.bind] at h
-  | ok a => exact ⟨a, rfl, by simpa [Bind.bind, Except.bind] using h⟩
 
 /-- A round evaluates to a witness exactly when each register and the crumb list
 read as its fields. -/
@@ -770,14 +735,6 @@ theorem toField_complete_spec [Field F] [DecidableEq F] [ToNat F]
 
 /-! ## The pure model is the gate model -/
 
-/-- A pair fold with componentwise steps splits into its component folds. -/
-private theorem foldl_pair {α : Type} (f g : F → α → F) :
-    ∀ (l : List α) (a b : F),
-      l.foldl (fun (st : F × F) x => (f st.1 x, g st.2 x)) (a, b)
-        = (l.foldl f a, l.foldl g b)
-  | [], _, _ => rfl
-  | x :: xs, a, b => foldl_pair f g xs (f a x) (g b x)
-
 /-- PS parity: `toFieldPure` computes the gate model's `toField` at the scalar's
 crumbs — the bit-pair `±1` fold is the `cFunc`/`dFunc` table fold, crumb by
 crumb. -/
@@ -813,12 +770,17 @@ theorem toFieldPure_eq_toField [Field F] [DecidableEq F] [ToNat F]
       rcases hlo : (ToNat.toNat scalar).testBit (16 * rows - 2 - 2 * i) <;>
         simp [Kimchi.Gate.EndoScalar.cFunc, Kimchi.Gate.EndoScalar.dFunc,
           e02, e03, e12, e13, e32, e21, e31, h2, h3]
-  have hpair := foldl_pair (F := F)
+  have hpair := List.foldl_hom₂ (List.range (8 * rows)) Prod.mk
     (fun a i => 2 * a + Kimchi.Gate.EndoScalar.cFunc
       ((crumbOfNat (8 * rows) i (ToNat.toNat scalar) : ℕ) : F))
     (fun b i => 2 * b + Kimchi.Gate.EndoScalar.dFunc
       ((crumbOfNat (8 * rows) i (ToNat.toNat scalar) : ℕ) : F))
-    (List.range (8 * rows)) 2 2
+    (fun st i =>
+      (2 * st.1 + Kimchi.Gate.EndoScalar.cFunc
+        ((crumbOfNat (8 * rows) i (ToNat.toNat scalar) : ℕ) : F),
+       2 * st.2 + Kimchi.Gate.EndoScalar.dFunc
+        ((crumbOfNat (8 * rows) i (ToNat.toNat scalar) : ℕ) : F)))
+    2 2 (fun _ _ _ => rfl)
   dsimp only [toFieldPure, Kimchi.Gate.EndoScalar.toField]
   rw [Kimchi.Gate.EndoScalar.decomposeA_eq_table h2 h3 hvalid,
     Kimchi.Gate.EndoScalar.decomposeB_eq_table h2 h3 hvalid]

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
@@ -42,11 +42,6 @@ private def crumbOfNat (count j k : ℕ) : ℕ :=
   2 * (if k.testBit (2 * (count - j) - 1) then 1 else 0)
     + (if k.testBit (2 * (count - j) - 2) then 1 else 0)
 
-/-- The scalar's crumbs, MSB-first (PS `chunks @2` of the reversed bits) — the honest
-crumb list the completeness laws read the gate model at. -/
-def crumbsOfNat [NatCast F] (count k : ℕ) : List F :=
-  (List.range count).map fun j => (crumbOfNat count j k : F)
-
 /-- The crumb table the bulk witness writes: row `r`'s entry `j` is crumb `8r + j`. -/
 private def crumbVals [NatCast F] (rows k : ℕ) : Vector (Vector F 8) rows :=
   Vector.ofFn fun r => Vector.ofFn fun j =>
@@ -290,11 +285,12 @@ theorem toField_spec [Field F] [DecidableEq F] [ToNat F]
 /-! ## Completeness
 
 The honest prover run accepts, and the results read as the gate model at the
-scalar's own crumbs (`crumbsOfNat`). The emitter needs only a readable scalar; the
-checked decomposition's `n = scalar` pin adds the boundary conditions of the
-representative — faithfulness and the `4 ^ (8·rows)` range. The crumb lemmas below
-are ℕ-side positional arithmetic; the loop's invariant carries the accumulator
-reads and the collected rounds' checks across table growth. -/
+scalar's own crumbs (`Kimchi.Gate.EndoScalar.crumbsOf`). The emitter needs only a
+readable scalar; the checked decomposition's `n = scalar` pin adds the boundary
+conditions of the representative — faithfulness and the `4 ^ (8·rows)` range. The
+witness's testBit crumbs meet the gate model's expansion at
+`map_crumbOfNat_eq_crumbsOf`; the loop's invariant carries the accumulator reads
+and the collected rounds' checks across table growth. -/
 
 /-- Every crumb is a valid 2-bit value. -/
 private theorem crumbOfNat_cast_valid [Field F] (count j k : ℕ) :
@@ -303,15 +299,6 @@ private theorem crumbOfNat_cast_valid [Field F] (count j k : ℕ) :
   unfold crumbOfNat
   by_cases h1 : k.testBit (2 * (count - j) - 1) <;>
     by_cases h0 : k.testBit (2 * (count - j) - 2) <;> simp [h1, h0]
-
-/-- Every extracted crumb is a valid 2-bit value — what the gate's completeness
-consumes. -/
-private theorem crumbsOfNat_valid [Field F] (count k : ℕ) :
-    ∀ x ∈ crumbsOfNat (F := F) count k, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3 := by
-  intro x hx
-  simp only [crumbsOfNat, List.mem_map, List.mem_range] at hx
-  obtain ⟨j, -, rfl⟩ := hx
-  exact crumbOfNat_cast_valid count j k
 
 /-- A crumb is a base-4 digit read from the top: crumb `j` of a `count`-crumb
 challenge is digit `count−1−j` of its value. -/
@@ -330,17 +317,19 @@ private theorem crumbOfNat_eq_digit (count j k : ℕ) (hj : j < count) :
     rcases Nat.mod_two_eq_zero_or_one q with h0 | h0 <;>
       simp [h1, h0] <;> omega
 
-/-- The Horner reconstruction at `ℕ`: the MSB-first crumbs fold back to the value
-modulo `4^count`. -/
-private theorem crumbsOfNat_foldl_nat (count k : ℕ) :
-    ((List.range count).map fun j => crumbOfNat count j k).foldl
-      (fun n x => 4 * n + x) 0 = k % 4 ^ count := by
+/-- The witness's testBit crumbs are the gate model's expansion: mapping `crumbOfNat`
+over the index range is `crumbsOf`. -/
+private theorem map_crumbOfNat_eq_crumbsOf [Field F] (count k : ℕ) :
+    ((List.range count).map fun j => ((crumbOfNat count j k : ℕ) : F))
+      = Kimchi.Gate.EndoScalar.crumbsOf count k := by
   induction count generalizing k with
-  | zero => simp [Nat.mod_one]
+  | zero => rfl
   | succ c ih =>
-    rw [List.range_succ, List.map_append, List.foldl_append]
-    have hmap : (List.range c).map (fun j => crumbOfNat (c + 1) j k)
-        = (List.range c).map (fun j => crumbOfNat c j (k / 4)) := by
+    rw [show Kimchi.Gate.EndoScalar.crumbsOf (F := F) (c + 1) k
+        = Kimchi.Gate.EndoScalar.crumbsOf c (k / 4) ++ [((k % 4 : ℕ) : F)] from rfl,
+      List.range_succ, List.map_append]
+    congr 1
+    · rw [← ih (k / 4)]
       apply List.map_congr_left
       intro j hj
       rw [List.mem_range] at hj
@@ -348,41 +337,9 @@ private theorem crumbsOfNat_foldl_nat (count k : ℕ) :
         crumbOfNat_eq_digit c j (k / 4) hj,
         show c + 1 - 1 - j = (c - 1 - j) + 1 by omega, pow_succ,
         mul_comm ((4 : ℕ) ^ (c - 1 - j)) 4, ← Nat.div_div_eq_div_mul]
-    have hlast : crumbOfNat (c + 1) c k = k % 4 := by
+    · simp only [List.map_cons, List.map_nil]
       rw [crumbOfNat_eq_digit (c + 1) c k (by omega)]
       simp
-    rw [hmap, ih]
-    simp only [List.map_cons, List.map_nil, List.foldl_cons, List.foldl_nil]
-    rw [hlast]
-    have hM : (0 : ℕ) < 4 ^ c := pow_pos (by norm_num) c
-    have hkdecomp : k = 4 * (k / 4 % 4 ^ c) + k % 4 + 4 ^ (c + 1) * (k / 4 / 4 ^ c) := by
-      have h1 := Nat.div_add_mod k 4
-      have h2 := Nat.div_add_mod (k / 4) (4 ^ c)
-      calc k = 4 * (k / 4) + k % 4 := h1.symm
-        _ = 4 * (4 ^ c * (k / 4 / 4 ^ c) + k / 4 % 4 ^ c) + k % 4 := by rw [h2]
-        _ = 4 * (k / 4 % 4 ^ c) + k % 4 + 4 ^ (c + 1) * (k / 4 / 4 ^ c) := by ring
-    have hlt : 4 * (k / 4 % 4 ^ c) + k % 4 < 4 ^ (c + 1) := by
-      have hr := Nat.mod_lt (k / 4) hM
-      have hs := Nat.mod_lt k (show 0 < 4 by norm_num)
-      have h41 : (4 : ℕ) ^ (c + 1) = 4 * 4 ^ c := by ring
-      omega
-    conv_rhs => rw [hkdecomp]
-    rw [Nat.add_mul_mod_self_left]
-    exact (Nat.mod_eq_of_lt hlt).symm
-
-/-- The register reconstruction recovers the challenge: the gate's `n` fold over the
-extracted crumbs is the value itself, for values in range — what `toField`'s
-`n = scalar` pin consumes. -/
-private theorem crumbsOfNat_reconstruct [Field F] (count k : ℕ) (hk : k < 4 ^ count) :
-    Kimchi.Gate.EndoScalar.nReconstruct (crumbsOfNat (F := F) count k) = (k : F) := by
-  unfold Kimchi.Gate.EndoScalar.nReconstruct crumbsOfNat
-  rw [show ((List.range count).map fun j => ((crumbOfNat count j k : ℕ) : F))
-      = ((List.range count).map fun j => crumbOfNat count j k).map Nat.cast by
-    rw [List.map_map]; rfl]
-  rw [List.foldl_map, show (0 : F) = ((0 : ℕ) : F) by norm_num,
-    List.foldl_hom (g₁ := fun n x => 4 * n + x) (Nat.cast (R := F))
-      (fun x y => by push_cast; ring),
-    crumbsOfNat_foldl_nat, Nat.mod_eq_of_lt hk]
 
 /-- Flattening the row-chunked table recovers the flat MSB-first stream. -/
 private theorem flatten_ofFn_rows {F : Type} (g : ℕ → F) :
@@ -398,11 +355,11 @@ private theorem flatten_ofFn_rows {F : Type} (g : ℕ → F) :
     congr 1
 
 /-- The bulk witness's table, flattened, is the crumb stream. -/
-private theorem crumbVals_flatten [NatCast F] (rows k : ℕ) :
+private theorem crumbVals_flatten [Field F] (rows k : ℕ) :
     ((crumbVals (F := F) rows k).toList.map Vector.toList).flatten
-      = crumbsOfNat (8 * rows) k := by
+      = Kimchi.Gate.EndoScalar.crumbsOf (8 * rows) k := by
   show ((Vector.ofFn _).toList.map Vector.toList).flatten = _
-  rw [Vector.toList_ofFn, List.map_ofFn]
+  rw [Vector.toList_ofFn, List.map_ofFn, ← map_crumbOfNat_eq_crumbsOf]
   exact flatten_ofFn_rows (fun i => (crumbOfNat (8 * rows) i k : F)) rows
 
 /-- The value-level row step: the three accumulator folds of one row. -/
@@ -551,11 +508,11 @@ theorem toFieldChecked'_complete_spec [Field F] [DecidableEq F] [ToNat F]
     ⦃Complete (fun env => (scalar.eval env).isOk)
         (fun env r env' => ∀ vv, scalar.eval env = .ok vv →
           r.1.eval env' = .ok (Kimchi.Gate.EndoScalar.decomposeA
-            (crumbsOfNat (8 * rows) (ToNat.toNat vv))) ∧
+            (Kimchi.Gate.EndoScalar.crumbsOf (8 * rows) (ToNat.toNat vv))) ∧
           r.2.1.eval env' = .ok (Kimchi.Gate.EndoScalar.decomposeB
-            (crumbsOfNat (8 * rows) (ToNat.toNat vv))) ∧
+            (Kimchi.Gate.EndoScalar.crumbsOf (8 * rows) (ToNat.toNat vv))) ∧
           r.2.2.eval env' = .ok (Kimchi.Gate.EndoScalar.nReconstruct
-            (crumbsOfNat (8 * rows) (ToNat.toNat vv)))) Q⦄
+            (Kimchi.Gate.EndoScalar.crumbsOf (8 * rows) (ToNat.toNat vv)))) Q⦄
     (toFieldChecked' (c := KimchiProverC F) rows scalar)
     ⦃Q⦄ := by
   simp only [toFieldChecked', mapAccumM]
@@ -645,7 +602,7 @@ theorem toFieldChecked'_complete_spec [Field F] [DecidableEq F] [ToNat F]
     rw [hv] at hv'
     injection hv' with hv'
     subst hv'
-    have hvalid := crumbsOfNat_valid (F := F) (8 * rows) (ToNat.toNat vv)
+    have hvalid := Kimchi.Gate.EndoScalar.crumbsOf_valid (F := F) (8 * rows) (ToNat.toNat vv)
     refine ⟨?_, ?_, ?_⟩
     · rw [Kimchi.Gate.EndoScalar.decomposeA_eq_table h2 h3 hvalid]
       exact CVar.eval_le hle₂ hA
@@ -669,7 +626,7 @@ theorem toField_complete_spec [Field F] [DecidableEq F] [ToNat F]
         (fun env r env' => ∀ vv ev, scalar.eval env = .ok vv →
           endo.eval env = .ok ev →
           r.eval env' = .ok (Kimchi.Gate.EndoScalar.toField
-            (crumbsOfNat (8 * rows) (ToNat.toNat vv)) ev)) Q⦄
+            (Kimchi.Gate.EndoScalar.crumbsOf (8 * rows) (ToNat.toNat vv)) ev)) Q⦄
     (toField (c := KimchiProverC F) rows scalar endo)
     ⦃Q⦄ := by
   simp only [toField]
@@ -690,7 +647,7 @@ theorem toField_complete_spec [Field F] [DecidableEq F] [ToNat F]
     rw [CVar.eval_le hle₁ hv] at hsv
     injection hsv with hsv
     subst hnv hsv
-    rw [crumbsOfNat_reconstruct (8 * rows) (ToNat.toNat vv) hlt, hfaith]
+    rw [Kimchi.Gate.EndoScalar.nReconstruct_crumbsOf, Nat.mod_eq_of_lt hlt, hfaith]
   · split
     · rename_i e
       simp only [wp, PredTrans.apply, prove]
@@ -742,8 +699,8 @@ theorem toFieldPure_eq_toField [Field F] [DecidableEq F] [ToNat F]
     (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) (rows : ℕ) (scalar endo : F) :
     toFieldPure rows scalar endo
       = Kimchi.Gate.EndoScalar.toField
-          (crumbsOfNat (8 * rows) (ToNat.toNat scalar)) endo := by
-  have hvalid := crumbsOfNat_valid (F := F) (8 * rows) (ToNat.toNat scalar)
+          (Kimchi.Gate.EndoScalar.crumbsOf (8 * rows) (ToNat.toNat scalar)) endo := by
+  have hvalid := Kimchi.Gate.EndoScalar.crumbsOf_valid (F := F) (8 * rows) (ToNat.toNat scalar)
   have hstep : (fun (st : F × F) (i : ℕ) =>
         let s : F :=
           if (ToNat.toNat scalar).testBit (16 * rows - 2 - 2 * i) then 1 else -1
@@ -755,21 +712,15 @@ theorem toFieldPure_eq_toField [Field F] [DecidableEq F] [ToNat F]
           ((crumbOfNat (8 * rows) i (ToNat.toNat scalar) : ℕ) : F),
          2 * st.2 + Kimchi.Gate.EndoScalar.dFunc
           ((crumbOfNat (8 * rows) i (ToNat.toNat scalar) : ℕ) : F)) := by
+    obtain ⟨c0, c1, c2, c3⟩ := Kimchi.Gate.EndoScalar.cFunc_table (F := F) h2 h3
+    obtain ⟨d0, d1, d2, d3⟩ := Kimchi.Gate.EndoScalar.dFunc_table (F := F) h2 h3
     funext st i
     have hb1 : 2 * (8 * rows - i) - 1 = 16 * rows - 1 - 2 * i := by omega
     have hb2 : 2 * (8 * rows - i) - 2 = 16 * rows - 2 - 2 * i := by omega
-    have e02 : (0 : F) ≠ 2 := fun h => h2 h.symm
-    have e03 : (0 : F) ≠ 3 := fun h => h3 h.symm
-    have e12 : (1 : F) ≠ 2 := fun h => (one_ne_zero : (1 : F) ≠ 0) (by linear_combination -h)
-    have e13 : (1 : F) ≠ 3 := fun h => h2 (by linear_combination -h)
-    have e32 : (3 : F) ≠ 2 := fun h => (one_ne_zero : (1 : F) ≠ 0) (by linear_combination h)
-    have e21 : (2 : F) ≠ 1 := fun h => (one_ne_zero : (1 : F) ≠ 0) (by linear_combination h)
-    have e31 : (3 : F) ≠ 1 := fun h => h2 (by linear_combination h)
     simp only [crumbOfNat, hb1, hb2]
     rcases hhi : (ToNat.toNat scalar).testBit (16 * rows - 1 - 2 * i) <;>
       rcases hlo : (ToNat.toNat scalar).testBit (16 * rows - 2 - 2 * i) <;>
-        simp [Kimchi.Gate.EndoScalar.cFunc, Kimchi.Gate.EndoScalar.dFunc,
-          e02, e03, e12, e13, e32, e21, e31, h2, h3]
+        simp [c0, c1, c2, c3, d0, d1, d2, d3]
   have hpair := List.foldl_hom₂ (List.range (8 * rows)) Prod.mk
     (fun a i => 2 * a + Kimchi.Gate.EndoScalar.cFunc
       ((crumbOfNat (8 * rows) i (ToNat.toNat scalar) : ℕ) : F))
@@ -783,8 +734,7 @@ theorem toFieldPure_eq_toField [Field F] [DecidableEq F] [ToNat F]
     2 2 (fun _ _ _ => rfl)
   dsimp only [toFieldPure, Kimchi.Gate.EndoScalar.toField]
   rw [Kimchi.Gate.EndoScalar.decomposeA_eq_table h2 h3 hvalid,
-    Kimchi.Gate.EndoScalar.decomposeB_eq_table h2 h3 hvalid]
-  unfold crumbsOfNat
-  rw [List.foldl_map, List.foldl_map, hstep, hpair]
+    Kimchi.Gate.EndoScalar.decomposeB_eq_table h2 h3 hvalid,
+    ← map_crumbOfNat_eq_crumbsOf, List.foldl_map, List.foldl_map, hstep, hpair]
 
 end Snarky.Kimchi.EndoScalar

--- a/formal/snarky/Snarky/Kimchi/Circuit/Poseidon.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/Poseidon.lean
@@ -77,7 +77,7 @@ open Std.Do
 /-- Window `i` of a satisfied chain, read off the list by index: `chainHolds` from
 position `k0` puts the gate's `Holds` on every five-apart window, at the constant
 table's row `k0 + i`. -/
-private theorem chainHolds_window [CommRing F] {M : Kimchi.Gate.Poseidon.Mds F}
+private theorem chainHolds_window [Field F] {M : Kimchi.Gate.Poseidon.Mds F}
     {rc : List (F × F × F)} :
     ∀ (i k0 : ℕ) (l : List (F × F × F)), chainHolds M rc k0 l →
       5 * i + 5 < l.length →
@@ -192,7 +192,7 @@ private theorem roundsUpTo_eq_rounds [Field F] (p : Poseidon.Params F) :
 
 /-- The decidable chain check reflects the chain reading (the gate's `ok_iff`,
 windowed). -/
-private theorem chainOk_iff [CommRing F] [DecidableEq F]
+private theorem chainOk_iff [Field F] [DecidableEq F]
     {M : Kimchi.Gate.Poseidon.Mds F} {rc : List (F × F × F)} :
     ∀ (k : ℕ) (l : List (F × F × F)), chainOk M rc k l = true ↔ chainHolds M rc k l
   | k, [] => by simp [chainOk, chainHolds]
@@ -208,7 +208,7 @@ private theorem chainOk_iff [CommRing F] [DecidableEq F]
 /-- A list whose successive entries are the gate's round images satisfies the chain
 reading: each window's fifteen constraint expressions vanish by the adjacency
 equations alone. -/
-private theorem chainHolds_of_succ [CommRing F] {M : Kimchi.Gate.Poseidon.Mds F}
+private theorem chainHolds_of_succ [Field F] {M : Kimchi.Gate.Poseidon.Mds F}
     {rc : List (F × F × F)} :
     ∀ (k : ℕ) (l : List (F × F × F)),
       (∀ j (hj1 : j + 1 < l.length) (hj0 : j < l.length),
@@ -243,7 +243,7 @@ private theorem chainHolds_of_succ [CommRing F] {M : Kimchi.Gate.Poseidon.Mds F}
   | k, [_, _, _, _, _], _ => by simp [chainHolds]
 
 /-- Element reads assemble into the state-list evaluation. -/
-private theorem evalStates_ok [CommRing F] [DecidableEq F] {env : Assignments F} :
+private theorem evalStates_ok [Field F] [DecidableEq F] {env : Assignments F} :
     ∀ (ts : List (FVar F × FVar F × FVar F)) (vs : List (F × F × F)),
       (∀ j (hj : j < ts.length) (hj' : j < vs.length),
         ts[j].1.eval env = .ok vs[j].1 ∧

--- a/formal/snarky/Snarky/Kimchi/Circuit/Utils.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/Utils.lean
@@ -1,0 +1,35 @@
+/-!
+# Kimchi circuit utilities
+
+Port of `Snarky.Circuit.Kimchi.Utils`
+(packages/snarky-kimchi/src/Snarky/Circuit/Kimchi/Utils.purs): `mapAccumM`, the
+accumulating traversal the gate gadgets thread their per-row state through.
+
+Name map: `mapAccumM` keeps its name. The module's `verifyCircuit`/`verifyCircuitM`
+are solver smoke-test `Effect` machinery with no analogue in the pure embedding and
+are not ported.
+
+Deviations from the PS original (per `formal/docs/snarky-kimchi-alignment.md`):
+- PS defines it as a `StateT` traversal; here it is a `forIn` loop, so the `Std.Do`
+  loop rules walk it directly and it owes no composition laws of its own. The
+  spelling is bind-for-bind the same traversal: one `f` call per element, outputs
+  collected in element order.
+- PS's `Traversable t` renders at `List` (the constraint payloads are lists).
+-/
+
+namespace Snarky.Kimchi
+
+/-- Thread an accumulator through a monadic map (PS `mapAccumM`): one `f` call per
+element in order, returning the outputs in element order and the final
+accumulator. -/
+def mapAccumM {m : Type u → Type v} [Monad m] {s a b : Type u}
+    (f : s → a → m (b × s)) (init : s) (xs : List a) : m (List b × s) := do
+  let mut acc := init
+  let mut out : List b := []
+  for x in xs do
+    let (y, acc') ← f acc x
+    out := out ++ [y]
+    acc := acc'
+  pure (out, acc)
+
+end Snarky.Kimchi

--- a/formal/snarky/Snarky/Kimchi/Semantics.lean
+++ b/formal/snarky/Snarky/Kimchi/Semantics.lean
@@ -2,6 +2,7 @@ import Snarky.Kimchi.Constraint
 import Snarky.Backend.WP
 import Kimchi.Gate.AddComplete
 import Kimchi.Gate.Poseidon
+import Kimchi.Gate.EndoScalar
 
 /-!
 # The kimchi constraint semantics
@@ -15,7 +16,8 @@ base gadget law, sound and complete, to this backend — and the landed gate pay
 read as the verified gates' own predicates/`ok` at the payload's operand values: one
 witness record for `.addComplete` (`read`/`eval`, one field per gate column), a chain
 of five-round windows over the state list for `.poseidon` (`chainHolds`/`chainOk` at
-the payload's parameter data; a value missing from the table rejects). `.pad` reads
+the payload's parameter data), one witness record per round for `.endoScalar`; a
+value missing from the table rejects. `.pad` reads
 vacuously (a padding row asserts nothing), as do the gate payloads with no landed
 gadget: the reading is deliberately per-constructor, and a vacuous case marks a
 constructor outside the landed gadget surface.
@@ -25,7 +27,9 @@ namespace Snarky.Kimchi
 
 open Snarky
 
-variable {F : Type} [CommRing F] [DecidableEq F]
+-- `Field` rather than `CommRing`: the EndoScalar gate's crumb-interpolation
+-- polynomials carry inverse-of-small-integer coefficients.
+variable {F : Type} [Field F] [DecidableEq F]
 
 /-- The payload's operand values under a valuation, as the verified gate's witness
 record — one field per gate column, in the gate's column order. -/
@@ -74,6 +78,18 @@ def Poseidon.chainHolds (M : Kimchi.Gate.Poseidon.Mds F) (rc : List (F × F × F
     | [] => True
   | _, _ => True
 
+/-- The payload round's operand values under a valuation, as the verified gate's
+witness record — one field per gate cell, the crumbs in index order. -/
+def EndoScalarRound.read (V : Valuation F) (r : EndoScalarRound F) :
+    Kimchi.Gate.EndoScalar.Witness F where
+  a0 := r.a0.val V
+  b0 := r.b0.val V
+  n0 := r.n0.val V
+  a8 := r.a8.val V
+  b8 := r.b8.val V
+  n8 := r.n8.val V
+  crumbs := r.xs.toList.map (·.val V)
+
 /-- The constraint-level semantics: `.basic` is the reference reading, the landed gate
 payloads the verified gates' predicates at the operand values, and the rest vacuous
 (module docstring). -/
@@ -81,8 +97,8 @@ def KimchiConstraint.Holds (V : Valuation F) : KimchiConstraint F → Prop
   | .basic con => ConstraintHolds.Holds V con
   | .addComplete c => Kimchi.Gate.AddComplete.Holds (AddComplete.read V c)
   | .poseidon c => Poseidon.chainHolds (Poseidon.mdsOf c.mds) c.rc 0 (Poseidon.read V c)
+  | .endoScalar rounds => ∀ r ∈ rounds, Kimchi.Gate.EndoScalar.Holds (EndoScalarRound.read V r)
   | .varBaseMul _ => True
-  | .endoScalar _ => True
   | .endoMul _ => True
   | .pad _ => True
 
@@ -140,6 +156,19 @@ def Poseidon.chainOk (M : Kimchi.Gate.Poseidon.Mds F) (rc : List (F × F × F)) 
     | [] => true
   | _, _ => true
 
+/-- The payload round's operand values on the prover's partial table, failing where
+a value is missing. -/
+def EndoScalarRound.eval (env : Assignments F) (r : EndoScalarRound F) :
+    Except EvalError (Kimchi.Gate.EndoScalar.Witness F) := do
+  let a0 ← r.a0.eval env
+  let b0 ← r.b0.eval env
+  let n0 ← r.n0.eval env
+  let a8 ← r.a8.eval env
+  let b8 ← r.b8.eval env
+  let n8 ← r.n8.eval env
+  let crumbs ← r.xs.toList.mapM (·.eval env)
+  return { a0, b0, n0, a8, b8, n8, crumbs }
+
 /-- The prover-side check: `.basic` is the reference check, the landed gate payloads
 the gates' `ok` at the evaluated values, and the rest vacuous (module docstring). -/
 def KimchiConstraint.check (con : KimchiConstraint F) (env : Assignments F) : Bool :=
@@ -153,8 +182,12 @@ def KimchiConstraint.check (con : KimchiConstraint F) (env : Assignments F) : Bo
     match Poseidon.evalStates env c.state with
     | .ok vs => Poseidon.chainOk (Poseidon.mdsOf c.mds) c.rc 0 vs
     | .error _ => false
+  | .endoScalar rounds =>
+    rounds.all fun r =>
+      match EndoScalarRound.eval env r with
+      | .ok w => Kimchi.Gate.EndoScalar.ok w
+      | .error _ => false
   | .varBaseMul _ => true
-  | .endoScalar _ => true
   | .endoMul _ => true
   | .pad _ => true
 

--- a/formal/snarky/Snarky/Kimchi/Semantics.lean
+++ b/formal/snarky/Snarky/Kimchi/Semantics.lean
@@ -189,8 +189,10 @@ class KimchiSystem (F c : Type) where
   addComplete : AddComplete F → c
   /-- Embed a Poseidon block payload. -/
   poseidon : PoseidonConstraint F → c
+  /-- Embed a challenge-decomposition payload. -/
+  endoScalar : EndoScalar F → c
 
-instance : KimchiSystem F (KimchiConstraint F) := ⟨.addComplete, .poseidon⟩
+instance : KimchiSystem F (KimchiConstraint F) := ⟨.addComplete, .poseidon, .endoScalar⟩
 
 instance [inst : KimchiSystem F c] : KimchiSystem F (Prover c) := inst
 

--- a/formal/snarky/roots.txt
+++ b/formal/snarky/roots.txt
@@ -379,6 +379,8 @@ Snarky.Kimchi.mapAccumM
 Snarky.Kimchi.EndoScalar.toField
 Snarky.Kimchi.EndoScalar.toFieldChecked'
 Snarky.Kimchi.EndoScalar.toFieldPure
+Snarky.Kimchi.EndoScalar.toFieldChecked'_spec
+Snarky.Kimchi.EndoScalar.toField_spec
 Snarky.Kimchi.Poseidon.poseidon_spec
 Snarky.Kimchi.Poseidon.poseidon_complete_spec
 Snarky.Kimchi.instCircuitTypeAffinePointFVar

--- a/formal/snarky/roots.txt
+++ b/formal/snarky/roots.txt
@@ -376,6 +376,9 @@ Snarky.Kimchi.AddFast.addFast_complete_spec
 Snarky.Kimchi.addComplete
 Snarky.Kimchi.poseidon
 Snarky.Kimchi.mapAccumM
+Snarky.Kimchi.EndoScalar.toField
+Snarky.Kimchi.EndoScalar.toFieldChecked'
+Snarky.Kimchi.EndoScalar.toFieldPure
 Snarky.Kimchi.Poseidon.poseidon_spec
 Snarky.Kimchi.Poseidon.poseidon_complete_spec
 Snarky.Kimchi.instCircuitTypeAffinePointFVar

--- a/formal/snarky/roots.txt
+++ b/formal/snarky/roots.txt
@@ -375,6 +375,7 @@ Snarky.Kimchi.AddFast.addFast_spec
 Snarky.Kimchi.AddFast.addFast_complete_spec
 Snarky.Kimchi.addComplete
 Snarky.Kimchi.poseidon
+Snarky.Kimchi.mapAccumM
 Snarky.Kimchi.Poseidon.poseidon_spec
 Snarky.Kimchi.Poseidon.poseidon_complete_spec
 Snarky.Kimchi.instCircuitTypeAffinePointFVar

--- a/formal/snarky/roots.txt
+++ b/formal/snarky/roots.txt
@@ -383,6 +383,7 @@ Snarky.Kimchi.EndoScalar.toFieldChecked'_spec
 Snarky.Kimchi.EndoScalar.toField_spec
 Snarky.Kimchi.EndoScalar.toFieldChecked'_complete_spec
 Snarky.Kimchi.EndoScalar.toField_complete_spec
+Snarky.Kimchi.EndoScalar.toFieldPure_eq_toField
 Snarky.Kimchi.Poseidon.poseidon_spec
 Snarky.Kimchi.Poseidon.poseidon_complete_spec
 Snarky.Kimchi.instCircuitTypeAffinePointFVar

--- a/formal/snarky/roots.txt
+++ b/formal/snarky/roots.txt
@@ -381,6 +381,8 @@ Snarky.Kimchi.EndoScalar.toFieldChecked'
 Snarky.Kimchi.EndoScalar.toFieldPure
 Snarky.Kimchi.EndoScalar.toFieldChecked'_spec
 Snarky.Kimchi.EndoScalar.toField_spec
+Snarky.Kimchi.EndoScalar.toFieldChecked'_complete_spec
+Snarky.Kimchi.EndoScalar.toField_complete_spec
 Snarky.Kimchi.Poseidon.poseidon_spec
 Snarky.Kimchi.Poseidon.poseidon_complete_spec
 Snarky.Kimchi.instCircuitTypeAffinePointFVar

--- a/formal/snarky/scripts/check_axioms.lean
+++ b/formal/snarky/scripts/check_axioms.lean
@@ -12,6 +12,7 @@ Run from `formal/snarky/`:  lake env lean scripts/check_axioms.lean
 import Snarky
 import Snarky.Kimchi.Circuit.AddComplete
 import Snarky.Kimchi.Circuit.Poseidon
+import Snarky.Kimchi.Circuit.EndoScalar
 import Lean.Elab.Command
 
 open Lean Lean.Elab.Command
@@ -85,6 +86,8 @@ def roots : List Name :=
     `Snarky.Kimchi.Poseidon.poseidon_spec,
     `Snarky.Kimchi.Poseidon.poseidon_complete_spec,
     `Snarky.Kimchi.AddFast.addFast_complete_spec,
+    `Snarky.Kimchi.EndoScalar.toFieldChecked'_spec,
+    `Snarky.Kimchi.EndoScalar.toField_spec,
     `Snarky.post_of_prove,
 
     `Snarky.addConstraint_spec,

--- a/formal/snarky/scripts/check_axioms.lean
+++ b/formal/snarky/scripts/check_axioms.lean
@@ -88,6 +88,8 @@ def roots : List Name :=
     `Snarky.Kimchi.AddFast.addFast_complete_spec,
     `Snarky.Kimchi.EndoScalar.toFieldChecked'_spec,
     `Snarky.Kimchi.EndoScalar.toField_spec,
+    `Snarky.Kimchi.EndoScalar.toFieldChecked'_complete_spec,
+    `Snarky.Kimchi.EndoScalar.toField_complete_spec,
     `Snarky.post_of_prove,
 
     `Snarky.addConstraint_spec,

--- a/formal/snarky/scripts/check_axioms.lean
+++ b/formal/snarky/scripts/check_axioms.lean
@@ -90,6 +90,7 @@ def roots : List Name :=
     `Snarky.Kimchi.EndoScalar.toField_spec,
     `Snarky.Kimchi.EndoScalar.toFieldChecked'_complete_spec,
     `Snarky.Kimchi.EndoScalar.toField_complete_spec,
+    `Snarky.Kimchi.EndoScalar.toFieldPure_eq_toField,
     `Snarky.post_of_prove,
 
     `Snarky.addConstraint_spec,

--- a/formal/snarky/scripts/check_cs_equality.lean
+++ b/formal/snarky/scripts/check_cs_equality.lean
@@ -11,10 +11,10 @@ ids pin the shared counter's numbering.
 
 The circuits transcribe `Test.Pickles.CircuitDiffs.Main`
 (packages/pickles-circuit-diffs/test/): every witness-carrying circuit built from the
-`Basic` gadget vocabulary, plus the landed gate gadgets (poseidon). The export also
-carries witness dumps for the remaining gate circuits (endo_scalar, endo_mul,
-var_base_mul); those are DELIBERATELY not in the corpus — each joins with its gadget
-slice, so the EndoScalar, EndoMul, and VarBaseMul reducers are uncovered by this
+`Basic` gadget vocabulary, plus the landed gate gadgets (poseidon,
+endo_scalar). The export also carries witness dumps for the remaining gate circuits
+(endo_mul, var_base_mul); those are DELIBERATELY not in the corpus — each joins with
+its gadget slice, so the EndoMul and VarBaseMul reducers are uncovered by this
 oracle until then.
 
 The dumps are the PS suite's gitignored export: generate with
@@ -29,7 +29,9 @@ import Snarky.DSL
 import Snarky.Kimchi.Backend.Compile
 import Snarky.Kimchi.Circuit.AddComplete
 import Snarky.Kimchi.Circuit.Poseidon
+import Snarky.Kimchi.Circuit.EndoScalar
 import Poseidon.Basic
+import Pasta.Endo
 
 open Lean Snarky Snarky.Kimchi Kimchi Kimchi.Index Kimchi.Fixture.PS CompElliptic.Fields.Pasta
 
@@ -170,6 +172,15 @@ def poseidonCircuit (s : Vector (FVar Fp) 3) : CircuitM Fp C (Vector (FVar Fp) 3
   let (a, b, c) ← poseidon Poseidon.fpParams (s[0], s[1], s[2])
   pure #v[a, b, c]
 
+/-- The Vesta endomorphism's scalar eigenvalue at the step field (PS
+`endoScalar @Vesta.BaseField @Fp`; `Pasta.vestaLam`). -/
+def endoVestaLam : Fp := (Pasta.vestaLam : ℤ)
+
+/-- `endo_scalar_step_circuit` (the PS gadget `Snarky.Circuit.Kimchi.EndoScalar.toField`
+at 8 rows and the constant Vesta eigenvalue). -/
+def endoScalarCircuit (scalar : FVar Fp) : CircuitM Fp C (FVar Fp) :=
+  EndoScalar.toField 8 scalar (.const endoVestaLam)
+
 /-! ## The comparison -/
 
 /-- An assembled circuit in the fixture's `Raw` shape (witness transposed to the
@@ -259,7 +270,9 @@ def targets : List (String × (Raw → List (String × Bool))) :=
       compareWith (a := AffinePoint Fp × AffinePoint Fp) (b := AffinePoint Fp)
         addCompleteCircuit),
     ("poseidon_step_circuit",
-      compareWith (a := Vector Fp 3) (b := Vector Fp 3) poseidonCircuit) ]
+      compareWith (a := Vector Fp 3) (b := Vector Fp 3) poseidonCircuit),
+    ("endo_scalar_step_circuit",
+      compareWith (a := Fp) (b := Fp) endoScalarCircuit) ]
 
 def main : IO Unit := do
   let dir ← resultsDir


### PR DESCRIPTION
The EndoScalar (GLV challenge-decomposition) slice of the kimchi gadget layer, following the Poseidon slice (#292) in the agreed gate order Poseidon → EndoScalar → EndoMul → VarBaseMul.

## The gadget

- **`mapAccumM`** (`Snarky/Kimchi/Circuit/Utils.lean`) — the accumulating traversal the gate gadgets thread per-row state through, spelled as a `forIn` loop so the `Std.Do` loop rules walk it directly (PS's `StateT` traversal, bind-for-bind).
- **`EndoScalar.toFieldChecked'` / `toField` / `toFieldPure`** (`Snarky/Kimchi/Circuit/EndoScalar.lean`) — one bulk crumb witness (eight MSB-first 2-bit crumbs per row), the threaded `(a8, b8, n8)` triple witness per row in the PS record's alphabetical allocation order, one `endoScalar` round-list constraint; `toField` pins `n = scalar` and folds the endo coefficient (constant endo folds constraint-free). The witness helpers speak the gate's own vocabulary: `crumbsWit` writes `crumbOfNat` crumbs and `rowWit` folds the gate's public `cFunc`/`dFunc` tables.
- **Corpus**: `endo_scalar_step_circuit` joins the byte-equality seam — 23/23 circuits byte-equal including raw variable ids (bulk crumbs 2–65, per-row triples 66–89).
- **Semantics**: the `.endoScalar` constructor reads as the verified gate's predicate per round (`EndoScalarRound.read`/`eval`), retiring another vacuous case; the semantics module strengthens `CommRing` to `Field` for the gate's interpolation coefficients.

## The laws

All four stated in the gate model's vocabulary (`decomposeA`/`decomposeB`/`nReconstruct`/`toField` at `crumbsOfNat`, the scalar's MSB-first crumb stream):

- **`toFieldChecked'_spec`** (sound): any satisfying valuation exhibits a valid crumb list of length `8·rows` whose decompositions carry the returned accumulators — the emitter's seeds `(2, 2, 0)` are those definitions'. The loop is handled by a valuation-free structural invariant (`Threaded`); the values arrive at the constraint after the loop via the per-round gate law.
- **`toField_spec`** (sound): the result reads as the gate model's `toField` — `a·endo + b` — over such a list whose `nReconstruct` is the scalar.
- **`toFieldChecked'_complete_spec`**: the honest prover run accepts on any readable scalar — no range condition — and the accumulators read as the decompositions of the scalar's crumbs. First completeness loop walk under `mvcgen`: the invariant carries an `Assignments.Le` chain, the accumulator reads, and the collected rounds' checks across table growth.
- **`toField_complete_spec`**: with the representative faithful and under the `4^(8·rows)` budget, the pin accepts and the result reads as `toField` at the crumbs.
- **`toFieldPure_eq_toField`** (PS parity): the pure model's bit-pair `±1` fold is the `cFunc`/`dFunc` table fold crumb by crumb, so `toFieldPure` computes the gate model.

## Kimchi-side (arrival-with-consumer)

`cFunc`/`dFunc` and `nReconstruct` go public as the folds every deployed prover runs; `decomposeA_eq_table`/`decomposeB_eq_table` bridge the interpolating folds to the bare tables on valid crumbs; the bare-table row lands (`buildTable`, `buildTable_eq_build`, `complete_table`) — the row the deployed provers fill, satisfying the gate.

## Cleanup

A closing audit of the module's elementary list/fold helpers deduplicated `bind_ok` (now public beside `EvalError`) and `mapM_eval_le` (WP's goes public), and replaced two bespoke fold lemmas with Mathlib's `List.foldl_hom₂` and core's `List.foldl_map`/`List.foldl_hom`.

All five specs and the parity bridge join `roots.txt` and the axiom gate. Every commit green on the full battery: build, corpus 23/23, style, snarky + kimchi axiom gates, deadcode 0, per-root lint, shake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)