### PR TITLE
snarky-kimchi: the gadget laws apply the gate-semantics theorems directly

### DIFF
--- a/formal/kimchi/Kimchi/Gate/AddComplete.lean
+++ b/formal/kimchi/Kimchi/Gate/AddComplete.lean
@@ -29,9 +29,10 @@ carries the constraint model; the theorems below are proved in
   sum `(x₁,y₁) + (x₂,y₂)` is the group element the gate encodes — `0` when `inf = 1`,
   else the affine output `(x₃, y₃)` — using that `inf` is boolean (`inf_boolean`). It
   splits into the per-case `sound_point_noninf` / `sound_point_inf`.
-* `complete` — COMPLETENESS, both cases in one statement: for on-curve inputs (`y₁ ≠ 0`),
-  an honest prover can fill a satisfying witness, casing internally on whether the sum is
-  finite or `∞`. Splits into the per-case `complete_noninf` / `complete_inf`.
+* `build` / `complete_build` — COMPLETENESS, constructive: the canonical row the honest
+  prover fills, and the theorem that it satisfies the gate for on-curve inputs
+  (`y₁ ≠ 0`), casing internally on whether the sum is finite or `∞`. `complete` is the
+  existential corollary.
 -/
 
 namespace Kimchi.Gate.AddComplete

--- a/formal/kimchi/Kimchi/Gate/Semantics/AddComplete.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/AddComplete.lean
@@ -73,122 +73,93 @@ theorem sound_noninf
       WeierstrassCurve.Affine.negAddY, WeierstrassCurve.Affine.addX, ha1, ha2, ha3]
     linear_combination -c5 - w.s * c4
 
-/-- COMPLETENESS: the honest prover can always fill in the witness. For on-curve
-    inputs whose sum is finite, there exists a satisfying witness, and its output
-    is the Mathlib affine sum. -/
-theorem complete_noninf
+/-- The canonical satisfying row: the slope, sum coordinates, and the three auxiliary
+    witnesses, as one pure function of the operand values — the row the honest prover
+    fills. `checkFinite` pins `inf` to `0`; otherwise `inf` is the inverse-pair test. -/
+def build (checkFinite : Bool) (x1 y1 x2 y2 : F) : Witness F :=
+  let s : F := if x1 = x2 then 3 * x1 * x1 / (2 * y1) else (y2 - y1) / (x2 - x1)
+  let x3 : F := s * s - (x1 + x2)
+  { x1 := x1, y1 := y1, x2 := x2, y2 := y2
+    x3 := x3
+    y3 := s * (x1 - x3) - y1
+    inf := if checkFinite then 0
+      else if decide (x1 = x2) && !decide (y1 = y2) then 1 else 0
+    sameX := if decide (x1 = x2) then 1 else 0
+    s := s
+    infZ := if y1 = y2 then 0 else if x1 = x2 then (y2 - y1)⁻¹ else 0
+    x21Inv := if x1 = x2 then 0 else (x2 - x1)⁻¹ }
+
+/-- COMPLETENESS, constructive: the canonical row satisfies the gate. For on-curve
+    operands with `y₁ ≠ 0` — `checkFinite` adding the finite-sum precondition —
+    `build`'s row meets every constraint. The consumable form for a deployed prover,
+    which is fixed code: an existential witness cannot certify the row it actually
+    fills. `complete` below is the existential corollary. -/
+theorem complete_build
     (W : WeierstrassCurve.Affine F)
     (ha : W.a₁ = 0 ∧ W.a₂ = 0 ∧ W.a₃ = 0 ∧ W.a₄ = 0)
-    (x1 y1 x2 y2 : F)
+    {checkFinite : Bool} {x1 y1 x2 y2 : F}
     (hon1 : W.Equation x1 y1) (hon2 : W.Equation x2 y2)
-    (hfin : ¬ (x1 = x2 ∧ y1 = W.negY x2 y2))
-    (hy1 : y1 ≠ 0) (h2 : (2 : F) ≠ 0) :
-    ∃ w : Witness F,
-      w.x1 = x1 ∧ w.y1 = y1 ∧ w.x2 = x2 ∧ w.y2 = y2 ∧ w.inf = 0
-      ∧ Holds w
-      ∧ w.x3 = W.addX x1 x2 (W.slope x1 x2 y1 y2)
-      ∧ w.y3 = W.addY x1 x2 y1 (W.slope x1 x2 y1 y2) := by
+    (hy1 : y1 ≠ 0) (h2 : (2 : F) ≠ 0)
+    (hfin : checkFinite = true → ¬(x1 = x2 ∧ y1 = W.negY x2 y2)) :
+    Holds (build checkFinite x1 y1 x2 y2) := by
   obtain ⟨ha1, ha2, ha3, ha4⟩ := ha
-  by_cases hx : x1 = x2
-  · -- doubling branch: sameX = 1, x21Inv = 0
-    have hy : y1 ≠ W.negY x2 y2 := fun h => hfin ⟨hx, h⟩
-    have hnegYx1 : W.negY x1 y1 = -y1 := by simp [WeierstrassCurve.Affine.negY, ha1, ha3]
-    have hyy : y1 + y1 ≠ 0 := by rw [← two_mul]; exact mul_ne_zero h2 hy1
-    have hyeq : y1 = y2 := WeierstrassCurve.Affine.Y_eq_of_Y_ne hon1 hon2 hx hy
-    refine ⟨{ x1 := x1, y1 := y1, x2 := x2, y2 := y2
-            , x3 := W.addX x1 x2 (W.slope x1 x2 y1 y2)
-            , y3 := W.addY x1 x2 y1 (W.slope x1 x2 y1 y2)
-            , inf := 0, sameX := 1, s := W.slope x1 x2 y1 y2
-            , infZ := 0, x21Inv := 0 },
-          rfl, rfl, rfl, rfl, rfl, ?_, rfl, rfl⟩
-    rw [holds_iff]
-    refine ⟨by ring, by rw [hx]; ring, ?_, ?_, ?_, by rw [← hyeq]; ring, by ring⟩
-    · -- c3: 2·s·y₁ = 3x₁²  (via slope = 3x₁²/(2y₁), cleared with eq_div_iff)
-      have hs : W.slope x1 x2 y1 y2 = 3 * x1 ^ 2 / (y1 + y1) := by
-        rw [WeierstrassCurve.Affine.slope_of_Y_ne hx hy, hnegYx1, sub_neg_eq_add]
-        simp only [ha1, ha2, ha4]; ring
-      have key : W.slope x1 x2 y1 y2 * (y1 + y1) = 3 * x1 ^ 2 := (eq_div_iff hyy).mp hs
-      linear_combination key
-    · simp only [WeierstrassCurve.Affine.addX, ha1, ha2]; ring
-    · simp only [WeierstrassCurve.Affine.addY, WeierstrassCurve.Affine.negY,
-        WeierstrassCurve.Affine.negAddY, WeierstrassCurve.Affine.addX, ha1, ha2, ha3]; ring
-  · -- addition branch: sameX = 0, x21Inv = (x₂−x₁)⁻¹
-    have hx21 : x2 - x1 ≠ 0 := sub_ne_zero.mpr (Ne.symm hx)
-    refine ⟨{ x1 := x1, y1 := y1, x2 := x2, y2 := y2
-            , x3 := W.addX x1 x2 (W.slope x1 x2 y1 y2)
-            , y3 := W.addY x1 x2 y1 (W.slope x1 x2 y1 y2)
-            , inf := 0, sameX := 0, s := W.slope x1 x2 y1 y2
-            , infZ := 0, x21Inv := (x2 - x1)⁻¹ },
-          rfl, rfl, rfl, rfl, rfl, ?_, rfl, rfl⟩
-    rw [holds_iff]
-    refine ⟨?_, by ring, ?_, ?_, ?_, by ring, by ring⟩
-    · -- c1: (x₂−x₁)⁻¹·(x₂−x₁) − 1 = 0
-      rw [inv_mul_cancel₀ hx21]; ring
-    · -- c3: (x₂−x₁)·s = y₂−y₁  (slope identity in multiplied-out form)
-      have hx12 : x1 - x2 ≠ 0 := sub_ne_zero.mpr hx
-      have key : W.slope x1 x2 y1 y2 * (x1 - x2) = y1 - y2 := by
-        rw [WeierstrassCurve.Affine.slope_of_X_ne hx]; field_simp
-      linear_combination -key
-    · simp only [WeierstrassCurve.Affine.addX, ha1, ha2]; ring
-    · simp only [WeierstrassCurve.Affine.addY, WeierstrassCurve.Affine.negY,
-        WeierstrassCurve.Affine.negAddY, WeierstrassCurve.Affine.addX, ha1, ha2, ha3]; ring
-
-omit [DecidableEq F] in
-/-- COMPLETENESS, infinity case. When the inputs sum to `∞` — `x₁ = x₂` and
-    `y₁ = negY x₂ y₂`, i.e. `P₂ = -P₁` — the honest prover can fill a satisfying witness
-    with `inf = 1`. The output columns carry the (unused) doubling slope `s = 3x₁²/(2y₁)`
-    so the `sameX = 1` slope constraint still holds; `infZ = 1/(y₂−y₁)` witnesses `inf`.
-    The companion to `complete_noninf`, closing completeness over both cases. -/
-theorem complete_inf
-    (W : WeierstrassCurve.Affine F)
-    (ha : W.a₁ = 0 ∧ W.a₂ = 0 ∧ W.a₃ = 0 ∧ W.a₄ = 0)
-    (x1 y1 x2 y2 : F)
-    (_hon1 : W.Equation x1 y1) (_hon2 : W.Equation x2 y2)
-    (hinf : x1 = x2 ∧ y1 = W.negY x2 y2)
-    (hy1 : y1 ≠ 0) (h2 : (2 : F) ≠ 0) :
-    ∃ w : Witness F,
-      w.x1 = x1 ∧ w.y1 = y1 ∧ w.x2 = x2 ∧ w.y2 = y2 ∧ w.inf = 1 ∧ Holds w := by
-  obtain ⟨ha1, -, ha3, -⟩ := ha
-  obtain ⟨hxe, hye⟩ := hinf
-  have hnegY2 : W.negY x2 y2 = -y2 := by simp [WeierstrassCurve.Affine.negY, ha1, ha3]
-  rw [hnegY2] at hye
-  have hy2 : y2 = -y1 := by linear_combination hye
-  have hden : (2 : F) * y1 ≠ 0 := mul_ne_zero h2 hy1
-  have hy21ne : y2 - y1 ≠ 0 := by
-    rw [hy2]; intro h; exact hden (by linear_combination -h)
-  set s : F := 3 * x1 ^ 2 / (2 * y1) with hsdef
-  refine ⟨{ x1 := x1, y1 := y1, x2 := x2, y2 := y2, x3 := s ^ 2 - x1 - x2,
-            y3 := s * (x1 - (s ^ 2 - x1 - x2)) - y1, inf := 1, sameX := 1, s := s,
-            infZ := 1 / (y2 - y1), x21Inv := 0 }, rfl, rfl, rfl, rfl, rfl, ?_⟩
+  have hcancel := mul_inv_cancel₀ (mul_ne_zero h2 hy1)
   rw [holds_iff]
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
-  · ring
-  · rw [hxe]; ring
-  · rw [hsdef]; field_simp; ring
-  · ring
-  · ring
-  · ring
-  · rw [mul_one_div, div_self hy21ne, sub_self]
+  by_cases hx : x1 = x2
+  · -- Equal x-coordinates: on-curve, the y-coordinates agree or are opposite.
+    have hyy : (y1 - y2) * (y1 + y2) = 0 := by
+      rw [WeierstrassCurve.Affine.equation_iff] at hon1 hon2
+      rw [ha1, ha2, ha3, ha4] at hon1 hon2
+      rw [hx] at hon1
+      linear_combination hon1 - hon2
+    by_cases hy : y1 = y2
+    · -- Doubling: `inf = 0` in both modes, `infZ = 0`.
+      simp only [build, if_pos hx, if_pos hy, decide_eq_true hx, decide_eq_true hy,
+        Bool.not_true, Bool.and_false, Bool.false_eq_true, if_false, if_true, ite_self]
+      refine ⟨by ring, by linear_combination -hx, ?_, by ring, by ring, ?_, by ring⟩
+      · linear_combination (3 * x1 * x1) * hcancel
+      · linear_combination -hy
+    · -- Inverse pair: `y₂ = −y₁`; excluded under `checkFinite`, else `inf = 1`.
+      have hy2 : y2 = -y1 := by
+        rcases mul_eq_zero.mp hyy with h | h
+        · exact absurd (by linear_combination h) hy
+        · linear_combination h
+      have hne : y2 - y1 ≠ 0 := by
+        rw [hy2]
+        intro h
+        rcases mul_eq_zero.mp (show y1 * 2 = 0 by linear_combination -h) with h' | h'
+        · exact hy1 h'
+        · exact h2 h'
+      cases checkFinite with
+      | true =>
+        exact absurd ⟨hx, by rw [WeierstrassCurve.Affine.negY, ha1, ha3, hy2]; ring⟩
+          (hfin rfl)
+      | false =>
+        simp only [build, if_pos hx, if_neg hy, decide_eq_true hx, decide_eq_false hy,
+          Bool.not_false, Bool.and_true, Bool.false_eq_true, if_false, if_true]
+        refine ⟨by ring, by linear_combination -hx, ?_, by ring, by ring, by ring, ?_⟩
+        · linear_combination (3 * x1 * x1) * hcancel
+        · linear_combination mul_inv_cancel₀ hne
+  · -- Distinct x-coordinates: the secant row; `inf = 0` in both modes.
+    have hne : x2 - x1 ≠ 0 := fun h => hx (by linear_combination -h)
+    simp only [build, if_neg hx, decide_eq_false hx, Bool.false_and,
+      Bool.false_eq_true, if_false, ite_self]
+    refine ⟨?_, by ring, ?_, by ring, by ring, by ring, by ring⟩
+    · linear_combination mul_inv_cancel₀ hne
+    · linear_combination (y2 - y1) * mul_inv_cancel₀ hne
 
-/-- COMPLETENESS, both cases in one statement. For any on-curve inputs with `y₁ ≠ 0`, an
-    honest prover can fill a satisfying witness — casing internally on whether the sum is
-    `∞` (`x₁=x₂ ∧ y₁ = negY x₂ y₂` → `complete_inf`, `inf=1`) or finite (`complete_noninf`,
-    `inf=0`). The single-theorem companion to `sound`. (`y₁ ≠ 0` excludes 2-torsion,
-    which the prime-order kimchi curves don't have — so it is no real restriction there.) -/
+/-- COMPLETENESS, existential: for any on-curve inputs with `y₁ ≠ 0` a satisfying
+    witness exists — `build`'s row. (`y₁ ≠ 0` excludes 2-torsion, which the
+    prime-order kimchi curves don't have — so it is no real restriction there.) -/
 theorem complete
     (W : WeierstrassCurve.Affine F)
     (ha : W.a₁ = 0 ∧ W.a₂ = 0 ∧ W.a₃ = 0 ∧ W.a₄ = 0)
     (x1 y1 x2 y2 : F)
     (hon1 : W.Equation x1 y1) (hon2 : W.Equation x2 y2)
     (hy1 : y1 ≠ 0) (h2 : (2 : F) ≠ 0) :
-    ∃ w : Witness F, w.x1 = x1 ∧ w.y1 = y1 ∧ w.x2 = x2 ∧ w.y2 = y2 ∧ Holds w := by
-  by_cases hd : x1 = x2 ∧ y1 = W.negY x2 y2
-  · obtain ⟨w, e1, e2, e3, e4, _, hcons⟩ :=
-      complete_inf W ha x1 y1 x2 y2 hon1 hon2 hd hy1 h2
-    exact ⟨w, e1, e2, e3, e4, hcons⟩
-  · obtain ⟨w, e1, e2, e3, e4, _, hcons, _, _⟩ :=
-      complete_noninf W ha x1 y1 x2 y2 hon1 hon2 hd hy1 h2
-    exact ⟨w, e1, e2, e3, e4, hcons⟩
+    ∃ w : Witness F, w.x1 = x1 ∧ w.y1 = y1 ∧ w.x2 = x2 ∧ w.y2 = y2 ∧ Holds w :=
+  ⟨build false x1 y1 x2 y2, rfl, rfl, rfl, rfl,
+    complete_build W ha hon1 hon2 hy1 h2 (fun h => Bool.noConfusion h)⟩
 
 end Faithfulness
 

--- a/formal/kimchi/Kimchi/Gate/Semantics/EndoScalar.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/EndoScalar.lean
@@ -288,7 +288,7 @@ private theorem nReconstruct_append_pos (xs ys : List F) :
           rw [hsnoc, hcons, List.length_cons, pow_succ]; ring
 
 /-- The crumbs of the first `m` rows of a run, concatenated MSB-first. -/
-private def chainCrumbs (w : ℕ → Witness F) (m : ℕ) : List F :=
+def chainCrumbs (w : ℕ → Witness F) (m : ℕ) : List F :=
   (List.range m).flatMap (fun i => (w i).crumbs)
 
 omit [Field F] in
@@ -306,7 +306,7 @@ omit [Field F] in
     `c * m` crumbs. This is what converts the stream-level budget `valNat_lt` into the deployed
     `4 ^ (c · #rows)` bound of the range check — at the deployed shape, eight rows of eight
     crumbs give `4 ^ 64 = 2 ^ 128`. -/
-private theorem chainCrumbs_length (c : ℕ) (w : ℕ → Witness F) :
+theorem chainCrumbs_length (c : ℕ) (w : ℕ → Witness F) :
     ∀ m, (∀ i, i < m → (w i).crumbs.length = c) → (chainCrumbs w m).length = c * m := by
   intro m
   induction m with
@@ -323,7 +323,7 @@ private theorem chainCrumbs_length (c : ℕ) (w : ℕ → Witness F) :
     Algorithm-2 decomposition of its whole concatenated crumb stream — exactly as a one-row
     `Holds` over `chainCrumbs w (m + 1)` would. The multi-row layout adds nothing to the
     arithmetic, as for `varBaseMul`'s `gateLadder` over its rows. -/
-private theorem chain_decompose (m : ℕ) (w : ℕ → Witness F)
+theorem chain_decompose (m : ℕ) (w : ℕ → Witness F)
     (hHolds : ∀ i, i ≤ m → Holds (w i))
     (ha0 : (w 0).a0 = 2) (hb0 : (w 0).b0 = 2) (hn0 : (w 0).n0 = 0)
     (haStep : ∀ i, i < m → (w (i + 1)).a0 = (w i).a8)

--- a/formal/kimchi/Kimchi/Gate/Semantics/EndoScalar.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/EndoScalar.lean
@@ -92,33 +92,6 @@ private theorem dPoly_eq_dFunc (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) {x : F}
   · rw [d2, g2]
   · rw [d3, g3]
 
-/-- The satisfying row built with the bare `cFunc`/`dFunc` tables in place of the
-    interpolating cubics — the row every deployed prover actually fills. On valid crumbs
-    it is `build` itself (`buildTable_eq_build`). -/
-def buildTable (a0 b0 n0 : F) (crumbs : List F) : Witness F :=
-  { a0, b0, n0
-  , n8 := crumbs.foldl (fun acc x => 4 * acc + x) n0
-  , a8 := crumbs.foldl (fun acc x => 2 * acc + cFunc x) a0
-  , b8 := crumbs.foldl (fun acc x => 2 * acc + dFunc x) b0
-  , crumbs }
-
-/-- On valid crumbs the bare-table row is the canonical build: the tables agree with the
-    cubics crumb by crumb. -/
-private theorem buildTable_eq_build (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) (a0 b0 n0 : F)
-    (crumbs : List F) (hvalid : ∀ x ∈ crumbs, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) :
-    buildTable a0 b0 n0 crumbs = build a0 b0 n0 crumbs := by
-  unfold buildTable build
-  rw [foldl_table crumbs a0 (fun x hx => (cPoly_eq_cFunc h2 h3 (hvalid x hx)).symm),
-    foldl_table crumbs b0 (fun x hx => (dPoly_eq_dFunc h2 h3 (hvalid x hx)).symm)]
-
-/-- **Completeness at the deployed tables**: the bare-table row satisfies the gate — the
-    row the deployed provers fill. -/
-theorem complete_table (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) (a0 b0 n0 : F)
-    (crumbs : List F) (hvalid : ∀ x ∈ crumbs, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) :
-    Holds (buildTable a0 b0 n0 crumbs) := by
-  rw [buildTable_eq_build h2 h3 a0 b0 n0 crumbs hvalid]
-  exact complete a0 b0 n0 crumbs hvalid
-
 /-- **Soundness.** A satisfying row genuinely runs Halo's Algorithm 2: the crumbs are valid 2-bit
     values, and the `a`/`b`/`n` accumulators are the Algorithm-2 folds — with the `a`/`b` folds
     using the *literal* `c_func`/`d_func` lookup tables (the cubics in `Holds` interpolate them, so
@@ -361,7 +334,7 @@ theorem chain_decompose (m : ℕ) (w : ℕ → Witness F)
 
 /-- The honest multi-row witness: thread the gate's `build` from the canonical `(2, 2, 0)`,
     each row started from the previous row's output accumulators. -/
-private def chainBuild (rows : ℕ → List F) : ℕ → Witness F
+def chainBuild (rows : ℕ → List F) : ℕ → Witness F
   | 0 => build 2 2 0 (rows 0)
   | i + 1 =>
     let prev := chainBuild rows i
@@ -371,7 +344,7 @@ private def chainBuild (rows : ℕ → List F) : ℕ → Witness F
     the concatenation of the given rows. Threading changes the accumulators, never the crumbs
     (`build`'s `crumbs` field is its argument), which is what lets a chunking of the value be read
     back off the chain as one crumb list. -/
-private theorem chainCrumbs_chainBuild (rows : ℕ → List F) (m : ℕ) :
+theorem chainCrumbs_chainBuild (rows : ℕ → List F) (m : ℕ) :
     chainCrumbs (chainBuild rows) m = (List.range m).flatMap rows :=
   List.flatMap_congr fun i _ => by cases i <;> rfl
 

--- a/formal/kimchi/scripts/check_axioms.lean
+++ b/formal/kimchi/scripts/check_axioms.lean
@@ -29,10 +29,10 @@ namespace Kimchi.CheckAxioms
     executable path. -/
 def roots : List Name :=
   [ `Kimchi.Gate.Generic.sound, `Kimchi.Gate.Generic.complete,
-    `Kimchi.Gate.AddComplete.sound_noninf, `Kimchi.Gate.AddComplete.complete_noninf,
+    `Kimchi.Gate.AddComplete.sound_noninf, `Kimchi.Gate.AddComplete.complete_build,
     `Kimchi.Gate.AddComplete.sound_point_noninf, `Kimchi.Gate.AddComplete.sound_point_inf,
     `Kimchi.Gate.AddComplete.ok_iff, `Kimchi.Gate.AddComplete.inf_boolean,
-    `Kimchi.Gate.AddComplete.complete_inf, `Kimchi.Gate.AddComplete.complete,
+    `Kimchi.Gate.AddComplete.complete,
     `Kimchi.Gate.AddComplete.sound,
     `Kimchi.Gate.VarBaseMul.sound, `Kimchi.Gate.VarBaseMul.complete,
     `Kimchi.Gate.VarBaseMul.varBaseMul_forbidden_correct,

--- a/formal/snarky/Snarky/Kimchi/Circuit/AddComplete.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/AddComplete.lean
@@ -358,6 +358,8 @@ end AddFast
 
 namespace AddFast
 
+open WeierstrassCurve.Affine
+
 /-- The value all seven witness computations jointly produce, as one pure function of
 the (sealed) operand coordinates: the row the honest prover fills. `checkFinite` pins
 `inf` to `0`; otherwise `inf` is the inverse-pair test. -/
@@ -454,9 +456,9 @@ private theorem readVar_bool_of_eval [Field F] [DecidableEq F]
 open Std.Do in
 /-- The tail's honest run, from pinned operand reads: with the sealed coordinates,
 `sameX`, and `inf` reading the row's operand values, and the row those values fill
-satisfying the verified gate, every check accepts; the outputs read on the final
-table. Applied manually per mode — its value arguments are not inferable from a call
-site. -/
+satisfying the verified gate, every check accepts; the outputs read the honest
+row's values on the final table. Applied manually per mode — its value arguments
+are not inferable from a call site. -/
 private theorem addFastTail_complete_spec [Field F] [DecidableEq F]
     (p1 p2 : AffinePoint (FVar F)) (sameX inf : BoolVar F)
     (x1v y1v x2v y2v : F) (ib : Bool)
@@ -470,8 +472,9 @@ private theorem addFastTail_complete_spec [Field F] [DecidableEq F]
           (↑sameX : CVar F).eval env = .ok (bit (decide (x1v = x2v))) ∧
           (↑inf : CVar F).eval env = .ok (bit ib))
         (fun _ (r : AddResult F) env' =>
-          (r.p.x.eval env').isOk ∧ (r.p.y.eval env').isOk ∧
-          ((↑r.isInfinity : CVar F).eval env').isOk)
+          r.p.x.eval env' = .ok (valueWitness true x1v y1v x2v y2v).x3 ∧
+          r.p.y.eval env' = .ok (valueWitness true x1v y1v x2v y2v).y3 ∧
+          (↑r.isInfinity : CVar F).eval env' = .ok (bit ib))
         Q⦄
     addFastTail (c := KimchiProverC F) p1 p2 sameX inf
     ⦃Q⦄ := by
@@ -554,16 +557,19 @@ private theorem addFastTail_complete_spec [Field F] [DecidableEq F]
     exact (Kimchi.Gate.AddComplete.ok_iff _).mpr hHolds
   · mvcgen
     refine hk _ st₆ ?_ ?_ ?_ (hle05.trans hle₆)
-    · rw [CVar.eval_le (hle₅.trans hle₆) hx3]; rfl
-    · rw [CVar.eval_le hle₆ hy3]; rfl
-    · rw [CVar.eval_le (hle05.trans hle₆) hinf]; rfl
+    · exact CVar.eval_le (hle₅.trans hle₆) hx3
+    · exact CVar.eval_le hle₆ hy3
+    · exact CVar.eval_le (hle05.trans hle₆) hinf
 
 /-- `addFast`'s honest run succeeds at the prover carrier: with the four operand
 coordinates readable, the operands on-curve (short shape), the first finite
 (`y ≠ 0`), and — under `checkFinite` — the sum finite, the checking interpreter at
-`KimchiProverC` accepts every row the gadget emits. The grant is the outputs reading
-on the final table. The executable seam (`kimchiSolve` at `kimchiOps`) is outside
-this statement: its ops-coherence lockstep is the open obligation
+`KimchiProverC` accepts every row the gadget emits, and the outputs read as the sum
+in Mathlib's group — *either* the infinity flag reads `1` and the sum is `0`, *or*
+it reads `0` and the output coordinates are a nonsingular point equal to the sum
+(the accepted row satisfies the verified gate, so its `sound` characterizes what
+was computed). The executable seam (`kimchiSolve` at `kimchiOps`) is outside this
+statement: its ops-coherence lockstep is the open obligation
 `Snarky.Kimchi.Constraint` records. -/
 theorem addFast_complete_spec [Field F] [DecidableEq F]
     (fin : Finiteness) (W : WeierstrassCurve.Affine F)
@@ -578,9 +584,16 @@ theorem addFast_complete_spec [Field F] [DecidableEq F]
             p2'.x.eval env = .ok x2 → p2'.y.eval env = .ok y2 →
             W.Equation x1 y1 ∧ W.Equation x2 y2 ∧ y1 ≠ 0 ∧
               (fin = .checkFinite → ¬(x1 = x2 ∧ y1 = W.negY x2 y2))))
-        (fun _ (r : AddResult F) env' =>
-          (r.p.x.eval env').isOk ∧ (r.p.y.eval env').isOk ∧
-          ((↑r.isInfinity : CVar F).eval env').isOk)
+        (fun env (r : AddResult F) env' =>
+          ∀ x1 y1 x2 y2, p1'.x.eval env = .ok x1 → p1'.y.eval env = .ok y1 →
+            p2'.x.eval env = .ok x2 → p2'.y.eval env = .ok y2 →
+            ∀ (h1 : W.Nonsingular x1 y1) (h2 : W.Nonsingular x2 y2),
+              ((↑r.isInfinity : CVar F).eval env' = .ok 1 ∧
+                Point.some _ _ h1 + Point.some _ _ h2 = 0) ∨
+              (∃ x3 y3, r.p.x.eval env' = .ok x3 ∧ r.p.y.eval env' = .ok y3 ∧
+                (↑r.isInfinity : CVar F).eval env' = .ok 0 ∧
+                ∃ h3 : W.Nonsingular x3 y3,
+                  Point.some _ _ h1 + Point.some _ _ h2 = Point.some _ _ h3))
         Q⦄
     addFast (c := KimchiProverC F) fin p1' p2'
     ⦃Q⦄ := by
@@ -610,13 +623,23 @@ theorem addFast_complete_spec [Field F] [DecidableEq F]
   cases fin with
   | checkFinite =>
     mvcgen
+    have hHolds := valueWitness_holds (checkFinite := true) W ha hon1 hon2 hy1ne htwo
+      (fun _ => hfin)
     refine addFastTail_complete_spec p1 p2 sameXU.val false_ x1v y1v x2v y2v false
-      (valueWitness_holds (checkFinite := true) W ha hon1 hon2 hy1ne htwo
-        (fun _ => hfin)) Q st₃
+      hHolds Q st₃
       ⟨⟨CVar.eval_le (hle₂.trans hle₃) hp1x, CVar.eval_le (hle₂.trans hle₃) hp1y,
         CVar.eval_le hle₃ hp2x, CVar.eval_le hle₃ hp2y, hsx, rfl⟩,
-      fun r st' hpost hle => hk r st' hpost.1 hpost.2.1 hpost.2.2
+      fun r st' hpost hle => hk r st' ?_
         ((hle₁.trans (hle₂.trans hle₃)).trans hle)⟩
+    intro a1 b1 a2 b2 ha1 hb1 ha2 hb2 h1 h2
+    rw [hx1] at ha1; rw [hy1] at hb1; rw [hx2] at ha2; rw [hy2] at hb2
+    injection ha1 with ha1; injection hb1 with hb1
+    injection ha2 with ha2; injection hb2 with hb2
+    subst ha1 hb1 ha2 hb2
+    rcases Kimchi.Gate.AddComplete.sound W ha _ h1 h2 hHolds hy1ne htwo with
+      ⟨hinf1, _⟩ | ⟨_, h3, hsum⟩
+    · exact absurd (hinf1 : (0 : F) = 1) zero_ne_one
+    · exact Or.inr ⟨_, _, hpost.1, hpost.2.1, hpost.2.2, h3, hsum⟩
   | dontCheckFinite =>
     mvcgen
     have hiw : (UnChecked.mk <$> infWit p1 p2 sameXU.val) st₃.env
@@ -628,16 +651,26 @@ theorem addFast_complete_spec [Field F] [DecidableEq F]
     refine ⟨by rw [hiw]; rfl, fun infU st₄ hinfr hle₄ => ?_⟩
     have hinfb : _ = _ := hinfr _ hiw
     mvcgen
+    have hHolds := valueWitness_holds (checkFinite := false) W ha hon1 hon2 hy1ne htwo
+      (fun h => Bool.noConfusion h)
     refine addFastTail_complete_spec p1 p2 sameXU.val infU.val x1v y1v x2v y2v
       (decide (x1v = x2v) && !decide (y1v = y2v))
-      (valueWitness_holds (checkFinite := false) W ha hon1 hon2 hy1ne htwo
-        (fun h => Bool.noConfusion h)) Q st₄
+      hHolds Q st₄
       ⟨⟨CVar.eval_le (hle₂.trans (hle₃.trans hle₄)) hp1x,
         CVar.eval_le (hle₂.trans (hle₃.trans hle₄)) hp1y,
         CVar.eval_le (hle₃.trans hle₄) hp2x, CVar.eval_le (hle₃.trans hle₄) hp2y,
         CVar.eval_le hle₄ hsx, hinfb⟩,
-      fun r st' hpost hle => hk r st' hpost.1 hpost.2.1 hpost.2.2
+      fun r st' hpost hle => hk r st' ?_
         ((hle₁.trans (hle₂.trans (hle₃.trans hle₄))).trans hle)⟩
+    intro a1 b1 a2 b2 ha1 hb1 ha2 hb2 h1 h2
+    rw [hx1] at ha1; rw [hy1] at hb1; rw [hx2] at ha2; rw [hy2] at hb2
+    injection ha1 with ha1; injection hb1 with hb1
+    injection ha2 with ha2; injection hb2 with hb2
+    subst ha1 hb1 ha2 hb2
+    rcases Kimchi.Gate.AddComplete.sound W ha _ h1 h2 hHolds hy1ne htwo with
+      ⟨hinf1, hsum⟩ | ⟨hinf0, h3, hsum⟩
+    · exact Or.inl ⟨hinf1 ▸ hpost.2.2, hsum⟩
+    · exact Or.inr ⟨_, _, hpost.1, hpost.2.1, hinf0 ▸ hpost.2.2, h3, hsum⟩
 
 end AddFast
 

--- a/formal/snarky/Snarky/Kimchi/Circuit/AddComplete.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/AddComplete.lean
@@ -360,83 +360,6 @@ namespace AddFast
 
 open WeierstrassCurve.Affine
 
-/-- The value all seven witness computations jointly produce, as one pure function of
-the (sealed) operand coordinates: the row the honest prover fills. `checkFinite` pins
-`inf` to `0`; otherwise `inf` is the inverse-pair test. -/
-private def valueWitness [Field F] [DecidableEq F] (checkFinite : Bool)
-    (x1 y1 x2 y2 : F) : Kimchi.Gate.AddComplete.Witness F :=
-  let s : F := if x1 = x2 then 3 * x1 * x1 / (2 * y1) else (y2 - y1) / (x2 - x1)
-  let x3 : F := s * s - (x1 + x2)
-  { x1 := x1, y1 := y1, x2 := x2, y2 := y2
-    x3 := x3
-    y3 := s * (x1 - x3) - y1
-    inf := if checkFinite then 0 else bit (decide (x1 = x2) && !decide (y1 = y2))
-    sameX := bit (decide (x1 = x2))
-    s := s
-    infZ := if y1 = y2 then 0 else if x1 = x2 then (y2 - y1)⁻¹ else 0
-    x21Inv := if x1 = x2 then 0 else (x2 - x1)⁻¹ }
-
-/-- The honest witness satisfies the verified gate: for on-curve operands on a
-short-shape curve — `checkFinite` mode adding the finite-sum precondition — the row
-`addFast` computes meets `Kimchi.Gate.AddComplete.Holds`. The proof replays the
-algebra of the gate's `complete_noninf`/`complete_inf` at the gadget's computed
-values (those theorems pin an existential witness, not this one). -/
-private theorem valueWitness_holds [Field F] [DecidableEq F]
-    (W : WeierstrassCurve.Affine F)
-    (ha : W.a₁ = 0 ∧ W.a₂ = 0 ∧ W.a₃ = 0 ∧ W.a₄ = 0)
-    {checkFinite : Bool} {x1 y1 x2 y2 : F}
-    (hon1 : W.Equation x1 y1) (hon2 : W.Equation x2 y2)
-    (hy1 : y1 ≠ 0) (h2 : (2 : F) ≠ 0)
-    (hfin : checkFinite = true → ¬(x1 = x2 ∧ y1 = W.negY x2 y2)) :
-    Kimchi.Gate.AddComplete.Holds (valueWitness checkFinite x1 y1 x2 y2) := by
-  obtain ⟨ha1, ha2, ha3, ha4⟩ := ha
-  have hcancel := mul_inv_cancel₀ (mul_ne_zero h2 hy1)
-  rw [Kimchi.Gate.AddComplete.holds_iff]
-  by_cases hx : x1 = x2
-  · -- Equal x-coordinates: on-curve, the y-coordinates agree or are opposite.
-    have hyy : (y1 - y2) * (y1 + y2) = 0 := by
-      rw [WeierstrassCurve.Affine.equation_iff] at hon1 hon2
-      rw [ha1, ha2, ha3, ha4] at hon1 hon2
-      rw [hx] at hon1
-      linear_combination hon1 - hon2
-    by_cases hy : y1 = y2
-    · -- Doubling: `inf = 0` in both modes, `infZ = 0`.
-      simp only [valueWitness, if_pos hx, if_pos hy, decide_eq_true hx,
-        decide_eq_true hy, Bool.not_true, Bool.and_false, bit, Bool.false_eq_true,
-        if_false, if_true, ite_self]
-      refine ⟨by ring, by linear_combination -hx, ?_, by ring, by ring, ?_, by ring⟩
-      · linear_combination (3 * x1 * x1) * hcancel
-      · linear_combination -hy
-    · -- Inverse pair: `y₂ = −y₁`; excluded under `checkFinite`, else `inf = 1`.
-      have hy2 : y2 = -y1 := by
-        rcases mul_eq_zero.mp hyy with h | h
-        · exact absurd (by linear_combination h) hy
-        · linear_combination h
-      have hne : y2 - y1 ≠ 0 := by
-        rw [hy2]
-        intro h
-        rcases mul_eq_zero.mp (show y1 * 2 = 0 by linear_combination -h) with h' | h'
-        · exact hy1 h'
-        · exact h2 h'
-      cases checkFinite with
-      | true =>
-        exact absurd ⟨hx, by rw [WeierstrassCurve.Affine.negY, ha1, ha3, hy2]; ring⟩
-          (hfin rfl)
-      | false =>
-        simp only [valueWitness, if_pos hx, if_neg hy, decide_eq_true hx,
-          decide_eq_false hy, Bool.not_false, Bool.and_true, bit,
-          Bool.false_eq_true, if_false, if_true]
-        refine ⟨by ring, by linear_combination -hx, ?_, by ring, by ring, by ring, ?_⟩
-        · linear_combination (3 * x1 * x1) * hcancel
-        · linear_combination mul_inv_cancel₀ hne
-  · -- Distinct x-coordinates: the secant row; `inf = 0` in both modes.
-    have hne : x2 - x1 ≠ 0 := fun h => hx (by linear_combination -h)
-    simp only [valueWitness, if_neg hx, decide_eq_false hx, Bool.false_and, bit,
-      Bool.false_eq_true, if_false, ite_self]
-    refine ⟨?_, by ring, ?_, by ring, by ring, by ring, by ring⟩
-    · linear_combination mul_inv_cancel₀ hne
-    · linear_combination (y2 - y1) * mul_inv_cancel₀ hne
-
 /-- Reading a bit variable back through the `Bool` decode: an encoded bit decodes to
 itself (the field is nontrivial). -/
 private theorem readVar_bool_of_eval [Field F] [DecidableEq F]
@@ -463,7 +386,7 @@ private theorem addFastTail_complete_spec [Field F] [DecidableEq F]
     (p1 p2 : AffinePoint (FVar F)) (sameX inf : BoolVar F)
     (x1v y1v x2v y2v : F) (ib : Bool)
     (hHolds : Kimchi.Gate.AddComplete.Holds
-      { valueWitness true x1v y1v x2v y2v with inf := bit ib })
+      { Kimchi.Gate.AddComplete.build true x1v y1v x2v y2v with inf := bit ib })
     (Q : PostCond (AddResult F) (.arg (ProverState F) (.except EvalError .pure))) :
     ⦃Complete
         (fun env =>
@@ -472,8 +395,8 @@ private theorem addFastTail_complete_spec [Field F] [DecidableEq F]
           (↑sameX : CVar F).eval env = .ok (bit (decide (x1v = x2v))) ∧
           (↑inf : CVar F).eval env = .ok (bit ib))
         (fun _ (r : AddResult F) env' =>
-          r.p.x.eval env' = .ok (valueWitness true x1v y1v x2v y2v).x3 ∧
-          r.p.y.eval env' = .ok (valueWitness true x1v y1v x2v y2v).y3 ∧
+          r.p.x.eval env' = .ok (Kimchi.Gate.AddComplete.build true x1v y1v x2v y2v).x3 ∧
+          r.p.y.eval env' = .ok (Kimchi.Gate.AddComplete.build true x1v y1v x2v y2v).y3 ∧
           (↑r.isInfinity : CVar F).eval env' = .ok (bit ib))
         Q⦄
     addFastTail (c := KimchiProverC F) p1 p2 sameX inf
@@ -545,8 +468,8 @@ private theorem addFastTail_complete_spec [Field F] [DecidableEq F]
   · show KimchiConstraint.check (.addComplete _) st₅.env = true
     have heval : AddComplete.eval st₅.env
         ⟨p1, p2, ⟨x3, y3⟩, inf.toCVar, sameX.toCVar, s, infZ, x21Inv⟩
-        = .ok { valueWitness true x1v y1v x2v y2v with inf := bit ib } := by
-      simp [AddComplete.eval, valueWitness,
+        = .ok { Kimchi.Gate.AddComplete.build true x1v y1v x2v y2v with inf := bit ib } := by
+      simp [AddComplete.eval, Kimchi.Gate.AddComplete.build, bit,
         CVar.eval_le hle05 hp1x, CVar.eval_le hle05 hp1y,
         CVar.eval_le hle05 hp2x, CVar.eval_le hle05 hp2y,
         CVar.eval_le hle₅ hx3, hy3, CVar.eval_le (hle₄.trans hle₅) hs,
@@ -623,8 +546,8 @@ theorem addFast_complete_spec [Field F] [DecidableEq F]
   cases fin with
   | checkFinite =>
     mvcgen
-    have hHolds := valueWitness_holds (checkFinite := true) W ha hon1 hon2 hy1ne htwo
-      (fun _ => hfin)
+    have hHolds := Kimchi.Gate.AddComplete.complete_build (checkFinite := true) W ha
+      hon1 hon2 hy1ne htwo (fun _ => hfin)
     refine addFastTail_complete_spec p1 p2 sameXU.val false_ x1v y1v x2v y2v false
       hHolds Q st₃
       ⟨⟨CVar.eval_le (hle₂.trans hle₃) hp1x, CVar.eval_le (hle₂.trans hle₃) hp1y,
@@ -651,8 +574,8 @@ theorem addFast_complete_spec [Field F] [DecidableEq F]
     refine ⟨by rw [hiw]; rfl, fun infU st₄ hinfr hle₄ => ?_⟩
     have hinfb : _ = _ := hinfr _ hiw
     mvcgen
-    have hHolds := valueWitness_holds (checkFinite := false) W ha hon1 hon2 hy1ne htwo
-      (fun h => Bool.noConfusion h)
+    have hHolds := Kimchi.Gate.AddComplete.complete_build (checkFinite := false) W ha
+      hon1 hon2 hy1ne htwo (fun h => Bool.noConfusion h)
     refine addFastTail_complete_spec p1 p2 sameXU.val infU.val x1v y1v x2v y2v
       (decide (x1v = x2v) && !decide (y1v = y2v))
       hHolds Q st₄

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
@@ -150,47 +150,134 @@ private theorem Threaded.snoc :
     subst hr
     exact ⟨w', tail ++ [_], rfl, hrest.snoc xs w⟩
 
-/-- A satisfied threading folds: every round's gate law chains through the shared
-accumulator variables, so `fin` reads as the bare-table folds of the concatenated
-crumb values from `st`'s values. -/
-private theorem threaded_sound [Field F] [DecidableEq F]
-    (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) (V : Valuation F) :
-    ∀ (pref : List (Vector (FVar F) 8)) (st fin : FVar F × FVar F × FVar F)
-      (rounds : List (EndoScalarRound F)),
+/-- The structural facts of a threading, indexed: the round count, the seed wiring
+of round `0`, the shared accumulator variables between adjacent rounds, and the
+final triple's wiring — everything the gate tower's `chain_decompose` consumes,
+extracted without touching a valuation. -/
+private theorem threaded_chain :
+    ∀ {pref : List (Vector (FVar F) 8)} {st fin : FVar F × FVar F × FVar F}
+      {rounds : List (EndoScalarRound F)},
       Threaded st pref rounds fin →
-      (∀ r ∈ rounds, Kimchi.Gate.EndoScalar.Holds (EndoScalarRound.read V r)) →
-      ∃ crumbs : List F,
-        (∀ x ∈ crumbs, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) ∧
-        crumbs.length = 8 * pref.length ∧
-        fin.1.val V = crumbs.foldl
-          (fun a x => 2 * a + Kimchi.Gate.EndoScalar.cFunc x) (st.1.val V) ∧
-        fin.2.1.val V = crumbs.foldl
-          (fun b x => 2 * b + Kimchi.Gate.EndoScalar.dFunc x) (st.2.1.val V) ∧
-        fin.2.2.val V = crumbs.foldl (fun n x => 4 * n + x) (st.2.2.val V)
-  | [], st, fin, rounds, h, _ => by
+      rounds.length = pref.length ∧
+      (∀ _ : 0 < rounds.length,
+        rounds[0].a0 = st.1 ∧ rounds[0].b0 = st.2.1 ∧ rounds[0].n0 = st.2.2) ∧
+      (∀ i (hi : i + 1 < rounds.length),
+        rounds[i + 1].a0 = rounds[i].a8 ∧ rounds[i + 1].b0 = rounds[i].b8 ∧
+        rounds[i + 1].n0 = rounds[i].n8) ∧
+      (∀ _ : 0 < rounds.length,
+        fin.1 = rounds[rounds.length - 1].a8 ∧
+        fin.2.1 = rounds[rounds.length - 1].b8 ∧
+        fin.2.2 = rounds[rounds.length - 1].n8) ∧
+      (rounds = [] → fin = st)
+  | [], st, fin, rounds, h => by
     obtain ⟨hr, hfin⟩ := h
     subst hr hfin
-    exact ⟨[], by simp, by simp, rfl, rfl, rfl⟩
-  | chunk :: rest, st, fin, rounds, h, hHolds => by
+    exact ⟨rfl, fun hi => absurd hi (by simp), fun i hi => absurd hi (by simp),
+      fun hi => absurd hi (by simp), fun _ => rfl⟩
+  | x :: rest, st, fin, rounds, h => by
     obtain ⟨w, tail, hr, hrest⟩ := h
     subst hr
-    have hs := Kimchi.Gate.EndoScalar.sound h2 h3 _ (hHolds _ (List.mem_cons_self ..))
-    obtain ⟨hvalid, hn, ha, hb⟩ := hs
-    simp only [EndoScalarRound.read] at hvalid hn ha hb
-    obtain ⟨crumbs', hvalid', hlen', ha', hb', hn'⟩ :=
-      threaded_sound h2 h3 V rest w fin tail hrest
-        (fun r hr => hHolds r (List.mem_cons_of_mem _ hr))
-    refine ⟨chunk.toList.map (·.val V) ++ crumbs', ?_, ?_, ?_, ?_, ?_⟩
+    obtain ⟨ihlen, ihhead, ihstep, ihlast, ihnil⟩ := threaded_chain hrest
+    refine ⟨by simpa using ihlen, fun _ => ⟨rfl, rfl, rfl⟩, ?_, ?_,
+      fun hcons => by cases hcons⟩
+    · intro i hi
+      cases i with
+      | zero =>
+        have htail : 0 < tail.length := by simpa using hi
+        obtain ⟨h1, h2, h3⟩ := ihhead htail
+        simpa only [List.getElem_cons_succ, List.getElem_cons_zero]
+          using ⟨h1, h2, h3⟩
+      | succ j =>
+        have hj : j + 1 < tail.length := by simpa using hi
+        simpa only [List.getElem_cons_succ] using ihstep j hj
+    · intro _
+      cases tail with
+      | nil =>
+        obtain rfl := ihnil rfl
+        exact ⟨rfl, rfl, rfl⟩
+      | cons t ts =>
+        obtain ⟨h1, h2, h3⟩ := ihlast (by simp)
+        simpa only [List.length_cons, Nat.add_sub_cancel, List.getElem_cons_succ]
+          using ⟨h1, h2, h3⟩
+
+/-- A satisfied threading from the seeds computes the gate tower's chain: the
+structural wiring (`threaded_chain`) instantiates `chain_decompose`'s indexed run
+at the payload reads, so `fin` reads as the decompositions of the concatenated
+crumb stream. The gadget layer contributes wiring only; the fold arithmetic is the
+tower's. -/
+private theorem threaded_sound [Field F] [DecidableEq F]
+    (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) (V : Valuation F)
+    {pref : List (Vector (FVar F) 8)} {fin : FVar F × FVar F × FVar F}
+    {rounds : List (EndoScalarRound F)}
+    (hthr : Threaded (.const 2, .const 2, .const 0) pref rounds fin)
+    (hHolds : ∀ r ∈ rounds, Kimchi.Gate.EndoScalar.Holds (EndoScalarRound.read V r)) :
+    ∃ crumbs : List F,
+      (∀ x ∈ crumbs, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) ∧
+      crumbs.length = 8 * pref.length ∧
+      fin.1.val V = Kimchi.Gate.EndoScalar.decomposeA crumbs ∧
+      fin.2.1.val V = Kimchi.Gate.EndoScalar.decomposeB crumbs ∧
+      fin.2.2.val V = Kimchi.Gate.EndoScalar.nReconstruct crumbs := by
+  obtain ⟨hlen, hhead, hstep, hlast, hnil⟩ := threaded_chain hthr
+  match hround : rounds, hthr with
+  | [], _ =>
+    obtain rfl := hnil rfl
+    refine ⟨[], by simp, by simp [← hlen], ?_, ?_, ?_⟩ <;>
+      simp [Kimchi.Gate.EndoScalar.decomposeA, Kimchi.Gate.EndoScalar.decomposeB,
+        Kimchi.Gate.EndoScalar.nReconstruct, CVar.val]
+  | r₀ :: rs, _ =>
+    subst hround
+    set w : ℕ → Kimchi.Gate.EndoScalar.Witness F :=
+      fun i => EndoScalarRound.read V ((r₀ :: rs).getD i r₀) with hw
+    have hwi : ∀ i (hi : i ≤ rs.length),
+        w i = EndoScalarRound.read V ((r₀ :: rs)[i]'(by simp; omega)) := by
+      intro i hi
+      simp only [hw]
+      congr 1
+      exact List.getD_eq_getElem _ _ (by simp; omega)
+    have hHolds' : ∀ i, i ≤ rs.length → Kimchi.Gate.EndoScalar.Holds (w i) := by
+      intro i hi
+      rw [hwi i hi]
+      exact hHolds _ (List.getElem_mem _)
+    obtain ⟨h01, h02, h03⟩ := hhead (by simp)
+    simp only [List.getElem_cons_zero] at h01 h02 h03
+    obtain ⟨hA, hB, hN⟩ := Kimchi.Gate.EndoScalar.chain_decompose rs.length w hHolds'
+      (by rw [hwi 0 (by omega)]; simp [EndoScalarRound.read, h01, CVar.val])
+      (by rw [hwi 0 (by omega)]; simp [EndoScalarRound.read, h02, CVar.val])
+      (by rw [hwi 0 (by omega)]; simp [EndoScalarRound.read, h03, CVar.val])
+      (fun i hi => by
+        obtain ⟨e, -, -⟩ := hstep i (by simpa using hi)
+        simp only [List.getElem_cons_succ] at e
+        rw [hwi (i + 1) (by omega), hwi i (by omega)]
+        simp [EndoScalarRound.read, e])
+      (fun i hi => by
+        obtain ⟨-, e, -⟩ := hstep i (by simpa using hi)
+        simp only [List.getElem_cons_succ] at e
+        rw [hwi (i + 1) (by omega), hwi i (by omega)]
+        simp [EndoScalarRound.read, e])
+      (fun i hi => by
+        obtain ⟨-, -, e⟩ := hstep i (by simpa using hi)
+        simp only [List.getElem_cons_succ] at e
+        rw [hwi (i + 1) (by omega), hwi i (by omega)]
+        simp [EndoScalarRound.read, e])
+    obtain ⟨hf1, hf2, hf3⟩ := hlast (by simp)
+    refine ⟨Kimchi.Gate.EndoScalar.chainCrumbs w (rs.length + 1), ?_, ?_, ?_, ?_, ?_⟩
     · intro x hx
-      rcases List.mem_append.mp hx with hx | hx
-      · exact hvalid x hx
-      · exact hvalid' x hx
-    · simp only [List.length_append, List.length_map, Vector.length_toList,
-        List.length_cons, hlen']
-      omega
-    · rw [List.foldl_append, ← ha, ha']
-    · rw [List.foldl_append, ← hb, hb']
-    · rw [List.foldl_append, ← hn, hn']
+      simp only [Kimchi.Gate.EndoScalar.chainCrumbs, List.mem_flatMap,
+        List.mem_range] at hx
+      obtain ⟨i, hi, hxi⟩ := hx
+      exact (Kimchi.Gate.EndoScalar.sound h2 h3 _ (hHolds' i (by omega))).1 x hxi
+    · rw [Kimchi.Gate.EndoScalar.chainCrumbs_length 8 w (rs.length + 1)
+        (fun i _ => by simp [hw, EndoScalarRound.read]), ← hlen]
+      simp
+    · rw [← hA, hwi rs.length (by omega)]
+      simp only [List.length_cons, Nat.add_sub_cancel] at hf1
+      simp [EndoScalarRound.read, hf1]
+    · rw [← hB, hwi rs.length (by omega)]
+      simp only [List.length_cons, Nat.add_sub_cancel] at hf2
+      simp [EndoScalarRound.read, hf2]
+    · rw [← hN, hwi rs.length (by omega)]
+      simp only [List.length_cons, Nat.add_sub_cancel] at hf3
+      simp [EndoScalarRound.read, hf3]
 
 open Std.Do in
 /-- The gate emitter is sound: some valid crumb list of length `8·rows` carries the
@@ -236,14 +323,8 @@ theorem toFieldChecked'_spec [Field F] [DecidableEq F] [ToNat F]
       have h := hpay
       rw [hV] at h
       exact h
-    obtain ⟨crumbs, hvalid, hlen, ha, hb, hn⟩ :=
-      threaded_sound h2 h3 s.V crumbVars.toList _ fin.fst fin.snd hthr hHolds
-    refine ⟨crumbs, hvalid, by simpa using hlen, ?_, ?_, ?_⟩
-    · rw [Kimchi.Gate.EndoScalar.decomposeA_eq_table h2 h3 hvalid]
-      simpa [CVar.val] using ha
-    · rw [Kimchi.Gate.EndoScalar.decomposeB_eq_table h2 h3 hvalid]
-      simpa [CVar.val] using hb
-    · simpa [Kimchi.Gate.EndoScalar.nReconstruct, CVar.val] using hn
+    obtain ⟨crumbs, hvalid, hlen, ha, hb, hn⟩ := threaded_sound h2 h3 s.V hthr hHolds
+    exact ⟨crumbs, hvalid, by simpa using hlen, ha, hb, hn⟩
 
 open Std.Do in
 /-- The checked decomposition is sound: the result reads as the gate model's

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
@@ -25,8 +25,9 @@ Deviations from the PS original (per `formal/docs/snarky-kimchi-alignment.md`):
   with `16 · rows` bits, and the bit reads go through `[ToNat F]`.
 - PS's record `exists` allocates its fields alphabetically; the per-row witness is
   the ordered triple `(a8, b8, n8)`, the same allocation spelled explicitly.
-- PS's `aF`/`bF` are the gate's own `cFunc`/`dFunc` tables (their throwing branches
-  rendered as the tables' `0`), so the witness folds are stated with them directly.
+- PS's `aF`/`bF` fold the bare tables; the row witness computes the gate's canonical
+  `Kimchi.Gate.EndoScalar.build` instead — the same field values on the honest (valid)
+  crumbs, and the form the gate's completeness certifies.
 - `toFieldPure` is generalized from PS's pinned 128 bits to `16 · rows`.
 -/
 
@@ -53,18 +54,17 @@ private def crumbsWit [Field F] [ToNat F] (rows : ℕ) (scalar : FVar F) :
   let v ← AsProver.readCVar scalar
   pure (crumbVals rows (ToNat.toNat v))
 
-/-- One row's accumulator witness: fold the row's eight crumbs into the three
-accumulators over the gate's bare tables, returned in the allocation order
-`(a8, b8, n8)`. -/
+/-- One row's accumulator witness: read the threaded registers and the row's eight
+crumbs, and take the gate's canonical row's outputs
+(`Kimchi.Gate.EndoScalar.build`), in the allocation order `(a8, b8, n8)`. -/
 private def rowWit [Field F] [DecidableEq F] (xs : Vector (FVar F) 8)
     (st : FVar F × FVar F × FVar F) : AsProver F (F × F × F) := do
   let a0 ← AsProver.readCVar st.1
   let b0 ← AsProver.readCVar st.2.1
   let n0 ← AsProver.readCVar st.2.2
   let vals ← xs.toList.mapM AsProver.readCVar
-  pure (vals.foldl (fun acc x => 2 * acc + Kimchi.Gate.EndoScalar.cFunc x) a0,
-        vals.foldl (fun acc x => 2 * acc + Kimchi.Gate.EndoScalar.dFunc x) b0,
-        vals.foldl (fun acc x => 4 * acc + x) n0)
+  let w := Kimchi.Gate.EndoScalar.build a0 b0 n0 vals
+  pure (w.a8, w.b8, w.n8)
 
 /-- The gate emitter (PS `toFieldChecked'`; OCaml
 `Pickles.Scalar_challenge.to_field_checked'`): the bulk crumb witness, the
@@ -372,8 +372,9 @@ scalar's own crumbs (`Kimchi.Gate.EndoScalar.crumbsOf`). The emitter needs only 
 readable scalar; the checked decomposition's `n = scalar` pin adds the boundary
 conditions of the representative — faithfulness and the `4 ^ (8·rows)` range. The
 witness's testBit crumbs meet the gate model's expansion at
-`map_crumbOfNat_eq_crumbsOf`; the loop's invariant carries the accumulator reads
-and the collected rounds' checks across table growth. -/
+`map_crumbOfNat_eq_crumbsOf`; the loop's invariant identifies the run with the
+gate's canonical chain (`chainBuild`), whose acceptance and reading are the gate's
+own `chain_complete` and `chain_decompose`. -/
 
 /-- Every crumb is a valid 2-bit value. -/
 private theorem crumbOfNat_cast_valid [Field F] (count j k : ℕ) :
@@ -445,24 +446,65 @@ private theorem crumbVals_flatten [Field F] (rows k : ℕ) :
   rw [Vector.toList_ofFn, List.map_ofFn, ← map_crumbOfNat_eq_crumbsOf]
   exact flatten_ofFn_rows (fun i => (crumbOfNat (8 * rows) i k : F)) rows
 
-/-- The value-level row step: the three accumulator folds of one row. -/
-private def accStep [Field F] [DecidableEq F] (st : F × F × F) (xs : List F) :
-    F × F × F :=
-  (xs.foldl (fun a x => 2 * a + Kimchi.Gate.EndoScalar.cFunc x) st.1,
-   xs.foldl (fun b x => 2 * b + Kimchi.Gate.EndoScalar.dFunc x) st.2.1,
-   xs.foldl (fun n x => 4 * n + x) st.2.2)
+/-- Every entry of one witness row is a valid crumb. -/
+private theorem crumbVals_row_valid [Field F] (rows n k : ℕ) (hk : k < rows) :
+    ∀ x ∈ ((crumbVals (F := F) rows n)[k]'hk).toList,
+      x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3 := by
+  intro x hx
+  simp only [crumbVals, Vector.getElem_ofFn, Vector.toList_ofFn, List.mem_ofFn] at hx
+  obtain ⟨j, rfl⟩ := hx
+  exact crumbOfNat_cast_valid _ _ _
 
-/-- Row-stepping is folding the concatenated crumbs. -/
-private theorem accStep_foldl [Field F] [DecidableEq F] :
-    ∀ (rs : List (List F)) (st : F × F × F),
-      rs.foldl accStep st
-        = (rs.flatten.foldl (fun a x => 2 * a + Kimchi.Gate.EndoScalar.cFunc x) st.1,
-           rs.flatten.foldl (fun b x => 2 * b + Kimchi.Gate.EndoScalar.dFunc x) st.2.1,
-           rs.flatten.foldl (fun n x => 4 * n + x) st.2.2)
-  | [], st => rfl
-  | r :: rs, st => by
-    simp only [List.foldl_cons, List.flatten_cons, List.foldl_append]
-    exact accStep_foldl rs _
+/-- The scalar's crumb rows as a total chain index (empty rows off the end) — the
+`rows` argument the gate's `chainBuild` threads. -/
+private def crumbRows [NatCast F] (rows k : ℕ) : ℕ → List F := fun i =>
+  ((crumbVals (F := F) rows k).toList.map Vector.toList).getD i []
+
+/-- In range, a chain row is the witness table's row. -/
+private theorem crumbRows_getElem [NatCast F] (rows k i : ℕ) (hi : i < rows) :
+    crumbRows (F := F) rows k i = ((crumbVals (F := F) rows k)[i]'hi).toList := by
+  simp only [crumbRows]
+  rw [List.getD_eq_getElem _ _ (by simp [hi])]
+  simp
+
+/-- Every chain row is valid crumbs (vacuously off the end). -/
+private theorem crumbRows_valid [Field F] (rows k : ℕ) :
+    ∀ i, ∀ x ∈ crumbRows (F := F) rows k i, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3 := by
+  intro i x hx
+  by_cases hi : i < rows
+  · rw [crumbRows_getElem rows k i hi] at hx
+    exact crumbVals_row_valid rows k i hi x hx
+  · rw [show crumbRows (F := F) rows k i = [] from by
+      simp only [crumbRows]
+      exact List.getD_eq_default _ _ (by simp; omega)] at hx
+    cases hx
+
+/-- Flattening over a row list's range through its total index is the flatten. -/
+private theorem flatMap_range_getD {α : Type} :
+    ∀ l : List (List α),
+      (List.range l.length).flatMap (fun i => l.getD i []) = l.flatten
+  | [] => rfl
+  | r :: rs => by
+    rw [List.length_cons, List.range_succ_eq_map, List.flatMap_cons, List.flatMap_map]
+    simp only [List.getD_cons_zero]
+    rw [show (fun i => (r :: rs).getD (i + 1) []) = (fun i => rs.getD i []) from
+        funext fun i => List.getD_cons_succ ..,
+      flatMap_range_getD rs, List.flatten_cons]
+
+/-- Rebuilding a chain row from its own registers is the row: `build` stores its
+arguments, so the chain step reads off the previous row's fields. -/
+private theorem build_fields [Field F] (rows' : ℕ → List F) (i : ℕ) :
+    Kimchi.Gate.EndoScalar.build
+        (Kimchi.Gate.EndoScalar.chainBuild rows' i).a0
+        (Kimchi.Gate.EndoScalar.chainBuild rows' i).b0
+        (Kimchi.Gate.EndoScalar.chainBuild rows' i).n0 (rows' i)
+      = Kimchi.Gate.EndoScalar.chainBuild rows' i := by
+  cases i <;> rfl
+
+/-- A chain row carries its own crumbs. -/
+private theorem chainBuild_crumbs [Field F] (rows' : ℕ → List F) (i : ℕ) :
+    (Kimchi.Gate.EndoScalar.chainBuild rows' i).crumbs = rows' i := by
+  cases i <;> rfl
 
 /-- Element reads assemble into the list read. -/
 private theorem mapM_eval_ok [Add F] [Mul F] {env : Assignments F} :
@@ -551,32 +593,16 @@ private theorem check_rounds_le [Field F] [DecidableEq F] {env env' : Assignment
     rw [round_eval_le hle he]
     exact hh
 
-/-- One more element folds onto the prefix. -/
-private theorem take_succ_foldl {α β : Type} (f : β → α → β) {l : List α} {k : ℕ}
-    (hk : k < l.length) (init : β) :
-    (l.take (k + 1)).foldl f init = f ((l.take k).foldl f init) l[k] := by
-  rw [List.take_add, List.take_one_drop_eq_of_lt_length hk]
-  simp only [List.foldl_append, List.foldl_cons, List.foldl_nil, List.get_eq_getElem]
-
-/-- Every entry of one witness row is a valid crumb. -/
-private theorem crumbVals_row_valid [Field F] (rows n k : ℕ) (hk : k < rows) :
-    ∀ x ∈ ((crumbVals (F := F) rows n)[k]'hk).toList,
-      x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3 := by
-  intro x hx
-  simp only [crumbVals, Vector.getElem_ofFn, Vector.toList_ofFn, List.mem_ofFn] at hx
-  obtain ⟨j, rfl⟩ := hx
-  exact crumbOfNat_cast_valid _ _ _
-
-/-- One row's accumulator witness computes the row step. -/
+/-- One row's accumulator witness computes the gate's canonical row's outputs. -/
 private theorem rowWit_ok [Field F] [DecidableEq F] {env : Assignments F}
     {xs : Vector (FVar F) 8} {st : FVar F × FVar F × FVar F} {a b n : F} {vs : List F}
     (ha : st.1.eval env = .ok a) (hb : st.2.1.eval env = .ok b)
     (hn : st.2.2.eval env = .ok n)
     (hxs : xs.toList.mapM (CVar.eval · env) = .ok vs) :
     rowWit xs st env
-      = .ok (vs.foldl (fun acc x => 2 * acc + Kimchi.Gate.EndoScalar.cFunc x) a,
-             vs.foldl (fun acc x => 2 * acc + Kimchi.Gate.EndoScalar.dFunc x) b,
-             vs.foldl (fun acc x => 4 * acc + x) n) := by
+      = .ok ((Kimchi.Gate.EndoScalar.build a b n vs).a8,
+             (Kimchi.Gate.EndoScalar.build a b n vs).b8,
+             (Kimchi.Gate.EndoScalar.build a b n vs).n8) := by
   simp [rowWit, AsProver.readCVar, ha, hb, hn, readAll_ok hxs, Bind.bind, ReaderT.bind,
     Except.bind, Pure.pure, ReaderT.pure, Except.pure]
 
@@ -585,7 +611,7 @@ open Std.Do in
 scalar — no range condition — and the returned accumulators read as the gate model's
 decompositions of the scalar's crumbs. -/
 theorem toFieldChecked'_complete_spec [Field F] [DecidableEq F] [ToNat F]
-    (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) (rows : ℕ) (scalar : FVar F)
+    (rows : ℕ) (scalar : FVar F)
     (Q : PostCond (FVar F × FVar F × FVar F)
       (.arg (ProverState F) (.except EvalError .pure))) :
     ⦃Complete (fun env => (scalar.eval env).isOk)
@@ -612,11 +638,11 @@ theorem toFieldChecked'_complete_spec [Field F] [DecidableEq F] [ToNat F]
   mvcgen
   case inv1 =>
     exact ⇓ p s' => ⌜st₁.env.Le s'.env ∧
-      (let stv := (((crumbVals (F := F) rows (ToNat.toNat vv)).toList.map
-          Vector.toList).take p.1.prefix.length).foldl accStep (2, 2, 0)
-       p.2.fst.1.eval s'.env = .ok stv.1 ∧
-       p.2.fst.2.1.eval s'.env = .ok stv.2.1 ∧
-       p.2.fst.2.2.eval s'.env = .ok stv.2.2) ∧
+      (let w := Kimchi.Gate.EndoScalar.chainBuild
+          (crumbRows (F := F) rows (ToNat.toNat vv)) p.1.prefix.length
+       p.2.fst.1.eval s'.env = .ok w.a0 ∧
+       p.2.fst.2.1.eval s'.env = .ok w.b0 ∧
+       p.2.fst.2.2.eval s'.env = .ok w.n0) ∧
       KimchiConstraint.check (.endoScalar p.2.snd) s'.env = true⌝
   case vc1.step =>
     rename_i pref cur suff hsplit b s' hinv
@@ -635,27 +661,29 @@ theorem toFieldChecked'_complete_spec [Field F] [DecidableEq F] [ToNat F]
       rw [← h1, Vector.getElem_toList]
     subst hcur
     have hxs : (crumbVars[pref.length]'hkrows).toList.mapM (CVar.eval · s'.env)
-        = .ok ((crumbVals (F := F) rows (ToNat.toNat vv))[pref.length]'hkrows).toList := by
+        = .ok (crumbRows (F := F) rows (ToNat.toNat vv) pref.length) := by
+      rw [crumbRows_getElem rows (ToNat.toNat vv) pref.length hkrows]
       refine mapM_eval_ok (by simp) ?_
       intro j hj hj'
       simp only [Vector.length_toList] at hj
       simp only [Vector.getElem_toList]
       exact CVar.eval_le hLe (hread pref.length hkrows j hj)
     have hrow := rowWit_ok (env := s'.env) hA hB hN hxs
+    rw [build_fields] at hrow
     refine ⟨by rw [hrow]; rfl, fun r st' hgrant' hle' => ?_⟩
     have hw := hgrant' _ hrow
     have heval : EndoScalarRound.eval st'.env
         { n0 := b.fst.2.2, n8 := r.2.2, a0 := b.fst.1, a8 := r.1,
           b0 := b.fst.2.1, b8 := r.2.1, xs := crumbVars[pref.length]'hkrows }
-        = .ok (Kimchi.Gate.EndoScalar.buildTable _ _ _
-            ((crumbVals (F := F) rows (ToNat.toNat vv))[pref.length]'hkrows).toList) :=
+        = .ok (Kimchi.Gate.EndoScalar.chainBuild
+            (crumbRows (F := F) rows (ToNat.toNat vv)) pref.length) :=
       round_eval_ok_iff.mpr ⟨CVar.eval_le hle' hA, CVar.eval_le hle' hB,
-        CVar.eval_le hle' hN, hw.1, hw.2.1, hw.2.2, mapM_eval_le hle' hxs⟩
+        CVar.eval_le hle' hN, hw.1, hw.2.1, hw.2.2, by
+          rw [chainBuild_crumbs]
+          exact mapM_eval_le hle' hxs⟩
     mvcgen
     refine ⟨hLe.trans hle', ?_, ?_⟩
     · simp only [List.length_append, List.length_cons, List.length_nil]
-      rw [take_succ_foldl accStep (by simp [hkrows]) (2, 2, 0)]
-      simp only [List.getElem_map, Vector.getElem_toList]
       exact ⟨hw.1, hw.2.1, hw.2.2⟩
     · simp only [KimchiConstraint.check, List.all_append, List.all_cons, List.all_nil,
         Bool.and_eq_true, and_true]
@@ -663,18 +691,19 @@ theorem toFieldChecked'_complete_spec [Field F] [DecidableEq F] [ToNat F]
       · simpa only [KimchiConstraint.check] using check_rounds_le hle' hcheck
       · simp only [heval]
         exact (Kimchi.Gate.EndoScalar.ok_iff _).mpr
-          (Kimchi.Gate.EndoScalar.complete_table h2 h3 _ _ _ _
-            (crumbVals_row_valid rows (ToNat.toNat vv) pref.length hkrows))
+          ((Kimchi.Gate.EndoScalar.chain_complete pref.length _
+            (fun i _ => crumbRows_valid rows (ToNat.toNat vv) i)).1 pref.length
+            (Nat.le_refl _))
   case vc2.vc1.pre =>
     refine ⟨Assignments.Le.refl st₁.env, ⟨?_, ?_, ?_⟩,
         by simp [KimchiConstraint.check]⟩ <;>
-      simp [CVar.eval]
+      simp [CVar.eval, Kimchi.Gate.EndoScalar.chainBuild,
+        Kimchi.Gate.EndoScalar.build]
   case vc3.vc1.post.success =>
     rename_i fin s' hinv
     obtain ⟨hLe, hacc, hcheck⟩ := hinv
     obtain ⟨hA, hB, hN⟩ := hacc
-    rw [List.take_of_length_le (by simp)] at hA hB hN
-    rw [accStep_foldl, crumbVals_flatten] at hA hB hN
+    simp only [Vector.length_toList] at hA hB hN
     refine addConstraint_complete_spec (c := KimchiConstraint F)
       (KimchiSystem.endoScalar fin.snd) (fun a => wp⟦pure fin.fst⟧ Q, Q.2) s'
       ⟨hcheck, fun u st₂ _ hle₂ => ?_⟩
@@ -685,13 +714,51 @@ theorem toFieldChecked'_complete_spec [Field F] [DecidableEq F] [ToNat F]
     rw [hv] at hv'
     injection hv' with hv'
     subst hv'
-    have hvalid := Kimchi.Gate.EndoScalar.crumbsOf_valid (F := F) (8 * rows) (ToNat.toNat vv)
-    refine ⟨?_, ?_, ?_⟩
-    · rw [Kimchi.Gate.EndoScalar.decomposeA_eq_table h2 h3 hvalid]
-      exact CVar.eval_le hle₂ hA
-    · rw [Kimchi.Gate.EndoScalar.decomposeB_eq_table h2 h3 hvalid]
-      exact CVar.eval_le hle₂ hB
-    · exact CVar.eval_le hle₂ hN
+    cases rows with
+    | zero =>
+      refine ⟨?_, ?_, ?_⟩ <;>
+        · refine CVar.eval_le hle₂ ?_
+          first
+            | (rw [show Kimchi.Gate.EndoScalar.decomposeA
+                    (Kimchi.Gate.EndoScalar.crumbsOf (F := F) (8 * 0)
+                      (ToNat.toNat vv)) = 2 from by
+                  simp [Kimchi.Gate.EndoScalar.crumbsOf,
+                    Kimchi.Gate.EndoScalar.decomposeA]]
+               exact hA)
+            | (rw [show Kimchi.Gate.EndoScalar.decomposeB
+                    (Kimchi.Gate.EndoScalar.crumbsOf (F := F) (8 * 0)
+                      (ToNat.toNat vv)) = 2 from by
+                  simp [Kimchi.Gate.EndoScalar.crumbsOf,
+                    Kimchi.Gate.EndoScalar.decomposeB]]
+               exact hB)
+            | (rw [show Kimchi.Gate.EndoScalar.nReconstruct
+                    (Kimchi.Gate.EndoScalar.crumbsOf (F := F) (8 * 0)
+                      (ToNat.toNat vv)) = 0 from by
+                  simp [Kimchi.Gate.EndoScalar.crumbsOf,
+                    Kimchi.Gate.EndoScalar.nReconstruct]]
+               exact hN)
+    | succ m =>
+      obtain ⟨hH, c1, c2, c3, s1, s2, s3, -⟩ :=
+        Kimchi.Gate.EndoScalar.chain_complete m
+          (crumbRows (F := F) (m + 1) (ToNat.toNat vv))
+          (fun i _ => crumbRows_valid (m + 1) (ToNat.toNat vv) i)
+      obtain ⟨dA, dB, dN⟩ := Kimchi.Gate.EndoScalar.chain_decompose m
+        (Kimchi.Gate.EndoScalar.chainBuild
+          (crumbRows (F := F) (m + 1) (ToNat.toNat vv)))
+        hH c1 c2 c3 s1 s2 s3
+      have hstream := flatMap_range_getD
+        (((crumbVals (F := F) (m + 1) (ToNat.toNat vv)).toList.map Vector.toList))
+      rw [show (((crumbVals (F := F) (m + 1) (ToNat.toNat vv)).toList.map
+          Vector.toList)).length = m + 1 from by simp,
+        crumbVals_flatten] at hstream
+      have hstream' : (List.range (m + 1)).flatMap
+            (crumbRows (F := F) (m + 1) (ToNat.toNat vv))
+          = Kimchi.Gate.EndoScalar.crumbsOf (8 * (m + 1)) (ToNat.toNat vv) := hstream
+      rw [Kimchi.Gate.EndoScalar.chainCrumbs_chainBuild, hstream'] at dA dB dN
+      refine ⟨?_, ?_, ?_⟩
+      · exact CVar.eval_le hle₂ (by rw [← dA]; exact hA)
+      · exact CVar.eval_le hle₂ (by rw [← dB]; exact hB)
+      · exact CVar.eval_le hle₂ (by rw [← dN]; exact hN)
   case vc4.vc1.post.except =>
     exact ExceptConds.entails_false
 
@@ -700,7 +767,7 @@ open Std.Do in
 readable scalar whose representative is faithful and fits the crumb budget, and the
 result reads as the gate model's `toField` at the scalar's crumbs. -/
 theorem toField_complete_spec [Field F] [DecidableEq F] [ToNat F]
-    (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) (rows : ℕ) (scalar endo : FVar F)
+    (rows : ℕ) (scalar endo : FVar F)
     (Q : PostCond (FVar F) (.arg (ProverState F) (.except EvalError .pure))) :
     ⦃Complete
         (fun env => (scalar.eval env).isOk ∧ (endo.eval env).isOk ∧
@@ -719,7 +786,7 @@ theorem toField_complete_spec [Field F] [DecidableEq F] [ToNat F]
   obtain ⟨vv, hv⟩ := CVar.evalOk hoks
   obtain ⟨ev, he⟩ := CVar.evalOk hoke
   obtain ⟨hfaith, hlt⟩ := hbound vv hv
-  refine toFieldChecked'_complete_spec h2 h3 rows scalar _ _
+  refine toFieldChecked'_complete_spec rows scalar _ _
     ⟨hoks, fun abn st₁ hpost₁ hle₁ => ?_⟩
   obtain ⟨hA, hB, hN⟩ := hpost₁ vv hv
   mvcgen

--- a/formal/snarky/Snarky/Kimchi/Circuit/Poseidon.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/Poseidon.lean
@@ -206,8 +206,8 @@ private theorem chainOk_iff [Field F] [DecidableEq F]
       Kimchi.Gate.Poseidon.ok_iff, chainOk_iff (k + 1) (s5 :: rest)]
 
 /-- A list whose successive entries are the gate's round images satisfies the chain
-reading: each window's fifteen constraint expressions vanish by the adjacency
-equations alone. -/
+reading: each window is the gate's canonical `build` at its head state, so the gate's
+`complete` applies window by window. -/
 private theorem chainHolds_of_succ [Field F] {M : Kimchi.Gate.Poseidon.Mds F}
     {rc : List (F × F × F)} :
     ∀ (k : ℕ) (l : List (F × F × F)),
@@ -224,11 +224,11 @@ private theorem chainHolds_of_succ [Field F] {M : Kimchi.Gate.Poseidon.Mds F}
       have e3 := hsucc 3 (by simp) (by simp)
       have e4 := hsucc 4 (by simp) (by simp)
       simp only [List.getElem_cons_zero, List.getElem_cons_succ] at e0 e1 e2 e3 e4
-      intro e he
-      simp only [Kimchi.Gate.Poseidon.constraints, rcRow, List.mem_cons,
-        List.not_mem_nil, or_false] at he
-      rcases he with h | h | h | h | h | h | h | h | h | h | h | h | h | h | h <;>
-        (subst h; simp [e0, e1, e2, e3, e4])
+      have hwin : (⟨s0, s1, s2, s3, s4, s5⟩ : Kimchi.Gate.Poseidon.Witness F)
+          = Kimchi.Gate.Poseidon.build M s0 (rcRow rc k) := by
+        simp [Kimchi.Gate.Poseidon.build, rcRow, e0, e1, e2, e3, e4]
+      rw [hwin]
+      exact Kimchi.Gate.Poseidon.complete M s0 (rcRow rc k)
     · refine chainHolds_of_succ (k + 1) (s5 :: rest) ?_
       intro j hj1 hj0
       have hs := hsucc (j + 5) (by simp at hj1 ⊢; omega) (by simp at hj1 ⊢; omega)


### PR DESCRIPTION
Review follow-on from #293: the gadget layer's laws should apply the `Kimchi/Gate/Semantics/*` soundness and completeness theorems directly, as the Poseidon laws already do. Two spots fell short; both closed.

## `addFast_complete_spec` promises the group sum

The completeness post said only that the honest run accepts and the outputs are *readable* — weaker than the gate's own theorems, and weaker than Poseidon's complete law (which characterizes the output as `blockCipher`). It now delivers the group-level characterization: for pinned input reads and nonsingularity witnesses, *either* the infinity flag reads `1` and `P₁ + P₂ = 0` in Mathlib's group, *or* it reads `0` and the output coordinates are a nonsingular point equal to the sum.

The derivation applies the gate's `sound` to the accepted run: the row the honest prover filled satisfies the verified gate, so `Kimchi.Gate.AddComplete.sound` characterizes what was computed. The internal tail spec's post carries the honest row's concrete values (instead of bare `isOk`s) to make that application possible.

This is the fact the EndoMul slice composes for its initial accumulator `P₀ = [2](T + φ(T))`.

## EndoScalar soundness reroutes through the chain lemmas

The sound law's conclusions were already in gate-semantics vocabulary, but the proof re-derived the chain folds at the gadget carrier (`threaded_sound`'s fold induction) instead of consuming `chain_decompose`. Now:

- `chainCrumbs`, `chainCrumbs_length`, `chain_decompose` go public in kimchi (arrival-with-consumer);
- `threaded_chain` extracts the threading's structural facts — round count, seed wiring, shared accumulator variables between adjacent rounds, the final triple — valuation-free;
- `threaded_sound` becomes wiring only: the extraction instantiates `chain_decompose`'s indexed run at the payload reads. The fold arithmetic lives solely in the gate-semantics layer, and the `decomposeA_eq_table` conversions vanish from the sound proof (`chain_decompose` concludes in `decomposeA` vocabulary directly).

The `threaded_chain` bridge is the shape the EndoMul slice reuses to consume `pallas_endoMul`/`vesta_endoMul` wholesale.

## Completeness goes constructive — one source for both directions

Review of the completeness side found the same disease in every remaining proof: existentially packaged gate completeness can never certify fixed prover code, so the gadget layer was replaying the gates' algebra privately. Three commits close it:

- **AddComplete**: the gate gains its canonical row `build` and `complete_build : Holds (build …)` (the gadget's former private `valueWitness`/`valueWitness_holds`, relocated); the `∃`-shaped `complete` becomes a one-line corollary and `complete_noninf`/`complete_inf` retire. `addFast_complete_spec` consumes `complete_build` for acceptance and the gate's `sound` for the output characterization.
- **Poseidon**: `chainHolds_of_succ`'s fifteen-way constraint case analysis becomes one identification — a window whose successor is the round image *is* the gate's `build`, so the gate's `complete` applies per window.
- **EndoScalar**: the row witness computes the gate's `build`; the completeness loop's invariant identifies the prover's run with the gate's threaded `chainBuild` (uniform — round `k`'s inputs are round `k−1`'s outputs); acceptance is `chain_complete`, the final reading is `chain_decompose` — the same theorem the sound law consumes. The bare-table detour (`buildTable`/`buildTable_eq_build`/`complete_table`) and the gadget's fold bookkeeping die, and the characteristic hypotheses `h2`/`h3` drop from both completeness specs (completeness needs no field non-degeneracy — they were an artifact of the detour).

Net: every soundness and completeness fact for every landed gadget now derives from its gate's single semantics development — universal theorems applied to the accepted run, constructive completeness at the canonical witness — with the gadget layer contributing wiring only.

Gates green: build, corpus 23/23, style, snarky + kimchi axiom gates, deadcode 0, per-root lint, shake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
