### PR TITLE
snarky-kimchi: AddComplete laws apply the gate-semantics theorems directly

### DIFF
--- a/formal/kimchi/Kimchi/Gate/AddComplete.lean
+++ b/formal/kimchi/Kimchi/Gate/AddComplete.lean
@@ -29,9 +29,10 @@ carries the constraint model; the theorems below are proved in
   sum `(x₁,y₁) + (x₂,y₂)` is the group element the gate encodes — `0` when `inf = 1`,
   else the affine output `(x₃, y₃)` — using that `inf` is boolean (`inf_boolean`). It
   splits into the per-case `sound_point_noninf` / `sound_point_inf`.
-* `complete` — COMPLETENESS, both cases in one statement: for on-curve inputs (`y₁ ≠ 0`),
-  an honest prover can fill a satisfying witness, casing internally on whether the sum is
-  finite or `∞`. Splits into the per-case `complete_noninf` / `complete_inf`.
+* `build` / `complete_build` — COMPLETENESS, constructive: the canonical row the honest
+  prover fills, and the theorem that it satisfies the gate for on-curve inputs
+  (`y₁ ≠ 0`), casing internally on whether the sum is finite or `∞`. `complete` is the
+  existential corollary.
 -/
 
 namespace Kimchi.Gate.AddComplete

--- a/formal/kimchi/Kimchi/Gate/Semantics/AddComplete.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/AddComplete.lean
@@ -73,122 +73,93 @@ theorem sound_noninf
       WeierstrassCurve.Affine.negAddY, WeierstrassCurve.Affine.addX, ha1, ha2, ha3]
     linear_combination -c5 - w.s * c4
 
-/-- COMPLETENESS: the honest prover can always fill in the witness. For on-curve
-    inputs whose sum is finite, there exists a satisfying witness, and its output
-    is the Mathlib affine sum. -/
-theorem complete_noninf
+/-- The canonical satisfying row: the slope, sum coordinates, and the three auxiliary
+    witnesses, as one pure function of the operand values — the row the honest prover
+    fills. `checkFinite` pins `inf` to `0`; otherwise `inf` is the inverse-pair test. -/
+def build (checkFinite : Bool) (x1 y1 x2 y2 : F) : Witness F :=
+  let s : F := if x1 = x2 then 3 * x1 * x1 / (2 * y1) else (y2 - y1) / (x2 - x1)
+  let x3 : F := s * s - (x1 + x2)
+  { x1 := x1, y1 := y1, x2 := x2, y2 := y2
+    x3 := x3
+    y3 := s * (x1 - x3) - y1
+    inf := if checkFinite then 0
+      else if decide (x1 = x2) && !decide (y1 = y2) then 1 else 0
+    sameX := if decide (x1 = x2) then 1 else 0
+    s := s
+    infZ := if y1 = y2 then 0 else if x1 = x2 then (y2 - y1)⁻¹ else 0
+    x21Inv := if x1 = x2 then 0 else (x2 - x1)⁻¹ }
+
+/-- COMPLETENESS, constructive: the canonical row satisfies the gate. For on-curve
+    operands with `y₁ ≠ 0` — `checkFinite` adding the finite-sum precondition —
+    `build`'s row meets every constraint. The consumable form for a deployed prover,
+    which is fixed code: an existential witness cannot certify the row it actually
+    fills. `complete` below is the existential corollary. -/
+theorem complete_build
     (W : WeierstrassCurve.Affine F)
     (ha : W.a₁ = 0 ∧ W.a₂ = 0 ∧ W.a₃ = 0 ∧ W.a₄ = 0)
-    (x1 y1 x2 y2 : F)
+    {checkFinite : Bool} {x1 y1 x2 y2 : F}
     (hon1 : W.Equation x1 y1) (hon2 : W.Equation x2 y2)
-    (hfin : ¬ (x1 = x2 ∧ y1 = W.negY x2 y2))
-    (hy1 : y1 ≠ 0) (h2 : (2 : F) ≠ 0) :
-    ∃ w : Witness F,
-      w.x1 = x1 ∧ w.y1 = y1 ∧ w.x2 = x2 ∧ w.y2 = y2 ∧ w.inf = 0
-      ∧ Holds w
-      ∧ w.x3 = W.addX x1 x2 (W.slope x1 x2 y1 y2)
-      ∧ w.y3 = W.addY x1 x2 y1 (W.slope x1 x2 y1 y2) := by
+    (hy1 : y1 ≠ 0) (h2 : (2 : F) ≠ 0)
+    (hfin : checkFinite = true → ¬(x1 = x2 ∧ y1 = W.negY x2 y2)) :
+    Holds (build checkFinite x1 y1 x2 y2) := by
   obtain ⟨ha1, ha2, ha3, ha4⟩ := ha
-  by_cases hx : x1 = x2
-  · -- doubling branch: sameX = 1, x21Inv = 0
-    have hy : y1 ≠ W.negY x2 y2 := fun h => hfin ⟨hx, h⟩
-    have hnegYx1 : W.negY x1 y1 = -y1 := by simp [WeierstrassCurve.Affine.negY, ha1, ha3]
-    have hyy : y1 + y1 ≠ 0 := by rw [← two_mul]; exact mul_ne_zero h2 hy1
-    have hyeq : y1 = y2 := WeierstrassCurve.Affine.Y_eq_of_Y_ne hon1 hon2 hx hy
-    refine ⟨{ x1 := x1, y1 := y1, x2 := x2, y2 := y2
-            , x3 := W.addX x1 x2 (W.slope x1 x2 y1 y2)
-            , y3 := W.addY x1 x2 y1 (W.slope x1 x2 y1 y2)
-            , inf := 0, sameX := 1, s := W.slope x1 x2 y1 y2
-            , infZ := 0, x21Inv := 0 },
-          rfl, rfl, rfl, rfl, rfl, ?_, rfl, rfl⟩
-    rw [holds_iff]
-    refine ⟨by ring, by rw [hx]; ring, ?_, ?_, ?_, by rw [← hyeq]; ring, by ring⟩
-    · -- c3: 2·s·y₁ = 3x₁²  (via slope = 3x₁²/(2y₁), cleared with eq_div_iff)
-      have hs : W.slope x1 x2 y1 y2 = 3 * x1 ^ 2 / (y1 + y1) := by
-        rw [WeierstrassCurve.Affine.slope_of_Y_ne hx hy, hnegYx1, sub_neg_eq_add]
-        simp only [ha1, ha2, ha4]; ring
-      have key : W.slope x1 x2 y1 y2 * (y1 + y1) = 3 * x1 ^ 2 := (eq_div_iff hyy).mp hs
-      linear_combination key
-    · simp only [WeierstrassCurve.Affine.addX, ha1, ha2]; ring
-    · simp only [WeierstrassCurve.Affine.addY, WeierstrassCurve.Affine.negY,
-        WeierstrassCurve.Affine.negAddY, WeierstrassCurve.Affine.addX, ha1, ha2, ha3]; ring
-  · -- addition branch: sameX = 0, x21Inv = (x₂−x₁)⁻¹
-    have hx21 : x2 - x1 ≠ 0 := sub_ne_zero.mpr (Ne.symm hx)
-    refine ⟨{ x1 := x1, y1 := y1, x2 := x2, y2 := y2
-            , x3 := W.addX x1 x2 (W.slope x1 x2 y1 y2)
-            , y3 := W.addY x1 x2 y1 (W.slope x1 x2 y1 y2)
-            , inf := 0, sameX := 0, s := W.slope x1 x2 y1 y2
-            , infZ := 0, x21Inv := (x2 - x1)⁻¹ },
-          rfl, rfl, rfl, rfl, rfl, ?_, rfl, rfl⟩
-    rw [holds_iff]
-    refine ⟨?_, by ring, ?_, ?_, ?_, by ring, by ring⟩
-    · -- c1: (x₂−x₁)⁻¹·(x₂−x₁) − 1 = 0
-      rw [inv_mul_cancel₀ hx21]; ring
-    · -- c3: (x₂−x₁)·s = y₂−y₁  (slope identity in multiplied-out form)
-      have hx12 : x1 - x2 ≠ 0 := sub_ne_zero.mpr hx
-      have key : W.slope x1 x2 y1 y2 * (x1 - x2) = y1 - y2 := by
-        rw [WeierstrassCurve.Affine.slope_of_X_ne hx]; field_simp
-      linear_combination -key
-    · simp only [WeierstrassCurve.Affine.addX, ha1, ha2]; ring
-    · simp only [WeierstrassCurve.Affine.addY, WeierstrassCurve.Affine.negY,
-        WeierstrassCurve.Affine.negAddY, WeierstrassCurve.Affine.addX, ha1, ha2, ha3]; ring
-
-omit [DecidableEq F] in
-/-- COMPLETENESS, infinity case. When the inputs sum to `∞` — `x₁ = x₂` and
-    `y₁ = negY x₂ y₂`, i.e. `P₂ = -P₁` — the honest prover can fill a satisfying witness
-    with `inf = 1`. The output columns carry the (unused) doubling slope `s = 3x₁²/(2y₁)`
-    so the `sameX = 1` slope constraint still holds; `infZ = 1/(y₂−y₁)` witnesses `inf`.
-    The companion to `complete_noninf`, closing completeness over both cases. -/
-theorem complete_inf
-    (W : WeierstrassCurve.Affine F)
-    (ha : W.a₁ = 0 ∧ W.a₂ = 0 ∧ W.a₃ = 0 ∧ W.a₄ = 0)
-    (x1 y1 x2 y2 : F)
-    (_hon1 : W.Equation x1 y1) (_hon2 : W.Equation x2 y2)
-    (hinf : x1 = x2 ∧ y1 = W.negY x2 y2)
-    (hy1 : y1 ≠ 0) (h2 : (2 : F) ≠ 0) :
-    ∃ w : Witness F,
-      w.x1 = x1 ∧ w.y1 = y1 ∧ w.x2 = x2 ∧ w.y2 = y2 ∧ w.inf = 1 ∧ Holds w := by
-  obtain ⟨ha1, -, ha3, -⟩ := ha
-  obtain ⟨hxe, hye⟩ := hinf
-  have hnegY2 : W.negY x2 y2 = -y2 := by simp [WeierstrassCurve.Affine.negY, ha1, ha3]
-  rw [hnegY2] at hye
-  have hy2 : y2 = -y1 := by linear_combination hye
-  have hden : (2 : F) * y1 ≠ 0 := mul_ne_zero h2 hy1
-  have hy21ne : y2 - y1 ≠ 0 := by
-    rw [hy2]; intro h; exact hden (by linear_combination -h)
-  set s : F := 3 * x1 ^ 2 / (2 * y1) with hsdef
-  refine ⟨{ x1 := x1, y1 := y1, x2 := x2, y2 := y2, x3 := s ^ 2 - x1 - x2,
-            y3 := s * (x1 - (s ^ 2 - x1 - x2)) - y1, inf := 1, sameX := 1, s := s,
-            infZ := 1 / (y2 - y1), x21Inv := 0 }, rfl, rfl, rfl, rfl, rfl, ?_⟩
+  have hcancel := mul_inv_cancel₀ (mul_ne_zero h2 hy1)
   rw [holds_iff]
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
-  · ring
-  · rw [hxe]; ring
-  · rw [hsdef]; field_simp; ring
-  · ring
-  · ring
-  · ring
-  · rw [mul_one_div, div_self hy21ne, sub_self]
+  by_cases hx : x1 = x2
+  · -- Equal x-coordinates: on-curve, the y-coordinates agree or are opposite.
+    have hyy : (y1 - y2) * (y1 + y2) = 0 := by
+      rw [WeierstrassCurve.Affine.equation_iff] at hon1 hon2
+      rw [ha1, ha2, ha3, ha4] at hon1 hon2
+      rw [hx] at hon1
+      linear_combination hon1 - hon2
+    by_cases hy : y1 = y2
+    · -- Doubling: `inf = 0` in both modes, `infZ = 0`.
+      simp only [build, if_pos hx, if_pos hy, decide_eq_true hx, decide_eq_true hy,
+        Bool.not_true, Bool.and_false, Bool.false_eq_true, if_false, if_true, ite_self]
+      refine ⟨by ring, by linear_combination -hx, ?_, by ring, by ring, ?_, by ring⟩
+      · linear_combination (3 * x1 * x1) * hcancel
+      · linear_combination -hy
+    · -- Inverse pair: `y₂ = −y₁`; excluded under `checkFinite`, else `inf = 1`.
+      have hy2 : y2 = -y1 := by
+        rcases mul_eq_zero.mp hyy with h | h
+        · exact absurd (by linear_combination h) hy
+        · linear_combination h
+      have hne : y2 - y1 ≠ 0 := by
+        rw [hy2]
+        intro h
+        rcases mul_eq_zero.mp (show y1 * 2 = 0 by linear_combination -h) with h' | h'
+        · exact hy1 h'
+        · exact h2 h'
+      cases checkFinite with
+      | true =>
+        exact absurd ⟨hx, by rw [WeierstrassCurve.Affine.negY, ha1, ha3, hy2]; ring⟩
+          (hfin rfl)
+      | false =>
+        simp only [build, if_pos hx, if_neg hy, decide_eq_true hx, decide_eq_false hy,
+          Bool.not_false, Bool.and_true, Bool.false_eq_true, if_false, if_true]
+        refine ⟨by ring, by linear_combination -hx, ?_, by ring, by ring, by ring, ?_⟩
+        · linear_combination (3 * x1 * x1) * hcancel
+        · linear_combination mul_inv_cancel₀ hne
+  · -- Distinct x-coordinates: the secant row; `inf = 0` in both modes.
+    have hne : x2 - x1 ≠ 0 := fun h => hx (by linear_combination -h)
+    simp only [build, if_neg hx, decide_eq_false hx, Bool.false_and,
+      Bool.false_eq_true, if_false, ite_self]
+    refine ⟨?_, by ring, ?_, by ring, by ring, by ring, by ring⟩
+    · linear_combination mul_inv_cancel₀ hne
+    · linear_combination (y2 - y1) * mul_inv_cancel₀ hne
 
-/-- COMPLETENESS, both cases in one statement. For any on-curve inputs with `y₁ ≠ 0`, an
-    honest prover can fill a satisfying witness — casing internally on whether the sum is
-    `∞` (`x₁=x₂ ∧ y₁ = negY x₂ y₂` → `complete_inf`, `inf=1`) or finite (`complete_noninf`,
-    `inf=0`). The single-theorem companion to `sound`. (`y₁ ≠ 0` excludes 2-torsion,
-    which the prime-order kimchi curves don't have — so it is no real restriction there.) -/
+/-- COMPLETENESS, existential: for any on-curve inputs with `y₁ ≠ 0` a satisfying
+    witness exists — `build`'s row. (`y₁ ≠ 0` excludes 2-torsion, which the
+    prime-order kimchi curves don't have — so it is no real restriction there.) -/
 theorem complete
     (W : WeierstrassCurve.Affine F)
     (ha : W.a₁ = 0 ∧ W.a₂ = 0 ∧ W.a₃ = 0 ∧ W.a₄ = 0)
     (x1 y1 x2 y2 : F)
     (hon1 : W.Equation x1 y1) (hon2 : W.Equation x2 y2)
     (hy1 : y1 ≠ 0) (h2 : (2 : F) ≠ 0) :
-    ∃ w : Witness F, w.x1 = x1 ∧ w.y1 = y1 ∧ w.x2 = x2 ∧ w.y2 = y2 ∧ Holds w := by
-  by_cases hd : x1 = x2 ∧ y1 = W.negY x2 y2
-  · obtain ⟨w, e1, e2, e3, e4, _, hcons⟩ :=
-      complete_inf W ha x1 y1 x2 y2 hon1 hon2 hd hy1 h2
-    exact ⟨w, e1, e2, e3, e4, hcons⟩
-  · obtain ⟨w, e1, e2, e3, e4, _, hcons, _, _⟩ :=
-      complete_noninf W ha x1 y1 x2 y2 hon1 hon2 hd hy1 h2
-    exact ⟨w, e1, e2, e3, e4, hcons⟩
+    ∃ w : Witness F, w.x1 = x1 ∧ w.y1 = y1 ∧ w.x2 = x2 ∧ w.y2 = y2 ∧ Holds w :=
+  ⟨build false x1 y1 x2 y2, rfl, rfl, rfl, rfl,
+    complete_build W ha hon1 hon2 hy1 h2 (fun h => Bool.noConfusion h)⟩
 
 end Faithfulness
 

--- a/formal/kimchi/scripts/check_axioms.lean
+++ b/formal/kimchi/scripts/check_axioms.lean
@@ -29,10 +29,10 @@ namespace Kimchi.CheckAxioms
     executable path. -/
 def roots : List Name :=
   [ `Kimchi.Gate.Generic.sound, `Kimchi.Gate.Generic.complete,
-    `Kimchi.Gate.AddComplete.sound_noninf, `Kimchi.Gate.AddComplete.complete_noninf,
+    `Kimchi.Gate.AddComplete.sound_noninf, `Kimchi.Gate.AddComplete.complete_build,
     `Kimchi.Gate.AddComplete.sound_point_noninf, `Kimchi.Gate.AddComplete.sound_point_inf,
     `Kimchi.Gate.AddComplete.ok_iff, `Kimchi.Gate.AddComplete.inf_boolean,
-    `Kimchi.Gate.AddComplete.complete_inf, `Kimchi.Gate.AddComplete.complete,
+    `Kimchi.Gate.AddComplete.complete,
     `Kimchi.Gate.AddComplete.sound,
     `Kimchi.Gate.VarBaseMul.sound, `Kimchi.Gate.VarBaseMul.complete,
     `Kimchi.Gate.VarBaseMul.varBaseMul_forbidden_correct,

--- a/formal/snarky/Snarky/Kimchi/Circuit/AddComplete.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/AddComplete.lean
@@ -358,6 +358,8 @@ end AddFast
 
 namespace AddFast
 
+open WeierstrassCurve.Affine
+
 /-- The value all seven witness computations jointly produce, as one pure function of
 the (sealed) operand coordinates: the row the honest prover fills. `checkFinite` pins
 `inf` to `0`; otherwise `inf` is the inverse-pair test. -/
@@ -454,9 +456,9 @@ private theorem readVar_bool_of_eval [Field F] [DecidableEq F]
 open Std.Do in
 /-- The tail's honest run, from pinned operand reads: with the sealed coordinates,
 `sameX`, and `inf` reading the row's operand values, and the row those values fill
-satisfying the verified gate, every check accepts; the outputs read on the final
-table. Applied manually per mode — its value arguments are not inferable from a call
-site. -/
+satisfying the verified gate, every check accepts; the outputs read the honest
+row's values on the final table. Applied manually per mode — its value arguments
+are not inferable from a call site. -/
 private theorem addFastTail_complete_spec [Field F] [DecidableEq F]
     (p1 p2 : AffinePoint (FVar F)) (sameX inf : BoolVar F)
     (x1v y1v x2v y2v : F) (ib : Bool)
@@ -470,8 +472,9 @@ private theorem addFastTail_complete_spec [Field F] [DecidableEq F]
           (↑sameX : CVar F).eval env = .ok (bit (decide (x1v = x2v))) ∧
           (↑inf : CVar F).eval env = .ok (bit ib))
         (fun _ (r : AddResult F) env' =>
-          (r.p.x.eval env').isOk ∧ (r.p.y.eval env').isOk ∧
-          ((↑r.isInfinity : CVar F).eval env').isOk)
+          r.p.x.eval env' = .ok (valueWitness true x1v y1v x2v y2v).x3 ∧
+          r.p.y.eval env' = .ok (valueWitness true x1v y1v x2v y2v).y3 ∧
+          (↑r.isInfinity : CVar F).eval env' = .ok (bit ib))
         Q⦄
     addFastTail (c := KimchiProverC F) p1 p2 sameX inf
     ⦃Q⦄ := by
@@ -554,16 +557,19 @@ private theorem addFastTail_complete_spec [Field F] [DecidableEq F]
     exact (Kimchi.Gate.AddComplete.ok_iff _).mpr hHolds
   · mvcgen
     refine hk _ st₆ ?_ ?_ ?_ (hle05.trans hle₆)
-    · rw [CVar.eval_le (hle₅.trans hle₆) hx3]; rfl
-    · rw [CVar.eval_le hle₆ hy3]; rfl
-    · rw [CVar.eval_le (hle05.trans hle₆) hinf]; rfl
+    · exact CVar.eval_le (hle₅.trans hle₆) hx3
+    · exact CVar.eval_le hle₆ hy3
+    · exact CVar.eval_le (hle05.trans hle₆) hinf
 
 /-- `addFast`'s honest run succeeds at the prover carrier: with the four operand
 coordinates readable, the operands on-curve (short shape), the first finite
 (`y ≠ 0`), and — under `checkFinite` — the sum finite, the checking interpreter at
-`KimchiProverC` accepts every row the gadget emits. The grant is the outputs reading
-on the final table. The executable seam (`kimchiSolve` at `kimchiOps`) is outside
-this statement: its ops-coherence lockstep is the open obligation
+`KimchiProverC` accepts every row the gadget emits, and the outputs read as the sum
+in Mathlib's group — *either* the infinity flag reads `1` and the sum is `0`, *or*
+it reads `0` and the output coordinates are a nonsingular point equal to the sum
+(the accepted row satisfies the verified gate, so its `sound` characterizes what
+was computed). The executable seam (`kimchiSolve` at `kimchiOps`) is outside this
+statement: its ops-coherence lockstep is the open obligation
 `Snarky.Kimchi.Constraint` records. -/
 theorem addFast_complete_spec [Field F] [DecidableEq F]
     (fin : Finiteness) (W : WeierstrassCurve.Affine F)
@@ -578,9 +584,16 @@ theorem addFast_complete_spec [Field F] [DecidableEq F]
             p2'.x.eval env = .ok x2 → p2'.y.eval env = .ok y2 →
             W.Equation x1 y1 ∧ W.Equation x2 y2 ∧ y1 ≠ 0 ∧
               (fin = .checkFinite → ¬(x1 = x2 ∧ y1 = W.negY x2 y2))))
-        (fun _ (r : AddResult F) env' =>
-          (r.p.x.eval env').isOk ∧ (r.p.y.eval env').isOk ∧
-          ((↑r.isInfinity : CVar F).eval env').isOk)
+        (fun env (r : AddResult F) env' =>
+          ∀ x1 y1 x2 y2, p1'.x.eval env = .ok x1 → p1'.y.eval env = .ok y1 →
+            p2'.x.eval env = .ok x2 → p2'.y.eval env = .ok y2 →
+            ∀ (h1 : W.Nonsingular x1 y1) (h2 : W.Nonsingular x2 y2),
+              ((↑r.isInfinity : CVar F).eval env' = .ok 1 ∧
+                Point.some _ _ h1 + Point.some _ _ h2 = 0) ∨
+              (∃ x3 y3, r.p.x.eval env' = .ok x3 ∧ r.p.y.eval env' = .ok y3 ∧
+                (↑r.isInfinity : CVar F).eval env' = .ok 0 ∧
+                ∃ h3 : W.Nonsingular x3 y3,
+                  Point.some _ _ h1 + Point.some _ _ h2 = Point.some _ _ h3))
         Q⦄
     addFast (c := KimchiProverC F) fin p1' p2'
     ⦃Q⦄ := by
@@ -610,13 +623,23 @@ theorem addFast_complete_spec [Field F] [DecidableEq F]
   cases fin with
   | checkFinite =>
     mvcgen
+    have hHolds := valueWitness_holds (checkFinite := true) W ha hon1 hon2 hy1ne htwo
+      (fun _ => hfin)
     refine addFastTail_complete_spec p1 p2 sameXU.val false_ x1v y1v x2v y2v false
-      (valueWitness_holds (checkFinite := true) W ha hon1 hon2 hy1ne htwo
-        (fun _ => hfin)) Q st₃
+      hHolds Q st₃
       ⟨⟨CVar.eval_le (hle₂.trans hle₃) hp1x, CVar.eval_le (hle₂.trans hle₃) hp1y,
         CVar.eval_le hle₃ hp2x, CVar.eval_le hle₃ hp2y, hsx, rfl⟩,
-      fun r st' hpost hle => hk r st' hpost.1 hpost.2.1 hpost.2.2
+      fun r st' hpost hle => hk r st' ?_
         ((hle₁.trans (hle₂.trans hle₃)).trans hle)⟩
+    intro a1 b1 a2 b2 ha1 hb1 ha2 hb2 h1 h2
+    rw [hx1] at ha1; rw [hy1] at hb1; rw [hx2] at ha2; rw [hy2] at hb2
+    injection ha1 with ha1; injection hb1 with hb1
+    injection ha2 with ha2; injection hb2 with hb2
+    subst ha1 hb1 ha2 hb2
+    rcases Kimchi.Gate.AddComplete.sound W ha _ h1 h2 hHolds hy1ne htwo with
+      ⟨hinf1, _⟩ | ⟨_, h3, hsum⟩
+    · exact absurd (hinf1 : (0 : F) = 1) zero_ne_one
+    · exact Or.inr ⟨_, _, hpost.1, hpost.2.1, hpost.2.2, h3, hsum⟩
   | dontCheckFinite =>
     mvcgen
     have hiw : (UnChecked.mk <$> infWit p1 p2 sameXU.val) st₃.env
@@ -628,16 +651,26 @@ theorem addFast_complete_spec [Field F] [DecidableEq F]
     refine ⟨by rw [hiw]; rfl, fun infU st₄ hinfr hle₄ => ?_⟩
     have hinfb : _ = _ := hinfr _ hiw
     mvcgen
+    have hHolds := valueWitness_holds (checkFinite := false) W ha hon1 hon2 hy1ne htwo
+      (fun h => Bool.noConfusion h)
     refine addFastTail_complete_spec p1 p2 sameXU.val infU.val x1v y1v x2v y2v
       (decide (x1v = x2v) && !decide (y1v = y2v))
-      (valueWitness_holds (checkFinite := false) W ha hon1 hon2 hy1ne htwo
-        (fun h => Bool.noConfusion h)) Q st₄
+      hHolds Q st₄
       ⟨⟨CVar.eval_le (hle₂.trans (hle₃.trans hle₄)) hp1x,
         CVar.eval_le (hle₂.trans (hle₃.trans hle₄)) hp1y,
         CVar.eval_le (hle₃.trans hle₄) hp2x, CVar.eval_le (hle₃.trans hle₄) hp2y,
         CVar.eval_le hle₄ hsx, hinfb⟩,
-      fun r st' hpost hle => hk r st' hpost.1 hpost.2.1 hpost.2.2
+      fun r st' hpost hle => hk r st' ?_
         ((hle₁.trans (hle₂.trans (hle₃.trans hle₄))).trans hle)⟩
+    intro a1 b1 a2 b2 ha1 hb1 ha2 hb2 h1 h2
+    rw [hx1] at ha1; rw [hy1] at hb1; rw [hx2] at ha2; rw [hy2] at hb2
+    injection ha1 with ha1; injection hb1 with hb1
+    injection ha2 with ha2; injection hb2 with hb2
+    subst ha1 hb1 ha2 hb2
+    rcases Kimchi.Gate.AddComplete.sound W ha _ h1 h2 hHolds hy1ne htwo with
+      ⟨hinf1, hsum⟩ | ⟨hinf0, h3, hsum⟩
+    · exact Or.inl ⟨hinf1 ▸ hpost.2.2, hsum⟩
+    · exact Or.inr ⟨_, _, hpost.1, hpost.2.1, hinf0 ▸ hpost.2.2, h3, hsum⟩
 
 end AddFast
 

--- a/formal/snarky/Snarky/Kimchi/Circuit/AddComplete.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/AddComplete.lean
@@ -360,83 +360,6 @@ namespace AddFast
 
 open WeierstrassCurve.Affine
 
-/-- The value all seven witness computations jointly produce, as one pure function of
-the (sealed) operand coordinates: the row the honest prover fills. `checkFinite` pins
-`inf` to `0`; otherwise `inf` is the inverse-pair test. -/
-private def valueWitness [Field F] [DecidableEq F] (checkFinite : Bool)
-    (x1 y1 x2 y2 : F) : Kimchi.Gate.AddComplete.Witness F :=
-  let s : F := if x1 = x2 then 3 * x1 * x1 / (2 * y1) else (y2 - y1) / (x2 - x1)
-  let x3 : F := s * s - (x1 + x2)
-  { x1 := x1, y1 := y1, x2 := x2, y2 := y2
-    x3 := x3
-    y3 := s * (x1 - x3) - y1
-    inf := if checkFinite then 0 else bit (decide (x1 = x2) && !decide (y1 = y2))
-    sameX := bit (decide (x1 = x2))
-    s := s
-    infZ := if y1 = y2 then 0 else if x1 = x2 then (y2 - y1)⁻¹ else 0
-    x21Inv := if x1 = x2 then 0 else (x2 - x1)⁻¹ }
-
-/-- The honest witness satisfies the verified gate: for on-curve operands on a
-short-shape curve — `checkFinite` mode adding the finite-sum precondition — the row
-`addFast` computes meets `Kimchi.Gate.AddComplete.Holds`. The proof replays the
-algebra of the gate's `complete_noninf`/`complete_inf` at the gadget's computed
-values (those theorems pin an existential witness, not this one). -/
-private theorem valueWitness_holds [Field F] [DecidableEq F]
-    (W : WeierstrassCurve.Affine F)
-    (ha : W.a₁ = 0 ∧ W.a₂ = 0 ∧ W.a₃ = 0 ∧ W.a₄ = 0)
-    {checkFinite : Bool} {x1 y1 x2 y2 : F}
-    (hon1 : W.Equation x1 y1) (hon2 : W.Equation x2 y2)
-    (hy1 : y1 ≠ 0) (h2 : (2 : F) ≠ 0)
-    (hfin : checkFinite = true → ¬(x1 = x2 ∧ y1 = W.negY x2 y2)) :
-    Kimchi.Gate.AddComplete.Holds (valueWitness checkFinite x1 y1 x2 y2) := by
-  obtain ⟨ha1, ha2, ha3, ha4⟩ := ha
-  have hcancel := mul_inv_cancel₀ (mul_ne_zero h2 hy1)
-  rw [Kimchi.Gate.AddComplete.holds_iff]
-  by_cases hx : x1 = x2
-  · -- Equal x-coordinates: on-curve, the y-coordinates agree or are opposite.
-    have hyy : (y1 - y2) * (y1 + y2) = 0 := by
-      rw [WeierstrassCurve.Affine.equation_iff] at hon1 hon2
-      rw [ha1, ha2, ha3, ha4] at hon1 hon2
-      rw [hx] at hon1
-      linear_combination hon1 - hon2
-    by_cases hy : y1 = y2
-    · -- Doubling: `inf = 0` in both modes, `infZ = 0`.
-      simp only [valueWitness, if_pos hx, if_pos hy, decide_eq_true hx,
-        decide_eq_true hy, Bool.not_true, Bool.and_false, bit, Bool.false_eq_true,
-        if_false, if_true, ite_self]
-      refine ⟨by ring, by linear_combination -hx, ?_, by ring, by ring, ?_, by ring⟩
-      · linear_combination (3 * x1 * x1) * hcancel
-      · linear_combination -hy
-    · -- Inverse pair: `y₂ = −y₁`; excluded under `checkFinite`, else `inf = 1`.
-      have hy2 : y2 = -y1 := by
-        rcases mul_eq_zero.mp hyy with h | h
-        · exact absurd (by linear_combination h) hy
-        · linear_combination h
-      have hne : y2 - y1 ≠ 0 := by
-        rw [hy2]
-        intro h
-        rcases mul_eq_zero.mp (show y1 * 2 = 0 by linear_combination -h) with h' | h'
-        · exact hy1 h'
-        · exact h2 h'
-      cases checkFinite with
-      | true =>
-        exact absurd ⟨hx, by rw [WeierstrassCurve.Affine.negY, ha1, ha3, hy2]; ring⟩
-          (hfin rfl)
-      | false =>
-        simp only [valueWitness, if_pos hx, if_neg hy, decide_eq_true hx,
-          decide_eq_false hy, Bool.not_false, Bool.and_true, bit,
-          Bool.false_eq_true, if_false, if_true]
-        refine ⟨by ring, by linear_combination -hx, ?_, by ring, by ring, by ring, ?_⟩
-        · linear_combination (3 * x1 * x1) * hcancel
-        · linear_combination mul_inv_cancel₀ hne
-  · -- Distinct x-coordinates: the secant row; `inf = 0` in both modes.
-    have hne : x2 - x1 ≠ 0 := fun h => hx (by linear_combination -h)
-    simp only [valueWitness, if_neg hx, decide_eq_false hx, Bool.false_and, bit,
-      Bool.false_eq_true, if_false, ite_self]
-    refine ⟨?_, by ring, ?_, by ring, by ring, by ring, by ring⟩
-    · linear_combination mul_inv_cancel₀ hne
-    · linear_combination (y2 - y1) * mul_inv_cancel₀ hne
-
 /-- Reading a bit variable back through the `Bool` decode: an encoded bit decodes to
 itself (the field is nontrivial). -/
 private theorem readVar_bool_of_eval [Field F] [DecidableEq F]
@@ -463,7 +386,7 @@ private theorem addFastTail_complete_spec [Field F] [DecidableEq F]
     (p1 p2 : AffinePoint (FVar F)) (sameX inf : BoolVar F)
     (x1v y1v x2v y2v : F) (ib : Bool)
     (hHolds : Kimchi.Gate.AddComplete.Holds
-      { valueWitness true x1v y1v x2v y2v with inf := bit ib })
+      { Kimchi.Gate.AddComplete.build true x1v y1v x2v y2v with inf := bit ib })
     (Q : PostCond (AddResult F) (.arg (ProverState F) (.except EvalError .pure))) :
     ⦃Complete
         (fun env =>
@@ -472,8 +395,8 @@ private theorem addFastTail_complete_spec [Field F] [DecidableEq F]
           (↑sameX : CVar F).eval env = .ok (bit (decide (x1v = x2v))) ∧
           (↑inf : CVar F).eval env = .ok (bit ib))
         (fun _ (r : AddResult F) env' =>
-          r.p.x.eval env' = .ok (valueWitness true x1v y1v x2v y2v).x3 ∧
-          r.p.y.eval env' = .ok (valueWitness true x1v y1v x2v y2v).y3 ∧
+          r.p.x.eval env' = .ok (Kimchi.Gate.AddComplete.build true x1v y1v x2v y2v).x3 ∧
+          r.p.y.eval env' = .ok (Kimchi.Gate.AddComplete.build true x1v y1v x2v y2v).y3 ∧
           (↑r.isInfinity : CVar F).eval env' = .ok (bit ib))
         Q⦄
     addFastTail (c := KimchiProverC F) p1 p2 sameX inf
@@ -545,8 +468,8 @@ private theorem addFastTail_complete_spec [Field F] [DecidableEq F]
   · show KimchiConstraint.check (.addComplete _) st₅.env = true
     have heval : AddComplete.eval st₅.env
         ⟨p1, p2, ⟨x3, y3⟩, inf.toCVar, sameX.toCVar, s, infZ, x21Inv⟩
-        = .ok { valueWitness true x1v y1v x2v y2v with inf := bit ib } := by
-      simp [AddComplete.eval, valueWitness,
+        = .ok { Kimchi.Gate.AddComplete.build true x1v y1v x2v y2v with inf := bit ib } := by
+      simp [AddComplete.eval, Kimchi.Gate.AddComplete.build, bit,
         CVar.eval_le hle05 hp1x, CVar.eval_le hle05 hp1y,
         CVar.eval_le hle05 hp2x, CVar.eval_le hle05 hp2y,
         CVar.eval_le hle₅ hx3, hy3, CVar.eval_le (hle₄.trans hle₅) hs,
@@ -623,8 +546,8 @@ theorem addFast_complete_spec [Field F] [DecidableEq F]
   cases fin with
   | checkFinite =>
     mvcgen
-    have hHolds := valueWitness_holds (checkFinite := true) W ha hon1 hon2 hy1ne htwo
-      (fun _ => hfin)
+    have hHolds := Kimchi.Gate.AddComplete.complete_build (checkFinite := true) W ha
+      hon1 hon2 hy1ne htwo (fun _ => hfin)
     refine addFastTail_complete_spec p1 p2 sameXU.val false_ x1v y1v x2v y2v false
       hHolds Q st₃
       ⟨⟨CVar.eval_le (hle₂.trans hle₃) hp1x, CVar.eval_le (hle₂.trans hle₃) hp1y,
@@ -651,8 +574,8 @@ theorem addFast_complete_spec [Field F] [DecidableEq F]
     refine ⟨by rw [hiw]; rfl, fun infU st₄ hinfr hle₄ => ?_⟩
     have hinfb : _ = _ := hinfr _ hiw
     mvcgen
-    have hHolds := valueWitness_holds (checkFinite := false) W ha hon1 hon2 hy1ne htwo
-      (fun h => Bool.noConfusion h)
+    have hHolds := Kimchi.Gate.AddComplete.complete_build (checkFinite := false) W ha
+      hon1 hon2 hy1ne htwo (fun h => Bool.noConfusion h)
     refine addFastTail_complete_spec p1 p2 sameXU.val infU.val x1v y1v x2v y2v
       (decide (x1v = x2v) && !decide (y1v = y2v))
       hHolds Q st₄


### PR DESCRIPTION
Part 1 of 3 of the gate-semantics-direct split (supersedes #294): each gadget's resolution as its own PR off main. This one: AddComplete.

**Commit 1 — the completeness post promises the group sum.** `addFast_complete_spec` said only that the honest run accepts and the outputs are *readable*. It now delivers the group-level characterization: for pinned input reads and nonsingularity witnesses, *either* the infinity flag reads `1` and `P₁ + P₂ = 0` in Mathlib's group, *or* it reads `0` and the output coordinates are a nonsingular point equal to the sum. The accepted row satisfies the verified gate, so the gate's combined `sound` characterizes what was computed. This is the fact the EndoMul slice composes for its initial accumulator `P₀ = [2](T + φ(T))`.

**Commit 2 — the gate's completeness goes constructive.** The gate gains its canonical row `build` and `complete_build : Holds (build …)` — the gadget's former private `valueWitness`/`valueWitness_holds`, relocated to where they belong. The `∃`-shaped `complete` becomes a one-line corollary, and `complete_noninf`/`complete_inf` retire: existential packaging can never certify fixed prover code, which is exactly why the gadget had grown a private replay of their algebra. `addFast_complete_spec` now consumes `complete_build` for acceptance and `sound` for the output characterization — both directions of both laws from the gate's single semantics development.

Gates green per commit: build, corpus 23/23, style, snarky + kimchi axiom gates, deadcode 0, per-root lint, shake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)