### PR TITLE
snarky: the first composition fixtures — pow2_pow and b_correct join the CS-equality corpus

### DIFF
--- a/formal/kimchi/KimchiFixture/PS.lean
+++ b/formal/kimchi/KimchiFixture/PS.lean
@@ -115,26 +115,53 @@ private def parseVarId (j : Json) : Except String (Option ℕ) := do
   let i ← j.getInt?
   return if i < 0 then none else some i.toNat
 
-/-- The PureScript side of a comparison JSON; `none` when the JSON is not a comparison
-or carries no witness. -/
-def parseComparison? (j : Json) : Except String (Option Raw) := do
-  let .ok ps := j.getObjVal? "purescript" | return none
-  let .ok w := ps.getObjVal? "witness" | return none
-  if w.isNull then return none
+/-- The gate table of a comparison JSON's PureScript side — the shared parse under
+both entry points below. -/
+private def parseGates (ps : Json) : Except String Raw := do
   let gatesJ ← (← ps.getObjVal? "gates").getArr?
   let typs ← gatesJ.mapM fun g => do parseGateKind (← (← g.getObjVal? "kind").getStr?)
   let coeffs ← gatesJ.mapM fun g => do
     parseArrOf parseSignedDecimal (← g.getObjVal? "coeffs")
   let wires ← gatesJ.mapM fun g => do parseArrOf parseWire (← g.getObjVal? "wires")
   let vars ← gatesJ.mapM fun g => do parseArrOf parseVarId (← g.getObjVal? "variables")
+  return {
+    publicInputSize := ← (← ps.getObjVal? "publicInputSize").getNat?
+    typs := typs
+    coeffs := coeffs
+    wires := wires
+    vars := vars
+    witness := #[]
+    pub := #[] }
+
+/-- The PureScript side of a comparison JSON; `none` when the JSON is not a comparison
+or carries no witness. -/
+def parseComparison? (j : Json) : Except String (Option Raw) := do
+  let .ok ps := j.getObjVal? "purescript" | return none
+  let .ok w := ps.getObjVal? "witness" | return none
+  if w.isNull then return none
+  let raw ← parseGates ps
   return some
-    { publicInputSize := ← (← ps.getObjVal? "publicInputSize").getNat?
-      typs := typs
-      coeffs := coeffs
-      wires := wires
-      vars := vars
+    { raw with
       witness := ← parseArrOf (parseArrOf parseHexLE) (← w.getObjVal? "witness")
       pub := ← parseArrOf parseHexLE (← w.getObjVal? "publicInputs") }
+
+/-- Like `parseComparison?`, but a comparison without a witness parses too (empty
+`witness`/`pub`): the constraint-system side — gate types, coefficients, wires,
+per-cell variable ids, public size — is present in every dump, witness-carrying or
+not. The CS-equality corpus reads through this entry so witness-less circuits still
+prove constraint equivalence; `parseComparison?` keeps its witness-only contract for
+the witness checker, which globs the results directory and skips on `none`. -/
+def parseComparisonCs? (j : Json) : Except String (Option Raw) := do
+  let .ok ps := j.getObjVal? "purescript" | return none
+  let raw ← parseGates ps
+  match ps.getObjVal? "witness" with
+  | .error _ => return some raw
+  | .ok w =>
+    if w.isNull then return some raw
+    return some
+      { raw with
+        witness := ← parseArrOf (parseArrOf parseHexLE) (← w.getObjVal? "witness")
+        pub := ← parseArrOf parseHexLE (← w.getObjVal? "publicInputs") }
 
 /-! ## Domain synthesis -/
 

--- a/formal/kimchi/roots.txt
+++ b/formal/kimchi/roots.txt
@@ -121,6 +121,7 @@ Kimchi.Fixture.parseComm
 Kimchi.Fixture.PS.Instance
 Kimchi.Fixture.PS.build
 Kimchi.Fixture.PS.parseComparison?
+Kimchi.Fixture.PS.parseComparisonCs?
 Kimchi.Index.build?
 Kimchi.Index.instDecidableSatisfies -- synthesis: decide (Satisfies ..) in check_ps_witness.lean
 Kimchi.Permutation.primitiveRootCertificate

--- a/formal/snarky/scripts/check_cs_equality.lean
+++ b/formal/snarky/scripts/check_cs_equality.lean
@@ -11,11 +11,21 @@ ids pin the shared counter's numbering.
 
 The circuits transcribe `Test.Pickles.CircuitDiffs.Main`
 (packages/pickles-circuit-diffs/test/): every witness-carrying circuit built from the
-`Basic` gadget vocabulary, plus the landed gate gadgets (poseidon,
-endo_scalar, endo_mul). The export also carries a witness dump for the remaining
-gate circuit (var_base_mul); it is DELIBERATELY not in the corpus — it joins with
-its gadget slice, so the VarBaseMul reducer is uncovered by this oracle until
-then.
+`Basic` gadget vocabulary, the landed gate gadgets (poseidon, endo_scalar,
+endo_mul), and the gadget-complete pickles sub-circuits (pow2_pow, b_correct — the
+first composition fixtures; their dumps are witness-less, so the checks are CS-side
+only). Deferred, with the blocker each waits on:
+- var_base_mul + scale_fast2_128, ftcomm_*, xhat_* (and everything downstream: ivp,
+  verify, wrap/step mains) — the VarBaseMul gadget slice;
+- bullet_reduce_one_step, bullet_reduce_step — the `endoInv` consumer of EndoMul
+  (gadget-complete otherwise);
+- hash_messages_*, finalize_other_proof_*, schnorr_verify — the sponge circuit layer
+  (packages/random-oracle; FOP additionally the OptSponge variant);
+- group_map_step — activatable now (Basic-only), transcription pending a
+  Tonelli–Shanks sqrt witness helper;
+- group_map_wrap, combine_poly_wrap — gadget-complete but Fq-side: this corpus is
+  Fp-typed throughout, so the wrap column needs an Fq mirror of the plumbing;
+- app_circuit_chunks2 — Basic-only but a 39MB dump (~2^16 rows): ingestion cost.
 
 The dumps are the PS suite's gitignored export: generate with
 `CIRCUIT_DIFFS_WITNESS_EXPORT=1 npx spago test -p pickles-circuit-diffs`. CI runs
@@ -188,6 +198,68 @@ def endoMulCircuit (input : AffinePoint (FVar Fp) × FVar Fp) :
     CircuitM Fp C (AffinePoint (FVar Fp)) :=
   endoMul Pasta.pallasEndo 32 input.1 input.2
 
+/-! ## Pickles sub-circuits
+
+Composition circuits from `packages/pickles`, transcribed against their dumps the
+same way the gadget circuits are — these are the first fixtures exercising the
+gadgets IN COMPOSITION. Their dumps are witness-less (`exactMatchEff`
+registrations), so the comparison checks the constraint-system side only: gate
+types, coefficients, wires, per-cell variable ids, public size. -/
+
+/-- `pow2_pow_step_circuit` (`Pickles.Util.Pow2.pow2PowSquare` at 16 squarings —
+sixteen `square` rows chained). -/
+def pow2PowCircuit (input : Vector (FVar Fp) 1) : CircuitM Fp C PUnit := do
+  let _ ← (List.range 16).foldlM (fun acc _ => square acc) input[0]
+  pure PUnit.unit
+
+/-- The Type1 shifted-scalar unshift constant `2^255 + 1` (PS `Shifted.shift1` at the
+255-bit step field): `fromShiftedType1Circuit t = 2·t + c`, constraint-free. -/
+def shift1c : Fp := 2 ^ 255 + 1
+
+/-- The challenge polynomial `∏ᵢ (1 + cᵢ·pt^(2^(k-1-i)))` (PS `IPA.bPolyCircuit`):
+`k−1` squarings (as generic `mul` rows, matching OCaml's `Field.( * )`), then the
+`k`-term product folded left, allocation order verbatim. -/
+def bPolyCircuit (chals : List (FVar Fp)) (pt : FVar Fp) :
+    CircuitM Fp C (FVar Fp) := do
+  let (squares, _) ← mapAccumM
+    (fun (prev : FVar Fp) (_ : Unit) => do
+      let sq ← mul prev prev
+      pure (sq, sq))
+    pt (List.replicate (chals.length - 1) ())
+  let powTwoPows := pt :: squares
+  match chals.zip powTwoPows.reverse with
+  | [] => pure (.const 1)
+  | (c0, pw0) :: rest => do
+    let cp0 ← mul c0 pw0
+    let init := CVar.add_ (.const 1) cp0
+    rest.foldlM
+      (fun acc (cpw : FVar Fp × FVar Fp) => do
+        let cp ← mul cpw.1 cpw.2
+        let term := CVar.add_ (.const 1) cp
+        mul term acc)
+      init
+
+/-- `b_correct_step_circuit` (PS `bCorrectStepCircuit` over `IPA.bCorrectCircuit`):
+16 raw 128-bit challenges expanded through `EndoScalar.toField` at 8 rows — in
+REVERSE order, OCaml's right-to-left evaluation — then
+`b(ζ) + evalscale·b(ζω)` compared against the Type1-unshifted claimed `b`.
+Input layout: challenges 0–15, `ζ` 16, `ζω` 17, `evalscale` 18, claimed `b` 19. -/
+def bCorrectCircuit (input : Vector (FVar Fp) 20) : CircuitM Fp C PUnit := do
+  let inl := input.toList
+  let endoVar : FVar Fp := .const endoVestaLam
+  let expandedRev ← ((inl.take 16).reverse).mapM
+    (fun c => EndoScalar.toField 8 c endoVar)
+  let expanded := expandedRev.reverse
+  let zero : FVar Fp := .const 0
+  let expectedB : FVar Fp :=
+    CVar.add_ (CVar.scale_ 2 (inl.getD 19 zero)) (.const shift1c)
+  let bZetaOmega ← bPolyCircuit expanded (inl.getD 17 zero)
+  let scaledB ← mul (inl.getD 18 zero) bZetaOmega
+  let bZeta ← bPolyCircuit expanded (inl.getD 16 zero)
+  let computedB := CVar.add_ bZeta scaledB
+  let _ ← equals expectedB computedB
+  pure PUnit.unit
+
 /-! ## The comparison -/
 
 /-- An assembled circuit in the fixture's `Raw` shape (witness transposed to the
@@ -281,7 +353,10 @@ def targets : List (String × (Raw → List (String × Bool))) :=
     ("endo_scalar_step_circuit",
       compareWith (a := Fp) (b := Fp) endoScalarCircuit),
     ("endo_mul_step_circuit",
-      compareWith (a := AffinePoint Fp × Fp) (b := AffinePoint Fp) endoMulCircuit) ]
+      compareWith (a := AffinePoint Fp × Fp) (b := AffinePoint Fp) endoMulCircuit),
+    ("pow2_pow_step_circuit", compareWith (a := Vector Fp 1) (b := PUnit) pow2PowCircuit),
+    ("b_correct_step_circuit",
+      compareWith (a := Vector Fp 20) (b := PUnit) bCorrectCircuit) ]
 
 def main : IO Unit := do
   let dir ← resultsDir
@@ -289,7 +364,7 @@ def main : IO Unit := do
   for (name, compare) in targets do
     let path := dir / s!"{name}.json"
     let raw ← IO.FS.readFile path
-    match Json.parse raw >>= parseComparison? with
+    match Json.parse raw >>= parseComparisonCs? with
     | .error e =>
       failures := failures + 1
       IO.println s!"✗ {name}: parse error: {e}"


### PR DESCRIPTION
With the gadget set complete minus VarBaseMul (#298), the CS-equality corpus grows past the gadget primitives into the pickles sub-circuits that compose them. Corpus 24 → 26, both new fixtures byte-equal on first run — gate types, coefficients, wires, public size, and the raw per-cell variable ids (the allocation-order contract, held through OCaml's right-to-left evaluation).

## Activated

- **`pow2_pow_step_circuit`** — `Pickles.Util.Pow2.pow2PowSquare` at 16 chained squares.
- **`b_correct_step_circuit`** — the first fixture proving a gadget constraint-equivalent IN COMPOSITION: 16 raw 128-bit challenges expanded through `EndoScalar.toField` at 8 rows in reverse evaluation order, the two `bPoly` square-and-fold passes, `b(ζ) + evalscale·b(ζω)`, and the Type1-unshifted (`2t + 2^255 + 1`) claim comparison.

## Ingestion

The pickles sub-circuit dumps are witness-less (`exactMatchEff` registrations export no solver run), so `KimchiFixture.PS` gains `parseComparisonCs?`: the constraint-system side parses from every dump, and `compareWith` already skips the witness checks when absent. `parseComparison?` keeps its witness-only contract — the witness checker globs the results directory and relies on its none-skip.

## The activation map

The corpus header now records the full gadget-dependency audit of every remaining registration:

- **VarBaseMul-gated** (the remaining gadget slice): `var_base_mul`, `scale_fast2_128`, `ftcomm_*`, `xhat_*` (via `scaleByShifted`), and everything downstream (ivp, verify, wrap/step mains).
- **`endoInv`-gated**: `bullet_reduce_one_step`, `bullet_reduce_step` — gadget-complete except for the unported witness-level EndoMul consumer; the nearest next target (would compose EndoMul + AddComplete).
- **Sponge-layer-gated**: `hash_messages_*`, `fop_*` (plus the OptSponge variant), `schnorr_verify` — whose `scale` is hand-rolled over `addFast`, so the sponge is its only blocker.
- **No gadget gap, pending work**: `group_map_step` (Tonelli–Shanks sqrt witness helper), `group_map_wrap`/`combine_poly_wrap` (Fq-side — the corpus plumbing is Fp-typed), `app_circuit_chunks2` (39 MB dump ingestion).

Battery green: build, corpus 26/26, witness checker 25/25 unchanged, style, kimchi (106) + snarky (120) axiom gates, deadcode 0, env linters, shake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)