### PR TITLE
snarky: the endoInv laws — sound and complete against the recip multiple

### DIFF
--- a/formal/kimchi/Kimchi/Gate/Semantics/EndoMul.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/EndoMul.lean
@@ -970,7 +970,8 @@ private theorem endoMul_ab (W : WeierstrassCurve.Affine F) [Fact (Nat.Prime W.or
     ∃ (hfin : W.Nonsingular (accX g m) (accY g m)) (k1 k2 : ℤ),
       Point.some _ _ hfin = (4 : ℤ) ^ m • Point.some _ _ hP0ns + k1 • T + k2 • φT
         ∧ (k2 : F) = ∑ j ∈ Finset.range (2 * m), (2 : F) ^ (2 * m - 1 - j) * aDigit g j
-        ∧ (k1 : F) = ∑ j ∈ Finset.range (2 * m), (2 : F) ^ (2 * m - 1 - j) * bDigit g j := by
+        ∧ (k1 : F) = ∑ j ∈ Finset.range (2 * m), (2 : F) ^ (2 * m - 1 - j) * bDigit g j
+        ∧ |k1| ≤ 4 ^ m - 1 ∧ |k2| ≤ 4 ^ m - 1 := by
   -- coordinate threading: row `i`'s input column equals the accumulator at step `i`
   have haccP : ∀ k, k < m → (g k).xP = accX g k ∧ (g k).yP = accY g k := by
     intro k hk
@@ -1003,7 +1004,8 @@ private theorem endoMul_ab (W : WeierstrassCurve.Affine F) [Fact (Nat.Prime W.or
   have hrow : ∀ i, i < m → ∃ c1 c2 : ℤ,
       P (i + 1) = (4 : ℤ) • P i + c1 • T + c2 • φT
         ∧ (c1 : F) = 2 * dPoly ((g i).b2 + 2 * (g i).b1) + dPoly ((g i).b4 + 2 * (g i).b3)
-        ∧ (c2 : F) = 2 * cPoly ((g i).b2 + 2 * (g i).b1) + cPoly ((g i).b4 + 2 * (g i).b3) := by
+        ∧ (c2 : F) = 2 * cPoly ((g i).b2 + 2 * (g i).b1) + cPoly ((g i).b4 + 2 * (g i).b3)
+        ∧ |c1| ≤ 3 ∧ |c2| ≤ 3 := by
     intro i hi
     obtain ⟨hxP, hyP⟩ := haccP i hi
     have hPi : W.Nonsingular (g i).xP (g i).yP := by rw [hxP, hyP]; exact key i (le_of_lt hi)
@@ -1012,9 +1014,9 @@ private theorem endoMul_ab (W : WeierstrassCurve.Affine F) [Fact (Nat.Prime W.or
     have hφTi : W.Nonsingular (endo * (g i).xT) (g i).yT := by
       obtain ⟨hx, hy⟩ := hbase i hi; rw [hx, hy]; exact hφTns
     obtain ⟨hxn1, hxn2⟩ := hxne i hi
-    obtain ⟨hS, c1, c2, hrel, hd1, hd2, -, -⟩ :=
+    obtain ⟨hS, c1, c2, hrel, hd1, hd2, hc1b, hc2b⟩ :=
       gate_advance W ha h2 h3 hodd endo (g i) (hholds i hi) hTi hφTi hPi hxn1 hxn2
-    refine ⟨c1, c2, ?_, hd1, hd2⟩
+    refine ⟨c1, c2, ?_, hd1, hd2, hc1b, hc2b⟩
     rw [hPval (i + 1) hi, hPval i (le_of_lt hi),
       some_congr W (key (i + 1) hi) hS rfl rfl,
       some_congr W (key i (le_of_lt hi)) hPi hxP.symm hyP.symm, hTeq,
@@ -1038,7 +1040,7 @@ private theorem endoMul_ab (W : WeierstrassCurve.Affine F) [Fact (Nat.Prime W.or
     have e4 : (2 * i + 1) / 2 = i := by omega
     have haE : aDigit g (2 * i) = cPoly ((g i).b2 + 2 * (g i).b1) := by simp [aDigit, e1, e2]
     have haO : aDigit g (2 * i + 1) = cPoly ((g i).b4 + 2 * (g i).b3) := by simp [aDigit, e3, e4]
-    rw [haE, haO, ← (hc i hi').2.2]
+    rw [haE, haO, ← (hc i hi').2.2.1]
   have hk1 : (k1 : F) = ∑ j ∈ Finset.range (2 * m), (2 : F) ^ (2 * m - 1 - j) * bDigit g j := by
     rw [hk1def, ← sum_reindex m (bDigit g)]; push_cast
     refine Finset.sum_congr rfl fun i hi => ?_
@@ -1050,7 +1052,33 @@ private theorem endoMul_ab (W : WeierstrassCurve.Affine F) [Fact (Nat.Prime W.or
     have hbE : bDigit g (2 * i) = dPoly ((g i).b2 + 2 * (g i).b1) := by simp [bDigit, e1, e2]
     have hbO : bDigit g (2 * i + 1) = dPoly ((g i).b4 + 2 * (g i).b3) := by simp [bDigit, e3, e4]
     rw [hbE, hbO, ← (hc i hi').2.1]
-  refine ⟨key m (le_refl m), k1, k2, ?_, hk2, hk1⟩
+  have hsum : ∀ n : ℕ, ∑ i ∈ Finset.range n, (4 : ℤ) ^ (n - 1 - i) * 3 = 4 ^ n - 1 := by
+    intro n
+    induction n with
+    | zero => simp
+    | succ k ih =>
+      rw [Finset.sum_range_succ,
+        Finset.sum_congr rfl (fun i hi => show (4 : ℤ) ^ (k + 1 - 1 - i) * 3
+          = 4 * ((4 : ℤ) ^ (k - 1 - i) * 3) from by
+            rw [show k + 1 - 1 - i = (k - 1 - i) + 1 from by
+              have := Finset.mem_range.mp hi; omega, pow_succ]; ring),
+        ← Finset.mul_sum, ih]
+      simp [pow_succ]; ring
+  have hbnd : ∀ c : ℕ → ℤ, (∀ i, i < m → |c i| ≤ 3) →
+      |∑ i ∈ Finset.range m, (4 : ℤ) ^ (m - 1 - i) * c i| ≤ 4 ^ m - 1 := by
+    intro c hc3
+    calc |∑ i ∈ Finset.range m, (4 : ℤ) ^ (m - 1 - i) * c i|
+        ≤ ∑ i ∈ Finset.range m, |(4 : ℤ) ^ (m - 1 - i) * c i| :=
+          Finset.abs_sum_le_sum_abs _ _
+      _ ≤ ∑ i ∈ Finset.range m, (4 : ℤ) ^ (m - 1 - i) * 3 := by
+          refine Finset.sum_le_sum fun i hi => ?_
+          rw [abs_mul, abs_pow, show |(4 : ℤ)| = 4 from rfl]
+          exact mul_le_mul_of_nonneg_left (hc3 i (Finset.mem_range.mp hi)) (by positivity)
+      _ = 4 ^ m - 1 := hsum m
+  refine ⟨key m (le_refl m), k1, k2, ?_,
+    hk2, hk1,
+    hk1def ▸ hbnd c1 (fun i hi => (hc i hi).2.2.2.1),
+    hk2def ▸ hbnd c2 (fun i hi => (hc i hi).2.2.2.2)⟩
   rw [← hPval m (le_refl m), hPm, hPval 0 (Nat.zero_le m),
     some_congr W (key 0 (Nat.zero_le m)) hP0ns rfl rfl]
 
@@ -1074,13 +1102,24 @@ theorem endoMul (W : WeierstrassCurve.Affine F) [Fact (Nat.Prime W.order)]
     (hxne : ∀ i, i < m → (g i).xP ≠ (1 + (endo - 1) * (g i).b1) * (g i).xT
                         ∧ (g i).xR ≠ (1 + (endo - 1) * (g i).b3) * (g i).xT)
     (lam : ℤ) (heig : φT = lam • T) :
-    ∃ (hfin : W.Nonsingular (accX g m) (accY g m)) (s : ℤ),
+    ∃ (hfin : W.Nonsingular (accX g m) (accY g m)) (s A B : ℤ),
       Point.some _ _ hfin = s • T
+        ∧ s = B + A * lam
+        ∧ |A| ≤ 3 * 4 ^ m ∧ |B| ≤ 3 * 4 ^ m
+        ∧ (A : F) = Kimchi.Gate.EndoScalar.decomposeA (crumbList g m)
+        ∧ (B : F) = Kimchi.Gate.EndoScalar.decomposeB (crumbList g m)
         ∧ (s : F) = Kimchi.Gate.EndoScalar.toField (crumbList g m) (lam : F) := by
-  obtain ⟨hfin, k1, k2, hPm, hk2, hk1⟩ :=
+  obtain ⟨hfin, k1, k2, hPm, hk2, hk1, hb1, hb2⟩ :=
     endoMul_ab W ha h2 h3 hodd endo m g hholds T φT hTns hTeq hφTns hφTeq hbase hthread hP0ns hxne
-  refine ⟨hfin, 2 * 4 ^ m + k1 + (2 * 4 ^ m + k2) * lam, ?_, ?_⟩
+  have h4 : (0 : ℤ) < 4 ^ m := by positivity
+  refine ⟨hfin, 2 * 4 ^ m + k1 + (2 * 4 ^ m + k2) * lam, 2 * 4 ^ m + k2, 2 * 4 ^ m + k1,
+    ?_, by ring,
+    (abs_add_le _ _).trans (by rw [abs_of_nonneg (by positivity : (0:ℤ) ≤ 2 * 4 ^ m)]; omega),
+    (abs_add_le _ _).trans (by rw [abs_of_nonneg (by positivity : (0:ℤ) ≤ 2 * 4 ^ m)]; omega),
+    ?_, ?_, ?_⟩
   · rw [hPm, hP0, heig]; module
+  · rw [(decompose_crumbList g m).1]; push_cast [hk2]; ring
+  · rw [(decompose_crumbList g m).2]; push_cast [hk1]; ring
   · simp +decide [EndoScalar.toField, hk1, hk2]
     rw [decompose_crumbList g m |>.1, decompose_crumbList g m |>.2]; ring
 
@@ -1305,8 +1344,12 @@ theorem endoMul_off (W : WeierstrassCurve.Affine F)
     (hP0ns : W.Nonsingular (g 0).xP (g 0).yP)
     (hP0 : Point.some _ _ hP0ns = (2 : ℤ) • T + (2 : ℤ) • φT)
     (lam : ℤ) (heig : φT = lam • T) :
-    ∃ (hfin : W.Nonsingular (accX g m) (accY g m)) (s : ℤ),
+    ∃ (hfin : W.Nonsingular (accX g m) (accY g m)) (s A B : ℤ),
       Point.some _ _ hfin = s • T
+        ∧ s = B + A * lam
+        ∧ |A| ≤ 3 * 4 ^ m ∧ |B| ≤ 3 * 4 ^ m
+        ∧ (A : F) = Kimchi.Gate.EndoScalar.decomposeA (crumbList g m)
+        ∧ (B : F) = Kimchi.Gate.EndoScalar.decomposeB (crumbList g m)
         ∧ (s : F) = Kimchi.Gate.EndoScalar.toField (crumbList g m) (lam : F) := by
   have hxne := accumulator_chain W h2 hodd endo T φT off m hbits g hholds hTns hTeq
     hφTns hφTeq hbase hthread hP0ns hP0
@@ -1777,9 +1820,11 @@ theorem pallas_endoMul (m : ℕ) (hbits : 4 * m ≤ 244)
   have hodd : Pallas.curve.toAffine.order ≠ 2 := by rw [pallas_card]; decide
   have hTne : T ≠ 0 := by rw [hTeq]; exact Point.some_ne_zero _
   have heig : φT = pallasLam • T := by rw [hφTeq, hTeq]; exact pallas_eigen hTns
-  exact endoMul_off Pallas.curve.toAffine (by decide) (by decide) hodd pallasEndo T φT
-    (fun a b ha' hb hba hbb => pallas_combo_off_targets ha' hb hba hbb hTne heig)
-    m hbits g hholds hTns hTeq hφTns hφTeq hbase hthread hP0ns hP0 pallasLam heig
+  obtain ⟨hfin, s, -, -, hpt, -, -, -, -, -, hcast⟩ :=
+    endoMul_off Pallas.curve.toAffine (by decide) (by decide) hodd pallasEndo T φT
+      (fun a b ha' hb hba hbb => pallas_combo_off_targets ha' hb hba hbb hTne heig)
+      m hbits g hholds hTns hTeq hφTns hφTeq hbase hthread hP0ns hP0 pallasLam heig
+  exact ⟨hfin, s, hpt, hcast⟩
 
 /-- **EndoMul at Vesta** — the other half of the 2-cycle, identical modulo `vesta_*`. -/
 theorem vesta_endoMul (m : ℕ) (hbits : 4 * m ≤ 244)
@@ -1802,9 +1847,11 @@ theorem vesta_endoMul (m : ℕ) (hbits : 4 * m ≤ 244)
   have hodd : Vesta.curve.toAffine.order ≠ 2 := by rw [vesta_card]; decide
   have hTne : T ≠ 0 := by rw [hTeq]; exact Point.some_ne_zero _
   have heig : φT = vestaLam • T := by rw [hφTeq, hTeq]; exact vesta_eigen hTns
-  exact endoMul_off Vesta.curve.toAffine (by decide) (by decide) hodd vestaEndo T φT
-    (fun a b ha' hb hba hbb => vesta_combo_off_targets ha' hb hba hbb hTne heig)
-    m hbits g hholds hTns hTeq hφTns hφTeq hbase hthread hP0ns hP0 vestaLam heig
+  obtain ⟨hfin, s, -, -, hpt, -, -, -, -, -, hcast⟩ :=
+    endoMul_off Vesta.curve.toAffine (by decide) (by decide) hodd vestaEndo T φT
+      (fun a b ha' hb hba hbb => vesta_combo_off_targets ha' hb hba hbb hTne heig)
+      m hbits g hholds hTns hTeq hφTns hφTeq hbase hthread hP0ns hP0 vestaLam heig
+  exact ⟨hfin, s, hpt, hcast⟩
 
 /-! ## The produce chain at the curves
 

--- a/formal/kimchi/Kimchi/Gate/Semantics/EndoMul.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/EndoMul.lean
@@ -1369,7 +1369,7 @@ off an accepted run. -/
 
 /-- A positively-weighted bounded two-base combination is nonzero: were
     `[a]·T + [b]·φT = 0`, then `[a+1]·T + [b]·φT = T`, which `off` forbids. -/
-private theorem combo_ne_zero {W : WeierstrassCurve.Affine F} {T φT : W.Point}
+theorem combo_ne_zero {W : WeierstrassCurve.Affine F} {T φT : W.Point}
     (off : ∀ a b : ℤ, a ≠ 0 → b ≠ 0 → |a| < 2 ^ 126 → |b| < 2 ^ 126 →
       a • T + b • φT ≠ T ∧ a • T + b • φT ≠ -T
         ∧ a • T + b • φT ≠ φT ∧ a • T + b • φT ≠ -φT)

--- a/formal/kimchi/Kimchi/Gate/Semantics/EndoScalar.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/EndoScalar.lean
@@ -202,6 +202,87 @@ def nReconstruct (crumbs : List F) : F := crumbs.foldl (fun n x => 4 * n + x) 0
 def toField (crumbs : List F) (lam : F) : F :=
   decomposeA crumbs * lam + decomposeB crumbs
 
+/-! ## The ℤ-shadow of the decomposition
+
+    `cPoly`/`dPoly` live in a field (their coefficients divide by 2 and 3), so the decompose
+    folds cannot be read over ℤ directly. On genuine base-4 digits they are integer tables,
+    and the folds have exact ℤ-shadows: `decomposeAInt`/`decomposeBInt`/`toIntZ` over the
+    pre-cast digit list. The cast lemmas below say each field-side fold is the image of its
+    shadow — which is what lets a bounded fold value be read in a SECOND field (the scalar
+    field) once a char-window argument pins the integer. -/
+
+/-- `cPoly`'s digit table `(0, 0, −1, 1)`, over ℤ. -/
+def cInt : ℕ → ℤ
+  | 2 => -1
+  | 3 => 1
+  | _ => 0
+
+/-- `dPoly`'s digit table `(−1, 1, 0, 0)`, over ℤ. -/
+def dInt : ℕ → ℤ
+  | 0 => -1
+  | 1 => 1
+  | _ => 0
+
+/-- The ℤ-shadow of `decomposeA`, over the pre-cast digits. -/
+def decomposeAInt (ds : List ℕ) : ℤ := ds.foldl (fun a d => 2 * a + cInt d) 2
+
+/-- The ℤ-shadow of `decomposeB`. -/
+def decomposeBInt (ds : List ℕ) : ℤ := ds.foldl (fun b d => 2 * b + dInt d) 2
+
+/-- The ℤ-shadow of `toField`: the effective scalar as an integer. -/
+def toIntZ (ds : List ℕ) (lam : ℤ) : ℤ := decomposeAInt ds * lam + decomposeBInt ds
+
+/-- On a digit `< 4`, `cPoly` at the cast digit is the cast of its ℤ table. Needs `2, 3`
+    invertible, like `cPoly_table`. -/
+theorem cPoly_digit (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) {d : ℕ} (hd : d < 4) :
+    cPoly ((d : F)) = ((cInt d : ℤ) : F) := by
+  obtain ⟨c0, c1, c2, c3⟩ := cPoly_table h2 h3
+  interval_cases d <;> push_cast <;> simp_all [cInt]
+
+/-- `dPoly`'s half of `cPoly_digit`. -/
+theorem dPoly_digit (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) {d : ℕ} (hd : d < 4) :
+    dPoly ((d : F)) = ((dInt d : ℤ) : F) := by
+  obtain ⟨d0, d1, d2, d3⟩ := dPoly_table h2 h3
+  interval_cases d <;> push_cast <;> simp_all [dInt]
+
+private theorem fold_digits
+    {p : F → F} {pz : ℕ → ℤ} (hp : ∀ d : ℕ, d < 4 → p ((d : F)) = ((pz d : ℤ) : F))
+    (ds : List ℕ) (h : ∀ d ∈ ds, d < 4) (z : ℤ) :
+    (ds.map (Nat.cast : ℕ → F)).foldl (fun a x => 2 * a + p x) ((z : ℤ) : F)
+      = ((ds.foldl (fun a d => 2 * a + pz d) z : ℤ) : F) := by
+  induction ds generalizing z with
+  | nil => rfl
+  | cons d ds ih =>
+    rw [List.map_cons, List.foldl_cons, List.foldl_cons,
+      hp d (h d List.mem_cons_self),
+      show 2 * ((z : ℤ) : F) + ((pz d : ℤ) : F) = (((2 * z + pz d : ℤ)) : F) from by
+        push_cast; ring]
+    exact ih (fun x hx => h x (List.mem_cons_of_mem _ hx)) _
+
+/-- `decomposeA` over cast digits is the cast of `decomposeAInt`. -/
+theorem decomposeA_digits (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
+    (ds : List ℕ) (h : ∀ d ∈ ds, d < 4) :
+    decomposeA (ds.map (Nat.cast : ℕ → F)) = ((decomposeAInt ds : ℤ) : F) := by
+  have := fold_digits (p := fun x => cPoly x) (pz := cInt)
+    (fun d hd => cPoly_digit h2 h3 hd) ds h 2
+  simpa [decomposeA, decomposeAInt] using this
+
+/-- `decomposeB` over cast digits is the cast of `decomposeBInt`. -/
+theorem decomposeB_digits (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
+    (ds : List ℕ) (h : ∀ d ∈ ds, d < 4) :
+    decomposeB (ds.map (Nat.cast : ℕ → F)) = ((decomposeBInt ds : ℤ) : F) := by
+  have := fold_digits (p := fun x => dPoly x) (pz := dInt)
+    (fun d hd => dPoly_digit h2 h3 hd) ds h 2
+  simpa [decomposeB, decomposeBInt] using this
+
+/-- `toField` over cast digits at a cast eigenvalue is the cast of `toIntZ` — the two-field
+    bridge: one integer scalar, read in any field with `2, 3` invertible. -/
+theorem toField_digits (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
+    (ds : List ℕ) (h : ∀ d ∈ ds, d < 4) (lam : ℤ) :
+    toField (ds.map (Nat.cast : ℕ → F)) ((lam : ℤ) : F) = ((toIntZ ds lam : ℤ) : F) := by
+  rw [toField, toIntZ, decomposeA_digits h2 h3 ds h, decomposeB_digits h2 h3 ds h]
+  push_cast; ring
+
 /-! ## Multi-row composition: threading rows is folding the concatenated crumbs.
 
     A challenge wider than one row's eight crumbs is laid out over several `EndoScalar` rows,
@@ -357,6 +438,27 @@ theorem crumbsOf_length (c k : ℕ) : (crumbsOf (F := F) c k).length = c := by
     rw [show crumbsOf (F := F) (c + 1) k = crumbsOf c (k / 4) ++ [((k % 4 : ℕ) : F)] from rfl,
       List.length_append, ih (k / 4)]
     rfl
+
+/-- The `ℕ` base-4 digit list of a challenge, MSB-first — `crumbsOf` before the cast. -/
+def digitsOf : ℕ → ℕ → List ℕ
+  | 0, _ => []
+  | c + 1, k => digitsOf c (k / 4) ++ [k % 4]
+
+theorem digitsOf_lt (c k : ℕ) : ∀ d ∈ digitsOf c k, d < 4 := by
+  induction c generalizing k with
+  | zero => simp [digitsOf]
+  | succ c ih =>
+    intro d hd
+    rcases List.mem_append.mp hd with h | h
+    · exact ih _ d h
+    · simp only [List.mem_singleton] at h
+      omega
+
+theorem crumbsOf_eq_map (c k : ℕ) :
+    crumbsOf (F := F) c k = (digitsOf c k).map (Nat.cast : ℕ → F) := by
+  induction c generalizing k with
+  | zero => rfl
+  | succ c ih => rw [crumbsOf, digitsOf, List.map_append, ih]; rfl
 
 /-- Every entry of `crumbsOf` is a 2-bit crumb, the tail one because `k % 4 < 4`. This is
     `complete`'s precondition, so the expansion feeds `build` directly. -/

--- a/formal/kimchi/Kimchi/Gate/Semantics/EndoScalar.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/EndoScalar.lean
@@ -185,12 +185,18 @@ open Kimchi.Gate.EndoScalar
 
 variable {F : Type*} [Field F]
 
-/-- The `a`-accumulator of the Algorithm-2 decomposition (`a := 2a + cPoly x`),
-    from the canonical init `2`. -/
-def decomposeA (crumbs : List F) : F := crumbs.foldl (fun a x => 2 * a + cPoly x) 2
+/-- The Algorithm-2 accumulator fold, once: double and add the step's contribution,
+    from the canonical init `2`. All decompose accumulators are instances — at `F`
+    with `cPoly`/`dPoly` (the gate's registers), at `ZMod order` (the decoded
+    challenge), and at ℤ with the digit tables (the shadow, `decomposeAInt` below). -/
+def decomposeFold {α R : Type*} [Semiring R] (step : α → R) (xs : List α) : R :=
+  xs.foldl (fun a x => 2 * a + step x) 2
 
-/-- The `b`-accumulator (`b := 2b + dPoly x`), from init `2`. -/
-def decomposeB (crumbs : List F) : F := crumbs.foldl (fun b x => 2 * b + dPoly x) 2
+/-- The `a`-accumulator of the Algorithm-2 decomposition (`a := 2a + cPoly x`). -/
+def decomposeA (crumbs : List F) : F := decomposeFold (fun x => cPoly x) crumbs
+
+/-- The `b`-accumulator (`b := 2b + dPoly x`). -/
+def decomposeB (crumbs : List F) : F := decomposeFold (fun x => dPoly x) crumbs
 
 /-- The raw challenge reconstructed from its base-4 crumbs (`n := 4n + x`), the
     gate's `n` register — public, as the reconstruction the wrapper pins to the
@@ -223,11 +229,12 @@ def dInt : ℕ → ℤ
   | 1 => 1
   | _ => 0
 
-/-- The ℤ-shadow of `decomposeA`, over the pre-cast digits. -/
-def decomposeAInt (ds : List ℕ) : ℤ := ds.foldl (fun a d => 2 * a + cInt d) 2
+/-- The ℤ-shadow of `decomposeA`, over the pre-cast digits: the same fold at the
+    initial ring, where the polynomial's digit values are the integer table. -/
+def decomposeAInt (ds : List ℕ) : ℤ := decomposeFold cInt ds
 
 /-- The ℤ-shadow of `decomposeB`. -/
-def decomposeBInt (ds : List ℕ) : ℤ := ds.foldl (fun b d => 2 * b + dInt d) 2
+def decomposeBInt (ds : List ℕ) : ℤ := decomposeFold dInt ds
 
 /-- The ℤ-shadow of `toField`: the effective scalar as an integer. -/
 def toIntZ (ds : List ℕ) (lam : ℤ) : ℤ := decomposeAInt ds * lam + decomposeBInt ds
@@ -265,7 +272,7 @@ theorem decomposeA_digits (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
     decomposeA (ds.map (Nat.cast : ℕ → F)) = ((decomposeAInt ds : ℤ) : F) := by
   have := fold_digits (p := fun x => cPoly x) (pz := cInt)
     (fun d hd => cPoly_digit h2 h3 hd) ds h 2
-  simpa [decomposeA, decomposeAInt] using this
+  simpa [decomposeA, decomposeAInt, decomposeFold] using this
 
 /-- `decomposeB` over cast digits is the cast of `decomposeBInt`. -/
 theorem decomposeB_digits (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
@@ -273,7 +280,7 @@ theorem decomposeB_digits (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
     decomposeB (ds.map (Nat.cast : ℕ → F)) = ((decomposeBInt ds : ℤ) : F) := by
   have := fold_digits (p := fun x => dPoly x) (pz := dInt)
     (fun d hd => dPoly_digit h2 h3 hd) ds h 2
-  simpa [decomposeB, decomposeBInt] using this
+  simpa [decomposeB, decomposeBInt, decomposeFold] using this
 
 /-- `toField` over cast digits at a cast eigenvalue is the cast of `toIntZ` — the two-field
     bridge: one integer scalar, read in any field with `2, 3` invertible. -/
@@ -315,14 +322,14 @@ private theorem foldInt_bounds {cz : ℕ → ℤ} (hc : ∀ d, |cz d| ≤ 1) (ds
 theorem decomposeAInt_bounds (ds : List ℕ) :
     2 ^ ds.length + 1 ≤ decomposeAInt ds ∧ decomposeAInt ds ≤ 3 * 2 ^ ds.length - 1 := by
   obtain ⟨hlo, hhi⟩ := foldInt_bounds cInt_abs_le ds 2 (by norm_num)
-  unfold decomposeAInt
+  unfold decomposeAInt decomposeFold
   constructor <;> omega
 
 /-- `decomposeBInt`'s half of the window. -/
 theorem decomposeBInt_bounds (ds : List ℕ) :
     2 ^ ds.length + 1 ≤ decomposeBInt ds ∧ decomposeBInt ds ≤ 3 * 2 ^ ds.length - 1 := by
   obtain ⟨hlo, hhi⟩ := foldInt_bounds dInt_abs_le ds 2 (by norm_num)
-  unfold decomposeBInt
+  unfold decomposeBInt decomposeFold
   constructor <;> omega
 
 /-! ## Multi-row composition: threading rows is folding the concatenated crumbs.
@@ -335,12 +342,12 @@ theorem decomposeBInt_bounds (ds : List ℕ) :
     single decomposition from `decomposeA xs`. -/
 theorem decomposeA_append (xs ys : List F) :
     decomposeA (xs ++ ys) = ys.foldl (fun a x => 2 * a + cPoly x) (decomposeA xs) := by
-  simp only [decomposeA, List.foldl_append]
+  simp only [decomposeA, decomposeFold, List.foldl_append]
 
 /-- Resuming the `b`-fold across a row boundary from `decomposeB xs`. -/
 theorem decomposeB_append (xs ys : List F) :
     decomposeB (xs ++ ys) = ys.foldl (fun b x => 2 * b + dPoly x) (decomposeB xs) := by
-  simp only [decomposeB, List.foldl_append]
+  simp only [decomposeB, decomposeFold, List.foldl_append]
 
 /-- Resuming the `n`-fold across a row boundary from `nReconstruct xs`. -/
 private theorem nReconstruct_append (xs ys : List F) :
@@ -418,8 +425,8 @@ theorem chain_decompose (m : ℕ) (w : ℕ → Witness F)
     obtain ⟨hn, ha, hb, _⟩ := (holds_iff _).mp (hHolds 0 (le_refl 0))
     rw [chainCrumbs_succ, chainCrumbs_zero, List.nil_append]
     refine ⟨?_, ?_, ?_⟩
-    · rw [ha, ha0, decomposeA]
-    · rw [hb, hb0, decomposeB]
+    · rw [ha, ha0, decomposeA, decomposeFold]
+    · rw [hb, hb0, decomposeB, decomposeFold]
     · rw [hn, hn0, nReconstruct]
   | succ k ih =>
     obtain ⟨ihA, ihB, ihN⟩ := ih (fun i hi => hHolds i (by omega))

--- a/formal/kimchi/Kimchi/Gate/Semantics/EndoScalar.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/EndoScalar.lean
@@ -283,6 +283,48 @@ theorem toField_digits (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
   rw [toField, toIntZ, decomposeA_digits h2 h3 ds h, decomposeB_digits h2 h3 ds h]
   push_cast; ring
 
+theorem cInt_abs_le (d : ℕ) : |cInt d| ≤ 1 := by
+  unfold cInt; split <;> decide
+
+theorem dInt_abs_le (d : ℕ) : |dInt d| ≤ 1 := by
+  unfold dInt; split <;> decide
+
+private theorem foldInt_bounds {cz : ℕ → ℤ} (hc : ∀ d, |cz d| ≤ 1) (ds : List ℕ) :
+    ∀ z : ℤ, 1 ≤ z →
+      2 ^ ds.length * z - (2 ^ ds.length - 1)
+          ≤ ds.foldl (fun a d => 2 * a + cz d) z
+        ∧ ds.foldl (fun a d => 2 * a + cz d) z
+          ≤ 2 ^ ds.length * z + (2 ^ ds.length - 1) := by
+  induction ds with
+  | nil => intro z hz; simp
+  | cons d ds ih =>
+    intro z hz
+    have hcd := hc d
+    have habs : -1 ≤ cz d ∧ cz d ≤ 1 := abs_le.mp hcd
+    have hz' : 1 ≤ 2 * z + cz d := by omega
+    obtain ⟨hlo, hhi⟩ := ih (2 * z + cz d) hz'
+    have hpow : (0 : ℤ) < 2 ^ ds.length := by positivity
+    simp only [List.foldl_cons, List.length_cons, pow_succ]
+    constructor
+    · nlinarith [hlo, habs.1, hpow]
+    · nlinarith [hhi, habs.2, hpow]
+
+/-- The `a`-shadow's window: from the init `2`, the fold lands in
+    `[2^n + 1, 3·2^n − 1]` (`n` the digit count) — positive and, for the deployed
+    64 digits, far under the off-targets box. -/
+theorem decomposeAInt_bounds (ds : List ℕ) :
+    2 ^ ds.length + 1 ≤ decomposeAInt ds ∧ decomposeAInt ds ≤ 3 * 2 ^ ds.length - 1 := by
+  obtain ⟨hlo, hhi⟩ := foldInt_bounds cInt_abs_le ds 2 (by norm_num)
+  unfold decomposeAInt
+  constructor <;> omega
+
+/-- `decomposeBInt`'s half of the window. -/
+theorem decomposeBInt_bounds (ds : List ℕ) :
+    2 ^ ds.length + 1 ≤ decomposeBInt ds ∧ decomposeBInt ds ≤ 3 * 2 ^ ds.length - 1 := by
+  obtain ⟨hlo, hhi⟩ := foldInt_bounds dInt_abs_le ds 2 (by norm_num)
+  unfold decomposeBInt
+  constructor <;> omega
+
 /-! ## Multi-row composition: threading rows is folding the concatenated crumbs.
 
     A challenge wider than one row's eight crumbs is laid out over several `EndoScalar` rows,
@@ -459,6 +501,11 @@ theorem crumbsOf_eq_map (c k : ℕ) :
   induction c generalizing k with
   | zero => rfl
   | succ c ih => rw [crumbsOf, digitsOf, List.map_append, ih]; rfl
+
+theorem digitsOf_length (c k : ℕ) : (digitsOf c k).length = c := by
+  induction c generalizing k with
+  | zero => rfl
+  | succ c ih => simp [digitsOf, ih]
 
 /-- Every entry of `crumbsOf` is a 2-bit crumb, the tail one because `k % 4 < 4`. This is
     `complete`'s precondition, so the expansion feeds `build` directly. -/

--- a/formal/kimchi/Kimchi/Gate/Semantics/VarBaseMul.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/VarBaseMul.lean
@@ -1150,6 +1150,19 @@ lemma eq_inv_smul_of_smul_eq (c : WeierstrassCurve.Affine F)
       add_smul, one_smul, mul_comm (c.order : ℤ) m, mul_smul, hkill, smul_zero, add_zero]
   rw [← hint, natCast_zsmul]
 
+/-- **Scalars act through their residues.** Two integers with the same image mod the
+    (prime) order act identically on every point: the order kills the difference. -/
+lemma smul_eq_smul_of_zmod_eq (c : WeierstrassCurve.Affine F)
+    [Fact (Nat.Prime c.order)]
+    {P : c.Point} {a b : ℤ} (h : (a : ZMod c.order) = (b : ZMod c.order)) :
+    a • P = b • P := by
+  haveI : NeZero c.order := ⟨(Fact.out : Nat.Prime c.order).ne_zero⟩
+  have hd : ((a - b : ℤ) : ZMod c.order) = 0 := by push_cast [h]; ring
+  obtain ⟨m, hm⟩ := (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp hd
+  have hkill : (c.order : ℤ) • P = 0 := by rw [natCast_zsmul]; exact card_nsmul_eq_zero'
+  have : a = b + c.order * m := by linarith
+  rw [this, add_smul, mul_comm, mul_smul, hkill, smul_zero, add_zero]
+
 /-- **No 2-torsion.** On a short-Weierstrass curve of odd prime `order`, every
     nonsingular affine point has `y ≠ 0`: a point with `y = 0` equals its own negation,
     hence is 2-torsion, and a group of odd prime order has none (`smul_ne_zero_of_lt`

--- a/formal/kimchi/Kimchi/Gate/Semantics/VarBaseMul.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/VarBaseMul.lean
@@ -1130,6 +1130,26 @@ lemma x_ne_xT_of_ne_base (c : WeierstrassCurve.Affine F)
     simp_all +decide [WeierstrassCurve.Affine.equation_iff]
   exact mul_left_cancel₀ (sub_ne_zero_of_ne hne) (by linear_combination h_eq)
 
+/-- **Prime-order inversion.** If `Q = [s]·P` with `s` a unit mod the (prime) order,
+    then `P = [s⁻¹]·Q` — the `recip` reading of a scalar multiple: `s⁻¹·s = 1 + m·order`
+    and the order kills every point. -/
+lemma eq_inv_smul_of_smul_eq (c : WeierstrassCurve.Affine F)
+    [Fact (Nat.Prime c.order)]
+    {P Q : c.Point} {s : ℤ} (hs : (s : ZMod c.order) ≠ 0) (h : Q = s • P) :
+    P = ((s : ZMod c.order)⁻¹.val : ℕ) • Q := by
+  haveI : NeZero c.order := ⟨(Fact.out : Nat.Prime c.order).ne_zero⟩
+  set k : ℕ := ((s : ZMod c.order)⁻¹).val with hk
+  have hks : ((k * s - 1 : ℤ) : ZMod c.order) = 0 := by
+    push_cast
+    rw [hk, ZMod.natCast_val, ZMod.cast_id, inv_mul_cancel₀ hs]
+    ring
+  obtain ⟨m, hm⟩ := (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp hks
+  have hkill : (c.order : ℤ) • P = 0 := by rw [natCast_zsmul]; exact card_nsmul_eq_zero'
+  have hint : (k : ℤ) • Q = P := by
+    rw [h, smul_smul, show (k : ℤ) * s = 1 + c.order * m from by linarith,
+      add_smul, one_smul, mul_comm (c.order : ℤ) m, mul_smul, hkill, smul_zero, add_zero]
+  rw [← hint, natCast_zsmul]
+
 /-- **No 2-torsion.** On a short-Weierstrass curve of odd prime `order`, every
     nonsingular affine point has `y ≠ 0`: a point with `y = 0` equals its own negation,
     hence is 2-torsion, and a group of odd prime order has none (`smul_ne_zero_of_lt`

--- a/formal/snarky/Snarky/Circuit/DSL/SizedF.lean
+++ b/formal/snarky/Snarky/Circuit/DSL/SizedF.lean
@@ -1,17 +1,22 @@
+import Snarky.Circuit.DSL.Bits
+import Snarky.Backend.Assignments
+
 /-!
 # Sized field elements
 
 Port of `Snarky.Circuit.DSL.SizedF`
 (packages/snarky/src/Snarky/Circuit/DSL/SizedF.purs): a value tagged with a
 type-level bit width. The tag is a contract, not an invariant: the wrapped value is
-promised to fit in `n` bits, and the laws consuming a `SizedF` state that promise as
-an explicit hypothesis (`ToNat.toNat v < 2 ^ n`-shaped, at the consumer).
+promised to fit in `n` bits, and the laws consuming a `SizedF` take that promise as
+their `SizedF.Fits` hypothesis.
 
 Deviations from the PS original (per `formal/docs/snarky-kimchi-alignment.md`):
-- Only the newtype is ported. PS's bit combinators (`fromBits`, `toBits`,
-  `coerceViaBits`, `fromField`) and the `CheckedType` instance (the high-bits-zero
-  range check emitted when a `SizedF` is witnessed) arrive with their consumers — no
-  ported circuit consumes them yet.
+- The newtype and its contract (`SizedF.Fits`) are ported. PS's bit combinators
+  (`fromBits`, `toBits`, `coerceViaBits`, `fromField`) and the `CheckedType` instance
+  (the high-bits-zero range check emitted when a `SizedF` is witnessed) arrive with
+  their consumers — no ported circuit consumes them yet. Once the check instance
+  lands, its soundness law concludes `Fits` from the emitted constraints, and
+  composition discharges the gadget laws' `Fits` hypotheses instead of assuming them.
 -/
 
 namespace Snarky
@@ -21,5 +26,14 @@ is promised to fit in `n` bits. Phantom: `n` never influences the data. -/
 structure SizedF (n : ℕ) (α : Type u) where
   /-- The wrapped value. -/
   val : α
+
+/-- The `SizedF` contract at an environment: the wrapped variable reads to a value
+that fits the tagged width, faithfully lifted (`ToNat` is a section of the cast at
+it). Gadget completeness laws take this as their scalar hypothesis; the future
+`CheckedType` port's soundness law concludes it (see the module docstring). -/
+def SizedF.Fits {F : Type} [Add F] [Mul F] [NatCast F] [ToNat F] {n : ℕ}
+    (s : SizedF n (FVar F)) (env : Assignments F) : Prop :=
+  ∀ v, s.val.eval env = .ok v →
+    ToNat.toNat v < 2 ^ n ∧ ((ToNat.toNat v : F) = v)
 
 end Snarky

--- a/formal/snarky/Snarky/Circuit/DSL/SizedF.lean
+++ b/formal/snarky/Snarky/Circuit/DSL/SizedF.lean
@@ -1,0 +1,25 @@
+/-!
+# Sized field elements
+
+Port of `Snarky.Circuit.DSL.SizedF`
+(packages/snarky/src/Snarky/Circuit/DSL/SizedF.purs): a value tagged with a
+type-level bit width. The tag is a contract, not an invariant: the wrapped value is
+promised to fit in `n` bits, and the laws consuming a `SizedF` state that promise as
+an explicit hypothesis (`ToNat.toNat v < 2 ^ n`-shaped, at the consumer).
+
+Deviations from the PS original (per `formal/docs/snarky-kimchi-alignment.md`):
+- Only the newtype is ported. PS's bit combinators (`fromBits`, `toBits`,
+  `coerceViaBits`, `fromField`) and the `CheckedType` instance (the high-bits-zero
+  range check emitted when a `SizedF` is witnessed) arrive with their consumers — no
+  ported circuit consumes them yet.
+-/
+
+namespace Snarky
+
+/-- A value tagged with a type-level bit width (PS `SizedF n f`): the wrapped value
+is promised to fit in `n` bits. Phantom: `n` never influences the data. -/
+structure SizedF (n : ℕ) (α : Type u) where
+  /-- The wrapped value. -/
+  val : α
+
+end Snarky

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
@@ -1487,9 +1487,9 @@ theorem endoInv_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F
   have hv₄ := CVar.eval_le hle₁₄ hv
   have hrpx₄ := CVar.eval_le hle₄ hrpx₃
   have hrpy₄ := CVar.eval_le hle₄ hrpy₃
-  refine endoMul_complete_spec d 32 (by norm_num) ⟨rp.1, rp.2⟩ scalar _ _
-    ⟨⟨by rw [hv₄]; rfl, by rw [hrpx₄]; rfl, by rw [hrpy₄]; rfl, ?_, ?_⟩,
-      fun computed st₅ hgr5 hle₅ => ?_⟩
+  mvcgen [endoMul_complete_spec]
+  refine ⟨⟨by rw [hv₄]; rfl, by rw [hrpx₄]; rfl, by rw [hrpy₄]; rfl, ?_, ?_⟩,
+    fun computed st₅ hgr5 hle₅ => ?_⟩
   · intro v' hv'
     rw [hv₄] at hv'
     injection hv' with hv'

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
@@ -881,8 +881,7 @@ theorem endoMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F
     ⦃Complete
         (fun env =>
           (scalar.val.eval env).isOk ∧ (t.x.eval env).isOk ∧ (t.y.eval env).isOk ∧
-          (∀ v, scalar.val.eval env = .ok v →
-            ToNat.toNat v < 4 ^ (2 * rounds) ∧ ((ToNat.toNat v : F) = v)) ∧
+          scalar.Fits env ∧
           (∀ x y, t.x.eval env = .ok x → t.y.eval env = .ok y → d.W.Nonsingular x y))
         (fun env r env' => ∀ v xv yv, scalar.val.eval env = .ok v →
           t.x.eval env = .ok xv → t.y.eval env = .ok yv →
@@ -913,6 +912,13 @@ theorem endoMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F
   obtain ⟨xv, hxv⟩ := CVar.evalOk hxok
   obtain ⟨yv, hyv⟩ := CVar.evalOk hyok
   obtain ⟨hrange, hfaith⟩ := hsc v hv
+  have hrange : ToNat.toNat v < 4 ^ (2 * rounds) := by
+    have hpow : (4 : ℕ) ^ (2 * rounds) = 2 ^ (4 * rounds) := by
+      rw [show (4 : ℕ) = 2 ^ 2 from rfl, ← pow_mul]
+      congr 1
+      ring
+    rw [hpow]
+    exact hrange
   have hT : W.Nonsingular xv yv := hcurve _ _ hxv hyv
   have hφT : W.Nonsingular (eb * xv) yv := hφns hT
   have hyne : yv ≠ 0 := y_ne_zero_of_odd_order W hodd hT
@@ -1393,8 +1399,7 @@ theorem endoInv_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F
     ⦃Complete
         (fun env =>
           (scalar.val.eval env).isOk ∧ (t.x.eval env).isOk ∧ (t.y.eval env).isOk ∧
-          (∀ v, scalar.val.eval env = .ok v →
-            ToNat.toNat v < 4 ^ 64 ∧ ((ToNat.toNat v : F) = v)) ∧
+          scalar.Fits env ∧
           (∀ x y, t.x.eval env = .ok x → t.y.eval env = .ok y → d.W.Nonsingular x y))
         (fun env r env' => ∀ v xv yv, scalar.val.eval env = .ok v →
           t.x.eval env = .ok xv → t.y.eval env = .ok yv →

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
@@ -1,4 +1,5 @@
 import Snarky.Circuit.DSL.Field
+import Snarky.Circuit.DSL.SizedF
 import Kimchi.Gate.Semantics.EndoMul
 import Kimchi.Gate.Semantics.VarBaseMul
 import Pasta.Endo
@@ -102,9 +103,10 @@ build `acc = [2](g + φ(g))` with two `addFast`s, run the `rounds` window rounds
 threading `(acc, nAcc)`, pin the scalar fold, emit one `endoMul` constraint, and
 return the final accumulator. -/
 def endoMul [Field F] [DecidableEq F] [ToNat F] [BasicSystem F c] [KimchiSystem F c]
-    (eb : F) (rounds : ℕ) (g : AffinePoint (FVar F)) (scalar : FVar F) :
+    (eb : F) (rounds : ℕ) (g : AffinePoint (FVar F))
+    (scalar : SizedF (4 * rounds) (FVar F)) :
     CircuitM F c (AffinePoint (FVar F)) := do
-  let bits ← witness (val := Vector (Vector F 4) rounds) (bitsWit rounds scalar)
+  let bits ← witness (val := Vector (Vector F 4) rounds) (bitsWit rounds scalar.val)
   let phix ← sealVar (CVar.scale_ eb g.x)
   let p1 ← addFast .checkFinite g ⟨phix, g.y⟩
   let p2 ← addFast .checkFinite p1.p p1.p
@@ -119,7 +121,7 @@ def endoMul [Field F] [DecidableEq F] [ToNat F] [BasicSystem F c] [KimchiSystem 
                inv := w.1 } : EndoMulRound F),
             (s, w.2.1)))
     (p2.p, .const 0) bits.toList
-  assertEqual fin.2 scalar
+  assertEqual fin.2 scalar.val
   addConstraint (KimchiSystem.endoMul { state, s := fin.1, nAcc := fin.2, endo := eb })
   pure fin.1
 
@@ -168,9 +170,9 @@ check's coefficients — PS's `curveParams`; `(q, lam')` are the scalar-field or
 and eigenvalue the advice decodes through. -/
 def endoInv [Field F] [DecidableEq F] [ToNat F] [BasicSystem F c] [KimchiSystem F c]
     (eb : F) (W : WeierstrassCurve.Affine F) (q : ℕ) (hq : q.Prime) (lam' : ZMod q)
-    (g : AffinePoint (FVar F)) (scalar : FVar F) :
+    (g : AffinePoint (FVar F)) (scalar : SizedF 128 (FVar F)) :
     CircuitM F c (AffinePoint (FVar F)) := do
-  let result ← witness (val := F × F) (endoInvWit W q hq lam' g scalar)
+  let result ← witness (val := F × F) (endoInvWit W q hq lam' g scalar.val)
   let rp : AffinePoint (FVar F) := ⟨result.1, result.2⟩
   let x2 ← square rp.x
   let x3 ← mul x2 rp.x
@@ -595,14 +597,14 @@ concretized only inside a larger circuit's instantiation, at the deployed
 dictionaries `HasEndo.pallas`/`HasEndo.vesta`. -/
 theorem endoMul_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F)
     (rounds : ℕ) (hbits : 4 * rounds ≤ 244)
-    (t : AffinePoint (FVar F)) (scalar : FVar F)
+    (t : AffinePoint (FVar F)) (scalar : SizedF (4 * rounds) (FVar F))
     (Q : PostCond (AffinePoint (FVar F)) (.arg (BuilderState F) .pure)) :
     ⦃Sound (fun V (r : AffinePoint (FVar F)) =>
         ∀ hT : d.W.Nonsingular (t.x.val V) (t.y.val V),
           ∃ crumbs : List F,
             (∀ x ∈ crumbs, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) ∧
             crumbs.length = 2 * rounds ∧
-            scalar.val V = Kimchi.Gate.EndoScalar.nReconstruct crumbs ∧
+            scalar.val.val V = Kimchi.Gate.EndoScalar.nReconstruct crumbs ∧
             ∃ (hfin : d.W.Nonsingular (r.x.val V) (r.y.val V)) (s : ℤ),
               Point.some _ _ hfin = s • Point.some _ _ hT ∧
               (s : F) = Kimchi.Gate.EndoScalar.toField crumbs (d.lam : F)) Q⦄
@@ -874,15 +876,15 @@ chain is the two pinned additions (`addFast_complete_spec`), and the register pi
 `chain_nAcc` through the bit-to-crumb bridge (`crumbList_ofBits`). -/
 theorem endoMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F)
     (rounds : ℕ) (hbits : 4 * rounds ≤ 244)
-    (t : AffinePoint (FVar F)) (scalar : FVar F)
+    (t : AffinePoint (FVar F)) (scalar : SizedF (4 * rounds) (FVar F))
     (Q : PostCond (AffinePoint (FVar F)) (.arg (ProverState F) (.except EvalError .pure))) :
     ⦃Complete
         (fun env =>
-          (scalar.eval env).isOk ∧ (t.x.eval env).isOk ∧ (t.y.eval env).isOk ∧
-          (∀ v, scalar.eval env = .ok v →
+          (scalar.val.eval env).isOk ∧ (t.x.eval env).isOk ∧ (t.y.eval env).isOk ∧
+          (∀ v, scalar.val.eval env = .ok v →
             ToNat.toNat v < 4 ^ (2 * rounds) ∧ ((ToNat.toNat v : F) = v)) ∧
           (∀ x y, t.x.eval env = .ok x → t.y.eval env = .ok y → d.W.Nonsingular x y))
-        (fun env r env' => ∀ v xv yv, scalar.eval env = .ok v →
+        (fun env r env' => ∀ v xv yv, scalar.val.eval env = .ok v →
           t.x.eval env = .ok xv → t.y.eval env = .ok yv →
           ∀ hT : d.W.Nonsingular xv yv,
           ∃ xS yS, r.x.eval env' = .ok xS ∧ r.y.eval env' = .ok yS ∧
@@ -915,7 +917,7 @@ theorem endoMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F
   have hφT : W.Nonsingular (eb * xv) yv := hφns hT
   have hyne : yv ≠ 0 := y_ne_zero_of_odd_order W hodd hT
   -- the bulk bit witness
-  have hwit : bitsWit rounds scalar st₀.env
+  have hwit : bitsWit rounds scalar.val st₀.env
       = .ok (Vector.ofFn fun r => Vector.ofFn fun j =>
           if (ToNat.toNat v).testBit (4 * rounds - 1 - (4 * r.1 + j.1))
           then 1 else 0) := by
@@ -1140,7 +1142,7 @@ theorem endoMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F
       rw [zero_mul, zero_add, hndef]
       exact hfaith
     -- the pin, the payload check, and the final grant
-    have hsv' : scalar.eval s'.env = .ok v :=
+    have hsv' : scalar.val.eval s'.env = .ok v :=
       CVar.eval_le ((hle₁.trans (hle₂.trans (hle₃.trans hle₄))).trans hLe) hv
     refine ⟨⟨by rw [hnP]; rfl, by rw [hsv']; rfl, fun rv sv hrv hsv => ?_⟩,
       fun u st₅ hle₅ => ?_⟩
@@ -1221,14 +1223,14 @@ equation to nonsingularity. The advice parameters `(q, hq, lam')` are universall
 quantified: soundness never consults the witness. -/
 theorem endoInv_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F)
     (q : ℕ) (hq : q.Prime) (lam' : ZMod q)
-    (t : AffinePoint (FVar F)) (scalar : FVar F)
+    (t : AffinePoint (FVar F)) (scalar : SizedF 128 (FVar F))
     (Q : PostCond (AffinePoint (FVar F)) (.arg (BuilderState F) .pure)) :
     ⦃Sound (fun V (r : AffinePoint (FVar F)) =>
         ∀ hg : d.W.Nonsingular (t.x.val V) (t.y.val V),
           ∃ crumbs : List F,
             (∀ x ∈ crumbs, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) ∧
             crumbs.length = 64 ∧
-            scalar.val V = Kimchi.Gate.EndoScalar.nReconstruct crumbs ∧
+            scalar.val.val V = Kimchi.Gate.EndoScalar.nReconstruct crumbs ∧
             ∃ (hres : d.W.Nonsingular (r.x.val V) (r.y.val V)) (s : ℤ),
               (s : F) = Kimchi.Gate.EndoScalar.toField crumbs (d.lam : F) ∧
               (s : ZMod d.W.order) ≠ 0 ∧
@@ -1386,15 +1388,15 @@ reading the decomposition integers through the char window (`char_big`), so the 
 pins close by residue action. Stepped through in the body. -/
 theorem endoInv_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F)
     [Fact (Nat.Prime d.W.order)]
-    (t : AffinePoint (FVar F)) (scalar : FVar F)
+    (t : AffinePoint (FVar F)) (scalar : SizedF 128 (FVar F))
     (Q : PostCond (AffinePoint (FVar F)) (.arg (ProverState F) (.except EvalError .pure))) :
     ⦃Complete
         (fun env =>
-          (scalar.eval env).isOk ∧ (t.x.eval env).isOk ∧ (t.y.eval env).isOk ∧
-          (∀ v, scalar.eval env = .ok v →
+          (scalar.val.eval env).isOk ∧ (t.x.eval env).isOk ∧ (t.y.eval env).isOk ∧
+          (∀ v, scalar.val.eval env = .ok v →
             ToNat.toNat v < 4 ^ 64 ∧ ((ToNat.toNat v : F) = v)) ∧
           (∀ x y, t.x.eval env = .ok x → t.y.eval env = .ok y → d.W.Nonsingular x y))
-        (fun env r env' => ∀ v xv yv, scalar.eval env = .ok v →
+        (fun env r env' => ∀ v xv yv, scalar.val.eval env = .ok v →
           t.x.eval env = .ok xv → t.y.eval env = .ok yv →
           ∀ hg : d.W.Nonsingular xv yv,
           ∃ xr yr, r.x.eval env' = .ok xr ∧ r.y.eval env' = .ok yr ∧
@@ -1444,7 +1446,8 @@ theorem endoInv_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F
     | zero => exact absurd hp hsmul_ne
     | some px py hpns => exact ⟨px, py, hpns, rfl⟩
   -- the honest witness computes exactly the advice pair
-  have hread : endoInvWit d.W d.W.order d.prime ((d.lam : ZMod d.W.order)) t scalar st₀.env
+  have hread : endoInvWit d.W d.W.order d.prime ((d.lam : ZMod d.W.order)) t scalar.val
+      st₀.env
       = .ok (px, py) := by
     simp only [endoInvWit, AsProver.readCVar, hv, hxv, hyv, Bind.bind, ReaderT.bind,
       Except.bind, Pure.pure]

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
@@ -210,6 +210,9 @@ structure HasEndo (F : Type) [Field F] [DecidableEq F] where
   lam : ℤ
   /-- The Pasta short-Weierstrass shape. -/
   short : W.a₁ = 0 ∧ W.a₂ = 0 ∧ W.a₃ = 0 ∧ W.a₄ = 0
+  /-- The curve is smooth, so an on-curve point is nonsingular
+  (`equation_iff_nonsingular_of_Δ_ne_zero`). -/
+  delta_ne : W.Δ ≠ 0
   /-- The group order is prime. -/
   prime : Nat.Prime W.order
   /-- The group order is not `2` — with `prime`, the group has no 2-torsion. -/
@@ -241,6 +244,7 @@ def HasEndo.pallas : HasEndo Fp where
   endo := pallasEndo
   lam := pallasLam
   short := ⟨rfl, rfl, rfl, rfl⟩
+  delta_ne := by decide
   prime := Fact.out
   odd := by rw [pallas_card]; decide
   two_ne := by decide
@@ -263,6 +267,7 @@ def HasEndo.vesta : HasEndo Fq where
   endo := vestaEndo
   lam := vestaLam
   short := ⟨rfl, rfl, rfl, rfl⟩
+  delta_ne := by decide
   prime := Fact.out
   odd := by rw [vesta_card]; decide
   two_ne := by decide
@@ -587,7 +592,7 @@ theorem endoMul_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F)
               (s : F) = Kimchi.Gate.EndoScalar.toField crumbs (d.lam : F)) Q⦄
     (endoMul (c := KimchiConstraint F) d.endo rounds t scalar)
     ⦃Q⦄ := by
-  obtain ⟨W, eb, lam, ha, hprime, hodd, h2, h3, heig, hφns, hoff, -⟩ := d
+  obtain ⟨W, eb, lam, ha, -, hprime, hodd, h2, h3, heig, hφns, hoff, -⟩ := d
   haveI : Fact (Nat.Prime W.order) := ⟨hprime⟩
   haveI : Fact (W.a₁ = 0 ∧ W.a₂ = 0 ∧ W.a₃ = 0) := ⟨⟨ha.1, ha.2.1, ha.2.2.1⟩⟩
   simp only [endoMul, mapAccumM]
@@ -873,7 +878,7 @@ theorem endoMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F
         Q⦄
     (endoMul (c := KimchiProverC F) d.endo rounds t scalar)
     ⦃Q⦄ := by
-  obtain ⟨W, eb, lam, ha, hprime, hodd, h2, h3, heig, hφns, hoff, hlam1⟩ := d
+  obtain ⟨W, eb, lam, ha, -, hprime, hodd, h2, h3, heig, hφns, hoff, hlam1⟩ := d
   haveI : Fact (Nat.Prime W.order) := ⟨hprime⟩
   haveI : Fact (W.a₁ = 0 ∧ W.a₂ = 0 ∧ W.a₃ = 0) := ⟨⟨ha.1, ha.2.1, ha.2.2.1⟩⟩
   simp only [endoMul, mapAccumM]
@@ -1180,6 +1185,83 @@ theorem endoMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F
         hsval⟩
   case vc4.vc1.vc1.vc1.vc1.refine_2.refine_2.post.except =>
     exact ExceptConds.entails_false
+
+open Kimchi.Gate.VarBaseMul (eq_inv_smul_of_smul_eq) in
+/-- The division gadget is sound: under any satisfying valuation, for an input point
+reading on-curve, some `[s]` with `(s : F) = EndoScalar.toField crumbs (d.lam)` and
+`scalar` reading as the crumbs' reconstruction maps the RESULT to the INPUT — and,
+`s` being a unit mod the prime order (free: the input is affine, hence nonzero), the
+result is `[s⁻¹]·g`, the PS defining equation
+`endoInv g a ~ scalarMul (recip (toFieldPure a endoScalar)) g`.
+The on-curve rows discharge `endoMul_spec`'s promise hypothesis at the WITNESSED
+point — the gadget's design point — with smoothness (`d.delta_ne`) upgrading their
+equation to nonsingularity. The advice parameters `(q, hq, lam')` are universally
+quantified: soundness never consults the witness. -/
+theorem endoInv_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F)
+    (q : ℕ) (hq : q.Prime) (lam' : ZMod q)
+    (t : AffinePoint (FVar F)) (scalar : FVar F)
+    (Q : PostCond (AffinePoint (FVar F)) (.arg (BuilderState F) .pure)) :
+    ⦃Sound (fun V (r : AffinePoint (FVar F)) =>
+        ∀ hg : d.W.Nonsingular (t.x.val V) (t.y.val V),
+          ∃ crumbs : List F,
+            (∀ x ∈ crumbs, x = 0 ∨ x = 1 ∨ x = 2 ∨ x = 3) ∧
+            crumbs.length = 64 ∧
+            scalar.val V = Kimchi.Gate.EndoScalar.nReconstruct crumbs ∧
+            ∃ (hres : d.W.Nonsingular (r.x.val V) (r.y.val V)) (s : ℤ),
+              (s : F) = Kimchi.Gate.EndoScalar.toField crumbs (d.lam : F) ∧
+              (s : ZMod d.W.order) ≠ 0 ∧
+              Point.some _ _ hg = s • Point.some _ _ hres ∧
+              Point.some _ _ hres
+                = ((s : ZMod d.W.order)⁻¹.val : ℕ) • Point.some _ _ hg) Q⦄
+    (endoInv (c := KimchiConstraint F) d.endo d.W q hq lam' t scalar)
+    ⦃Q⦄ := by
+  haveI : Fact (Nat.Prime d.W.order) := ⟨d.prime⟩
+  haveI : Fact (d.W.a₁ = 0 ∧ d.W.a₂ = 0 ∧ d.W.a₃ = 0) :=
+    ⟨⟨d.short.1, d.short.2.1, d.short.2.2.1⟩⟩
+  simp only [endoInv]
+  mvcgen
+  rename_i s hpre
+  intro result _
+  mvcgen
+  intro x2 _ hx2
+  mvcgen
+  intro x3 _ hx3
+  mvcgen
+  intro _ _ hsq
+  mvcgen
+  refine endoMul_spec d 32 (by norm_num) ⟨result.1, result.2⟩ scalar _ _ ?_
+  intro computed nvc hcomp
+  mvcgen
+  intro _ _ heqx
+  mvcgen
+  intro _ _ heqy
+  mvcgen
+  refine hpre ⟨result.1, result.2⟩ _ ?_
+  intro hg
+  -- the on-curve rows read as the curve equation at the witnessed point
+  have hEq : d.W.Equation (result.1.val s.V) (result.2.val s.V) := by
+    rw [d.W.equation_iff, d.short.1, d.short.2.1, d.short.2.2.1]
+    simp only [CVar.val_add_, CVar.val_scale_, CVar.val] at hsq
+    rw [hx3, hx2] at hsq
+    linear_combination hsq
+  have hres : d.W.Nonsingular (result.1.val s.V) (result.2.val s.V) :=
+    (d.W.equation_iff_nonsingular_of_Δ_ne_zero d.delta_ne).mp hEq
+  -- `endoMul`'s promise at the witnessed point
+  obtain ⟨crumbs, hval, hlen, hn, hfin, sZ, hseq, hcast⟩ := hcomp hres
+  -- the pins carry the computed point to the input
+  have hgeq : Point.some _ _ hg = sZ • Point.some _ _ hres :=
+    (Kimchi.Gate.EndoMul.some_congr d.W hg hfin heqx.symm heqy.symm).trans hseq
+  -- the scalar is a unit mod the order: the input is affine, hence nonzero
+  have hs0 : (sZ : ZMod d.W.order) ≠ 0 := by
+    intro h0
+    obtain ⟨m, hm⟩ := (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp h0
+    refine Point.some_ne_zero hg (hgeq.trans ?_)
+    have hkill : (d.W.order : ℤ) • Point.some _ _ hres = 0 := by
+      rw [natCast_zsmul]
+      exact card_nsmul_eq_zero'
+    rw [hm, mul_comm, mul_smul, hkill, smul_zero]
+  exact ⟨crumbs, hval, by omega, hn, hres, sZ, hcast, hs0, hgeq,
+    eq_inv_smul_of_smul_eq d.W hs0 hgeq⟩
 
 end EndoMul
 

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
@@ -1285,6 +1285,279 @@ theorem endoInv_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F)
   exact ⟨crumbs, hval, by omega, hn, hres, sZ, hcast, hs0, hgeq,
     eq_inv_smul_of_smul_eq d.W hs0 hgeq⟩
 
+open Kimchi.Gate.EndoScalar in
+/-- The scalar side of `endoInv`'s completeness, packaged away from the walk: at any
+on-curve point, the endo-decoded challenge is a unit mod the order (its ℤ-shadow is a
+positive bounded GLV combo, priced by `combo_ne_zero`), and any integer with the
+decomposition shape `endoMul` hands back is congruent to it (the char window
+`d.char_big` reads the bounded decomposition integers exactly). The digit-shadow
+recursion (`digitsOf`) stays inside this proof — the walk's context never carries it,
+which keeps the walk's elaboration off the 64-deep symbolic unfolding. -/
+private theorem endoInv_scalar_facts [Field F] [DecidableEq F] (d : HasEndo F)
+    [Fact (Nat.Prime d.W.order)] {xv yv : F} (hg : d.W.Nonsingular xv yv) (n : ℕ) :
+    Kimchi.Gate.EndoScalar.toField (crumbsOf 64 n) ((d.lam : ZMod d.W.order)) ≠ 0 ∧
+    ∀ s A B : ℤ, s = B + A * d.lam → |A| ≤ 3 * 4 ^ 32 → |B| ≤ 3 * 4 ^ 32 →
+      (A : F) = Kimchi.Gate.EndoScalar.decomposeA (crumbsOf (2 * 32) n) →
+      (B : F) = Kimchi.Gate.EndoScalar.decomposeB (crumbsOf (2 * 32) n) →
+      ((s : ℤ) : ZMod d.W.order)
+        = Kimchi.Gate.EndoScalar.toField (crumbsOf 64 n) ((d.lam : ZMod d.W.order)) := by
+  haveI : NeZero d.W.order := ⟨d.prime.ne_zero⟩
+  -- the residues of 2 and 3 are units: the order is prime and avoids both
+  have h2q : (2 : ZMod d.W.order) ≠ 0 := by
+    have h : ((2 : ℤ) : ZMod d.W.order) ≠ 0 := by
+      rw [Ne, ZMod.intCast_zmod_eq_zero_iff_dvd]
+      intro hdvd
+      have h2 : d.W.order ∣ 2 := by exact_mod_cast hdvd
+      exact d.odd ((Nat.prime_dvd_prime_iff_eq d.prime Nat.prime_two).mp h2)
+    exact_mod_cast h
+  have h3q : (3 : ZMod d.W.order) ≠ 0 := by
+    have h : ((3 : ℤ) : ZMod d.W.order) ≠ 0 := by
+      rw [Ne, ZMod.intCast_zmod_eq_zero_iff_dvd]
+      intro hdvd
+      have h3 : d.W.order ∣ 3 := by exact_mod_cast hdvd
+      exact d.order_ne_three ((Nat.prime_dvd_prime_iff_eq d.prime Nat.prime_three).mp h3)
+    exact_mod_cast h
+  obtain ⟨hAlo, hAhi⟩ := decomposeAInt_bounds (digitsOf 64 n)
+  obtain ⟨hBlo, hBhi⟩ := decomposeBInt_bounds (digitsOf 64 n)
+  rw [digitsOf_length] at hAlo hAhi hBlo hBhi
+  have h64 : (0 : ℤ) < 2 ^ 64 := by positivity
+  have heffz : Kimchi.Gate.EndoScalar.toField (crumbsOf 64 n) ((d.lam : ZMod d.W.order))
+      = ((toIntZ (digitsOf 64 n) d.lam : ℤ) : ZMod d.W.order) := by
+    rw [crumbsOf_eq_map, toField_digits h2q h3q _ (digitsOf_lt 64 _) d.lam]
+  have hAZF : Kimchi.Gate.EndoScalar.decomposeA (crumbsOf (2 * 32) n)
+      = ((decomposeAInt (digitsOf 64 n) : ℤ) : F) := by
+    rw [show (2 * 32 : ℕ) = 64 from rfl, crumbsOf_eq_map,
+      decomposeA_digits d.two_ne d.three_ne _ (digitsOf_lt 64 _)]
+  have hBZF : Kimchi.Gate.EndoScalar.decomposeB (crumbsOf (2 * 32) n)
+      = ((decomposeBInt (digitsOf 64 n) : ℤ) : F) := by
+    rw [show (2 * 32 : ℕ) = 64 from rfl, crumbsOf_eq_map,
+      decomposeB_digits d.two_ne d.three_ne _ (digitsOf_lt 64 _)]
+  constructor
+  · -- the decoded challenge is a unit: its shadow is a positive bounded GLV combo
+    rw [heffz]
+    intro h0
+    obtain ⟨mm, hm⟩ := (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp h0
+    have hkill : (toIntZ (digitsOf 64 n) d.lam) • (Point.some _ _ hg : d.W.Point) = 0 := by
+      have horder : (d.W.order : ℤ) • (Point.some _ _ hg : d.W.Point) = 0 := by
+        rw [natCast_zsmul]; exact card_nsmul_eq_zero'
+      rw [hm, mul_comm, mul_smul, horder, smul_zero]
+    have hexp : (toIntZ (digitsOf 64 n) d.lam) • (Point.some _ _ hg : d.W.Point)
+        = decomposeBInt (digitsOf 64 n) • (Point.some _ _ hg : d.W.Point)
+          + decomposeAInt (digitsOf 64 n)
+            • (d.lam • (Point.some _ _ hg : d.W.Point)) := by
+      rw [toIntZ]; module
+    exact Kimchi.Gate.EndoMul.combo_ne_zero
+      (fun a b ha hb hba hbb =>
+        d.off_targets ha hb hba hbb (Point.some_ne_zero hg) rfl)
+      (by linarith) (by linarith) (by norm_num at hBhi ⊢; linarith)
+      (by norm_num at hAhi ⊢; linarith)
+      (hexp ▸ hkill)
+  · -- the char window reads the decomposition exactly, then residues agree
+    intro s A B hsab hAle hBle hAval hBval
+    have hwindow : ∀ X XZ : ℤ, |X| ≤ 3 * 4 ^ 32 →
+        2 ^ 64 + 1 ≤ XZ → XZ ≤ 3 * 2 ^ 64 - 1 → ((X - XZ : ℤ) : F) = 0 → X = XZ := by
+      intro X XZ hXle hXZlo hXZhi hcast
+      have habs : |X - XZ| < 2 ^ 127 := by
+        rw [abs_lt]
+        obtain ⟨hX1, hX2⟩ := abs_le.mp hXle
+        rw [show (3 : ℤ) * 4 ^ 32 = 3 * 2 ^ 64 from by norm_num] at hX1 hX2
+        have hbig : (6 : ℤ) * 2 ^ 64 < 2 ^ 127 := by norm_num
+        constructor <;> linarith
+      have := d.char_big _ habs hcast
+      omega
+    have hAeq : A = decomposeAInt (digitsOf 64 n) :=
+      hwindow _ _ hAle hAlo hAhi (by push_cast; rw [hAval, hAZF]; ring)
+    have hBeq : B = decomposeBInt (digitsOf 64 n) :=
+      hwindow _ _ hBle hBlo hBhi (by push_cast; rw [hBval, hBZF]; ring)
+    rw [heffz, hsab, hAeq, hBeq, toIntZ]
+    push_cast
+    ring
+
+open Kimchi.Gate.EndoScalar in
+open Kimchi.Gate.VarBaseMul (smul_ne_zero_of_lt smul_eq_smul_of_zmod_eq) in
+/-- The division gadget is complete at the honest advice: instantiated in its own
+scalar field (`q := W.order`, `λ' := λ mod q`), the prover's run succeeds whenever the
+input point reads on-curve and the challenge is faithful and in range, and the result
+reads as `[eff⁻¹]·g` for `eff` the endo-decoded challenge — the PS witness's defining
+equation. The run never errors because `eff` is a unit mod the order (`combo_ne_zero`
+at the ℤ-shadow's window), the advice point is a genuine Mathlib point (so the
+on-curve rows pass), and `endoMul` returns `[s]·[eff⁻¹]·g = g` — `s ≡ eff (mod q)` by
+reading the decomposition integers through the char window (`char_big`), so the final
+pins close by residue action. Stepped through in the body. -/
+theorem endoInv_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F)
+    [Fact (Nat.Prime d.W.order)]
+    (t : AffinePoint (FVar F)) (scalar : FVar F)
+    (Q : PostCond (AffinePoint (FVar F)) (.arg (ProverState F) (.except EvalError .pure))) :
+    ⦃Complete
+        (fun env =>
+          (scalar.eval env).isOk ∧ (t.x.eval env).isOk ∧ (t.y.eval env).isOk ∧
+          (∀ v, scalar.eval env = .ok v →
+            ToNat.toNat v < 4 ^ 64 ∧ ((ToNat.toNat v : F) = v)) ∧
+          (∀ x y, t.x.eval env = .ok x → t.y.eval env = .ok y → d.W.Nonsingular x y))
+        (fun env r env' => ∀ v xv yv, scalar.eval env = .ok v →
+          t.x.eval env = .ok xv → t.y.eval env = .ok yv →
+          ∀ hg : d.W.Nonsingular xv yv,
+          ∃ xr yr, r.x.eval env' = .ok xr ∧ r.y.eval env' = .ok yr ∧
+            ∃ hres : d.W.Nonsingular xr yr,
+              Point.some _ _ hres
+                = ((Kimchi.Gate.EndoScalar.toField
+                    (Kimchi.Gate.EndoScalar.crumbsOf 64 (ToNat.toNat v))
+                    ((d.lam : ZMod d.W.order)))⁻¹.val : ℕ)
+                  • Point.some _ _ hg)
+        Q⦄
+    (endoInv (c := KimchiProverC F) d.endo d.W d.W.order d.prime
+      ((d.lam : ZMod d.W.order)) t scalar)
+    ⦃Q⦄ := by
+  haveI : NeZero d.W.order := ⟨d.prime.ne_zero⟩
+  haveI : Fact (d.W.a₁ = 0 ∧ d.W.a₂ = 0 ∧ d.W.a₃ = 0) :=
+    ⟨⟨d.short.1, d.short.2.1, d.short.2.2.1⟩⟩
+  simp only [endoInv]
+  mvcgen
+  rename_i st₀ hpre
+  obtain ⟨⟨hsok, hxok, hyok, hsc, hcurve⟩, hk⟩ := hpre
+  obtain ⟨v, hv⟩ := CVar.evalOk hsok
+  obtain ⟨xv, hxv⟩ := CVar.evalOk hxok
+  obtain ⟨yv, hyv⟩ := CVar.evalOk hyok
+  obtain ⟨hrange, hfaith⟩ := hsc v hv
+  have hg : d.W.Nonsingular xv yv := hcurve _ _ hxv hyv
+  -- the scalar facts, packaged: unit challenge + residue agreement
+  obtain ⟨heffne', hkey⟩ := endoInv_scalar_facts d hg (ToNat.toNat v)
+  obtain ⟨eff, heff⟩ : ∃ eff : ZMod d.W.order,
+      eff = Kimchi.Gate.EndoScalar.toField (crumbsOf 64 (ToNat.toNat v))
+        ((d.lam : ZMod d.W.order)) := ⟨_, rfl⟩
+  have heffne : eff ≠ 0 := heff ▸ heffne'
+  -- the input point
+  obtain ⟨G, hG⟩ : ∃ G : d.W.Point, G = Point.some _ _ hg := ⟨_, rfl⟩
+  have hGne : G ≠ 0 := by rw [hG]; exact Point.some_ne_zero hg
+  -- the advice scalar and point
+  obtain ⟨k, hkdef⟩ : ∃ k : ℕ, k = eff⁻¹.val := ⟨_, rfl⟩
+  have hinv_ne : eff⁻¹ ≠ 0 := inv_ne_zero heffne
+  have hkne : k ≠ 0 := by rw [hkdef, Ne, ZMod.val_eq_zero]; exact hinv_ne
+  have hklt : k < d.W.order := by rw [hkdef]; exact ZMod.val_lt _
+  have hsmul_ne : (k : ℤ) • G ≠ 0 := fun h0 =>
+    smul_ne_zero_of_lt d.W hGne
+      (by exact_mod_cast Nat.pos_of_ne_zero hkne) (by exact_mod_cast hklt) h0
+  obtain ⟨px, py, hpns, hpteq⟩ :
+      ∃ px py, ∃ hpns : d.W.Nonsingular px py, (k : ℕ) • G = Point.some _ _ hpns := by
+    rw [natCast_zsmul] at hsmul_ne
+    cases hp : (k : ℕ) • G with
+    | zero => exact absurd hp hsmul_ne
+    | some px py hpns => exact ⟨px, py, hpns, rfl⟩
+  -- the honest witness computes exactly the advice pair
+  have hread : endoInvWit d.W d.W.order d.prime ((d.lam : ZMod d.W.order)) t scalar st₀.env
+      = .ok (px, py) := by
+    simp only [endoInvWit, AsProver.readCVar, hv, hxv, hyv, Bind.bind, ReaderT.bind,
+      Except.bind, Pure.pure]
+    rw [dif_pos hg, ← heff, ← hkdef, hG.symm, hpteq]
+    rfl
+  refine ⟨by rw [hread]; rfl, fun rp st₁ hgrantW hle₁ => ?_⟩
+  obtain ⟨hrpx, hrpy⟩ := hgrantW _ hread
+  mvcgen
+  -- x² row
+  refine ⟨by rw [hrpx]; rfl, fun x2 st₂ hgr2 hle₂ => ?_⟩
+  have hx2 : x2.eval st₂.env = .ok (px * px) := hgr2 _ hrpx
+  have hrpx₂ := CVar.eval_le hle₂ hrpx
+  mvcgen
+  -- x³ row
+  refine ⟨⟨by rw [hx2]; rfl, by rw [hrpx₂]; rfl⟩, fun x3 st₃ hgr3 hle₃ => ?_⟩
+  have hx3 : x3.eval st₃.env = .ok (px * px * px) := hgr3 _ _ hx2 hrpx₂
+  have hrpx₃ := CVar.eval_le hle₃ hrpx₂
+  have hrpy₃ := CVar.eval_le (hle₂.trans hle₃) hrpy
+  -- the on-curve row: the advice point satisfies the curve equation
+  have hEq : py * py = px * px * px + d.W.a₄ * px + d.W.a₆ := by
+    have h := (d.W.equation_iff px py).mp hpns.1
+    rw [d.short.1, d.short.2.1, d.short.2.2.1] at h
+    linear_combination h
+  have hrhs : (CVar.add_ (CVar.add_ x3 (CVar.scale_ d.W.a₄ rp.1)) (CVar.const d.W.a₆)).eval
+      st₃.env = .ok (px * px * px + d.W.a₄ * px + d.W.a₆) := by
+    rw [CVar.eval_add_]
+    simp only [CVar.eval, CVar.eval_add_, hx3, CVar.eval_scale_ hrpx₃ d.W.a₄]
+  mvcgen
+  refine ⟨⟨by rw [hrpy₃]; rfl, by rw [hrhs]; rfl, ?_⟩, fun u₄ st₄ hle₄ => ?_⟩
+  · intro yv' rhv' hyv' hrhv'
+    rw [hrpy₃] at hyv'
+    injection hyv' with hyv'
+    rw [hrhs] at hrhv'
+    injection hrhv' with hrhv'
+    rw [← hyv', ← hrhv']
+    exact hEq
+  mvcgen
+  -- the endoMul sub-run at the advice point
+  have hle₁₄ := hle₁.trans (hle₂.trans (hle₃.trans hle₄))
+  have hv₄ := CVar.eval_le hle₁₄ hv
+  have hrpx₄ := CVar.eval_le hle₄ hrpx₃
+  have hrpy₄ := CVar.eval_le hle₄ hrpy₃
+  refine endoMul_complete_spec d 32 (by norm_num) ⟨rp.1, rp.2⟩ scalar _ _
+    ⟨⟨by rw [hv₄]; rfl, by rw [hrpx₄]; rfl, by rw [hrpy₄]; rfl, ?_, ?_⟩,
+      fun computed st₅ hgr5 hle₅ => ?_⟩
+  · intro v' hv'
+    rw [hv₄] at hv'
+    injection hv' with hv'
+    subst hv'
+    exact ⟨by norm_num; exact hrange, hfaith⟩
+  · intro x' y' hx' hy'
+    rw [hrpx₄] at hx'
+    injection hx' with hx'
+    rw [hrpy₄] at hy'
+    injection hy' with hy'
+    rw [← hx', ← hy']
+    exact hpns
+  obtain ⟨xS, yS, hxS, hyS, hfin, s, A, B, hpt, hsab, hAle, hBle, hAval, hBval, hsval⟩ :=
+    hgr5 v px py hv₄ hrpx₄ hrpy₄ hpns
+  -- the scalar's residue is the decoded challenge (the packaged key fact)
+  have hsmod : ((s : ℤ) : ZMod d.W.order) = eff := by
+    rw [heff]
+    exact hkey s A B hsab hAle hBle hAval hBval
+  have hsk : ((s * (k : ℤ) : ℤ) : ZMod d.W.order) = ((1 : ℤ) : ZMod d.W.order) := by
+    push_cast
+    rw [hsmod, hkdef, ZMod.natCast_val, ZMod.cast_id]
+    exact mul_inv_cancel₀ heffne
+  -- the computed point returns to the input
+  have hchain : Point.some _ _ hfin = Point.some _ _ hg := by
+    rw [hpt, ← hpteq, ← natCast_zsmul, smul_smul, smul_eq_smul_of_zmod_eq d.W hsk,
+      one_smul]
+    exact hG
+  have hxyeq : xS = xv ∧ yS = yv := by
+    injection hchain with h1 h2
+    exact ⟨h1, h2⟩
+  mvcgen
+  -- the two pins
+  have hxv₅ := CVar.eval_le (hle₁₄.trans hle₅) hxv
+  have hyv₅ := CVar.eval_le (hle₁₄.trans hle₅) hyv
+  refine ⟨⟨by rw [hxS]; rfl, by rw [hxv₅]; rfl, ?_⟩, fun u₆ st₆ hle₆ => ?_⟩
+  · intro a' b' ha' hb'
+    rw [hxS] at ha'
+    injection ha' with ha'
+    rw [hxv₅] at hb'
+    injection hb' with hb'
+    rw [← ha', ← hb']
+    exact hxyeq.1
+  mvcgen
+  refine ⟨⟨by rw [CVar.eval_le hle₆ hyS]; rfl, by rw [CVar.eval_le hle₆ hyv₅]; rfl, ?_⟩,
+    fun u₇ st₇ hle₇ => ?_⟩
+  · intro a' b' ha' hb'
+    rw [CVar.eval_le hle₆ hyS] at ha'
+    injection ha' with ha'
+    rw [CVar.eval_le hle₆ hyv₅] at hb'
+    injection hb' with hb'
+    rw [← ha', ← hb']
+    exact hxyeq.2
+  mvcgen
+  -- the return value carries the defining equation
+  refine hk ⟨rp.1, rp.2⟩ st₇ (fun v' xv' yv' hv' hxv' hyv' hg' => ?_)
+    (hle₁₄.trans (hle₅.trans (hle₆.trans hle₇)))
+  rw [hv] at hv'
+  injection hv' with hv'
+  rw [hxv] at hxv'
+  injection hxv' with hxv'
+  rw [hyv] at hyv'
+  injection hyv' with hyv'
+  subst hv' hxv' hyv'
+  have hleTail := hle₂.trans (hle₃.trans (hle₄.trans (hle₅.trans (hle₆.trans hle₇))))
+  refine ⟨px, py, CVar.eval_le hleTail hrpx, CVar.eval_le hleTail hrpy, hpns, ?_⟩
+  rw [← heff, ← hkdef]
+  exact (hG ▸ hpteq).symm
+
 end EndoMul
 
 end Snarky.Kimchi

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
@@ -234,6 +234,12 @@ structure HasEndo (F : Type) [Field F] [DecidableEq F] where
       a • T + b • φT ≠ φT ∧ a • T + b • φT ≠ -φT
   /-- `[1 + λ]` does not kill a nonzero point — the init sum `T + φT` is finite. -/
   lam_succ_smul : ∀ T : W.Point, T ≠ 0 → (1 + lam) • T ≠ 0
+  /-- The order is not `3` either: with `odd`, both `2` and `3` are units in
+  `ZMod order`, which lets the decompose tables be read in the scalar field. -/
+  order_ne_three : W.order ≠ 3
+  /-- The char window: integers below `2^127` in magnitude embed injectively in `F`,
+  so bounded fold values with equal `F`-images are equal integers. -/
+  char_big : ∀ z : ℤ, |z| < 2 ^ 127 → (z : F) = 0 → z = 0
 
 open CompElliptic.Curves.Pasta CompElliptic.Fields.Pasta Pasta in
 /-- The dictionary at deployed Pallas: `pallasEndo`/`pallasLam`, the facts from
@@ -259,6 +265,11 @@ def HasEndo.pallas : HasEndo Fp where
     exact Kimchi.Gate.VarBaseMul.smul_ne_zero_of_lt Pallas.curve.toAffine hTne
       (by norm_num [pallasLam])
       (by rw [pallas_card]; norm_num [pallasLam])
+  order_ne_three := by rw [pallas_card]; decide
+  char_big := fun z hz h0 => by
+    have hdvd : ((PALLAS_BASE_CARD : ℕ) : ℤ) ∣ z :=
+      (ZMod.intCast_zmod_eq_zero_iff_dvd z _).mp h0
+    exact Int.eq_zero_of_abs_lt_dvd hdvd (hz.trans (by norm_num))
 
 open CompElliptic.Curves.Pasta CompElliptic.Fields.Pasta Pasta in
 /-- The dictionary at deployed Vesta — the other half of the 2-cycle. -/
@@ -282,6 +293,11 @@ def HasEndo.vesta : HasEndo Fq where
     exact Kimchi.Gate.VarBaseMul.smul_ne_zero_of_lt Vesta.curve.toAffine hTne
       (by norm_num [vestaLam])
       (by rw [vesta_card]; norm_num [vestaLam])
+  order_ne_three := by rw [vesta_card]; decide
+  char_big := fun z hz h0 => by
+    have hdvd : ((PALLAS_SCALAR_CARD : ℕ) : ℤ) ∣ z :=
+      (ZMod.intCast_zmod_eq_zero_iff_dvd z _).mp h0
+    exact Int.eq_zero_of_abs_lt_dvd hdvd (hz.trans (by norm_num))
 
 namespace EndoMul
 
@@ -592,7 +608,7 @@ theorem endoMul_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F)
               (s : F) = Kimchi.Gate.EndoScalar.toField crumbs (d.lam : F)) Q⦄
     (endoMul (c := KimchiConstraint F) d.endo rounds t scalar)
     ⦃Q⦄ := by
-  obtain ⟨W, eb, lam, ha, -, hprime, hodd, h2, h3, heig, hφns, hoff, -⟩ := d
+  obtain ⟨W, eb, lam, ha, -, hprime, hodd, h2, h3, heig, hφns, hoff, -, -, -⟩ := d
   haveI : Fact (Nat.Prime W.order) := ⟨hprime⟩
   haveI : Fact (W.a₁ = 0 ∧ W.a₂ = 0 ∧ W.a₃ = 0) := ⟨⟨ha.1, ha.2.1, ha.2.2.1⟩⟩
   simp only [endoMul, mapAccumM]
@@ -878,7 +894,7 @@ theorem endoMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F
         Q⦄
     (endoMul (c := KimchiProverC F) d.endo rounds t scalar)
     ⦃Q⦄ := by
-  obtain ⟨W, eb, lam, ha, -, hprime, hodd, h2, h3, heig, hφns, hoff, hlam1⟩ := d
+  obtain ⟨W, eb, lam, ha, -, hprime, hodd, h2, h3, heig, hφns, hoff, hlam1, -, -⟩ := d
   haveI : Fact (Nat.Prime W.order) := ⟨hprime⟩
   haveI : Fact (W.a₁ = 0 ∧ W.a₂ = 0 ∧ W.a₃ = 0) := ⟨⟨ha.1, ha.2.1, ha.2.2.1⟩⟩
   simp only [endoMul, mapAccumM]

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
@@ -1300,13 +1300,18 @@ positive bounded GLV combo, priced by `combo_ne_zero`), and any integer with the
 decomposition shape `endoMul` hands back is congruent to it (the char window
 `d.char_big` reads the bounded decomposition integers exactly). The digit-shadow
 recursion (`digitsOf`) stays inside this proof — the walk's context never carries it,
-which keeps the walk's elaboration off the 64-deep symbolic unfolding. -/
+which keeps the walk's elaboration off the 64-deep symbolic unfolding.
+
+Numeral convention: everything here is spelled at the 128-bit challenge's literals —
+`64` crumbs (crumbs are 2-bit, `64 = 128 / 2`) and `2 ^ 64` bound magnitudes. The
+caller bridges `endoMul`'s rounds-arithmetic spellings (`2 * 32`, `4 ^ 32` at
+`rounds = 32`) once, at the application. -/
 private theorem endoInv_scalar_facts [Field F] [DecidableEq F] (d : HasEndo F)
     [Fact (Nat.Prime d.W.order)] {xv yv : F} (hg : d.W.Nonsingular xv yv) (n : ℕ) :
     Kimchi.Gate.EndoScalar.toField (crumbsOf 64 n) ((d.lam : ZMod d.W.order)) ≠ 0 ∧
-    ∀ s A B : ℤ, s = B + A * d.lam → |A| ≤ 3 * 4 ^ 32 → |B| ≤ 3 * 4 ^ 32 →
-      (A : F) = Kimchi.Gate.EndoScalar.decomposeA (crumbsOf (2 * 32) n) →
-      (B : F) = Kimchi.Gate.EndoScalar.decomposeB (crumbsOf (2 * 32) n) →
+    ∀ s A B : ℤ, s = B + A * d.lam → |A| ≤ 3 * 2 ^ 64 → |B| ≤ 3 * 2 ^ 64 →
+      (A : F) = Kimchi.Gate.EndoScalar.decomposeA (crumbsOf 64 n) →
+      (B : F) = Kimchi.Gate.EndoScalar.decomposeB (crumbsOf 64 n) →
       ((s : ℤ) : ZMod d.W.order)
         = Kimchi.Gate.EndoScalar.toField (crumbsOf 64 n) ((d.lam : ZMod d.W.order)) := by
   haveI : NeZero d.W.order := ⟨d.prime.ne_zero⟩
@@ -1332,14 +1337,12 @@ private theorem endoInv_scalar_facts [Field F] [DecidableEq F] (d : HasEndo F)
   have heffz : Kimchi.Gate.EndoScalar.toField (crumbsOf 64 n) ((d.lam : ZMod d.W.order))
       = ((toIntZ (digitsOf 64 n) d.lam : ℤ) : ZMod d.W.order) := by
     rw [crumbsOf_eq_map, toField_digits h2q h3q _ (digitsOf_lt 64 _) d.lam]
-  have hAZF : Kimchi.Gate.EndoScalar.decomposeA (crumbsOf (2 * 32) n)
+  have hAZF : Kimchi.Gate.EndoScalar.decomposeA (crumbsOf 64 n)
       = ((decomposeAInt (digitsOf 64 n) : ℤ) : F) := by
-    rw [show (2 * 32 : ℕ) = 64 from rfl, crumbsOf_eq_map,
-      decomposeA_digits d.two_ne d.three_ne _ (digitsOf_lt 64 _)]
-  have hBZF : Kimchi.Gate.EndoScalar.decomposeB (crumbsOf (2 * 32) n)
+    rw [crumbsOf_eq_map, decomposeA_digits d.two_ne d.three_ne _ (digitsOf_lt 64 _)]
+  have hBZF : Kimchi.Gate.EndoScalar.decomposeB (crumbsOf 64 n)
       = ((decomposeBInt (digitsOf 64 n) : ℤ) : F) := by
-    rw [show (2 * 32 : ℕ) = 64 from rfl, crumbsOf_eq_map,
-      decomposeB_digits d.two_ne d.three_ne _ (digitsOf_lt 64 _)]
+    rw [crumbsOf_eq_map, decomposeB_digits d.two_ne d.three_ne _ (digitsOf_lt 64 _)]
   constructor
   · -- the decoded challenge is a unit: its shadow is a positive bounded GLV combo
     rw [heffz]
@@ -1362,13 +1365,12 @@ private theorem endoInv_scalar_facts [Field F] [DecidableEq F] (d : HasEndo F)
       (hexp ▸ hkill)
   · -- the char window reads the decomposition exactly, then residues agree
     intro s A B hsab hAle hBle hAval hBval
-    have hwindow : ∀ X XZ : ℤ, |X| ≤ 3 * 4 ^ 32 →
+    have hwindow : ∀ X XZ : ℤ, |X| ≤ 3 * 2 ^ 64 →
         2 ^ 64 + 1 ≤ XZ → XZ ≤ 3 * 2 ^ 64 - 1 → ((X - XZ : ℤ) : F) = 0 → X = XZ := by
       intro X XZ hXle hXZlo hXZhi hcast
       have habs : |X - XZ| < 2 ^ 127 := by
         rw [abs_lt]
         obtain ⟨hX1, hX2⟩ := abs_le.mp hXle
-        rw [show (3 : ℤ) * 4 ^ 32 = 3 * 2 ^ 64 from by norm_num] at hX1 hX2
         have hbig : (6 : ℤ) * 2 ^ 64 < 2 ^ 127 := by norm_num
         constructor <;> linarith
       have := d.char_big _ habs hcast
@@ -1515,7 +1517,9 @@ theorem endoInv_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F
   -- the scalar's residue is the decoded challenge (the packaged key fact)
   have hsmod : ((s : ℤ) : ZMod d.W.order) = eff := by
     rw [heff]
-    exact hkey s A B hsab hAle hBle hAval hBval
+    -- endoMul's rounds-arithmetic spellings bridge to the 128-bit literals here, once
+    exact hkey s A B hsab (by norm_num at hAle ⊢; exact hAle)
+      (by norm_num at hBle ⊢; exact hBle) hAval hBval
   have hsk : ((s * (k : ℤ) : ℤ) : ZMod d.W.order) = ((1 : ℤ) : ZMod d.W.order) := by
     push_cast
     rw [hsmod, hkdef, ZMod.natCast_val, ZMod.cast_id]

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
@@ -886,8 +886,14 @@ theorem endoMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F
           t.x.eval env = .ok xv → t.y.eval env = .ok yv →
           ∀ hT : d.W.Nonsingular xv yv,
           ∃ xS yS, r.x.eval env' = .ok xS ∧ r.y.eval env' = .ok yS ∧
-            ∃ (hfin : d.W.Nonsingular xS yS) (s : ℤ),
+            ∃ (hfin : d.W.Nonsingular xS yS) (s A B : ℤ),
               Point.some _ _ hfin = s • Point.some _ _ hT ∧
+              s = B + A * d.lam ∧
+              |A| ≤ 3 * 4 ^ rounds ∧ |B| ≤ 3 * 4 ^ rounds ∧
+              (A : F) = Kimchi.Gate.EndoScalar.decomposeA
+                (Kimchi.Gate.EndoScalar.crumbsOf (2 * rounds) (ToNat.toNat v)) ∧
+              (B : F) = Kimchi.Gate.EndoScalar.decomposeB
+                (Kimchi.Gate.EndoScalar.crumbsOf (2 * rounds) (ToNat.toNat v)) ∧
               (s : F) = Kimchi.Gate.EndoScalar.toField
                 (Kimchi.Gate.EndoScalar.crumbsOf (2 * rounds) (ToNat.toNat v))
                 (d.lam : F))
@@ -1185,7 +1191,7 @@ theorem endoMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F
             exact ⟨rfl, rfl⟩)
           (fun i _ => ⟨rfl, rfl⟩)
           hP0ns hP0 lam (heig hT hφT)
-      rw [hcl] at hsval
+      rw [hcl] at hAval hBval hsval
       have hax := accX_chainBuild eb xv yv x0v y0v 0 bsv rounds
       have hay := accY_chainBuild eb xv yv x0v y0v 0 bsv rounds
       have hfin : W.Nonsingular
@@ -1196,9 +1202,9 @@ theorem endoMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F
       exact ⟨(Kimchi.Gate.EndoMul.chainBuild eb xv yv x0v y0v 0 bsv rounds).xP,
         (Kimchi.Gate.EndoMul.chainBuild eb xv yv x0v y0v 0 bsv rounds).yP,
         CVar.eval_le (hle₅.trans hle₆) hxP, CVar.eval_le (hle₅.trans hle₆) hyP,
-        hfin, s,
+        hfin, s, A, B,
         (Kimchi.Gate.EndoMul.some_congr W hfin hfin' hax.symm hay.symm).trans hseq,
-        hsval⟩
+        hsab, hAle, hBle, hAval, hBval, hsval⟩
   case vc4.vc1.vc1.vc1.vc1.refine_2.refine_2.post.except =>
     exact ExceptConds.entails_false
 

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
@@ -519,7 +519,7 @@ private theorem threaded_sound [Field F] [DecidableEq F]
     -- the run count is the traversed prefix's
     have hm : rs.length + 1 = pref.length := by simpa using hlen
     -- the point chain: `endoMul_off` at the extracted run
-    obtain ⟨hfin', s, hseq, hsval⟩ :=
+    obtain ⟨hfin', s, A, B, hseq, hsab, hAle, hBle, hAval, hBval, hsval⟩ :=
       endoMul_off W h2 h3 hodd eb (Point.some _ _ hT) (Point.some _ _ hφT) hoff
         (rs.length + 1) (by omega) g hHolds hTns hTeq hφTns hφTeq
         (fun i hi =>
@@ -1152,7 +1152,7 @@ theorem endoMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F
       injection hyv' with hyv'
       subst hv' hxv' hyv'
       -- the point chain: `endoMul_off` at the honest walk
-      obtain ⟨hfin', s, hseq, hsval⟩ :=
+      obtain ⟨hfin', s, A, B, hseq, hsab, hAle, hBle, hAval, hBval, hsval⟩ :=
         Kimchi.Gate.EndoMul.endoMul_off W h2 h3 hodd eb
           (Point.some _ _ hT) (Point.some _ _ hφT)
           (fun a b ha' hb' hba hbb => hoff ha' hb' hba hbb hTne (heig hT hφT))

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
@@ -476,7 +476,7 @@ private theorem threaded_sound [Field F] [DecidableEq F]
     · rw [hP0, heig]; module
     · push_cast
       simp [Kimchi.Gate.EndoScalar.toField, Kimchi.Gate.EndoScalar.decomposeA,
-        Kimchi.Gate.EndoScalar.decomposeB]
+        Kimchi.Gate.EndoScalar.decomposeB, Kimchi.Gate.EndoScalar.decomposeFold]
       ring
   | r₀ :: rs, hthr' =>
     subst hround

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
@@ -205,6 +205,7 @@ private theorem threaded_sound [Field F] [DecidableEq F]
     obtain ⟨rfl, rfl⟩ := Threaded.nil hthr'
     refine ⟨[], by simp, by simp, ?_, ?_, ?_⟩ <;>
       simp [Kimchi.Gate.EndoScalar.decomposeA, Kimchi.Gate.EndoScalar.decomposeB,
+        Kimchi.Gate.EndoScalar.decomposeFold,
         Kimchi.Gate.EndoScalar.nReconstruct, CVar.val]
   | r₀ :: rs, hthr' =>
     subst hround
@@ -700,13 +701,15 @@ theorem toFieldChecked'_complete_spec [Field F] [DecidableEq F] [ToNat F]
                     (Kimchi.Gate.EndoScalar.crumbsOf (F := F) (8 * 0)
                       (ToNat.toNat vv)) = 2 from by
                   simp [Kimchi.Gate.EndoScalar.crumbsOf,
-                    Kimchi.Gate.EndoScalar.decomposeA]]
+                    Kimchi.Gate.EndoScalar.decomposeA,
+                    Kimchi.Gate.EndoScalar.decomposeFold]]
                exact hA)
             | (rw [show Kimchi.Gate.EndoScalar.decomposeB
                     (Kimchi.Gate.EndoScalar.crumbsOf (F := F) (8 * 0)
                       (ToNat.toNat vv)) = 2 from by
                   simp [Kimchi.Gate.EndoScalar.crumbsOf,
-                    Kimchi.Gate.EndoScalar.decomposeB]]
+                    Kimchi.Gate.EndoScalar.decomposeB,
+                    Kimchi.Gate.EndoScalar.decomposeFold]]
                exact hB)
             | (rw [show Kimchi.Gate.EndoScalar.nReconstruct
                     (Kimchi.Gate.EndoScalar.crumbsOf (F := F) (8 * 0)

--- a/formal/snarky/roots.txt
+++ b/formal/snarky/roots.txt
@@ -389,6 +389,7 @@ Snarky.Kimchi.Poseidon.poseidon_spec
 Snarky.Kimchi.Poseidon.poseidon_complete_spec
 Snarky.Kimchi.EndoMul.endoMul_spec
 Snarky.Kimchi.EndoMul.endoMul_complete_spec
+Snarky.Kimchi.EndoMul.endoInv_spec
 -- The deployed endo dictionaries: no per-curve law statements exist — the generic laws
 -- are concretized inside a larger circuit's instantiation — so these values are the
 -- discharge artifacts AND the exhibit that the dictionary is satisfiable at Pasta.

--- a/formal/snarky/roots.txt
+++ b/formal/snarky/roots.txt
@@ -390,6 +390,7 @@ Snarky.Kimchi.Poseidon.poseidon_complete_spec
 Snarky.Kimchi.EndoMul.endoMul_spec
 Snarky.Kimchi.EndoMul.endoMul_complete_spec
 Snarky.Kimchi.EndoMul.endoInv_spec
+Snarky.Kimchi.EndoMul.endoInv_complete_spec
 -- The deployed endo dictionaries: no per-curve law statements exist — the generic laws
 -- are concretized inside a larger circuit's instantiation — so these values are the
 -- discharge artifacts AND the exhibit that the dictionary is satisfiable at Pasta.

--- a/formal/snarky/scripts/check_axioms.lean
+++ b/formal/snarky/scripts/check_axioms.lean
@@ -98,6 +98,7 @@ def roots : List Name :=
     `Snarky.Kimchi.EndoMul.endoMul_spec,
     `Snarky.Kimchi.EndoMul.endoMul_complete_spec,
     `Snarky.Kimchi.EndoMul.endoInv_spec,
+    `Snarky.Kimchi.EndoMul.endoInv_complete_spec,
     `Snarky.Kimchi.HasEndo.pallas,
     `Snarky.Kimchi.HasEndo.vesta,
     `Snarky.post_of_prove,

--- a/formal/snarky/scripts/check_axioms.lean
+++ b/formal/snarky/scripts/check_axioms.lean
@@ -97,6 +97,7 @@ def roots : List Name :=
     `Snarky.Kimchi.EndoScalar.toField_complete_spec,
     `Snarky.Kimchi.EndoMul.endoMul_spec,
     `Snarky.Kimchi.EndoMul.endoMul_complete_spec,
+    `Snarky.Kimchi.EndoMul.endoInv_spec,
     `Snarky.Kimchi.HasEndo.pallas,
     `Snarky.Kimchi.HasEndo.vesta,
     `Snarky.post_of_prove,

--- a/formal/snarky/scripts/check_cs_equality.lean
+++ b/formal/snarky/scripts/check_cs_equality.lean
@@ -196,7 +196,7 @@ def endoScalarCircuit (scalar : FVar Fp) : CircuitM Fp C (FVar Fp) :=
 128 bits / 32 rounds and the Pallas endo coefficient). -/
 def endoMulCircuit (input : AffinePoint (FVar Fp) × FVar Fp) :
     CircuitM Fp C (AffinePoint (FVar Fp)) :=
-  endoMul Pasta.pallasEndo 32 input.1 input.2
+  endoMul Pasta.pallasEndo 32 input.1 ⟨input.2⟩
 
 /-! ## Pickles sub-circuits
 

--- a/formal/snarky/scripts/check_cs_equality.lean
+++ b/formal/snarky/scripts/check_cs_equality.lean
@@ -272,8 +272,8 @@ def bulletReduceOneCircuit (input : Vector (FVar Fp) 5) : CircuitM Fp C PUnit :=
   let r : AffinePoint (FVar Fp) := ⟨input[2], input[3]⟩
   let lScaled ← endoInv Pasta.pallasEndo CompElliptic.Curves.Pasta.Pallas.curve.toAffine
     PALLAS_SCALAR_CARD pallasOrderPrime ((Pasta.pallasLam : ℤ) : ZMod PALLAS_SCALAR_CARD)
-    l input[4]
-  let rScaled ← endoMul Pasta.pallasEndo 32 r input[4]
+    l ⟨input[4]⟩
+  let rScaled ← endoMul Pasta.pallasEndo 32 r ⟨input[4]⟩
   let _ ← addComplete lScaled rScaled
   pure PUnit.unit
 
@@ -290,8 +290,8 @@ def bulletReduceCircuit (input : Vector (FVar Fp) 75) : CircuitM Fp C PUnit := d
     let u := pt (60 + j)
     let lScaled ← endoInv Pasta.pallasEndo CompElliptic.Curves.Pasta.Pallas.curve.toAffine
       PALLAS_SCALAR_CARD pallasOrderPrime ((Pasta.pallasLam : ℤ) : ZMod PALLAS_SCALAR_CARD)
-      l u
-    let rScaled ← endoMul Pasta.pallasEndo 32 r u
+      l ⟨u⟩
+    let rScaled ← endoMul Pasta.pallasEndo 32 r ⟨u⟩
     addComplete lScaled rScaled)
   match terms with
   | [] => pure PUnit.unit


### PR DESCRIPTION
The law pair for the division gadget (#300), generic over `HasEndo` like its endoMul siblings, both directions from the PS defining equation `endoInv g a ~ scalarMul (recip (toFieldPure a endoScalar)) g`.

## Soundness — `endoInv_spec`

Under any satisfying valuation, for an on-curve input `g`: some `[s]` with `(s : F) = EndoScalar.toField crumbs λ` (and `scalar` reading as the crumbs' reconstruction) maps the result to the input, and — `s` being a unit mod the prime order, free since `g` is affine hence nonzero — the result is `[s⁻¹]·g`. The proof is the gadget's design made formal: the inline on-curve rows discharge `endoMul_spec`'s promise hypothesis at the witnessed point, with the new dictionary field `delta_ne` (smoothness) upgrading their equation to nonsingularity. The advice parameters are universally quantified: soundness never consults the witness.

## Completeness — `endoInv_complete_spec`

Instantiated in its own scalar field (`q := W.order`, `λ' := λ mod q`), the honest run succeeds whenever the input reads on-curve and the challenge is faithful and in range, and the result reads as `[eff⁻¹]·g` for `eff` the endo-decoded challenge. The walk is bind-by-bind mvcgen over the component complete specs — `endoMul_complete_spec` passed invocation-scoped — plus one quarantined scalar lemma proving the two facts the gadget owes: `eff` is a unit mod the order (its ℤ-shadow is a positive bounded GLV combo, priced by `combo_ne_zero`), and endoMul's scalar satisfies `s ≡ eff (mod q)`.

## The two-field bridge (the kimchi half)

Completeness needs `s` mod the group order, but the chain tower pinned `s` only through its F-image. The bridge, built bottom-up with no new hypotheses:

- **Decomposition exposed**: `gate_advance`'s `|c| ≤ 3` bounds (already proved, previously discarded) thread up through `endoMul_ab` to `endoMul`/`endoMul_off`, whose posts now read `∃ s A B, s = B + A·λ` with `|A|,|B| ≤ 3·4^m` and F-image pins at the canonical crumbs. Deployed entries keep their published shape.
- **ℤ-shadow**: `digitsOf` (the digit list `crumbsOf` casts), integer tables for `cPoly`/`dPoly`, and `decomposeAInt`/`decomposeBInt`/`toIntZ` with cast lemmas into any field with 2 and 3 invertible — one integer scalar, read once in the base field and once in the scalar field. Window bounds `[2^n + 1, 3·2^n − 1]` make the shadow positive and boxed.
- **Dictionary**: `HasEndo` gains `delta_ne`, `order_ne_three`, and `char_big` (integers under `2^127` embed injectively in `F` — what turns bounded F-pinned integers into exact values). All three discharged in both deployed dictionaries.
- **Toolkit**: `eq_inv_smul_of_smul_eq` (the recip reading of a scalar multiple at prime order) and `smul_eq_smul_of_zmod_eq` (scalars act through their residues) in the VarBaseMul kit; `combo_ne_zero` goes public.

## Proof-engineering notes

Two elaboration traps, recorded in the quarantine lemma's docstring: hypotheses mentioning `digitsOf` at a symbolic challenge whnf-unfold 64 levels deep (445k unfoldings) and stall mvcgen — so the digit shadow stays inside `endoInv_scalar_facts`, whose statement mentions only `crumbsOf`; and `set` traverses the wp-term goal, so the walk introduces names with goal-blind `obtain ⟨x, hx⟩ : ∃ x, x = e` instead.

Battery green: build, corpus 26/26, witness checker 25/25, style, snarky gate 122 roots / kimchi 106, deadcode 0, env linters, shake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Addendum: SizedF

A follow-up commit ports `Snarky.Circuit.DSL.SizedF` (the base-DSL bit-width tag) and restates both gadgets over it: `endoMul` takes `SizedF (4 * rounds)`, `endoInv` takes `SizedF 128`, mirroring the PS signatures and pinning the size relations at the types. Newtype only — PS's bit combinators and the `CheckedType` range check arrive with their consumers. Note for #301: its bulletReduce transcriptions call these gadgets with bare `FVar` scalars; whichever PR merges second needs the two call sites wrapped in `⟨·⟩`.