### PR TITLE
snarky: the varBaseMul gadget — the 5-bit double-add ladder, oracle-checked

### DIFF
--- a/formal/scripts/deadcode.lean
+++ b/formal/scripts/deadcode.lean
@@ -40,6 +40,7 @@ import Snarky.Kimchi.Circuit.Poseidon
 import Snarky.Kimchi.Circuit.Utils
 import Snarky.Kimchi.Circuit.EndoScalar
 import Snarky.Kimchi.Circuit.EndoMul
+import Snarky.Kimchi.Circuit.VarBaseMul
 import Snarky.Kimchi.Semantics
 -- The fixture-decoding libraries are not part of any package's main library, so import them
 -- explicitly: their declarations are authored code, and some are declared roots.

--- a/formal/snarky/Snarky/Kimchi/Circuit/AddComplete.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/AddComplete.lean
@@ -58,7 +58,7 @@ instance : CheckedType F c (AffinePoint (FVar F)) where
 
 /-- Seal a point coordinatewise, `y` before `x` — OCaml's `seal` maps over the tuple
 right to left (PS `sealPoint` preserves the order; emission order is fixture bytes). -/
-private def sealPoint [Add F] [Mul F] [Zero F] [One F] [DecidableEq F] [BasicSystem F c]
+def sealPoint [Add F] [Mul F] [Zero F] [One F] [DecidableEq F] [BasicSystem F c]
     (p : AffinePoint (FVar F)) : CircuitM F c (AffinePoint (FVar F)) := do
   let y ← sealVar p.y
   let x ← sealVar p.x

--- a/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
@@ -1,0 +1,188 @@
+import Snarky.Circuit.DSL.Field
+import Snarky.Circuit.DSL.Assert
+import Snarky.Circuit.DSL.Bits
+import Snarky.Circuit.DSL.Boolean
+import Snarky.Types.Shifted
+import Snarky.Kimchi.Circuit.AddComplete
+import Snarky.Kimchi.Circuit.Utils
+import Kimchi.Gate.VarBaseMul
+
+/-!
+# The VarBaseMul gadget
+
+Port of `Snarky.Circuit.Kimchi.VarBaseMul`
+(packages/snarky-kimchi/src/Snarky/Circuit/Kimchi/VarBaseMul.purs; OCaml
+`Pickles.Plonk_curve_ops.scale_fast`): the double-add ladder `varBaseMul` — witness
+the scalar's bits, walk `acc' = 2·acc + Q` per bit with `Q = (xT, (2b−1)·yT)` in
+5-bit rows, pin the running scalar register, emit one `varBaseMul` constraint — and
+its consumers `scaleFast1` (`Type1` scalars), `scaleFast2`/`scaleFast2'` (split
+scalars for the larger-scalar-field case), and `splitFieldVar`.
+
+The byte contract (allocation order, row shapes) is oracle-checked by the corpus:
+`var_base_mul_step_circuit` (`scaleFast1` at the full 255-bit ladder) and
+`scale_fast2_128_step_circuit` (`scaleFast2'` through `splitFieldVar`). The
+downstream VarBaseMul-consuming fixtures (`ftcomm`, `xhat`, the mains) stay deferred
+to the pickles buildout.
+
+Deviations from the PS original (per `formal/docs/snarky-kimchi-alignment.md`):
+- PS batches the whole witness chain through `mkWitnessTable`/`computeVbmChain`
+  (`doubleAddChain`'s projective walk with Montgomery batch inversion); the port
+  computes each bit step sequentially from the threaded variables via the gate
+  model's `Kimchi.Gate.VarBaseMul.stepBit` — `Projective.purs` certifies the batched
+  rows equal the sequential per-step formulas, so the advice values are identical.
+  Advice-only: the emitted circuit is untouched.
+- PS's chain computation reports degenerate steps (`DivisionByZero`); the port's
+  advice is total — field division returns junk on a zero denominator instead of
+  aborting the prover run. Identical on non-degenerate inputs.
+- PS allocates each bit step's five advice values through five separate `exists`;
+  the port witnesses the quintet in one call — five fresh variables in the same
+  order, so the variable ids agree.
+- `s1Sq` and `s2` are witnessed and never read back — dead allocations kept for
+  OCaml variable-id parity, exactly as PS keeps them.
+- PS's type-level width bookkeeping (`FieldSizeInBits`, `Mul 5 nChunks bitsUsed`)
+  renders as the plain parameters `(n chunks : ℕ)` with `bitsUsed := 5 * chunks`;
+  the laws state the bounds the types enforced.
+-/
+
+namespace Snarky.Kimchi
+
+open Snarky
+
+variable {F c : Type}
+
+/-- The scalar's `n` bits LSB-first as field values, in ONE witness (PS `unpackPure`
+under a single `exists`). -/
+private def lsbBitsWit [Field F] [ToNat F] (n : ℕ) (scalar : FVar F) :
+    AsProver F (Vector F n) := do
+  let v ← AsProver.readCVar scalar
+  pure (Vector.ofFn fun i => if (ToNat.toNat v).testBit i.1 then 1 else 0)
+
+/-- Per-chunk scalar-register advice: fold `2a + b` over the chunk's five bits from
+the previous register (PS's `foldl (\\a b -> double a + b)`). -/
+private def nAccWit [Field F] (nPrev : FVar F) (bs : Vector (FVar F) 5) :
+    AsProver F F := do
+  let a ← AsProver.readCVar nPrev
+  let b0 ← AsProver.readCVar bs[0]
+  let b1 ← AsProver.readCVar bs[1]
+  let b2 ← AsProver.readCVar bs[2]
+  let b3 ← AsProver.readCVar bs[3]
+  let b4 ← AsProver.readCVar bs[4]
+  pure (b4 + 2 * (b3 + 2 * (b2 + 2 * (b1 + 2 * (b0 + 2 * a)))))
+
+/-- One bit step's advice quintet `(s1, s1Sq, s2, xRes, yRes)`: the wired slope and
+result from the gate model's `stepBit`, plus the two dead registers. -/
+private def bitWit [Field F] [DecidableEq F] (t : AffinePoint (FVar F))
+    (b : FVar F) (acc : AffinePoint (FVar F)) :
+    AsProver F (F × F × F × F × F) := do
+  let xb ← AsProver.readCVar t.x
+  let yb ← AsProver.readCVar t.y
+  let xi ← AsProver.readCVar acc.x
+  let yi ← AsProver.readCVar acc.y
+  let bv ← AsProver.readCVar b
+  let (s1, xo, yo) := Kimchi.Gate.VarBaseMul.stepBit bv xb yb xi yi
+  let s1Sq := s1 * s1
+  let s2 := 2 * yi / (2 * xi + xb - s1Sq) - s1
+  pure (s1, s1Sq, s2, xo, yo)
+
+/-- What `varBaseMul` hands back (PS's `{ g, lsbBits }` record): the scalar multiple
+and the scalar's full bit decomposition, which `scaleFast2` pins. -/
+structure VarBaseMulResult (n : ℕ) (F : Type) where
+  /-- The computed multiple. -/
+  g : AffinePoint (FVar F)
+  /-- The scalar's `n` witnessed bits, LSB-first. -/
+  lsbBits : Vector (FVar F) n
+
+/-- The variable-base scalar multiplication (PS `varBaseMul`; OCaml
+`scale_fast_unpack`): seal the base, witness the scalar's `n` LSB bits, build
+`acc = [2]·T` with one `addFast`, walk the top `5 * chunks` bits MSB-first in 5-bit
+rows — per row the register witness then five bit-step quintets — pin the final
+register to the scalar, and emit one `varBaseMul` constraint. -/
+def varBaseMul [Field F] [DecidableEq F] [ToNat F] [BasicSystem F c]
+    [KimchiSystem F c] (n chunks : ℕ) (base' : AffinePoint (FVar F))
+    (scalar : Type1 (FVar F)) : CircuitM F c (VarBaseMulResult n F) := do
+  let base ← sealPoint base'
+  let lsbBits ← witness (val := Vector F n) (lsbBitsWit n scalar.val)
+  let p ← addFast .checkFinite base base
+  let msb : List (FVar F) := (lsbBits.toList.take (5 * chunks)).reverse
+  let window : ℕ → Vector (FVar F) 5 := fun i =>
+    Vector.ofFn fun j => msb.getD (5 * i + j.1) (.const 0)
+  let (rounds, fin) ← mapAccumM
+    (fun (st : AffinePoint (FVar F) × FVar F) (bs : Vector (FVar F) 5) => do
+      let nAcc ← witness (val := F) (nAccWit st.2 bs)
+      let w0 ← witness (val := F × F × F × F × F) (bitWit base bs[0] st.1)
+      let a1 : AffinePoint (FVar F) := ⟨w0.2.2.2.1, w0.2.2.2.2⟩
+      let w1 ← witness (val := F × F × F × F × F) (bitWit base bs[1] a1)
+      let a2 : AffinePoint (FVar F) := ⟨w1.2.2.2.1, w1.2.2.2.2⟩
+      let w2 ← witness (val := F × F × F × F × F) (bitWit base bs[2] a2)
+      let a3 : AffinePoint (FVar F) := ⟨w2.2.2.2.1, w2.2.2.2.2⟩
+      let w3 ← witness (val := F × F × F × F × F) (bitWit base bs[3] a3)
+      let a4 : AffinePoint (FVar F) := ⟨w3.2.2.2.1, w3.2.2.2.2⟩
+      let w4 ← witness (val := F × F × F × F × F) (bitWit base bs[4] a4)
+      let a5 : AffinePoint (FVar F) := ⟨w4.2.2.2.1, w4.2.2.2.2⟩
+      pure (({ acc0 := st.1, acc1 := a1, acc2 := a2, acc3 := a3, acc4 := a4,
+               acc5 := a5,
+               bit0 := bs[0], bit1 := bs[1], bit2 := bs[2], bit3 := bs[3],
+               bit4 := bs[4],
+               slope0 := w0.1, slope1 := w1.1, slope2 := w2.1, slope3 := w3.1,
+               slope4 := w4.1,
+               nPrev := st.2, nNext := nAcc, base } : ScaleRound F),
+            (a5, nAcc)))
+    (p.p, .const 0) ((List.range chunks).map window)
+  addConstraint (KimchiSystem.varBaseMul rounds)
+  assertEqual fin.2 scalar.val
+  pure ⟨fin.1, lsbBits⟩
+
+/-- `scaleFast1 g a ~ [fromShifted a]·g` (PS docstring) — the `Type1` path, for a
+scalar field no larger than the circuit field. Drops the bits. -/
+def scaleFast1 [Field F] [DecidableEq F] [ToNat F] [BasicSystem F c]
+    [KimchiSystem F c] (n chunks : ℕ) (p : AffinePoint (FVar F))
+    (t : Type1 (FVar F)) : CircuitM F c (AffinePoint (FVar F)) := do
+  let r ← varBaseMul n chunks p t
+  pure r.g
+
+/-- `scaleFast2 g (sDiv2, sOdd) ~ [2·sDiv2 + sOdd + 2^n]·g` — the split path, for a
+scalar field larger than the circuit field: run the ladder on `sDiv2`, pin its high
+bits to zero, and fold the parity in by conditionally subtracting the base. -/
+def scaleFast2 [Field F] [DecidableEq F] [ToNat F] [BasicSystem F c]
+    [KimchiSystem F c] (n chunks sDiv2Bits : ℕ) (base : AffinePoint (FVar F))
+    (sDiv2 : FVar F) (sOdd : BoolVar F) : CircuitM F c (AffinePoint (FVar F)) := do
+  let r ← varBaseMul n chunks base ⟨sDiv2⟩
+  (r.lsbBits.toList.drop sDiv2Bits).forM fun bit => assertEqual bit (.const 0)
+  -- the else branch first (PS `if_ sOdd g =<< …`): `g − base` via the pure negation
+  let negBase : AffinePoint (FVar F) := ⟨base.x, CVar.negate_ base.y⟩
+  let q ← addFast .checkFinite r.g negBase
+  -- the point conditional selects coordinatewise, `y` BEFORE `x`: PS's record `if_`
+  -- builds right-to-left (the fixture pins the emission order)
+  let y ← select sOdd r.g.y q.p.y
+  let x ← select sOdd r.g.x q.p.x
+  pure ⟨x, y⟩
+
+/-- The parity split of a field value (PS `splitField`): `s = 2·sDiv2 + sOdd`. -/
+def splitField [Field F] [ToNat F] (s : F) : F × Bool :=
+  let odd := (ToNat.toNat s) % 2 = 1
+  ((if odd then s - 1 else s) / 2, odd)
+
+/-- The joined value of a parity split (PS `joinField`). -/
+def joinField [Field F] (sDiv2 : F) (sOdd : Bool) : F :=
+  2 * sDiv2 + (if sOdd then 1 else 0)
+
+private def splitFieldWit [Field F] [ToNat F] (s : FVar F) : AsProver F (F × Bool) := do
+  let v ← AsProver.readCVar s
+  pure (splitField v)
+
+/-- Witness a parity split and constrain it (PS `splitFieldVar`):
+`s = 2·sDiv2 + sOdd`, one linear assert. -/
+def splitFieldVar [Field F] [DecidableEq F] [ToNat F] [BasicSystem F c]
+    (s : FVar F) : CircuitM F c (FVar F × BoolVar F) := do
+  let r ← witness (val := F × Bool) (splitFieldWit s)
+  assertEqual s (CVar.add_ (CVar.scale_ 2 r.1) ↑r.2)
+  pure r
+
+/-- `scaleFast2' g s ~ [s + 2^n]·g`: split the raw scalar, then `scaleFast2`. -/
+def scaleFast2' [Field F] [DecidableEq F] [ToNat F] [BasicSystem F c]
+    [KimchiSystem F c] (n chunks sDiv2Bits : ℕ) (base : AffinePoint (FVar F))
+    (s : FVar F) : CircuitM F c (AffinePoint (FVar F)) := do
+  let (sDiv2, sOdd) ← splitFieldVar s
+  scaleFast2 n chunks sDiv2Bits base sDiv2 sOdd
+
+end Snarky.Kimchi

--- a/formal/snarky/Snarky/Kimchi/Semantics.lean
+++ b/formal/snarky/Snarky/Kimchi/Semantics.lean
@@ -311,9 +311,11 @@ class KimchiSystem (F c : Type) where
   endoScalar : EndoScalar F → c
   /-- Embed an endomorphism-multiplication payload. -/
   endoMul : EndoMul F → c
+  /-- Embed a variable-base scalar-multiplication payload. -/
+  varBaseMul : VarBaseMul F → c
 
 instance : KimchiSystem F (KimchiConstraint F) :=
-  ⟨.addComplete, .poseidon, .endoScalar, .endoMul⟩
+  ⟨.addComplete, .poseidon, .endoScalar, .endoMul, .varBaseMul⟩
 
 instance [inst : KimchiSystem F c] : KimchiSystem F (Prover c) := inst
 

--- a/formal/snarky/Snarky/Types/Shifted.lean
+++ b/formal/snarky/Snarky/Types/Shifted.lean
@@ -1,0 +1,27 @@
+/-!
+# Shifted scalar types
+
+Port of `Snarky.Types.Shifted`
+(packages/snarky-kimchi/src/Snarky/Types/Shifted.purs): the wrappers marking a scalar
+as SHIFTED — carried in a form whose true value the consuming ladder recovers.
+`Type1 t` stands for the scalar `2·t + 2^n + 1` (`n` the field size in bits), the
+representation used when the scalar field is no larger than the circuit field;
+`varBaseMul`'s ladder consumes it.
+
+Deviations from the PS original (per `formal/docs/snarky-kimchi-alignment.md`):
+- Only the `Type1` newtype is ported — the `varBaseMul` gadget's scalar wrapper. PS's
+  `Type2`/`SplitField` (the split representation for the larger-scalar-field case),
+  the `Shifted` class, the forbidden-values checks, and the shifted circuit ops are
+  consumed only by the pickles modules and arrive with them. The shift equation
+  above is likewise not code here: it is the semantic reading the laws state.
+-/
+
+namespace Snarky
+
+/-- A scalar carried shifted (PS `Type1`): the wrapped value `t` stands for
+`2·t + 2^n + 1`. Phantom: the ladder consuming it realizes the shift. -/
+structure Type1 (α : Type u) where
+  /-- The shifted representative. -/
+  val : α
+
+end Snarky

--- a/formal/snarky/roots.txt
+++ b/formal/snarky/roots.txt
@@ -378,6 +378,12 @@ Snarky.Kimchi.addComplete
 Snarky.Kimchi.poseidon
 Snarky.Kimchi.endoMul
 Snarky.Kimchi.endoInv
+Snarky.Kimchi.varBaseMul
+Snarky.Kimchi.scaleFast1
+Snarky.Kimchi.scaleFast2
+Snarky.Kimchi.scaleFast2'
+Snarky.Kimchi.splitFieldVar
+Snarky.Kimchi.joinField
 Snarky.Kimchi.mapAccumM
 Snarky.Kimchi.EndoScalar.toField
 Snarky.Kimchi.EndoScalar.toFieldChecked'

--- a/formal/snarky/scripts/check_cs_equality.lean
+++ b/formal/snarky/scripts/check_cs_equality.lean
@@ -16,8 +16,9 @@ endo_mul), and the gadget-complete pickles sub-circuits (pow2_pow, b_correct,
 bullet_reduce_one_step, bullet_reduce_step — composition fixtures, the bullet pair
 composing endoInv + endoMul + addComplete; their dumps are witness-less, so the
 checks are CS-side only). Deferred, with the blocker each waits on:
-- var_base_mul + scale_fast2_128, ftcomm_*, xhat_* (and everything downstream: ivp,
-  verify, wrap/step mains) — the VarBaseMul gadget slice;
+- ftcomm_*, xhat_* (and everything downstream: ivp, verify, wrap/step mains) — the
+  pickles buildout (var_base_mul and scale_fast2_128 themselves are ACTIVE below:
+  the VarBaseMul gadget's own oracle checks);
 - hash_messages_*, finalize_other_proof_*, schnorr_verify — the sponge circuit layer
   (packages/random-oracle; FOP additionally the OptSponge variant);
 - group_map_step — activatable now (Basic-only), transcription pending a
@@ -40,6 +41,7 @@ import Snarky.Kimchi.Circuit.AddComplete
 import Snarky.Kimchi.Circuit.Poseidon
 import Snarky.Kimchi.Circuit.EndoScalar
 import Snarky.Kimchi.Circuit.EndoMul
+import Snarky.Kimchi.Circuit.VarBaseMul
 import Poseidon.Basic
 import Pasta.Endo
 
@@ -196,6 +198,20 @@ def endoScalarCircuit (scalar : FVar Fp) : CircuitM Fp C (FVar Fp) :=
 def endoMulCircuit (input : AffinePoint (FVar Fp) × FVar Fp) :
     CircuitM Fp C (AffinePoint (FVar Fp)) :=
   endoMul Pasta.pallasEndo 32 input.1 ⟨input.2⟩
+
+/-- `var_base_mul_step_circuit` (the PS gadget
+`Snarky.Circuit.Kimchi.VarBaseMul.scaleFast1` at 51 chunks — the full 255-bit
+ladder). -/
+def varBaseMulCircuit (input : AffinePoint (FVar Fp) × FVar Fp) :
+    CircuitM Fp C (AffinePoint (FVar Fp)) :=
+  scaleFast1 255 51 input.1 ⟨input.2⟩
+
+/-- `scale_fast2_128_step_circuit` (the PS gadget
+`Snarky.Circuit.Kimchi.VarBaseMul.scaleFast2'` at 26 chunks / 127 `sDiv2` bits — the
+128-bit split-scalar path, exercising `splitFieldVar` and `scaleFast2`). -/
+def scaleFast2_128Circuit (input : AffinePoint (FVar Fp) × FVar Fp) :
+    CircuitM Fp C (AffinePoint (FVar Fp)) :=
+  scaleFast2' 255 26 127 input.1 input.2
 
 /-! ## Pickles sub-circuits
 
@@ -393,6 +409,10 @@ def targets : List (String × (Raw → List (String × Bool))) :=
       compareWith (a := Fp) (b := Fp) endoScalarCircuit),
     ("endo_mul_step_circuit",
       compareWith (a := AffinePoint Fp × Fp) (b := AffinePoint Fp) endoMulCircuit),
+    ("var_base_mul_step_circuit",
+      compareWith (a := AffinePoint Fp × Fp) (b := AffinePoint Fp) varBaseMulCircuit),
+    ("scale_fast2_128_step_circuit",
+      compareWith (a := AffinePoint Fp × Fp) (b := AffinePoint Fp) scaleFast2_128Circuit),
     ("pow2_pow_step_circuit", compareWith (a := Vector Fp 1) (b := PUnit) pow2PowCircuit),
     ("b_correct_step_circuit",
       compareWith (a := Vector Fp 20) (b := PUnit) bCorrectCircuit),


### PR DESCRIPTION
The last un-ported kimchi gadget: `varBaseMul` and its consumers, constraints + circuit only — the laws are the next slice, and the semantics stubs (`Holds → True`) deliberately stay until then. Scoped per discussion: the gadget's own oracle checks activate; everything downstream (`ftcomm`, `xhat`, the mains) stays deferred to the pickles buildout.

## The port

- **`Snarky/Types/Shifted.lean`** — `Type1` only, the shifted-scalar wrapper the ladder consumes (`Type1 t` stands for `2·t + 2^n + 1`). `Type2`/`SplitField`/the `Shifted` class are consumed only by pickles modules and arrive with them.
- **`Snarky/Kimchi/Circuit/VarBaseMul.lean`** — `varBaseMul`: seal the base, witness the scalar's LSB bits in one call, init the accumulator at `[2]·T`, walk the top `5·chunks` bits MSB-first in 5-bit rows — per row the register witness, then per bit the quintet `s1/s1Sq/s2/xRes/yRes` (the middle two are dead allocations, kept for variable-id parity with OCaml) — pin the final register, emit one `varBaseMul` constraint. Plus `scaleFast1`, `scaleFast2`, `scaleFast2'`, `splitFieldVar`. The advice reuses the gate model's `stepBit` rather than forking the row math; PS's Montgomery-batched witness chain renders as the sequential per-step computation it is certified equal to.
- Wiring: `KimchiSystem` gains the `varBaseMul` embedding (the constraint layer was already ported); `sealPoint` publicized from AddComplete instead of forked.

## The oracle checks — corpus 28 → 30

- **`var_base_mul_step_circuit`** — `scaleFast1` at the full 255-bit ladder (51 chunks, 109 rows). Witness-carrying: beyond CS byte-equality (gate types, coefficients, wires, raw per-cell variable ids), the corpus re-solved the witness — the `stepBit` advice values match PS's batched chain exactly, first run.
- **`scale_fast2_128_step_circuit`** — `scaleFast2'` at 26 chunks / 127 `sDiv2` bits, exercising `splitFieldVar`, the high-bit zero pins, and the conditional subtract. This one caught the slice's single transcription error: PS's record `if_` emits the **y** select before the **x** (right-to-left record building) — fixed and now pinned by the fixture.

Battery green: build, corpus 30/30, witness checker 25/25 unchanged, style, snarky gate 122 roots, deadcode 0, linters, shake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)