### PR TITLE
The varBaseMul completeness law — the honest ladder run accepts and lands on fromShifted

### DIFF
--- a/formal/kimchi/Kimchi/Gate/Semantics/VarBaseMul.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/VarBaseMul.lean
@@ -1994,6 +1994,267 @@ theorem varBaseMul_off {F : Type*} [Field F] [DecidableEq F]
   · exact varBaseMul_forbidden_correct c m g T s hTne hholds hTns hTeq hbase hthread
       hP0ns hP0 h2 hodd hr1 hr2 hq4 hs hnf
 
+/-! ## The produce chain
+
+The honest walk: `chainBuild` threads the gate's canonical row (`build`) from the doubled
+init accumulator through a flat bit stream, five bits per row. `chain_complete` is its
+conditional completeness — under either ladder regime, every generated row satisfies the
+gate. The non-degeneracy is PRODUCED forward, not read off an accepted run: the
+accumulator entering bit step `j` is the ladder multiple `[ladderK bs j]·T`, the regime
+prices all four degeneracy residues at every step (`ladder_subwrap_nondegen` /
+`ladder_nondegen_tight`), and each generated step's two secant denominators are derived
+from those residues before the step is certified (`step_produce`). -/
+
+variable {F : Type*} [Field F] [DecidableEq F]
+
+/-- The ±1 sign a bit value selects: `+1` for `b = 1`, `−1` otherwise — the honest ℤ
+reading of the gate's `2·b − 1`. -/
+def bitSign (b : F) : ℤ := if b = 1 then 1 else -1
+
+/-- The honest ladder value after `j` bit steps of the stream `bs`, from the doubled
+init: `k 0 = 2`, `k (j+1) = 2·k j + bitSign (bs j)`. On a boolean stream this is the
+signed double-and-add ladder the pricing kernel prices; on the stream of a scalar's
+bits it decodes to `Type1`'s `2·s + 2^L + 1` (`ladderK_eq_bitsVal`). -/
+def ladderK (bs : ℕ → F) : ℕ → ℤ
+  | 0 => 2
+  | j + 1 => 2 * ladderK bs j + bitSign (bs j)
+
+/-- The honest rows: row `i` is `build` at the threaded accumulator and register,
+consuming bits `5i … 5i+4` of the stream. -/
+def chainBuild (xT yT x0 y0 n0 : F) (bs : ℕ → F) : ℕ → Witness F
+  | 0 => build xT yT x0 y0 n0 (bs 0) (bs 1) (bs 2) (bs 3) (bs 4)
+  | i + 1 =>
+    build xT yT (chainBuild xT yT x0 y0 n0 bs i).x5 (chainBuild xT yT x0 y0 n0 bs i).y5
+      (chainBuild xT yT x0 y0 n0 bs i).nPrime
+      (bs (5 * (i + 1))) (bs (5 * (i + 1) + 1)) (bs (5 * (i + 1) + 2))
+      (bs (5 * (i + 1) + 3)) (bs (5 * (i + 1) + 4))
+
+omit [DecidableEq F] in
+/-- Every `chainBuild` row is `build` at its own threaded fields — the uniform
+re-expression the produce induction rewrites with. -/
+theorem chainBuild_eta (xT yT x0 y0 n0 : F) (bs : ℕ → F) (i : ℕ) :
+    chainBuild xT yT x0 y0 n0 bs i
+      = build xT yT (chainBuild xT yT x0 y0 n0 bs i).x0
+          (chainBuild xT yT x0 y0 n0 bs i).y0 (chainBuild xT yT x0 y0 n0 bs i).n
+          (bs (5 * i)) (bs (5 * i + 1)) (bs (5 * i + 2)) (bs (5 * i + 3))
+          (bs (5 * i + 4)) := by
+  cases i <;> rfl
+
+/-- One honest bit step: at an accumulator `[k]·T` whose four degeneracy residues the
+regime has priced away, the generated `stepBit` values satisfy the bit block and the
+output is the nonsingular `[2k + bitSign b]·T`. The two secant denominators are derived,
+not assumed: `xi ≠ xT` from `k ≢ ±1`, and the second denominator from the intermediate
+`I + Q ≠ ±I`, i.e. `2k ≢ ∓1` (stepped through in the body). -/
+private lemma step_produce (c : WeierstrassCurve.Affine F)
+    [Fact (c.a₁ = 0 ∧ c.a₂ = 0 ∧ c.a₃ = 0)] [Fact (Nat.Prime c.order)]
+    (h2 : (2 : F) ≠ 0) (hodd : c.order ≠ 2)
+    {xT yT b xi yi : F}
+    (hTns : c.Nonsingular xT yT) (hTne : Point.some _ _ hTns ≠ 0)
+    (hI : c.Nonsingular xi yi) (hbit : b = 0 ∨ b = 1)
+    {k : ℤ} (hIk : Point.some _ _ hI = k • Point.some _ _ hTns)
+    (hq1 : ¬((c.order : ℤ) ∣ (k - 1))) (hq2 : ¬((c.order : ℤ) ∣ (k + 1)))
+    (hq3 : ¬((c.order : ℤ) ∣ (2 * k - 1))) (hq4 : ¬((c.order : ℤ) ∣ (2 * k + 1))) :
+    singleBitHolds b xT yT (stepBit b xT yT xi yi).1 xi yi
+        (stepBit b xT yT xi yi).2.1 (stepBit b xT yT xi yi).2.2
+    ∧ ∃ hO : c.Nonsingular (stepBit b xT yT xi yi).2.1 (stepBit b xT yT xi yi).2.2,
+        Point.some _ _ hO = (2 * k + bitSign b) • Point.some _ _ hTns := by
+  have hshort : c.a₁ = 0 ∧ c.a₂ = 0 ∧ c.a₃ = 0 := Fact.out
+  -- the sign-selected target `Q = ±T` and its scalar
+  have hQ : c.Nonsingular xT ((2 * b - 1) * yT) := signed_target_nonsingular c hshort hTns hbit
+  obtain ⟨e, heQ, -, hepm⟩ := signed_target c hshort hTns hQ hbit
+  -- first denominator: `xi ≠ xT` from `k ≢ ±1`
+  have hxne : xi ≠ xT := by
+    apply x_ne_xT_of_ne_base c hI hTns
+    · contrapose! hq1
+      have hd : (k - 1) • Point.some _ _ hTns = 0 := by
+        rw [sub_smul, one_smul, ← hIk, hq1, sub_self]
+      exact (zsmul_eq_zero_iff_order_dvd c hTne _).1 hd
+    · contrapose! hq2
+      rw [← zsmul_eq_zero_iff_order_dvd c hTne, add_zsmul, one_zsmul, ← hIk, hq2,
+        neg_add_cancel]
+  -- the generated values, named
+  set s1 : F := (yi - (2 * b - 1) * yT) / (xi - xT) with hs1
+  set t : F := 2 * xi + xT - s1 * s1 with htdef
+  have e1 : (stepBit b xT yT xi yi).1 = s1 := rfl
+  -- the intermediate `M = I + Q = [k + e]·T` at the generated first slope
+  obtain ⟨hM, hMadd⟩ := secant_add c hshort hI hQ hxne hs1
+    (x3 := s1 * s1 - xi - xT) (y3 := s1 * (xi - (s1 * s1 - xi - xT)) - yi) rfl rfl
+  have hMk : Point.some _ _ hM = (k + e) • Point.some _ _ hTns := by
+    rw [← hMadd, hIk, heQ]; module
+  -- second denominator: `M ≠ ±I` from `2k ≢ ∓1`, so `x_M ≠ xi` and `t = xi − x_M ≠ 0`
+  have hMneI : Point.some _ _ hM ≠ Point.some _ _ hI := by
+    intro h
+    have he0 : e • Point.some _ _ hTns = 0 := by
+      have h' : ((k + e) - k) • Point.some _ _ hTns = 0 := by
+        rw [sub_smul, ← hMk, h, hIk, sub_self]
+      simpa using h'
+    rcases hepm with rfl | rfl
+    · rw [one_zsmul] at he0; exact hTne he0
+    · rw [neg_one_zsmul, neg_eq_zero] at he0; exact hTne he0
+  have hMnegI : Point.some _ _ hM ≠ -Point.some _ _ hI := by
+    intro h
+    have hz : (2 * k + e) • Point.some _ _ hTns = 0 := by
+      have h' : (k + e) • Point.some _ _ hTns + k • Point.some _ _ hTns = 0 := by
+        rw [← hMk, ← hIk, h, neg_add_cancel]
+      calc (2 * k + e) • Point.some _ _ hTns
+          = (k + e) • Point.some _ _ hTns + k • Point.some _ _ hTns := by module
+        _ = 0 := h'
+    have hdvd := (zsmul_eq_zero_iff_order_dvd c hTne _).1 hz
+    rcases hepm with rfl | rfl
+    · exact hq4 hdvd
+    · exact hq3 (by rwa [show 2 * k + (-1 : ℤ) = 2 * k - 1 from by ring] at hdvd)
+  have hxMne : s1 * s1 - xi - xT ≠ xi := x_ne_xT_of_ne_base c hM hI hMneI hMnegI
+  have htne : t ≠ 0 := by
+    rw [htdef]
+    intro h0
+    exact hxMne (by linear_combination -h0)
+  -- the generated block holds, and the sound step reads its output back
+  have hbb : b * b - b = 0 := by rcases hbit with rfl | rfl <;> ring
+  have hh := stepBit_holds b xT yT xi yi hbb (sub_ne_zero_of_ne hxne)
+    (by rw [e1, ← htdef]; exact htne)
+  obtain ⟨-, -, hO, e', hepm', heF', hOeq⟩ :=
+    gate_step_advance' c h2 hodd hTns hI hQ hbit hTne k hIk hq1 hq2 hh
+  have he' : e' = bitSign b := by
+    rcases hbit with rfl | rfl
+    · rcases hepm' with rfl | rfl
+      · exact absurd (by linear_combination heF' : (2 : F) = 0) h2
+      · simp [bitSign]
+    · rcases hepm' with rfl | rfl
+      · simp [bitSign]
+      · exact absurd (by linear_combination -heF' : (2 : F) = 0) h2
+  exact ⟨hh, hO, by rw [hOeq, he']⟩
+
+/-- One honest row: five `step_produce` steps threaded through `build`. The row's
+constraints hold and the output accumulator is the nonsingular five-fold advance
+`[k (j+5)]·T`, for any scalar sequence `k` satisfying the ladder recurrence on the
+row's bits whose window `[j, j+5)` the regime has priced. -/
+private lemma row_produce (c : WeierstrassCurve.Affine F)
+    [Fact (c.a₁ = 0 ∧ c.a₂ = 0 ∧ c.a₃ = 0)] [Fact (Nat.Prime c.order)]
+    (h2 : (2 : F) ≠ 0) (hodd : c.order ≠ 2)
+    {xT yT : F} (hTns : c.Nonsingular xT yT) (hTne : Point.some _ _ hTns ≠ 0)
+    {b0 b1 b2 b3 b4 x0 y0 : F} (n : F)
+    (hb0 : b0 = 0 ∨ b0 = 1) (hb1 : b1 = 0 ∨ b1 = 1) (hb2 : b2 = 0 ∨ b2 = 1)
+    (hb3 : b3 = 0 ∨ b3 = 1) (hb4 : b4 = 0 ∨ b4 = 1)
+    (hI : c.Nonsingular x0 y0)
+    {k : ℕ → ℤ} {j : ℕ}
+    (hIk : Point.some _ _ hI = k j • Point.some _ _ hTns)
+    (hk1 : k (j + 1) = 2 * k j + bitSign b0)
+    (hk2 : k (j + 2) = 2 * k (j + 1) + bitSign b1)
+    (hk3 : k (j + 3) = 2 * k (j + 2) + bitSign b2)
+    (hk4 : k (j + 4) = 2 * k (j + 3) + bitSign b3)
+    (hk5 : k (j + 5) = 2 * k (j + 4) + bitSign b4)
+    (hq : ∀ l, j ≤ l → l < j + 5 →
+      ¬((c.order : ℤ) ∣ (k l - 1)) ∧ ¬((c.order : ℤ) ∣ (k l + 1))
+      ∧ ¬((c.order : ℤ) ∣ (2 * k l - 1)) ∧ ¬((c.order : ℤ) ∣ (2 * k l + 1))) :
+    Holds (build xT yT x0 y0 n b0 b1 b2 b3 b4)
+    ∧ ∃ h5 : c.Nonsingular (build xT yT x0 y0 n b0 b1 b2 b3 b4).x5
+        (build xT yT x0 y0 n b0 b1 b2 b3 b4).y5,
+        Point.some _ _ h5 = k (j + 5) • Point.some _ _ hTns := by
+  obtain ⟨hd1, hd2, hd3, hd4⟩ := hq j le_rfl (by omega)
+  obtain ⟨hh0, hO1, hP1⟩ := step_produce c h2 hodd hTns hTne hI hb0 hIk hd1 hd2 hd3 hd4
+  rw [← hk1] at hP1
+  obtain ⟨hd1, hd2, hd3, hd4⟩ := hq (j + 1) (by omega) (by omega)
+  obtain ⟨hh1, hO2, hP2⟩ := step_produce c h2 hodd hTns hTne hO1 hb1 hP1 hd1 hd2 hd3 hd4
+  rw [← hk2] at hP2
+  obtain ⟨hd1, hd2, hd3, hd4⟩ := hq (j + 2) (by omega) (by omega)
+  obtain ⟨hh2, hO3, hP3⟩ := step_produce c h2 hodd hTns hTne hO2 hb2 hP2 hd1 hd2 hd3 hd4
+  rw [← hk3] at hP3
+  obtain ⟨hd1, hd2, hd3, hd4⟩ := hq (j + 3) (by omega) (by omega)
+  obtain ⟨hh3, hO4, hP4⟩ := step_produce c h2 hodd hTns hTne hO3 hb3 hP3 hd1 hd2 hd3 hd4
+  rw [← hk4] at hP4
+  obtain ⟨hd1, hd2, hd3, hd4⟩ := hq (j + 4) (by omega) (by omega)
+  obtain ⟨hh4, hO5, hP5⟩ := step_produce c h2 hodd hTns hTne hO4 hb4 hP4 hd1 hd2 hd3 hd4
+  rw [← hk5] at hP5
+  exact ⟨(holds_iff _).mpr
+    ⟨by simp only [decompHolds, decompCons, build]; ring, hh0, hh1, hh2, hh3, hh4⟩,
+    hO5, hP5⟩
+
+/-- **Completeness of the honest ladder.** From the doubled init `P₀ = [2]·T`, under
+either ladder regime — subwrap (`3·2^(5m) ≤ order`, no condition on the bits) or the
+one-wrap band with the stream's ladder value `ladderK bs (5m)` avoiding the forbidden
+residues — every generated row satisfies the gate. The regime dichotomy is
+`varBaseMul_off`'s, at the honest values. -/
+theorem chain_complete (c : WeierstrassCurve.Affine F)
+    [Fact (c.a₁ = 0 ∧ c.a₂ = 0 ∧ c.a₃ = 0)] [Fact (Nat.Prime c.order)]
+    (h2 : (2 : F) ≠ 0) (hodd : c.order ≠ 2) (m : ℕ)
+    {xT yT : F} (hTns : c.Nonsingular xT yT)
+    (bs : ℕ → F) (hbs : ∀ j, j < 5 * m → bs j = 0 ∨ bs j = 1)
+    {x0 y0 : F} (n0 : F) (hP0 : c.Nonsingular x0 y0)
+    (hP0eq : Point.some _ _ hP0 = (2 : ℤ) • Point.some _ _ hTns)
+    (hregime : 3 * 2 ^ (5 * m) ≤ c.order ∨
+      (2 ^ (5 * m - 1) < c.order ∧ c.order < 2 ^ (5 * m) ∧ c.order % 4 = 1 ∧
+        ladderK bs (5 * m) ∉ forbiddenValues c.order)) :
+    ∀ i, i < m → Holds (chainBuild xT yT x0 y0 n0 bs i) := by
+  have hTne : Point.some _ _ hTns ≠ 0 := Point.some_ne_zero hTns
+  have hε : ∀ j, j < 5 * m → bitSign (bs j) = 1 ∨ bitSign (bs j) = -1 := by
+    intro j _
+    unfold bitSign
+    split <;> simp
+  -- the regime prices all four degeneracy residues at every bit step
+  have hquad : ∀ j, j < 5 * m →
+      ¬((c.order : ℤ) ∣ (ladderK bs j - 1)) ∧ ¬((c.order : ℤ) ∣ (ladderK bs j + 1))
+      ∧ ¬((c.order : ℤ) ∣ (2 * ladderK bs j - 1))
+      ∧ ¬((c.order : ℤ) ∣ (2 * ladderK bs j + 1)) := by
+    rcases hregime with hsub | ⟨hr1, hr2, hq4, hnf⟩
+    · exact Ladder.ladder_subwrap_nondegen c.order (5 * m) hsub (ladderK bs)
+        (fun j => bitSign (bs j)) rfl hε (fun j _ => rfl)
+    · refine Ladder.ladder_nondegen_tight c.order (5 * m)
+        (Fact.out : Nat.Prime c.order) hq4 hr1 hr2 (ladderK bs)
+        (fun j => bitSign (bs j)) rfl hε (fun j _ => rfl) ?_
+      intro t ht hdvd
+      exact hnf ⟨t, ht, hdvd⟩
+  -- rows hold and the accumulator threads as the ladder multiple
+  have main : ∀ i, i ≤ m →
+      (∀ i', i' < i → Holds (chainBuild xT yT x0 y0 n0 bs i'))
+      ∧ ∃ hIi : c.Nonsingular (chainBuild xT yT x0 y0 n0 bs i).x0
+          (chainBuild xT yT x0 y0 n0 bs i).y0,
+          Point.some _ _ hIi = ladderK bs (5 * i) • Point.some _ _ hTns := by
+    intro i
+    induction i with
+    | zero =>
+      intro _
+      exact ⟨fun i' hi' => absurd hi' (Nat.not_lt_zero i'), hP0, by simpa using hP0eq⟩
+    | succ i ih =>
+      intro hi
+      obtain ⟨hrows, hIi, hIeq⟩ := ih (by omega)
+      obtain ⟨hrow, h5, h5eq⟩ := row_produce c h2 hodd hTns hTne
+        (chainBuild xT yT x0 y0 n0 bs i).n
+        (hbs (5 * i) (by omega)) (hbs (5 * i + 1) (by omega)) (hbs (5 * i + 2) (by omega))
+        (hbs (5 * i + 3) (by omega)) (hbs (5 * i + 4) (by omega)) hIi
+        (k := ladderK bs) (j := 5 * i) hIeq rfl rfl rfl rfl rfl
+        (fun l hl hl' => hquad l (by omega))
+      refine ⟨fun i' hi' => ?_, ?_⟩
+      · rcases Nat.lt_or_ge i' i with h | h
+        · exact hrows i' h
+        · have : i' = i := by omega
+          subst this
+          rw [chainBuild_eta]
+          exact hrow
+      · show ∃ hIi : c.Nonsingular (chainBuild xT yT x0 y0 n0 bs i).x5
+            (chainBuild xT yT x0 y0 n0 bs i).y5,
+            Point.some _ _ hIi = ladderK bs (5 * (i + 1)) • Point.some _ _ hTns
+        rw [chainBuild_eta xT yT x0 y0 n0 bs i,
+          show (5 : ℕ) * (i + 1) = 5 * i + 5 from by ring]
+        exact ⟨h5, h5eq⟩
+  exact (main m le_rfl).1
+
+/-- On a boolean stream the ladder decodes as `Type1`'s unshift of the base-2 value:
+`ladderK bs L = 2·bitsVal(bits) + 2^L + 1` — how a caller discharges
+`chain_complete`'s forbidden-band condition from the scalar it actually fed. -/
+theorem ladderK_eq_bitsVal (bs : ℕ → F) (L : ℕ)
+    (hb : ∀ j, j < L → bs j = 0 ∨ bs j = 1) :
+    ladderK bs L = 2 * bitsVal ((List.range L).map bs) + 2 ^ L + 1 := by
+  induction L with
+  | zero => simp [ladderK, bitsVal]
+  | succ L ih =>
+    have hsnoc : bitsVal ((List.range (L + 1)).map bs)
+        = 2 * bitsVal ((List.range L).map bs) + (if bs L = 1 then 1 else 0) := by
+      rw [List.range_succ, List.map_append]
+      simp [bitsVal, List.foldl_append]
+    rw [show ladderK bs (L + 1) = 2 * ladderK bs L + bitSign (bs L) from rfl,
+      ih (fun j hj => hb j (by omega)), hsnoc]
+    rcases hb L (by omega) with h | h <;> simp [bitSign, h] <;> ring
+
 /-! ## The `scaleFast1` / Type1 direction: soundness via the forbidden band (Vesta)
 
 `scaleFast2` (the Pallas direction, below) range-checks the register, so its soundness is the

--- a/formal/kimchi/Kimchi/Gate/Semantics/VarBaseMul.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/VarBaseMul.lean
@@ -2119,128 +2119,115 @@ section ChainFields
 
 variable (xT yT x0 y0 n0 : F) (bs : ℕ → F)
 
-omit [DecidableEq F] in
+omit [DecidableEq F]
+
 theorem chainBuild_succ_x0 (i : ℕ) :
     (chainBuild xT yT x0 y0 n0 bs (i + 1)).x0 = (chainBuild xT yT x0 y0 n0 bs i).x5 :=
   rfl
 
-omit [DecidableEq F] in
 theorem chainBuild_succ_y0 (i : ℕ) :
     (chainBuild xT yT x0 y0 n0 bs (i + 1)).y0 = (chainBuild xT yT x0 y0 n0 bs i).y5 :=
   rfl
 
-omit [DecidableEq F] in
 theorem chainBuild_succ_n (i : ℕ) :
     (chainBuild xT yT x0 y0 n0 bs (i + 1)).n
       = (chainBuild xT yT x0 y0 n0 bs i).nPrime :=
   rfl
 
-omit [DecidableEq F] in
-theorem chainBuild_s0 (m : ℕ) :
+/-- The row's fixed cells: the base is the argument and the five bits are the
+stream's window `5m … 5m+4`. -/
+theorem chainBuild_fields (m : ℕ) :
+    (chainBuild xT yT x0 y0 n0 bs m).xT = xT
+    ∧ (chainBuild xT yT x0 y0 n0 bs m).yT = yT
+    ∧ (chainBuild xT yT x0 y0 n0 bs m).b0 = bs (5 * m)
+    ∧ (chainBuild xT yT x0 y0 n0 bs m).b1 = bs (5 * m + 1)
+    ∧ (chainBuild xT yT x0 y0 n0 bs m).b2 = bs (5 * m + 2)
+    ∧ (chainBuild xT yT x0 y0 n0 bs m).b3 = bs (5 * m + 3)
+    ∧ (chainBuild xT yT x0 y0 n0 bs m).b4 = bs (5 * m + 4) := by
+  cases m <;> exact ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+
+theorem accX_chainBuild (m : ℕ) :
+    accX (chainBuild xT yT x0 y0 n0 bs) m = (chainBuild xT yT x0 y0 n0 bs m).x0 := by
+  cases m <;> rfl
+
+theorem accY_chainBuild (m : ℕ) :
+    accY (chainBuild xT yT x0 y0 n0 bs) m = (chainBuild xT yT x0 y0 n0 bs m).y0 := by
+  cases m <;> rfl
+
+theorem accN_chainBuild (m : ℕ) :
+    accN (chainBuild xT yT x0 y0 n0 bs) m = (chainBuild xT yT x0 y0 n0 bs m).n := by
+  cases m <;> rfl
+
+/-- Bit step 0 of row `m`: the slope and the output accumulator are the gate
+model's `stepBit` at the step's own input cells. -/
+theorem chainBuild_step0 (m : ℕ) :
     (chainBuild xT yT x0 y0 n0 bs m).s0
       = (stepBit (bs (5 * m)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x0
-          (chainBuild xT yT x0 y0 n0 bs m).y0).1 := by
-  cases m <;> rfl
-
-omit [DecidableEq F] in
-theorem chainBuild_x1 (m : ℕ) :
-    (chainBuild xT yT x0 y0 n0 bs m).x1
+          (chainBuild xT yT x0 y0 n0 bs m).y0).1
+    ∧ (chainBuild xT yT x0 y0 n0 bs m).x1
       = (stepBit (bs (5 * m)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x0
-          (chainBuild xT yT x0 y0 n0 bs m).y0).2.1 := by
-  cases m <;> rfl
-
-omit [DecidableEq F] in
-theorem chainBuild_y1 (m : ℕ) :
-    (chainBuild xT yT x0 y0 n0 bs m).y1
+          (chainBuild xT yT x0 y0 n0 bs m).y0).2.1
+    ∧ (chainBuild xT yT x0 y0 n0 bs m).y1
       = (stepBit (bs (5 * m)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x0
           (chainBuild xT yT x0 y0 n0 bs m).y0).2.2 := by
-  cases m <;> rfl
+  cases m <;> exact ⟨rfl, rfl, rfl⟩
 
-omit [DecidableEq F] in
-theorem chainBuild_s1 (m : ℕ) :
+/-- Bit step 1 of row `m`: the slope and the output accumulator are the gate
+model's `stepBit` at the step's own input cells. -/
+theorem chainBuild_step1 (m : ℕ) :
     (chainBuild xT yT x0 y0 n0 bs m).s1
       = (stepBit (bs (5 * m + 1)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x1
-          (chainBuild xT yT x0 y0 n0 bs m).y1).1 := by
-  cases m <;> rfl
-
-omit [DecidableEq F] in
-theorem chainBuild_x2 (m : ℕ) :
-    (chainBuild xT yT x0 y0 n0 bs m).x2
+          (chainBuild xT yT x0 y0 n0 bs m).y1).1
+    ∧ (chainBuild xT yT x0 y0 n0 bs m).x2
       = (stepBit (bs (5 * m + 1)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x1
-          (chainBuild xT yT x0 y0 n0 bs m).y1).2.1 := by
-  cases m <;> rfl
-
-omit [DecidableEq F] in
-theorem chainBuild_y2 (m : ℕ) :
-    (chainBuild xT yT x0 y0 n0 bs m).y2
+          (chainBuild xT yT x0 y0 n0 bs m).y1).2.1
+    ∧ (chainBuild xT yT x0 y0 n0 bs m).y2
       = (stepBit (bs (5 * m + 1)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x1
           (chainBuild xT yT x0 y0 n0 bs m).y1).2.2 := by
-  cases m <;> rfl
+  cases m <;> exact ⟨rfl, rfl, rfl⟩
 
-omit [DecidableEq F] in
-theorem chainBuild_s2 (m : ℕ) :
+/-- Bit step 2 of row `m`: the slope and the output accumulator are the gate
+model's `stepBit` at the step's own input cells. -/
+theorem chainBuild_step2 (m : ℕ) :
     (chainBuild xT yT x0 y0 n0 bs m).s2
       = (stepBit (bs (5 * m + 2)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x2
-          (chainBuild xT yT x0 y0 n0 bs m).y2).1 := by
-  cases m <;> rfl
-
-omit [DecidableEq F] in
-theorem chainBuild_x3 (m : ℕ) :
-    (chainBuild xT yT x0 y0 n0 bs m).x3
+          (chainBuild xT yT x0 y0 n0 bs m).y2).1
+    ∧ (chainBuild xT yT x0 y0 n0 bs m).x3
       = (stepBit (bs (5 * m + 2)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x2
-          (chainBuild xT yT x0 y0 n0 bs m).y2).2.1 := by
-  cases m <;> rfl
-
-omit [DecidableEq F] in
-theorem chainBuild_y3 (m : ℕ) :
-    (chainBuild xT yT x0 y0 n0 bs m).y3
+          (chainBuild xT yT x0 y0 n0 bs m).y2).2.1
+    ∧ (chainBuild xT yT x0 y0 n0 bs m).y3
       = (stepBit (bs (5 * m + 2)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x2
           (chainBuild xT yT x0 y0 n0 bs m).y2).2.2 := by
-  cases m <;> rfl
+  cases m <;> exact ⟨rfl, rfl, rfl⟩
 
-omit [DecidableEq F] in
-theorem chainBuild_s3 (m : ℕ) :
+/-- Bit step 3 of row `m`: the slope and the output accumulator are the gate
+model's `stepBit` at the step's own input cells. -/
+theorem chainBuild_step3 (m : ℕ) :
     (chainBuild xT yT x0 y0 n0 bs m).s3
       = (stepBit (bs (5 * m + 3)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x3
-          (chainBuild xT yT x0 y0 n0 bs m).y3).1 := by
-  cases m <;> rfl
-
-omit [DecidableEq F] in
-theorem chainBuild_x4 (m : ℕ) :
-    (chainBuild xT yT x0 y0 n0 bs m).x4
+          (chainBuild xT yT x0 y0 n0 bs m).y3).1
+    ∧ (chainBuild xT yT x0 y0 n0 bs m).x4
       = (stepBit (bs (5 * m + 3)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x3
-          (chainBuild xT yT x0 y0 n0 bs m).y3).2.1 := by
-  cases m <;> rfl
-
-omit [DecidableEq F] in
-theorem chainBuild_y4 (m : ℕ) :
-    (chainBuild xT yT x0 y0 n0 bs m).y4
+          (chainBuild xT yT x0 y0 n0 bs m).y3).2.1
+    ∧ (chainBuild xT yT x0 y0 n0 bs m).y4
       = (stepBit (bs (5 * m + 3)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x3
           (chainBuild xT yT x0 y0 n0 bs m).y3).2.2 := by
-  cases m <;> rfl
+  cases m <;> exact ⟨rfl, rfl, rfl⟩
 
-omit [DecidableEq F] in
-theorem chainBuild_s4 (m : ℕ) :
+/-- Bit step 4 of row `m`: the slope and the output accumulator are the gate
+model's `stepBit` at the step's own input cells. -/
+theorem chainBuild_step4 (m : ℕ) :
     (chainBuild xT yT x0 y0 n0 bs m).s4
       = (stepBit (bs (5 * m + 4)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x4
-          (chainBuild xT yT x0 y0 n0 bs m).y4).1 := by
-  cases m <;> rfl
-
-omit [DecidableEq F] in
-theorem chainBuild_x5 (m : ℕ) :
-    (chainBuild xT yT x0 y0 n0 bs m).x5
+          (chainBuild xT yT x0 y0 n0 bs m).y4).1
+    ∧ (chainBuild xT yT x0 y0 n0 bs m).x5
       = (stepBit (bs (5 * m + 4)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x4
-          (chainBuild xT yT x0 y0 n0 bs m).y4).2.1 := by
-  cases m <;> rfl
-
-omit [DecidableEq F] in
-theorem chainBuild_y5 (m : ℕ) :
-    (chainBuild xT yT x0 y0 n0 bs m).y5
+          (chainBuild xT yT x0 y0 n0 bs m).y4).2.1
+    ∧ (chainBuild xT yT x0 y0 n0 bs m).y5
       = (stepBit (bs (5 * m + 4)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x4
           (chainBuild xT yT x0 y0 n0 bs m).y4).2.2 := by
-  cases m <;> rfl
+  cases m <;> exact ⟨rfl, rfl, rfl⟩
 
-omit [DecidableEq F] in
 theorem chainBuild_nPrime (m : ℕ) :
     (chainBuild xT yT x0 y0 n0 bs m).nPrime
       = bs (5 * m + 4) + 2 * (bs (5 * m + 3) + 2 * (bs (5 * m + 2)

--- a/formal/kimchi/Kimchi/Gate/Semantics/VarBaseMul.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/VarBaseMul.lean
@@ -1272,8 +1272,16 @@ private def gateBit (g : ℕ → Witness F) (j : ℕ) : F :=
   | 3 => (g (j / 5)).b3
   | _ => (g (j / 5)).b4
 
+/-- The `±1` sign a bit value selects: `+1` for `b = 1`, `−1` otherwise — the honest ℤ
+reading of the gate's `2·b − 1`. -/
+def bitSign (b : F) : ℤ := if b = 1 then 1 else -1
+
+/-- Either sign, whatever the value. -/
+lemma bitSign_eq (b : F) : bitSign b = 1 ∨ bitSign b = -1 := by
+  unfold bitSign; split <;> simp
+
 /-- The signed bit `±1` at sub-step `j`. -/
-private def gateBitSign (g : ℕ → Witness F) (j : ℕ) : ℤ := if gateBit g j = 1 then 1 else -1
+private def gateBitSign (g : ℕ → Witness F) (j : ℕ) : ℤ := bitSign (gateBit g j)
 
 /-- The integer double-and-add ladder over the gate bits, with `k 0 = 2`. -/
 def gateLadder (g : ℕ → Witness F) : ℕ → ℤ
@@ -1286,8 +1294,7 @@ private lemma gateLadder_succ (g : ℕ → Witness F) (j : ℕ) :
     gateLadder g (j + 1) = 2 * gateLadder g j + gateBitSign g j := rfl
 
 private lemma gateBitSign_eq (g : ℕ → Witness F) (j : ℕ) :
-    gateBitSign g j = 1 ∨ gateBitSign g j = -1 := by
-  unfold gateBitSign; split <;> simp
+    gateBitSign g j = 1 ∨ gateBitSign g j = -1 := bitSign_eq _
 
 /-- The unsigned bit at sub-step `j`: `1` if set, else `0` (same `= 1` test as `gateBitSign`). -/
 private def ubit (g : ℕ → Witness F) (j : ℕ) : ℤ := if gateBit g j = 1 then 1 else 0
@@ -1295,7 +1302,7 @@ private def ubit (g : ℕ → Witness F) (j : ℕ) : ℤ := if gateBit g j = 1 t
 /-- The signed digit is `2·(unsigned bit) − 1`, unconditionally (same `gateBit = 1` test). -/
 private lemma gateBitSign_eq_ubit (g : ℕ → Witness F) (j : ℕ) :
     gateBitSign g j = 2 * ubit g j - 1 := by
-  unfold gateBitSign ubit; split <;> ring
+  unfold gateBitSign bitSign ubit; split <;> ring
 
 /-- The unsigned scalar register the ladder bits encode (Horner over `ubit`), `r 0 = 0`. -/
 def gateRegister (g : ℕ → Witness F) : ℕ → ℤ
@@ -1326,15 +1333,22 @@ private lemma gateBit_block (g : ℕ → Witness F) (i : ℕ) :
   unfold gateBit; simp +decide [ Nat.add_mod ] ;
   norm_num [ Nat.add_div ]
 
-/-- The signed bit `e` produced by `signed_target` matches `gateBitSign`. -/
-private lemma e_eq_gateBitSign (g : ℕ → Witness F) (j : ℕ) {b : F} (hgb : gateBit g j = b)
-    (hbit : b = 0 ∨ b = 1) {e : ℤ} (he2 : (e : F) = 2 * b - 1) (he : e = 1 ∨ e = -1)
-    (h2 : (2 : F) ≠ 0) : e = gateBitSign g j := by
-  cases hbit <;> simp_all +decide [ gateBitSign ];
+/-- The signed bit `e` produced by `signed_target` is the bit's sign. -/
+private lemma e_eq_bitSign {b : F} (hbit : b = 0 ∨ b = 1) {e : ℤ}
+    (he2 : (e : F) = 2 * b - 1) (he : e = 1 ∨ e = -1) (h2 : (2 : F) ≠ 0) :
+    e = bitSign b := by
+  cases hbit <;> simp_all +decide [ bitSign ];
   · cases he <;> simp_all +decide;
     exact h2 ( by linear_combination' he2 );
   · rcases he with ( rfl | rfl ) <;> norm_num at *;
     grind +extAll
+
+/-- The gate-indexed reading of `e_eq_bitSign`. -/
+private lemma e_eq_gateBitSign (g : ℕ → Witness F) (j : ℕ) {b : F} (hgb : gateBit g j = b)
+    (hbit : b = 0 ∨ b = 1) {e : ℤ} (he2 : (e : F) = 2 * b - 1) (he : e = 1 ∨ e = -1)
+    (h2 : (2 : F) ≠ 0) : e = gateBitSign g j := by
+  rw [show gateBitSign g j = bitSign b from by unfold gateBitSign; rw [hgb]]
+  exact e_eq_bitSign hbit he2 he h2
 
 /-- Per sub-step advance using *only* the x-condition `k ≢ ±1`; the t-condition `t ≠ 0`
     is supplied by `tne_of_holds` (the constraints + prime order), not by `2k ≢ ±1`. -/
@@ -2053,24 +2067,12 @@ The honest walk: `chainBuild` threads the gate's canonical row (`build`) from th
 init accumulator through a flat bit stream, five bits per row. `chain_complete` is its
 conditional completeness — under either ladder regime, every generated row satisfies the
 gate. The non-degeneracy is PRODUCED forward, not read off an accepted run: the
-accumulator entering bit step `j` is the ladder multiple `[ladderK bs j]·T`, the regime
+accumulator entering bit step `j` is the ladder multiple `[gateLadder g j]·T`, the regime
 prices all four degeneracy residues at every step (`ladder_subwrap_nondegen` /
 `ladder_nondegen_tight`), and each generated step's two secant denominators are derived
 from those residues before the step is certified (`step_produce`). -/
 
 variable {F : Type*} [Field F] [DecidableEq F]
-
-/-- The ±1 sign a bit value selects: `+1` for `b = 1`, `−1` otherwise — the honest ℤ
-reading of the gate's `2·b − 1`. -/
-def bitSign (b : F) : ℤ := if b = 1 then 1 else -1
-
-/-- The honest ladder value after `j` bit steps of the stream `bs`, from the doubled
-init: `k 0 = 2`, `k (j+1) = 2·k j + bitSign (bs j)`. On a boolean stream this is the
-signed double-and-add ladder the pricing kernel prices; on the stream of a scalar's
-bits it decodes to `Type1`'s `2·s + 2^L + 1` (`ladderK_eq_bitsVal`). -/
-def ladderK (bs : ℕ → F) : ℕ → ℤ
-  | 0 => 2
-  | j + 1 => 2 * ladderK bs j + bitSign (bs j)
 
 /-- The honest rows: row `i` is `build` at the threaded accumulator and register,
 consuming bits `5i … 5i+4` of the stream. -/
@@ -2081,6 +2083,22 @@ def chainBuild (xT yT x0 y0 n0 : F) (bs : ℕ → F) : ℕ → Witness F
       (chainBuild xT yT x0 y0 n0 bs i).nPrime
       (bs (5 * (i + 1))) (bs (5 * (i + 1) + 1)) (bs (5 * (i + 1) + 2))
       (bs (5 * (i + 1) + 3)) (bs (5 * (i + 1) + 4))
+
+omit [DecidableEq F] in
+/-- The walk's gate bits ARE the stream it was built from: sub-step `j` reads `bs j`.
+What lets the honest walk speak the sound side's ladder vocabulary (`gateLadder`)
+rather than a second copy of it. -/
+private lemma gateBit_chainBuild (xT yT x0 y0 n0 : F) (bs : ℕ → F) (j : ℕ) :
+    gateBit (chainBuild xT yT x0 y0 n0 bs) j = bs j := by
+  have h : j = 5 * (j / 5) + j % 5 := by omega
+  have h5 : j % 5 < 5 := Nat.mod_lt _ (by omega)
+  unfold gateBit
+  interval_cases hm : (j % 5) <;> (conv_rhs => rw [h]) <;> cases (j / 5) <;> rfl
+
+/-- Hence the walk's signed digit at sub-step `j` is the stream bit's sign. -/
+private lemma gateBitSign_chainBuild (xT yT x0 y0 n0 : F) (bs : ℕ → F) (j : ℕ) :
+    gateBitSign (chainBuild xT yT x0 y0 n0 bs) j = bitSign (bs j) := by
+  unfold gateBitSign; rw [gateBit_chainBuild]
 
 omit [DecidableEq F] in
 /-- Every `chainBuild` row is `build` at its own threaded fields — the uniform
@@ -2306,15 +2324,7 @@ private lemma step_produce (c : WeierstrassCurve.Affine F)
     (by rw [e1, ← htdef]; exact htne)
   obtain ⟨-, -, hO, e', hepm', heF', hOeq⟩ :=
     gate_step_advance' c h2 hodd hTns hI hQ hbit hTne k hIk hq1 hq2 hh
-  have he' : e' = bitSign b := by
-    rcases hbit with rfl | rfl
-    · rcases hepm' with rfl | rfl
-      · exact absurd (by linear_combination heF' : (2 : F) = 0) h2
-      · simp [bitSign]
-    · rcases hepm' with rfl | rfl
-      · simp [bitSign]
-      · exact absurd (by linear_combination -heF' : (2 : F) = 0) h2
-  exact ⟨hh, hO, by rw [hOeq, he']⟩
+  exact ⟨hh, hO, by rw [hOeq, e_eq_bitSign hbit heF' hepm' h2]⟩
 
 /-- One honest row: five `step_produce` steps threaded through `build`. The row's
 constraints hold and the output accumulator is the nonsingular five-fold advance
@@ -2363,9 +2373,12 @@ private lemma row_produce (c : WeierstrassCurve.Affine F)
 
 /-- **Completeness of the honest ladder.** From the doubled init `P₀ = [2]·T`, under
 either ladder regime — subwrap (`3·2^(5m) ≤ order`, no condition on the bits) or the
-one-wrap band with the stream's ladder value `ladderK bs (5m)` avoiding the forbidden
-residues — every generated row satisfies the gate. The regime dichotomy is
-`varBaseMul_off`'s, at the honest values. -/
+one-wrap band with the walk's ladder value `gateLadder (chainBuild …) (5m)` avoiding
+the forbidden residues — every generated row satisfies the gate. The regime dichotomy
+is `varBaseMul_off`'s, at the honest values, and stated in its vocabulary: the walk's
+gate bits are the stream (`gateBit_chainBuild`), so the sound side's `gateLadder` is
+the honest ladder and `gateLadder_eq_register` is the decode a caller discharges the
+band condition with. -/
 theorem chain_complete (c : WeierstrassCurve.Affine F)
     [Fact (c.a₁ = 0 ∧ c.a₂ = 0 ∧ c.a₃ = 0)] [Fact (Nat.Prime c.order)]
     (h2 : (2 : F) ≠ 0) (hodd : c.order ≠ 2) (m : ℕ)
@@ -2375,24 +2388,23 @@ theorem chain_complete (c : WeierstrassCurve.Affine F)
     (hP0eq : Point.some _ _ hP0 = (2 : ℤ) • Point.some _ _ hTns)
     (hregime : 3 * 2 ^ (5 * m) ≤ c.order ∨
       (2 ^ (5 * m - 1) < c.order ∧ c.order < 2 ^ (5 * m) ∧ c.order % 4 = 1 ∧
-        ladderK bs (5 * m) ∉ forbiddenValues c.order)) :
+        gateLadder (chainBuild xT yT x0 y0 n0 bs) (5 * m) ∉ forbiddenValues c.order)) :
     ∀ i, i < m → Holds (chainBuild xT yT x0 y0 n0 bs i) := by
   have hTne : Point.some _ _ hTns ≠ 0 := Point.some_ne_zero hTns
-  have hε : ∀ j, j < 5 * m → bitSign (bs j) = 1 ∨ bitSign (bs j) = -1 := by
-    intro j _
-    unfold bitSign
-    split <;> simp
+  set g := chainBuild xT yT x0 y0 n0 bs with hg
   -- the regime prices all four degeneracy residues at every bit step
   have hquad : ∀ j, j < 5 * m →
-      ¬((c.order : ℤ) ∣ (ladderK bs j - 1)) ∧ ¬((c.order : ℤ) ∣ (ladderK bs j + 1))
-      ∧ ¬((c.order : ℤ) ∣ (2 * ladderK bs j - 1))
-      ∧ ¬((c.order : ℤ) ∣ (2 * ladderK bs j + 1)) := by
+      ¬((c.order : ℤ) ∣ (gateLadder g j - 1)) ∧ ¬((c.order : ℤ) ∣ (gateLadder g j + 1))
+      ∧ ¬((c.order : ℤ) ∣ (2 * gateLadder g j - 1))
+      ∧ ¬((c.order : ℤ) ∣ (2 * gateLadder g j + 1)) := by
     rcases hregime with hsub | ⟨hr1, hr2, hq4, hnf⟩
-    · exact Ladder.ladder_subwrap_nondegen c.order (5 * m) hsub (ladderK bs)
-        (fun j => bitSign (bs j)) rfl hε (fun j _ => rfl)
+    · exact Ladder.ladder_subwrap_nondegen c.order (5 * m) hsub (gateLadder g)
+        (gateBitSign g) (gateLadder_zero g) (fun j _ => gateBitSign_eq g j)
+        (fun j _ => gateLadder_succ g j)
     · refine Ladder.ladder_nondegen_tight c.order (5 * m)
-        (Fact.out : Nat.Prime c.order) hq4 hr1 hr2 (ladderK bs)
-        (fun j => bitSign (bs j)) rfl hε (fun j _ => rfl) ?_
+        (Fact.out : Nat.Prime c.order) hq4 hr1 hr2 (gateLadder g)
+        (gateBitSign g) (gateLadder_zero g) (fun j _ => gateBitSign_eq g j)
+        (fun j _ => gateLadder_succ g j) ?_
       intro t ht hdvd
       exact hnf ⟨t, ht, hdvd⟩
   -- rows hold and the accumulator threads as the ladder multiple
@@ -2400,7 +2412,7 @@ theorem chain_complete (c : WeierstrassCurve.Affine F)
       (∀ i', i' < i → Holds (chainBuild xT yT x0 y0 n0 bs i'))
       ∧ ∃ hIi : c.Nonsingular (chainBuild xT yT x0 y0 n0 bs i).x0
           (chainBuild xT yT x0 y0 n0 bs i).y0,
-          Point.some _ _ hIi = ladderK bs (5 * i) • Point.some _ _ hTns := by
+          Point.some _ _ hIi = gateLadder g (5 * i) • Point.some _ _ hTns := by
     intro i
     induction i with
     | zero =>
@@ -2413,7 +2425,12 @@ theorem chain_complete (c : WeierstrassCurve.Affine F)
         (chainBuild xT yT x0 y0 n0 bs i).n
         (hbs (5 * i) (by omega)) (hbs (5 * i + 1) (by omega)) (hbs (5 * i + 2) (by omega))
         (hbs (5 * i + 3) (by omega)) (hbs (5 * i + 4) (by omega)) hIi
-        (k := ladderK bs) (j := 5 * i) hIeq rfl rfl rfl rfl rfl
+        (k := gateLadder g) (j := 5 * i) hIeq
+        (by rw [gateLadder_succ, gateBitSign_chainBuild])
+        (by rw [gateLadder_succ, gateBitSign_chainBuild])
+        (by rw [gateLadder_succ, gateBitSign_chainBuild])
+        (by rw [gateLadder_succ, gateBitSign_chainBuild])
+        (by rw [gateLadder_succ, gateBitSign_chainBuild])
         (fun l hl hl' => hquad l (by omega))
       refine ⟨fun i' hi' => ?_, ?_⟩
       · rcases Nat.lt_or_ge i' i with h | h
@@ -2424,28 +2441,11 @@ theorem chain_complete (c : WeierstrassCurve.Affine F)
           exact hrow
       · show ∃ hIi : c.Nonsingular (chainBuild xT yT x0 y0 n0 bs i).x5
             (chainBuild xT yT x0 y0 n0 bs i).y5,
-            Point.some _ _ hIi = ladderK bs (5 * (i + 1)) • Point.some _ _ hTns
+            Point.some _ _ hIi = gateLadder g (5 * (i + 1)) • Point.some _ _ hTns
         rw [chainBuild_eta xT yT x0 y0 n0 bs i,
           show (5 : ℕ) * (i + 1) = 5 * i + 5 from by ring]
         exact ⟨h5, h5eq⟩
   exact (main m le_rfl).1
-
-/-- On a boolean stream the ladder decodes as `Type1`'s unshift of the base-2 value:
-`ladderK bs L = 2·bitsVal(bits) + 2^L + 1` — how a caller discharges
-`chain_complete`'s forbidden-band condition from the scalar it actually fed. -/
-theorem ladderK_eq_bitsVal (bs : ℕ → F) (L : ℕ)
-    (hb : ∀ j, j < L → bs j = 0 ∨ bs j = 1) :
-    ladderK bs L = 2 * bitsVal ((List.range L).map bs) + 2 ^ L + 1 := by
-  induction L with
-  | zero => simp [ladderK, bitsVal]
-  | succ L ih =>
-    have hsnoc : bitsVal ((List.range (L + 1)).map bs)
-        = 2 * bitsVal ((List.range L).map bs) + (if bs L = 1 then 1 else 0) := by
-      rw [List.range_succ, List.map_append]
-      simp [bitsVal, List.foldl_append]
-    rw [show ladderK bs (L + 1) = 2 * ladderK bs L + bitSign (bs L) from rfl,
-      ih (fun j hj => hb j (by omega)), hsnoc]
-    rcases hb L (by omega) with h | h <;> simp [bitSign, h] <;> ring
 
 /-! ## The `scaleFast1` / Type1 direction: soundness via the forbidden band (Vesta)
 

--- a/formal/kimchi/Kimchi/Gate/Semantics/VarBaseMul.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/VarBaseMul.lean
@@ -2112,9 +2112,10 @@ theorem chainBuild_eta (xT yT x0 y0 n0 : F) (bs : ℕ → F) (i : ℕ) :
           (bs (5 * i + 4)) := by
   cases i <;> rfl
 
-/-! The per-field equations of a walk row, each at the row's own threaded cells — the
-vocabulary a prover-side identification consumes so it never has to normalize
-`build`'s five-step let chain itself. -/
+/-! The walk's structural equations: how a row's input cells thread from the previous
+row's outputs, and which of its cells are the arguments. The per-field equations of a
+row itself belong to `build` (`Kimchi/Gate/VarBaseMul`), which the walk is built from
+and `chainBuild_eta` re-expresses it as. -/
 
 section ChainFields
 
@@ -2157,83 +2158,6 @@ theorem accY_chainBuild (m : ℕ) :
 
 theorem accN_chainBuild (m : ℕ) :
     accN (chainBuild xT yT x0 y0 n0 bs) m = (chainBuild xT yT x0 y0 n0 bs m).n := by
-  cases m <;> rfl
-
-/-- Bit step 0 of row `m`: the slope and the output accumulator are the gate
-model's `stepBit` at the step's own input cells. -/
-theorem chainBuild_step0 (m : ℕ) :
-    (chainBuild xT yT x0 y0 n0 bs m).s0
-      = (stepBit (bs (5 * m)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x0
-          (chainBuild xT yT x0 y0 n0 bs m).y0).1
-    ∧ (chainBuild xT yT x0 y0 n0 bs m).x1
-      = (stepBit (bs (5 * m)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x0
-          (chainBuild xT yT x0 y0 n0 bs m).y0).2.1
-    ∧ (chainBuild xT yT x0 y0 n0 bs m).y1
-      = (stepBit (bs (5 * m)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x0
-          (chainBuild xT yT x0 y0 n0 bs m).y0).2.2 := by
-  cases m <;> exact ⟨rfl, rfl, rfl⟩
-
-/-- Bit step 1 of row `m`: the slope and the output accumulator are the gate
-model's `stepBit` at the step's own input cells. -/
-theorem chainBuild_step1 (m : ℕ) :
-    (chainBuild xT yT x0 y0 n0 bs m).s1
-      = (stepBit (bs (5 * m + 1)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x1
-          (chainBuild xT yT x0 y0 n0 bs m).y1).1
-    ∧ (chainBuild xT yT x0 y0 n0 bs m).x2
-      = (stepBit (bs (5 * m + 1)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x1
-          (chainBuild xT yT x0 y0 n0 bs m).y1).2.1
-    ∧ (chainBuild xT yT x0 y0 n0 bs m).y2
-      = (stepBit (bs (5 * m + 1)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x1
-          (chainBuild xT yT x0 y0 n0 bs m).y1).2.2 := by
-  cases m <;> exact ⟨rfl, rfl, rfl⟩
-
-/-- Bit step 2 of row `m`: the slope and the output accumulator are the gate
-model's `stepBit` at the step's own input cells. -/
-theorem chainBuild_step2 (m : ℕ) :
-    (chainBuild xT yT x0 y0 n0 bs m).s2
-      = (stepBit (bs (5 * m + 2)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x2
-          (chainBuild xT yT x0 y0 n0 bs m).y2).1
-    ∧ (chainBuild xT yT x0 y0 n0 bs m).x3
-      = (stepBit (bs (5 * m + 2)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x2
-          (chainBuild xT yT x0 y0 n0 bs m).y2).2.1
-    ∧ (chainBuild xT yT x0 y0 n0 bs m).y3
-      = (stepBit (bs (5 * m + 2)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x2
-          (chainBuild xT yT x0 y0 n0 bs m).y2).2.2 := by
-  cases m <;> exact ⟨rfl, rfl, rfl⟩
-
-/-- Bit step 3 of row `m`: the slope and the output accumulator are the gate
-model's `stepBit` at the step's own input cells. -/
-theorem chainBuild_step3 (m : ℕ) :
-    (chainBuild xT yT x0 y0 n0 bs m).s3
-      = (stepBit (bs (5 * m + 3)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x3
-          (chainBuild xT yT x0 y0 n0 bs m).y3).1
-    ∧ (chainBuild xT yT x0 y0 n0 bs m).x4
-      = (stepBit (bs (5 * m + 3)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x3
-          (chainBuild xT yT x0 y0 n0 bs m).y3).2.1
-    ∧ (chainBuild xT yT x0 y0 n0 bs m).y4
-      = (stepBit (bs (5 * m + 3)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x3
-          (chainBuild xT yT x0 y0 n0 bs m).y3).2.2 := by
-  cases m <;> exact ⟨rfl, rfl, rfl⟩
-
-/-- Bit step 4 of row `m`: the slope and the output accumulator are the gate
-model's `stepBit` at the step's own input cells. -/
-theorem chainBuild_step4 (m : ℕ) :
-    (chainBuild xT yT x0 y0 n0 bs m).s4
-      = (stepBit (bs (5 * m + 4)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x4
-          (chainBuild xT yT x0 y0 n0 bs m).y4).1
-    ∧ (chainBuild xT yT x0 y0 n0 bs m).x5
-      = (stepBit (bs (5 * m + 4)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x4
-          (chainBuild xT yT x0 y0 n0 bs m).y4).2.1
-    ∧ (chainBuild xT yT x0 y0 n0 bs m).y5
-      = (stepBit (bs (5 * m + 4)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x4
-          (chainBuild xT yT x0 y0 n0 bs m).y4).2.2 := by
-  cases m <;> exact ⟨rfl, rfl, rfl⟩
-
-theorem chainBuild_nPrime (m : ℕ) :
-    (chainBuild xT yT x0 y0 n0 bs m).nPrime
-      = bs (5 * m + 4) + 2 * (bs (5 * m + 3) + 2 * (bs (5 * m + 2)
-          + 2 * (bs (5 * m + 1) + 2 * (bs (5 * m)
-          + 2 * (chainBuild xT yT x0 y0 n0 bs m).n)))) := by
   cases m <;> rfl
 
 end ChainFields

--- a/formal/kimchi/Kimchi/Gate/Semantics/VarBaseMul.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/VarBaseMul.lean
@@ -1964,6 +1964,59 @@ theorem runBits_bool (m : ℕ) (g : ℕ → Witness F)
       · exact hbool _ ((singleBitHolds_iff _ _ _ _ _ _ _ _).mp h.2.2.2.2.1).1
       · exact hbool _ ((singleBitHolds_iff _ _ _ _ _ _ _ _).mp h.2.2.2.2.2).1
 
+/-- The five-bit windows tile the flat stream: a `runBits`-shaped flatMap over rows
+reads the same list as the plain range read. -/
+theorem flatMap_range_window (bs : ℕ → F) (m : ℕ) :
+    (List.range m).flatMap
+        (fun i => [bs (5 * i), bs (5 * i + 1), bs (5 * i + 2), bs (5 * i + 3),
+          bs (5 * i + 4)])
+      = (List.range (5 * m)).map bs := by
+  induction m with
+  | zero => rfl
+  | succ m ih =>
+    rw [List.range_succ, List.flatMap_append, ih,
+      show 5 * (m + 1) = 5 * m + 5 from by ring, List.range_add, List.map_append,
+      List.flatMap_cons, List.flatMap_nil]
+    simp [show List.range 5 = [0, 1, 2, 3, 4] from by decide]
+
+/-- The ℤ-decode reconstructs a bounded scalar from its MSB-first bit reads: position
+`j` of the list carries `testBit (L − 1 − j)`. How the honest witness's register fold
+recovers the scalar it unpacked. -/
+theorem bitsVal_testBit (x L : ℕ) (hx : x < 2 ^ L) :
+    bitsVal ((List.range L).map fun j => if x.testBit (L - 1 - j) then (1 : F) else 0)
+      = (x : ℤ) := by
+  induction L generalizing x with
+  | zero =>
+    have hx0 : x = 0 := by simpa using hx
+    subst hx0
+    rfl
+  | succ L ih =>
+    have hsplit : ((List.range (L + 1)).map
+          fun j => if x.testBit (L + 1 - 1 - j) then (1 : F) else 0)
+        = ((List.range L).map
+            fun j => if (x / 2).testBit (L - 1 - j) then (1 : F) else 0)
+          ++ [if x.testBit 0 then (1 : F) else 0] := by
+      rw [List.range_succ, List.map_append]
+      congr 1
+      · apply List.map_congr_left
+        intro j hj
+        have hj' : j < L := List.mem_range.mp hj
+        rw [show L + 1 - 1 - j = (L - 1 - j) + 1 from by omega, Nat.testBit_add_one]
+      · simp
+    have hfold : ∀ (l : List F) (b : F),
+        bitsVal (l ++ [b]) = 2 * bitsVal l + (if b = 1 then 1 else 0) := by
+      intro l b
+      simp [bitsVal, List.foldl_append]
+    rw [hsplit, hfold, ih (x / 2) (by omega)]
+    have hbit0 : x.testBit 0 = decide (x % 2 = 1) := Nat.testBit_zero x
+    rcases Nat.mod_two_eq_zero_or_one x with h | h
+    · rw [show (if x.testBit 0 then (1 : F) else 0) = 0 from by rw [hbit0, h]; simp,
+        if_neg (zero_ne_one (α := F))]
+      omega
+    · rw [show (if x.testBit 0 then (1 : F) else 0) = 1 from by rw [hbit0, h]; simp,
+        if_pos rfl]
+      omega
+
 end RunBits
 
 /-- **The generic off-band entry point.** `varBaseMul_subwrap_correct` and
@@ -2039,6 +2092,145 @@ theorem chainBuild_eta (xT yT x0 y0 n0 : F) (bs : ℕ → F) (i : ℕ) :
           (bs (5 * i)) (bs (5 * i + 1)) (bs (5 * i + 2)) (bs (5 * i + 3))
           (bs (5 * i + 4)) := by
   cases i <;> rfl
+
+/-! The per-field equations of a walk row, each at the row's own threaded cells — the
+vocabulary a prover-side identification consumes so it never has to normalize
+`build`'s five-step let chain itself. -/
+
+section ChainFields
+
+variable (xT yT x0 y0 n0 : F) (bs : ℕ → F)
+
+omit [DecidableEq F] in
+theorem chainBuild_succ_x0 (i : ℕ) :
+    (chainBuild xT yT x0 y0 n0 bs (i + 1)).x0 = (chainBuild xT yT x0 y0 n0 bs i).x5 :=
+  rfl
+
+omit [DecidableEq F] in
+theorem chainBuild_succ_y0 (i : ℕ) :
+    (chainBuild xT yT x0 y0 n0 bs (i + 1)).y0 = (chainBuild xT yT x0 y0 n0 bs i).y5 :=
+  rfl
+
+omit [DecidableEq F] in
+theorem chainBuild_succ_n (i : ℕ) :
+    (chainBuild xT yT x0 y0 n0 bs (i + 1)).n
+      = (chainBuild xT yT x0 y0 n0 bs i).nPrime :=
+  rfl
+
+omit [DecidableEq F] in
+theorem chainBuild_s0 (m : ℕ) :
+    (chainBuild xT yT x0 y0 n0 bs m).s0
+      = (stepBit (bs (5 * m)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x0
+          (chainBuild xT yT x0 y0 n0 bs m).y0).1 := by
+  cases m <;> rfl
+
+omit [DecidableEq F] in
+theorem chainBuild_x1 (m : ℕ) :
+    (chainBuild xT yT x0 y0 n0 bs m).x1
+      = (stepBit (bs (5 * m)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x0
+          (chainBuild xT yT x0 y0 n0 bs m).y0).2.1 := by
+  cases m <;> rfl
+
+omit [DecidableEq F] in
+theorem chainBuild_y1 (m : ℕ) :
+    (chainBuild xT yT x0 y0 n0 bs m).y1
+      = (stepBit (bs (5 * m)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x0
+          (chainBuild xT yT x0 y0 n0 bs m).y0).2.2 := by
+  cases m <;> rfl
+
+omit [DecidableEq F] in
+theorem chainBuild_s1 (m : ℕ) :
+    (chainBuild xT yT x0 y0 n0 bs m).s1
+      = (stepBit (bs (5 * m + 1)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x1
+          (chainBuild xT yT x0 y0 n0 bs m).y1).1 := by
+  cases m <;> rfl
+
+omit [DecidableEq F] in
+theorem chainBuild_x2 (m : ℕ) :
+    (chainBuild xT yT x0 y0 n0 bs m).x2
+      = (stepBit (bs (5 * m + 1)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x1
+          (chainBuild xT yT x0 y0 n0 bs m).y1).2.1 := by
+  cases m <;> rfl
+
+omit [DecidableEq F] in
+theorem chainBuild_y2 (m : ℕ) :
+    (chainBuild xT yT x0 y0 n0 bs m).y2
+      = (stepBit (bs (5 * m + 1)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x1
+          (chainBuild xT yT x0 y0 n0 bs m).y1).2.2 := by
+  cases m <;> rfl
+
+omit [DecidableEq F] in
+theorem chainBuild_s2 (m : ℕ) :
+    (chainBuild xT yT x0 y0 n0 bs m).s2
+      = (stepBit (bs (5 * m + 2)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x2
+          (chainBuild xT yT x0 y0 n0 bs m).y2).1 := by
+  cases m <;> rfl
+
+omit [DecidableEq F] in
+theorem chainBuild_x3 (m : ℕ) :
+    (chainBuild xT yT x0 y0 n0 bs m).x3
+      = (stepBit (bs (5 * m + 2)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x2
+          (chainBuild xT yT x0 y0 n0 bs m).y2).2.1 := by
+  cases m <;> rfl
+
+omit [DecidableEq F] in
+theorem chainBuild_y3 (m : ℕ) :
+    (chainBuild xT yT x0 y0 n0 bs m).y3
+      = (stepBit (bs (5 * m + 2)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x2
+          (chainBuild xT yT x0 y0 n0 bs m).y2).2.2 := by
+  cases m <;> rfl
+
+omit [DecidableEq F] in
+theorem chainBuild_s3 (m : ℕ) :
+    (chainBuild xT yT x0 y0 n0 bs m).s3
+      = (stepBit (bs (5 * m + 3)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x3
+          (chainBuild xT yT x0 y0 n0 bs m).y3).1 := by
+  cases m <;> rfl
+
+omit [DecidableEq F] in
+theorem chainBuild_x4 (m : ℕ) :
+    (chainBuild xT yT x0 y0 n0 bs m).x4
+      = (stepBit (bs (5 * m + 3)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x3
+          (chainBuild xT yT x0 y0 n0 bs m).y3).2.1 := by
+  cases m <;> rfl
+
+omit [DecidableEq F] in
+theorem chainBuild_y4 (m : ℕ) :
+    (chainBuild xT yT x0 y0 n0 bs m).y4
+      = (stepBit (bs (5 * m + 3)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x3
+          (chainBuild xT yT x0 y0 n0 bs m).y3).2.2 := by
+  cases m <;> rfl
+
+omit [DecidableEq F] in
+theorem chainBuild_s4 (m : ℕ) :
+    (chainBuild xT yT x0 y0 n0 bs m).s4
+      = (stepBit (bs (5 * m + 4)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x4
+          (chainBuild xT yT x0 y0 n0 bs m).y4).1 := by
+  cases m <;> rfl
+
+omit [DecidableEq F] in
+theorem chainBuild_x5 (m : ℕ) :
+    (chainBuild xT yT x0 y0 n0 bs m).x5
+      = (stepBit (bs (5 * m + 4)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x4
+          (chainBuild xT yT x0 y0 n0 bs m).y4).2.1 := by
+  cases m <;> rfl
+
+omit [DecidableEq F] in
+theorem chainBuild_y5 (m : ℕ) :
+    (chainBuild xT yT x0 y0 n0 bs m).y5
+      = (stepBit (bs (5 * m + 4)) xT yT (chainBuild xT yT x0 y0 n0 bs m).x4
+          (chainBuild xT yT x0 y0 n0 bs m).y4).2.2 := by
+  cases m <;> rfl
+
+omit [DecidableEq F] in
+theorem chainBuild_nPrime (m : ℕ) :
+    (chainBuild xT yT x0 y0 n0 bs m).nPrime
+      = bs (5 * m + 4) + 2 * (bs (5 * m + 3) + 2 * (bs (5 * m + 2)
+          + 2 * (bs (5 * m + 1) + 2 * (bs (5 * m)
+          + 2 * (chainBuild xT yT x0 y0 n0 bs m).n)))) := by
+  cases m <;> rfl
+
+end ChainFields
 
 /-- One honest bit step: at an accumulator `[k]·T` whose four degeneracy residues the
 regime has priced away, the generated `stepBit` values satisfy the bit block and the

--- a/formal/kimchi/Kimchi/Gate/Semantics/VarBaseMul.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/VarBaseMul.lean
@@ -1979,8 +1979,9 @@ theorem runBits_bool (m : ℕ) (g : ℕ → Witness F)
       · exact hbool _ ((singleBitHolds_iff _ _ _ _ _ _ _ _).mp h.2.2.2.2.2).1
 
 /-- The five-bit windows tile the flat stream: a `runBits`-shaped flatMap over rows
-reads the same list as the plain range read. -/
-theorem flatMap_range_window (bs : ℕ → F) (m : ℕ) :
+reads the same list as the plain range read. Element type is free — the gadget's
+prover-side reading tiles variables, not just field values. -/
+theorem flatMap_range_window {α : Type*} (bs : ℕ → α) (m : ℕ) :
     (List.range m).flatMap
         (fun i => [bs (5 * i), bs (5 * i + 1), bs (5 * i + 2), bs (5 * i + 3),
           bs (5 * i + 4)])

--- a/formal/kimchi/Kimchi/Gate/VarBaseMul.lean
+++ b/formal/kimchi/Kimchi/Gate/VarBaseMul.lean
@@ -277,6 +277,101 @@ def build [Field F] (xb yb x0 y0 n b0 b1 b2 b3 b4 : F) : Witness F :=
   , n, nPrime := b4 + 2 * (b3 + 2 * (b2 + 2 * (b1 + 2 * (b0 + 2 * n))))
   , b0, b1, b2, b3, b4, s0, s1, s2, s3, s4 }
 
+/-! ## The canonical row's fields
+
+`build`'s five-step `let` chain, read one field at a time. A consumer identifying a
+prover's cells with the canonical row rewrites with these instead of normalising the
+chain itself. -/
+
+section BuildFields
+
+variable [Field F] (xb yb x0 y0 n b0 b1 b2 b3 b4 : F)
+
+/-- The row's fixed cells are the arguments. -/
+theorem build_fields :
+    (build xb yb x0 y0 n b0 b1 b2 b3 b4).xT = xb
+    ∧ (build xb yb x0 y0 n b0 b1 b2 b3 b4).yT = yb
+    ∧ (build xb yb x0 y0 n b0 b1 b2 b3 b4).x0 = x0
+    ∧ (build xb yb x0 y0 n b0 b1 b2 b3 b4).y0 = y0
+    ∧ (build xb yb x0 y0 n b0 b1 b2 b3 b4).n = n
+    ∧ (build xb yb x0 y0 n b0 b1 b2 b3 b4).b0 = b0
+    ∧ (build xb yb x0 y0 n b0 b1 b2 b3 b4).b1 = b1
+    ∧ (build xb yb x0 y0 n b0 b1 b2 b3 b4).b2 = b2
+    ∧ (build xb yb x0 y0 n b0 b1 b2 b3 b4).b3 = b3
+    ∧ (build xb yb x0 y0 n b0 b1 b2 b3 b4).b4 = b4 :=
+  ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+
+/-- The register update. -/
+theorem build_nPrime :
+    (build xb yb x0 y0 n b0 b1 b2 b3 b4).nPrime
+      = b4 + 2 * (b3 + 2 * (b2 + 2 * (b1 + 2 * (b0 + 2 * n)))) := rfl
+
+/-- Bit step 0: the slope and the output accumulator are `stepBit` at the step's own
+input cells. -/
+theorem build_step0 :
+    (build xb yb x0 y0 n b0 b1 b2 b3 b4).s0 = (stepBit b0 xb yb x0 y0).1
+    ∧ (build xb yb x0 y0 n b0 b1 b2 b3 b4).x1 = (stepBit b0 xb yb x0 y0).2.1
+    ∧ (build xb yb x0 y0 n b0 b1 b2 b3 b4).y1 = (stepBit b0 xb yb x0 y0).2.2 :=
+  ⟨rfl, rfl, rfl⟩
+
+/-- Bit step 1: the slope and the output accumulator are `stepBit` at the step's own
+input cells. -/
+theorem build_step1 :
+    (build xb yb x0 y0 n b0 b1 b2 b3 b4).s1
+      = (stepBit b1 xb yb (build xb yb x0 y0 n b0 b1 b2 b3 b4).x1
+          (build xb yb x0 y0 n b0 b1 b2 b3 b4).y1).1
+    ∧ (build xb yb x0 y0 n b0 b1 b2 b3 b4).x2
+      = (stepBit b1 xb yb (build xb yb x0 y0 n b0 b1 b2 b3 b4).x1
+          (build xb yb x0 y0 n b0 b1 b2 b3 b4).y1).2.1
+    ∧ (build xb yb x0 y0 n b0 b1 b2 b3 b4).y2
+      = (stepBit b1 xb yb (build xb yb x0 y0 n b0 b1 b2 b3 b4).x1
+          (build xb yb x0 y0 n b0 b1 b2 b3 b4).y1).2.2 :=
+  ⟨rfl, rfl, rfl⟩
+
+/-- Bit step 2: the slope and the output accumulator are `stepBit` at the step's own
+input cells. -/
+theorem build_step2 :
+    (build xb yb x0 y0 n b0 b1 b2 b3 b4).s2
+      = (stepBit b2 xb yb (build xb yb x0 y0 n b0 b1 b2 b3 b4).x2
+          (build xb yb x0 y0 n b0 b1 b2 b3 b4).y2).1
+    ∧ (build xb yb x0 y0 n b0 b1 b2 b3 b4).x3
+      = (stepBit b2 xb yb (build xb yb x0 y0 n b0 b1 b2 b3 b4).x2
+          (build xb yb x0 y0 n b0 b1 b2 b3 b4).y2).2.1
+    ∧ (build xb yb x0 y0 n b0 b1 b2 b3 b4).y3
+      = (stepBit b2 xb yb (build xb yb x0 y0 n b0 b1 b2 b3 b4).x2
+          (build xb yb x0 y0 n b0 b1 b2 b3 b4).y2).2.2 :=
+  ⟨rfl, rfl, rfl⟩
+
+/-- Bit step 3: the slope and the output accumulator are `stepBit` at the step's own
+input cells. -/
+theorem build_step3 :
+    (build xb yb x0 y0 n b0 b1 b2 b3 b4).s3
+      = (stepBit b3 xb yb (build xb yb x0 y0 n b0 b1 b2 b3 b4).x3
+          (build xb yb x0 y0 n b0 b1 b2 b3 b4).y3).1
+    ∧ (build xb yb x0 y0 n b0 b1 b2 b3 b4).x4
+      = (stepBit b3 xb yb (build xb yb x0 y0 n b0 b1 b2 b3 b4).x3
+          (build xb yb x0 y0 n b0 b1 b2 b3 b4).y3).2.1
+    ∧ (build xb yb x0 y0 n b0 b1 b2 b3 b4).y4
+      = (stepBit b3 xb yb (build xb yb x0 y0 n b0 b1 b2 b3 b4).x3
+          (build xb yb x0 y0 n b0 b1 b2 b3 b4).y3).2.2 :=
+  ⟨rfl, rfl, rfl⟩
+
+/-- Bit step 4: the slope and the output accumulator are `stepBit` at the step's own
+input cells. -/
+theorem build_step4 :
+    (build xb yb x0 y0 n b0 b1 b2 b3 b4).s4
+      = (stepBit b4 xb yb (build xb yb x0 y0 n b0 b1 b2 b3 b4).x4
+          (build xb yb x0 y0 n b0 b1 b2 b3 b4).y4).1
+    ∧ (build xb yb x0 y0 n b0 b1 b2 b3 b4).x5
+      = (stepBit b4 xb yb (build xb yb x0 y0 n b0 b1 b2 b3 b4).x4
+          (build xb yb x0 y0 n b0 b1 b2 b3 b4).y4).2.1
+    ∧ (build xb yb x0 y0 n b0 b1 b2 b3 b4).y5
+      = (stepBit b4 xb yb (build xb yb x0 y0 n b0 b1 b2 b3 b4).x4
+          (build xb yb x0 y0 n b0 b1 b2 b3 b4).y4).2.2 :=
+  ⟨rfl, rfl, rfl⟩
+
+end BuildFields
+
 instance : Fact (Nat.Prime 97) := ⟨by norm_num⟩
 
 /-- A concrete 5-bit step over `ZMod 97`: target `T = (3, 5)`, input acc `(10, 20)`,

--- a/formal/kimchi/roots.txt
+++ b/formal/kimchi/roots.txt
@@ -42,7 +42,6 @@ Kimchi.Gate.VarBaseMul.accN
 Kimchi.Gate.VarBaseMul.chain_accN
 Kimchi.Gate.VarBaseMul.runBits_bool
 Kimchi.Gate.VarBaseMul.chain_complete
-Kimchi.Gate.VarBaseMul.ladderK_eq_bitsVal
 Kimchi.Gate.VarBaseMul.varBaseMul_scaleFast1
 Kimchi.Gate.VarBaseMul.varBaseMul_scaleFast2
 

--- a/formal/kimchi/roots.txt
+++ b/formal/kimchi/roots.txt
@@ -41,6 +41,8 @@ Kimchi.Gate.VarBaseMul.gateRegister_eq_bitsVal
 Kimchi.Gate.VarBaseMul.accN
 Kimchi.Gate.VarBaseMul.chain_accN
 Kimchi.Gate.VarBaseMul.runBits_bool
+Kimchi.Gate.VarBaseMul.chain_complete
+Kimchi.Gate.VarBaseMul.ladderK_eq_bitsVal
 Kimchi.Gate.VarBaseMul.varBaseMul_scaleFast1
 Kimchi.Gate.VarBaseMul.varBaseMul_scaleFast2
 

--- a/formal/kimchi/scripts/check_axioms.lean
+++ b/formal/kimchi/scripts/check_axioms.lean
@@ -38,6 +38,8 @@ def roots : List Name :=
     `Kimchi.Gate.VarBaseMul.varBaseMul_forbidden_correct,
     `Kimchi.Gate.VarBaseMul.varBaseMul_subwrap_correct,
     `Kimchi.Gate.VarBaseMul.varBaseMul_off,
+    `Kimchi.Gate.VarBaseMul.chain_complete,
+    `Kimchi.Gate.VarBaseMul.ladderK_eq_bitsVal,
     `Kimchi.Gate.VarBaseMul.varBaseMul_scaleFast1,
     `Kimchi.Gate.VarBaseMul.varBaseMul_scaleFast2,
     `Kimchi.Gate.EndoScalar.sound, `Kimchi.Gate.EndoScalar.complete,

--- a/formal/kimchi/scripts/check_axioms.lean
+++ b/formal/kimchi/scripts/check_axioms.lean
@@ -39,7 +39,6 @@ def roots : List Name :=
     `Kimchi.Gate.VarBaseMul.varBaseMul_subwrap_correct,
     `Kimchi.Gate.VarBaseMul.varBaseMul_off,
     `Kimchi.Gate.VarBaseMul.chain_complete,
-    `Kimchi.Gate.VarBaseMul.ladderK_eq_bitsVal,
     `Kimchi.Gate.VarBaseMul.varBaseMul_scaleFast1,
     `Kimchi.Gate.VarBaseMul.varBaseMul_scaleFast2,
     `Kimchi.Gate.EndoScalar.sound, `Kimchi.Gate.EndoScalar.complete,

--- a/formal/snarky/Snarky/Backend/WP.lean
+++ b/formal/snarky/Snarky/Backend/WP.lean
@@ -872,6 +872,12 @@ instance instWitnessReadsF {F : Type} [Add F] [Mul F] :
   reads_of_grant h := mapM_eval_singleton h
   reads_le hle h := CVar.eval_le hle h
 
+/-- The `F`-leaf reading IS the eval equation — the coercion a grant consumer
+applies, since unification alone cannot unfold the instance projection against a
+metavariable-headed expected type. -/
+theorem reads_fvar {F : Type} [Add F] [Mul F] {r : FVar F} {env : Assignments F}
+    {x : F} (h : WitnessReads.Reads (F := F) r env x) : r.eval env = .ok x := h
+
 instance instWitnessReadsBool {F : Type} [Add F] [Mul F] [Zero F] [One F]
     [DecidableEq F] : WitnessReads F Bool (BoolVar F) where
   Reads r env b := (↑r : CVar F).eval env = .ok (bit b)

--- a/formal/snarky/Snarky/Backend/WP.lean
+++ b/formal/snarky/Snarky/Backend/WP.lean
@@ -872,12 +872,6 @@ instance instWitnessReadsF {F : Type} [Add F] [Mul F] :
   reads_of_grant h := mapM_eval_singleton h
   reads_le hle h := CVar.eval_le hle h
 
-/-- The `F`-leaf reading IS the eval equation — the coercion a grant consumer
-applies, since unification alone cannot unfold the instance projection against a
-metavariable-headed expected type. -/
-theorem reads_fvar {F : Type} [Add F] [Mul F] {r : FVar F} {env : Assignments F}
-    {x : F} (h : WitnessReads.Reads (F := F) r env x) : r.eval env = .ok x := h
-
 instance instWitnessReadsBool {F : Type} [Add F] [Mul F] [Zero F] [One F]
     [DecidableEq F] : WitnessReads F Bool (BoolVar F) where
   Reads r env b := (↑r : CVar F).eval env = .ok (bit b)

--- a/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
@@ -90,6 +90,32 @@ private def bitWit [Field F] [DecidableEq F] (t : AffinePoint (FVar F))
   let s2 := 2 * yi / (2 * xi + xb - s1Sq) - s1
   pure (s1, s1Sq, s2, xo, yo)
 
+/-- One 5-bit round (PS's `mapAccumM` body): the register advice, then five bit-step
+quintets threaded through the accumulator, collected as the gate's `ScaleRound`
+record and the next `(acc, register)` pair. Named so it carries its own law per
+reading — the caller's loop then walks one registered spec per round. -/
+def scaleRound [Field F] [DecidableEq F] [BasicSystem F c]
+    (base : AffinePoint (FVar F)) (st : AffinePoint (FVar F) × FVar F)
+    (bs : Vector (FVar F) 5) :
+    CircuitM F c (ScaleRound F × (AffinePoint (FVar F) × FVar F)) := do
+  let nAcc ← witness (val := F) (nAccWit st.2 bs)
+  let w0 ← witness (val := F × F × F × F × F) (bitWit base bs[0] st.1)
+  let a1 : AffinePoint (FVar F) := ⟨w0.2.2.2.1, w0.2.2.2.2⟩
+  let w1 ← witness (val := F × F × F × F × F) (bitWit base bs[1] a1)
+  let a2 : AffinePoint (FVar F) := ⟨w1.2.2.2.1, w1.2.2.2.2⟩
+  let w2 ← witness (val := F × F × F × F × F) (bitWit base bs[2] a2)
+  let a3 : AffinePoint (FVar F) := ⟨w2.2.2.2.1, w2.2.2.2.2⟩
+  let w3 ← witness (val := F × F × F × F × F) (bitWit base bs[3] a3)
+  let a4 : AffinePoint (FVar F) := ⟨w3.2.2.2.1, w3.2.2.2.2⟩
+  let w4 ← witness (val := F × F × F × F × F) (bitWit base bs[4] a4)
+  let a5 : AffinePoint (FVar F) := ⟨w4.2.2.2.1, w4.2.2.2.2⟩
+  pure (({ acc0 := st.1, acc1 := a1, acc2 := a2, acc3 := a3, acc4 := a4, acc5 := a5,
+           bit0 := bs[0], bit1 := bs[1], bit2 := bs[2], bit3 := bs[3], bit4 := bs[4],
+           slope0 := w0.1, slope1 := w1.1, slope2 := w2.1, slope3 := w3.1,
+           slope4 := w4.1,
+           nPrev := st.2, nNext := nAcc, base } : ScaleRound F),
+         (a5, nAcc))
+
 /-- What `varBaseMul` hands back (PS's `{ g, lsbBits }` record): the scalar multiple
 and the scalar's full bit decomposition, which `scaleFast2` pins. -/
 structure VarBaseMulResult (n : ℕ) (F : Type) where
@@ -112,27 +138,7 @@ def varBaseMul [Field F] [DecidableEq F] [ToNat F] [BasicSystem F c]
   let msb : List (FVar F) := (lsbBits.toList.take (5 * chunks)).reverse
   let window : ℕ → Vector (FVar F) 5 := fun i =>
     Vector.ofFn fun j => msb.getD (5 * i + j.1) (.const 0)
-  let (rounds, fin) ← mapAccumM
-    (fun (st : AffinePoint (FVar F) × FVar F) (bs : Vector (FVar F) 5) => do
-      let nAcc ← witness (val := F) (nAccWit st.2 bs)
-      let w0 ← witness (val := F × F × F × F × F) (bitWit base bs[0] st.1)
-      let a1 : AffinePoint (FVar F) := ⟨w0.2.2.2.1, w0.2.2.2.2⟩
-      let w1 ← witness (val := F × F × F × F × F) (bitWit base bs[1] a1)
-      let a2 : AffinePoint (FVar F) := ⟨w1.2.2.2.1, w1.2.2.2.2⟩
-      let w2 ← witness (val := F × F × F × F × F) (bitWit base bs[2] a2)
-      let a3 : AffinePoint (FVar F) := ⟨w2.2.2.2.1, w2.2.2.2.2⟩
-      let w3 ← witness (val := F × F × F × F × F) (bitWit base bs[3] a3)
-      let a4 : AffinePoint (FVar F) := ⟨w3.2.2.2.1, w3.2.2.2.2⟩
-      let w4 ← witness (val := F × F × F × F × F) (bitWit base bs[4] a4)
-      let a5 : AffinePoint (FVar F) := ⟨w4.2.2.2.1, w4.2.2.2.2⟩
-      pure (({ acc0 := st.1, acc1 := a1, acc2 := a2, acc3 := a3, acc4 := a4,
-               acc5 := a5,
-               bit0 := bs[0], bit1 := bs[1], bit2 := bs[2], bit3 := bs[3],
-               bit4 := bs[4],
-               slope0 := w0.1, slope1 := w1.1, slope2 := w2.1, slope3 := w3.1,
-               slope4 := w4.1,
-               nPrev := st.2, nNext := nAcc, base } : ScaleRound F),
-            (a5, nAcc)))
+  let (rounds, fin) ← mapAccumM (scaleRound base)
     (p.p, .const 0) ((List.range chunks).map window)
   addConstraint (KimchiSystem.varBaseMul rounds)
   assertEqual fin.2 scalar.val
@@ -540,7 +546,7 @@ theorem varBaseMul_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCurve F)
   haveI : Fact (Nat.Prime d.W.order) := ⟨d.prime⟩
   haveI : Fact (d.W.a₁ = 0 ∧ d.W.a₂ = 0 ∧ d.W.a₃ = 0) :=
     ⟨⟨d.short.1, d.short.2.1, d.short.2.2.1⟩⟩
-  simp only [varBaseMul, mapAccumM]
+  simp only [varBaseMul, scaleRound, mapAccumM]
   mvcgen
   rename_i s hpre
   intro sbase _ hsx hsy
@@ -991,6 +997,180 @@ private theorem bitWit_ok [Field F] [DecidableEq F] {env : Assignments F}
   simp [bitWit, AsProver.readCVar, hxb, hyb, hxi, hyi, hb,
     Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
 
+open Std.Do in
+open Kimchi.Gate.VarBaseMul (build_fields build_nPrime
+  build_step0 build_step1 build_step2 build_step3 build_step4) in
+/-- **One round is the gate's canonical row.** On readable base, accumulator and
+register cells and five readable bits, the honest round accepts and its collected
+`ScaleRound` reads as `build` at exactly those values — the returned accumulator and
+register being that row's `x5`/`y5`/`nPrime`. Stated over the gate model's row rather
+than any particular walk, so the caller's loop supplies only the reads and gets the
+row back; registered, so `mvcgen` applies it once per iteration. -/
+@[spec] theorem scaleRound_complete_spec [Field F] [DecidableEq F]
+    (base : AffinePoint (FVar F)) (st : AffinePoint (FVar F) × FVar F)
+    (bs : Vector (FVar F) 5)
+    (Q : PostCond (ScaleRound F × (AffinePoint (FVar F) × FVar F))
+      (.arg (ProverState F) (.except EvalError .pure))) :
+    ⦃Complete
+        (fun env => (base.x.eval env).isOk ∧ (base.y.eval env).isOk ∧
+          (st.1.x.eval env).isOk ∧ (st.1.y.eval env).isOk ∧ (st.2.eval env).isOk ∧
+          ∀ (j : ℕ) (hj : j < 5), ((bs[j]'hj).eval env).isOk)
+        (fun env r env' => ∀ xT yT x0 y0 nv b0 b1 b2 b3 b4,
+          base.x.eval env = .ok xT → base.y.eval env = .ok yT →
+          st.1.x.eval env = .ok x0 → st.1.y.eval env = .ok y0 →
+          st.2.eval env = .ok nv →
+          bs[0].eval env = .ok b0 → bs[1].eval env = .ok b1 →
+          bs[2].eval env = .ok b2 → bs[3].eval env = .ok b3 →
+          bs[4].eval env = .ok b4 →
+          ScaleRound.eval env' r.1
+              = .ok (Kimchi.Gate.VarBaseMul.build xT yT x0 y0 nv b0 b1 b2 b3 b4)
+            ∧ r.2.1.x.eval env'
+                = .ok (Kimchi.Gate.VarBaseMul.build xT yT x0 y0 nv b0 b1 b2 b3 b4).x5
+            ∧ r.2.1.y.eval env'
+                = .ok (Kimchi.Gate.VarBaseMul.build xT yT x0 y0 nv b0 b1 b2 b3 b4).y5
+            ∧ r.2.2.eval env'
+                = .ok (Kimchi.Gate.VarBaseMul.build xT yT x0 y0 nv b0 b1 b2 b3 b4).nPrime)
+        Q⦄
+    (scaleRound (c := KimchiProverC F) base st bs)
+    ⦃Q⦄ := by
+  simp only [scaleRound]
+  mvcgen
+  rename_i st₀ hpre
+  obtain ⟨⟨hbxk, hbyk, haxk, hayk, hank, hbk⟩, hk⟩ := hpre
+  obtain ⟨xT, hxT⟩ := CVar.evalOk hbxk
+  obtain ⟨yT, hyT⟩ := CVar.evalOk hbyk
+  obtain ⟨x0, hx0⟩ := CVar.evalOk haxk
+  obtain ⟨y0, hy0⟩ := CVar.evalOk hayk
+  obtain ⟨nv, hnv⟩ := CVar.evalOk hank
+  obtain ⟨b0, hb0⟩ := CVar.evalOk (hbk 0 (by omega))
+  obtain ⟨b1, hb1⟩ := CVar.evalOk (hbk 1 (by omega))
+  obtain ⟨b2, hb2⟩ := CVar.evalOk (hbk 2 (by omega))
+  obtain ⟨b3, hb3⟩ := CVar.evalOk (hbk 3 (by omega))
+  obtain ⟨b4, hb4⟩ := CVar.evalOk (hbk 4 (by omega))
+  -- the register advice computes the row's `nPrime`
+  have hnOk : nAccWit st.2 bs st₀.env
+      = .ok (Kimchi.Gate.VarBaseMul.build xT yT x0 y0 nv b0 b1 b2 b3 b4).nPrime := by
+    rw [nAccWit_ok hnv hb0 hb1 hb2 hb3 hb4, build_nPrime]
+  refine ⟨by rw [hnOk]; rfl, fun nAcc st₁ hgN hle₁ => ?_⟩
+  have hnA := reads_fvar (hgN _ hnOk)
+  mvcgen
+  -- the five bit steps, each reading the previous accumulator
+  have hw0Ok := bitWit_ok (CVar.eval_le hle₁ hxT) (CVar.eval_le hle₁ hyT)
+    (CVar.eval_le hle₁ hx0) (CVar.eval_le hle₁ hy0) (CVar.eval_le hle₁ hb0)
+  refine ⟨by rw [hw0Ok]; rfl, fun w0 st₂ hg0 hle₂ => ?_⟩
+  obtain ⟨hs0', -, -, hx1', hy1'⟩ := hg0 _ hw0Ok
+  obtain ⟨es0, ex0, ey0⟩ := build_step0 xT yT x0 y0 nv b0 b1 b2 b3 b4
+  obtain ⟨-, -, hfx0, hfy0, -, hfb0, hfb1, hfb2, hfb3, hfb4⟩ :=
+    build_fields xT yT x0 y0 nv b0 b1 b2 b3 b4
+  rw [← es0] at hs0'
+  rw [← ex0] at hx1'
+  rw [← ey0] at hy1'
+  have hs0 := reads_fvar hs0'
+  have hx1 := reads_fvar hx1'
+  have hy1 := reads_fvar hy1'
+  mvcgen
+  have hw1Ok := bitWit_ok (acc := ⟨w0.2.2.2.1, w0.2.2.2.2⟩)
+    (CVar.eval_le (hle₁.trans hle₂) hxT) (CVar.eval_le (hle₁.trans hle₂) hyT)
+    hx1 hy1 (CVar.eval_le (hle₁.trans hle₂) hb1)
+  refine ⟨by rw [hw1Ok]; rfl, fun w1 st₃ hg1 hle₃ => ?_⟩
+  obtain ⟨hs1', -, -, hx2', hy2'⟩ := hg1 _ hw1Ok
+  obtain ⟨es1, ex1, ey1⟩ := build_step1 xT yT x0 y0 nv b0 b1 b2 b3 b4
+  rw [← es1] at hs1'
+  rw [← ex1] at hx2'
+  rw [← ey1] at hy2'
+  have hs1 := reads_fvar hs1'
+  have hx2 := reads_fvar hx2'
+  have hy2 := reads_fvar hy2'
+  mvcgen
+  have hw2Ok := bitWit_ok (acc := ⟨w1.2.2.2.1, w1.2.2.2.2⟩)
+    (CVar.eval_le ((hle₁.trans hle₂).trans hle₃) hxT)
+    (CVar.eval_le ((hle₁.trans hle₂).trans hle₃) hyT) hx2 hy2
+    (CVar.eval_le ((hle₁.trans hle₂).trans hle₃) hb2)
+  refine ⟨by rw [hw2Ok]; rfl, fun w2 st₄ hg2 hle₄ => ?_⟩
+  obtain ⟨hs2', -, -, hx3', hy3'⟩ := hg2 _ hw2Ok
+  obtain ⟨es2, ex2, ey2⟩ := build_step2 xT yT x0 y0 nv b0 b1 b2 b3 b4
+  rw [← es2] at hs2'
+  rw [← ex2] at hx3'
+  rw [← ey2] at hy3'
+  have hs2 := reads_fvar hs2'
+  have hx3 := reads_fvar hx3'
+  have hy3 := reads_fvar hy3'
+  mvcgen
+  have hw3Ok := bitWit_ok (acc := ⟨w2.2.2.2.1, w2.2.2.2.2⟩)
+    (CVar.eval_le (((hle₁.trans hle₂).trans hle₃).trans hle₄) hxT)
+    (CVar.eval_le (((hle₁.trans hle₂).trans hle₃).trans hle₄) hyT) hx3 hy3
+    (CVar.eval_le (((hle₁.trans hle₂).trans hle₃).trans hle₄) hb3)
+  refine ⟨by rw [hw3Ok]; rfl, fun w3 st₅ hg3 hle₅ => ?_⟩
+  obtain ⟨hs3', -, -, hx4', hy4'⟩ := hg3 _ hw3Ok
+  obtain ⟨es3, ex3, ey3⟩ := build_step3 xT yT x0 y0 nv b0 b1 b2 b3 b4
+  rw [← es3] at hs3'
+  rw [← ex3] at hx4'
+  rw [← ey3] at hy4'
+  have hs3 := reads_fvar hs3'
+  have hx4 := reads_fvar hx4'
+  have hy4 := reads_fvar hy4'
+  mvcgen
+  have hw4Ok := bitWit_ok (acc := ⟨w3.2.2.2.1, w3.2.2.2.2⟩)
+    (CVar.eval_le ((((hle₁.trans hle₂).trans hle₃).trans hle₄).trans hle₅) hxT)
+    (CVar.eval_le ((((hle₁.trans hle₂).trans hle₃).trans hle₄).trans hle₅) hyT)
+    hx4 hy4
+    (CVar.eval_le ((((hle₁.trans hle₂).trans hle₃).trans hle₄).trans hle₅) hb4)
+  refine ⟨by rw [hw4Ok]; rfl, fun w4 st₆ hg4 hle₆ => ?_⟩
+  obtain ⟨hs4', -, -, hx5', hy5'⟩ := hg4 _ hw4Ok
+  obtain ⟨es4, ex4, ey4⟩ := build_step4 xT yT x0 y0 nv b0 b1 b2 b3 b4
+  rw [← es4] at hs4'
+  rw [← ex4] at hx5'
+  rw [← ey4] at hy5'
+  have hs4 := reads_fvar hs4'
+  have hx5 := reads_fvar hx5'
+  have hy5 := reads_fvar hy5'
+  mvcgen
+  have hleA : st₀.env.Le st₆.env :=
+    hle₁.trans ((((hle₂.trans hle₃).trans hle₄).trans hle₅).trans hle₆)
+  refine hk _ st₆ ?_ hleA
+  intro xT' yT' x0' y0' nv' b0' b1' b2' b3' b4'
+    hxT' hyT' hx0' hy0' hnv' hb0' hb1' hb2' hb3' hb4'
+  rw [hxT] at hxT'; injection hxT' with hxT'
+  rw [hyT] at hyT'; injection hyT' with hyT'
+  rw [hx0] at hx0'; injection hx0' with hx0'
+  rw [hy0] at hy0'; injection hy0' with hy0'
+  rw [hnv] at hnv'; injection hnv' with hnv'
+  rw [hb0] at hb0'; injection hb0' with hb0'
+  rw [hb1] at hb1'; injection hb1' with hb1'
+  rw [hb2] at hb2'; injection hb2' with hb2'
+  rw [hb3] at hb3'; injection hb3' with hb3'
+  rw [hb4] at hb4'; injection hb4' with hb4'
+  subst hxT' hyT' hx0' hy0' hnv' hb0' hb1' hb2' hb3' hb4'
+  refine ⟨evalScale_ok_iff.mpr ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_,
+      ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩, hx5, hy5,
+    CVar.eval_le ((((hle₂.trans hle₃).trans hle₄).trans hle₅).trans hle₆) hnA⟩
+  · exact CVar.eval_le hleA hxT
+  · exact CVar.eval_le hleA hyT
+  · rw [hfx0]; exact CVar.eval_le hleA hx0
+  · rw [hfy0]; exact CVar.eval_le hleA hy0
+  · exact CVar.eval_le (((hle₃.trans hle₄).trans hle₅).trans hle₆) hx1
+  · exact CVar.eval_le (((hle₃.trans hle₄).trans hle₅).trans hle₆) hy1
+  · exact CVar.eval_le ((hle₄.trans hle₅).trans hle₆) hx2
+  · exact CVar.eval_le ((hle₄.trans hle₅).trans hle₆) hy2
+  · exact CVar.eval_le (hle₅.trans hle₆) hx3
+  · exact CVar.eval_le (hle₅.trans hle₆) hy3
+  · exact CVar.eval_le hle₆ hx4
+  · exact CVar.eval_le hle₆ hy4
+  · exact hx5
+  · exact hy5
+  · exact CVar.eval_le hleA hnv
+  · exact CVar.eval_le ((((hle₂.trans hle₃).trans hle₄).trans hle₅).trans hle₆) hnA
+  · rw [hfb0]; exact CVar.eval_le hleA hb0
+  · rw [hfb1]; exact CVar.eval_le hleA hb1
+  · rw [hfb2]; exact CVar.eval_le hleA hb2
+  · rw [hfb3]; exact CVar.eval_le hleA hb3
+  · rw [hfb4]; exact CVar.eval_le hleA hb4
+  · exact CVar.eval_le (((hle₃.trans hle₄).trans hle₅).trans hle₆) hs0
+  · exact CVar.eval_le ((hle₄.trans hle₅).trans hle₆) hs1
+  · exact CVar.eval_le (hle₅.trans hle₆) hs2
+  · exact CVar.eval_le hle₆ hs3
+  · exact hs4
+
 open Kimchi.Gate.VarBaseMul (y_ne_zero_of_odd_order smul_ne_zero_of_lt) in
 /-- The gadget is complete, generic over the curve dictionary: the honest prover run
 accepts on a readable on-curve base and a readable in-range faithful scalar whose
@@ -1152,7 +1332,14 @@ theorem varBaseMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
         Kimchi.Gate.VarBaseMul.Holds w⌝
   case vc1.step =>
     rename_i pref cur suff hsplit b s' hinv
-    obtain ⟨hLe, ⟨hxI, hyI, hnI⟩, hrounds⟩ := hinv
+    obtain ⟨hLe, ⟨hxI₀, hyI₀, hnI₀⟩, hrounds⟩ := hinv
+    -- name the walk index the loop cursor carries
+    have hxI : b.fst.1.x.eval s'.env
+        = .ok (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF pref.length).x0 := hxI₀
+    have hyI : b.fst.1.y.eval s'.env
+        = .ok (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF pref.length).y0 := hyI₀
+    have hnI : b.fst.2.eval s'.env
+        = .ok (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF pref.length).n := hnI₀
     have hkrows : pref.length < chunks := by
       have hlen := congrArg List.length hsplit
       simp only [List.length_map, List.length_range, List.length_append,
@@ -1200,189 +1387,40 @@ theorem varBaseMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
       intro j hj
       simp only [Vector.getElem_ofFn]
       exact hbit j hj
-    -- shorthands for the row
-    have hxT' : base.x.eval s'.env = .ok xv :=
-      CVar.eval_le ((hle₂.trans hle₃).trans hLe) hsx
-    have hyT' : base.y.eval s'.env = .ok yv :=
-      CVar.eval_le ((hle₂.trans hle₃).trans hLe) hsy
     have hcurj0 : ((Vector.ofFn (fun j : Fin 5 =>
         ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
           (.const 0)))[0]'(by omega)).eval s'.env
         = .ok (bsF (5 * pref.length)) := hcurj 0 (by omega)
-    -- the register witness
-    have hnOk : nAccWit b.fst.2 (Vector.ofFn (fun j : Fin 5 =>
-        ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
-          (.const 0))) s'.env
-        = .ok ((Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-            pref.length).nPrime) := by
-      rw [nAccWit_ok hnI hcurj0 (hcurj 1 (by omega))
-        (hcurj 2 (by omega)) (hcurj 3 (by omega)) (hcurj 4 (by omega)),
-        Kimchi.Gate.VarBaseMul.chainBuild_nPrime]
-    refine ⟨by rw [hnOk]; rfl, fun nAcc st₄ hgN hle₄ => ?_⟩
-    have hnA : nAcc.eval st₄.env = .ok ((Kimchi.Gate.VarBaseMul.chainBuild
-        xv yv x0v y0v 0 bsF pref.length).nPrime) := hgN _ hnOk
-    mvcgen
-    -- the five bit steps: each quintet reads the previous accumulator and
-    -- computes `stepBit`, i.e. the walk's next fields
-    have hw0Ok := bitWit_ok (CVar.eval_le hle₄ hxT') (CVar.eval_le hle₄ hyT')
-      (CVar.eval_le hle₄ hxI) (CVar.eval_le hle₄ hyI) (CVar.eval_le hle₄ hcurj0)
-    refine ⟨by rw [hw0Ok]; rfl, fun w0 st₅ hg0 hle₅ => ?_⟩
-    obtain ⟨hs0e', -, -, hx1e', hy1e'⟩ := hg0 _ hw0Ok
-    obtain ⟨es0, ex0, ey0⟩ :=
-      Kimchi.Gate.VarBaseMul.chainBuild_step0 xv yv x0v y0v 0 bsF pref.length
-    rw [← es0] at hs0e'
-    rw [← ex0] at hx1e'
-    rw [← ey0] at hy1e'
-    have hs0e := reads_fvar hs0e'
-    have hx1e := reads_fvar hx1e'
-    have hy1e := reads_fvar hy1e'
-    mvcgen
-    have hw1Ok := bitWit_ok (acc := ⟨w0.2.2.2.1, w0.2.2.2.2⟩)
-      (CVar.eval_le (hle₄.trans hle₅) hxT') (CVar.eval_le (hle₄.trans hle₅) hyT')
-      hx1e hy1e (CVar.eval_le (hle₄.trans hle₅) (hcurj 1 (by omega)))
-    refine ⟨by rw [hw1Ok]; rfl, fun w1 st₆ hg1 hle₆ => ?_⟩
-    obtain ⟨hs1e', -, -, hx2e', hy2e'⟩ := hg1 _ hw1Ok
-    obtain ⟨es1, ex1, ey1⟩ :=
-      Kimchi.Gate.VarBaseMul.chainBuild_step1 xv yv x0v y0v 0 bsF pref.length
-    rw [← es1] at hs1e'
-    rw [← ex1] at hx2e'
-    rw [← ey1] at hy2e'
-    have hs1e := reads_fvar hs1e'
-    have hx2e := reads_fvar hx2e'
-    have hy2e := reads_fvar hy2e'
-    mvcgen
-    have hw2Ok := bitWit_ok (acc := ⟨w1.2.2.2.1, w1.2.2.2.2⟩)
-      (CVar.eval_le ((hle₄.trans hle₅).trans hle₆) hxT')
-      (CVar.eval_le ((hle₄.trans hle₅).trans hle₆) hyT') hx2e hy2e
-      (CVar.eval_le ((hle₄.trans hle₅).trans hle₆) (hcurj 2 (by omega)))
-    refine ⟨by rw [hw2Ok]; rfl, fun w2 st₇ hg2 hle₇ => ?_⟩
-    obtain ⟨hs2e', -, -, hx3e', hy3e'⟩ := hg2 _ hw2Ok
-    obtain ⟨es2, ex2, ey2⟩ :=
-      Kimchi.Gate.VarBaseMul.chainBuild_step2 xv yv x0v y0v 0 bsF pref.length
-    rw [← es2] at hs2e'
-    rw [← ex2] at hx3e'
-    rw [← ey2] at hy3e'
-    have hs2e := reads_fvar hs2e'
-    have hx3e := reads_fvar hx3e'
-    have hy3e := reads_fvar hy3e'
-    mvcgen
-    have hw3Ok := bitWit_ok (acc := ⟨w2.2.2.2.1, w2.2.2.2.2⟩)
-      (CVar.eval_le (((hle₄.trans hle₅).trans hle₆).trans hle₇) hxT')
-      (CVar.eval_le (((hle₄.trans hle₅).trans hle₆).trans hle₇) hyT') hx3e hy3e
-      (CVar.eval_le (((hle₄.trans hle₅).trans hle₆).trans hle₇)
-        (hcurj 3 (by omega)))
-    refine ⟨by rw [hw3Ok]; rfl, fun w3 st₈ hg3 hle₈ => ?_⟩
-    obtain ⟨hs3e', -, -, hx4e', hy4e'⟩ := hg3 _ hw3Ok
-    obtain ⟨es3, ex3, ey3⟩ :=
-      Kimchi.Gate.VarBaseMul.chainBuild_step3 xv yv x0v y0v 0 bsF pref.length
-    rw [← es3] at hs3e'
-    rw [← ex3] at hx4e'
-    rw [← ey3] at hy4e'
-    have hs3e := reads_fvar hs3e'
-    have hx4e := reads_fvar hx4e'
-    have hy4e := reads_fvar hy4e'
-    mvcgen
-    have hw4Ok := bitWit_ok (acc := ⟨w3.2.2.2.1, w3.2.2.2.2⟩)
-      (CVar.eval_le ((((hle₄.trans hle₅).trans hle₆).trans hle₇).trans hle₈) hxT')
-      (CVar.eval_le ((((hle₄.trans hle₅).trans hle₆).trans hle₇).trans hle₈) hyT')
-      hx4e hy4e
-      (CVar.eval_le ((((hle₄.trans hle₅).trans hle₆).trans hle₇).trans hle₈)
-        (hcurj 4 (by omega)))
-    refine ⟨by rw [hw4Ok]; rfl, fun w4 st₉ hg4 hle₉ => ?_⟩
-    obtain ⟨hs4e', -, -, hx5e', hy5e'⟩ := hg4 _ hw4Ok
-    obtain ⟨es4, ex4, ey4⟩ :=
-      Kimchi.Gate.VarBaseMul.chainBuild_step4 xv yv x0v y0v 0 bsF pref.length
-    rw [← es4] at hs4e'
-    rw [← ex4] at hx5e'
-    rw [← ey4] at hy5e'
-    have hs4e := reads_fvar hs4e'
-    have hx5e := reads_fvar hx5e'
-    have hy5e := reads_fvar hy5e'
-    mvcgen
-    -- the collected round reads as the walk's row
-    have hleB : st₄.env.Le st₉.env :=
-      (((hle₅.trans hle₆).trans hle₇).trans hle₈).trans hle₉
-    have hleA : s'.env.Le st₉.env := hle₄.trans hleB
-    have hround : ScaleRound.eval st₉.env
-        { acc0 := b.fst.1,
-          acc1 := ⟨w0.2.2.2.1, w0.2.2.2.2⟩, acc2 := ⟨w1.2.2.2.1, w1.2.2.2.2⟩,
-          acc3 := ⟨w2.2.2.2.1, w2.2.2.2.2⟩, acc4 := ⟨w3.2.2.2.1, w3.2.2.2.2⟩,
-          acc5 := ⟨w4.2.2.2.1, w4.2.2.2.2⟩,
-          bit0 := (Vector.ofFn (fun j : Fin 5 =>
-            ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
-              (.const 0)))[0],
-          bit1 := (Vector.ofFn (fun j : Fin 5 =>
-            ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
-              (.const 0)))[1],
-          bit2 := (Vector.ofFn (fun j : Fin 5 =>
-            ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
-              (.const 0)))[2],
-          bit3 := (Vector.ofFn (fun j : Fin 5 =>
-            ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
-              (.const 0)))[3],
-          bit4 := (Vector.ofFn (fun j : Fin 5 =>
-            ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
-              (.const 0)))[4],
-          slope0 := w0.1, slope1 := w1.1, slope2 := w2.1, slope3 := w3.1,
-          slope4 := w4.1,
-          nPrev := b.fst.2, nNext := nAcc, base := base }
-        = .ok (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-            pref.length) := by
-      obtain ⟨hfxT, hfyT, hfb0, hfb1, hfb2, hfb3, hfb4⟩ :=
-        Kimchi.Gate.VarBaseMul.chainBuild_fields xv yv x0v y0v 0 bsF pref.length
-      refine evalScale_ok_iff.mpr
-        ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_,
-          ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
-      · rw [hfxT]
-        exact CVar.eval_le hleA hxT'
-      · rw [hfyT]
-        exact CVar.eval_le hleA hyT'
-      · exact CVar.eval_le hleA hxI
-      · exact CVar.eval_le hleA hyI
-      · exact CVar.eval_le ((((hle₆.trans hle₇).trans hle₈).trans hle₉)) hx1e
-      · exact CVar.eval_le ((((hle₆.trans hle₇).trans hle₈).trans hle₉)) hy1e
-      · exact CVar.eval_le (((hle₇.trans hle₈).trans hle₉)) hx2e
-      · exact CVar.eval_le (((hle₇.trans hle₈).trans hle₉)) hy2e
-      · exact CVar.eval_le ((hle₈.trans hle₉)) hx3e
-      · exact CVar.eval_le ((hle₈.trans hle₉)) hy3e
-      · exact CVar.eval_le hle₉ hx4e
-      · exact CVar.eval_le hle₉ hy4e
-      · exact hx5e
-      · exact hy5e
-      · exact CVar.eval_le hleA hnI
-      · exact CVar.eval_le hleB hnA
-      · rw [hfb0]
-        exact CVar.eval_le hleA hcurj0
-      · rw [hfb1]
-        exact CVar.eval_le hleA (hcurj 1 (by omega))
-      · rw [hfb2]
-        exact CVar.eval_le hleA (hcurj 2 (by omega))
-      · rw [hfb3]
-        exact CVar.eval_le hleA (hcurj 3 (by omega))
-      · rw [hfb4]
-        exact CVar.eval_le hleA (hcurj 4 (by omega))
-      · exact CVar.eval_le ((((hle₆.trans hle₇).trans hle₈).trans hle₉)) hs0e
-      · exact CVar.eval_le (((hle₇.trans hle₈).trans hle₉)) hs1e
-      · exact CVar.eval_le ((hle₈.trans hle₉)) hs2e
-      · exact CVar.eval_le hle₉ hs3e
-      · exact hs4e
+    have hxT' : base.x.eval s'.env = .ok xv :=
+      CVar.eval_le ((hle₂.trans hle₃).trans hLe) hsx
+    have hyT' : base.y.eval s'.env = .ok yv :=
+      CVar.eval_le ((hle₂.trans hle₃).trans hLe) hsy
+    -- the round's own law does the rest
+    refine ⟨⟨by rw [hxT']; rfl, by rw [hyT']; rfl, by rw [hxI]; rfl,
+      by rw [hyI]; rfl, by rw [hnI]; rfl,
+      fun j hj => by rw [hcurj j hj]; rfl⟩, fun r st₄ hpost hle₄ => ?_⟩
+    obtain ⟨hrow, hx5, hy5, hn5⟩ := hpost xv yv _ _ _ _ _ _ _ _
+      hxT' hyT' hxI hyI hnI hcurj0 (hcurj 1 (by omega))
+      (hcurj 2 (by omega)) (hcurj 3 (by omega)) (hcurj 4 (by omega))
+    rw [← Kimchi.Gate.VarBaseMul.chainBuild_eta xv yv x0v y0v 0 bsF pref.length] at hrow hx5 hy5 hn5
     -- restore the invariant at the extended prefix
-    refine ⟨hLe.trans hleA, ⟨?_, ?_, ?_⟩, ?_⟩
+    intro _
+    refine ⟨hLe.trans hle₄, ⟨?_, ?_, ?_⟩, ?_⟩
     · simp only [List.length_append, List.length_cons, List.length_nil]
       rw [Kimchi.Gate.VarBaseMul.chainBuild_succ_x0]
-      exact hx5e
+      exact hx5
     · simp only [List.length_append, List.length_cons, List.length_nil]
       rw [Kimchi.Gate.VarBaseMul.chainBuild_succ_y0]
-      exact hy5e
+      exact hy5
     · simp only [List.length_append, List.length_cons, List.length_nil]
       rw [Kimchi.Gate.VarBaseMul.chainBuild_succ_n]
-      exact CVar.eval_le hleB hnA
-    · intro r hr
-      simp only [List.mem_append, List.mem_cons, List.not_mem_nil, or_false] at hr
-      rcases hr with hr | rfl
-      · obtain ⟨w, hev, hHw⟩ := hrounds r hr
-        exact ⟨w, evalScale_le hleA hev, hHw⟩
-      · exact ⟨_, hround, hHolds pref.length hkrows⟩
+      exact hn5
+    · intro r' hr'
+      simp only [List.mem_append, List.mem_cons, List.not_mem_nil, or_false] at hr'
+      rcases hr' with hr' | rfl
+      · obtain ⟨w, hev, hHw⟩ := hrounds r' hr'
+        exact ⟨w, evalScale_le hle₄ hev, hHw⟩
+      · exact ⟨_, hrow, hHolds pref.length hkrows⟩
   case vc2.vc1.vc1.vc1.refine_2.pre =>
     refine ⟨Assignments.Le.refl st₃.env, ⟨hx0e, hy0e, rfl⟩, fun r hr => ?_⟩
     exact absurd hr List.not_mem_nil

--- a/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
@@ -1019,7 +1019,9 @@ open Kimchi.Gate.VarBaseMul (y_ne_zero_of_odd_order smul_ne_zero_of_lt) in
 accepts on a readable on-curve base and a readable in-range faithful scalar whose
 `Type1` decode satisfies the ladder regime, and the returned point reads as the
 defining equation's honest side — `[fromShifted t]·g` at the scalar's canonical
-value. The regime precondition is per-scalar, exactly the fact the soundness law
+value. The returned bits read as the scalar's, LSB-first: `scaleFast2` pins the ones
+above its width to zero, so its own completeness needs them named here.
+The regime precondition is per-scalar, exactly the fact the soundness law
 conditions on; at the deployed widths the subwrap arm discharges it for every chunk
 count below full width, and at full width it is the `Type1` forbidden-band check's
 contract. The loop invariant identifies the run with the honest walk `chainBuild`;
@@ -1041,14 +1043,18 @@ theorem varBaseMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
               (Type1.fromShifted (5 * chunks) ⟨(ToNat.toNat v : ℤ)⟩)) ∧
           (∀ x y, base'.x.eval env = .ok x → base'.y.eval env = .ok y →
             d.W.Nonsingular x y))
-        (fun env r env' => ∀ v xv yv, scalar.val.eval env = .ok v →
-          base'.x.eval env = .ok xv → base'.y.eval env = .ok yv →
-          ∀ hT : d.W.Nonsingular xv yv,
-          ∃ xS yS, r.g.x.eval env' = .ok xS ∧ r.g.y.eval env' = .ok yS ∧
-            ∃ hfin : d.W.Nonsingular xS yS,
-              Point.some _ _ hfin
-                = Type1.fromShifted (5 * chunks) ⟨(ToNat.toNat v : ℤ)⟩
-                    • Point.some _ _ hT)
+        (fun env r env' =>
+          (∀ v, scalar.val.eval env = .ok v →
+            ∀ (i : ℕ) (hi : i < n), (r.lsbBits[i]'hi).eval env'
+              = .ok (if (ToNat.toNat v).testBit i then (1 : F) else 0)) ∧
+          (∀ v xv yv, scalar.val.eval env = .ok v →
+            base'.x.eval env = .ok xv → base'.y.eval env = .ok yv →
+            ∀ hT : d.W.Nonsingular xv yv,
+            ∃ xS yS, r.g.x.eval env' = .ok xS ∧ r.g.y.eval env' = .ok yS ∧
+              ∃ hfin : d.W.Nonsingular xS yS,
+                Point.some _ _ hfin
+                  = Type1.fromShifted (5 * chunks) ⟨(ToNat.toNat v : ℤ)⟩
+                      • Point.some _ _ hT))
         Q⦄
     (varBaseMul (c := KimchiProverC F) n chunks base' scalar)
     ⦃Q⦄ := by
@@ -1450,8 +1456,15 @@ theorem varBaseMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
     simp only [wp, PredTrans.apply, prove]
     intro hf
     refine hk ⟨finp.fst.1, bits⟩ ⟨st₅.nv, st₅.env, hf⟩
-      (fun v' xv' yv' hv' hxv' hyv' hT' => ?_)
+      (fun v' hv' i hi => ?_) (fun v' xv' yv' hv' hxv' hyv' hT' => ?_)
       ((hle₁.trans (hle₂.trans hle₃)).trans (hLe.trans (hle₄.trans hle₅)))
+    · -- the scalar's bits: the honest witness's reads, transported to the final table
+      rw [hv] at hv'
+      injection hv' with hv'
+      subst hv'
+      have hr := hread i hi
+      simp only [Vector.getElem_ofFn] at hr
+      exact CVar.eval_le (hle₃.trans (hLe.trans (hle₄.trans hle₅))) hr
     rw [hv] at hv'
     injection hv' with hv'
     rw [hxv] at hxv'

--- a/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
@@ -1154,16 +1154,31 @@ theorem varBaseMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
     split
     · exact Or.inr rfl
     · exact Or.inl rfl
-  have hladder : Kimchi.Gate.VarBaseMul.ladderK bsF (5 * chunks)
+  -- the walk's bits ARE the stream, so its run reads back as the stream
+  have hrun : Kimchi.Gate.VarBaseMul.runBits
+      (fun i => Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF i) chunks
+      = (List.range (5 * chunks)).map bsF := by
+    unfold Kimchi.Gate.VarBaseMul.runBits
+    rw [List.flatMap_congr (fun i _ => by
+      obtain ⟨-, -, hb0, hb1, hb2, hb3, hb4⟩ :=
+        chainBuildV_fields xv yv x0v y0v 0 bsF i
+      rw [hb0, hb1, hb2, hb3, hb4]),
+      Kimchi.Gate.VarBaseMul.flatMap_range_window]
+  -- and the walk's ladder is the scalar's `Type1` unshift, by the sound side's decode
+  have hladder : Kimchi.Gate.VarBaseMul.gateLadder
+        (fun i => Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF i) (5 * chunks)
       = 2 * (nn : ℤ) + 2 ^ (5 * chunks) + 1 := by
-    rw [Kimchi.Gate.VarBaseMul.ladderK_eq_bitsVal bsF (5 * chunks) hbsb, hbsF,
+    rw [Kimchi.Gate.VarBaseMul.gateLadder_eq_register,
+      Kimchi.Gate.VarBaseMul.gateRegister_eq_bitsVal, hrun, hbsF,
       Kimchi.Gate.VarBaseMul.bitsVal_testBit nn (5 * chunks) hrange]
+  simp only [HasCurve.LadderRegime, Type1.fromShifted] at hregpre
   have hregime' : 3 * 2 ^ (5 * chunks) ≤ d.W.order ∨
       (2 ^ (5 * chunks - 1) < d.W.order ∧ d.W.order < 2 ^ (5 * chunks) ∧
         d.W.order % 4 = 1 ∧
-        Kimchi.Gate.VarBaseMul.ladderK bsF (5 * chunks)
+        Kimchi.Gate.VarBaseMul.gateLadder
+            (fun i => Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF i)
+            (5 * chunks)
           ∉ Kimchi.Gate.VarBaseMul.forbiddenValues d.W.order) := by
-    simp only [HasCurve.LadderRegime, Type1.fromShifted] at hregpre
     rcases hregpre with h | ⟨h1, h2', h3, h4⟩
     · exact Or.inl h
     · exact Or.inr ⟨h1, h2', h3, by rw [hladder]; exact h4⟩
@@ -1531,15 +1546,6 @@ theorem varBaseMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
     obtain ⟨hLe, ⟨hxP, hyP, hnP⟩, hrounds⟩ := hinv
     simp only [List.length_map, List.length_range] at hxP hyP hnP hrounds
     -- the register pin: the final register reads as the scalar
-    have hrun : Kimchi.Gate.VarBaseMul.runBits
-        (fun i => Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF i) chunks
-        = (List.range (5 * chunks)).map bsF := by
-      unfold Kimchi.Gate.VarBaseMul.runBits
-      rw [List.flatMap_congr (fun i _ => by
-        obtain ⟨-, -, hb0, hb1, hb2, hb3, hb4⟩ :=
-          chainBuildV_fields xv yv x0v y0v 0 bsF i
-        rw [hb0, hb1, hb2, hb3, hb4]),
-        Kimchi.Gate.VarBaseMul.flatMap_range_window]
     have hreg : (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF chunks).n
         = v := by
       have hchain := Kimchi.Gate.VarBaseMul.chain_accN chunks
@@ -1602,11 +1608,7 @@ theorem varBaseMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
         rw [hx1, hy1, hx0', hy0']
         exact ⟨rfl, rfl⟩)
       (fun i _ => ⟨rfl, rfl⟩) hP0ns hP0eq d.two_ne d.odd
-      (by
-        rw [Kimchi.Gate.VarBaseMul.gateLadder_eq_register,
-          Kimchi.Gate.VarBaseMul.gateRegister_eq_bitsVal, hrun, hbsF,
-          Kimchi.Gate.VarBaseMul.bitsVal_testBit nn (5 * chunks) hrange])
-      (by rw [← hladder]; exact hregime')
+      hladder.symm hregpre
     have hax := accX_chainBuildV xv yv x0v y0v 0 bsF chunks
     have hay := accY_chainBuildV xv yv x0v y0v 0 bsF chunks
     have hfin : d.W.Nonsingular

--- a/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
@@ -1008,40 +1008,6 @@ private theorem bitWit_ok [Field F] [DecidableEq F] {env : Assignments F}
   simp [bitWit, AsProver.readCVar, hxb, hyb, hxi, hyi, hb,
     Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
 
-/-- The walk's base and bit cells are the arguments, at every row. -/
-private theorem chainBuildV_fields [Field F] [DecidableEq F]
-    (xT yT x0 y0 n0 : F) (bs : ℕ → F) (m : ℕ) :
-    (Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs m).xT = xT
-    ∧ (Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs m).yT = yT
-    ∧ (Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs m).b0 = bs (5 * m)
-    ∧ (Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs m).b1 = bs (5 * m + 1)
-    ∧ (Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs m).b2 = bs (5 * m + 2)
-    ∧ (Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs m).b3 = bs (5 * m + 3)
-    ∧ (Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs m).b4 = bs (5 * m + 4) := by
-  cases m <;> exact ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
-
-/-- `accX`/`accY`/`accN` at the walk are the next row's input cells. -/
-private theorem accX_chainBuildV [Field F] [DecidableEq F]
-    (xT yT x0 y0 n0 : F) (bs : ℕ → F) (m : ℕ) :
-    Kimchi.Gate.VarBaseMul.accX
-        (fun i => Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs i) m
-      = (Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs m).x0 := by
-  cases m <;> rfl
-
-private theorem accY_chainBuildV [Field F] [DecidableEq F]
-    (xT yT x0 y0 n0 : F) (bs : ℕ → F) (m : ℕ) :
-    Kimchi.Gate.VarBaseMul.accY
-        (fun i => Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs i) m
-      = (Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs m).y0 := by
-  cases m <;> rfl
-
-private theorem accN_chainBuildV [Field F] [DecidableEq F]
-    (xT yT x0 y0 n0 : F) (bs : ℕ → F) (m : ℕ) :
-    Kimchi.Gate.VarBaseMul.accN
-        (fun i => Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs i) m
-      = (Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs m).n := by
-  cases m <;> rfl
-
 /-- The `F`-leaf reading is the eval equation — the coercion the grant consumers
 apply (unification alone cannot unfold the instance projection against a
 metavariable-headed expected type). -/
@@ -1161,7 +1127,7 @@ theorem varBaseMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
     unfold Kimchi.Gate.VarBaseMul.runBits
     rw [List.flatMap_congr (fun i _ => by
       obtain ⟨-, -, hb0, hb1, hb2, hb3, hb4⟩ :=
-        chainBuildV_fields xv yv x0v y0v 0 bsF i
+        Kimchi.Gate.VarBaseMul.chainBuild_fields xv yv x0v y0v 0 bsF i
       rw [hb0, hb1, hb2, hb3, hb4]),
       Kimchi.Gate.VarBaseMul.flatMap_range_window]
   -- and the walk's ladder is the scalar's `Type1` unshift, by the sound side's decode
@@ -1279,9 +1245,11 @@ theorem varBaseMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
       (CVar.eval_le hle₄ hxI) (CVar.eval_le hle₄ hyI) (CVar.eval_le hle₄ hcurj0)
     refine ⟨by rw [hw0Ok]; rfl, fun w0 st₅ hg0 hle₅ => ?_⟩
     obtain ⟨hs0e', -, -, hx1e', hy1e'⟩ := hg0 _ hw0Ok
-    rw [← Kimchi.Gate.VarBaseMul.chainBuild_s0] at hs0e'
-    rw [← Kimchi.Gate.VarBaseMul.chainBuild_x1] at hx1e'
-    rw [← Kimchi.Gate.VarBaseMul.chainBuild_y1] at hy1e'
+    obtain ⟨es0, ex0, ey0⟩ :=
+      Kimchi.Gate.VarBaseMul.chainBuild_step0 xv yv x0v y0v 0 bsF pref.length
+    rw [← es0] at hs0e'
+    rw [← ex0] at hx1e'
+    rw [← ey0] at hy1e'
     have hs0e := reads_fvar hs0e'
     have hx1e := reads_fvar hx1e'
     have hy1e := reads_fvar hy1e'
@@ -1291,9 +1259,11 @@ theorem varBaseMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
       hx1e hy1e (CVar.eval_le (hle₄.trans hle₅) (hcurj 1 (by omega)))
     refine ⟨by rw [hw1Ok]; rfl, fun w1 st₆ hg1 hle₆ => ?_⟩
     obtain ⟨hs1e', -, -, hx2e', hy2e'⟩ := hg1 _ hw1Ok
-    rw [← Kimchi.Gate.VarBaseMul.chainBuild_s1] at hs1e'
-    rw [← Kimchi.Gate.VarBaseMul.chainBuild_x2] at hx2e'
-    rw [← Kimchi.Gate.VarBaseMul.chainBuild_y2] at hy2e'
+    obtain ⟨es1, ex1, ey1⟩ :=
+      Kimchi.Gate.VarBaseMul.chainBuild_step1 xv yv x0v y0v 0 bsF pref.length
+    rw [← es1] at hs1e'
+    rw [← ex1] at hx2e'
+    rw [← ey1] at hy2e'
     have hs1e := reads_fvar hs1e'
     have hx2e := reads_fvar hx2e'
     have hy2e := reads_fvar hy2e'
@@ -1304,9 +1274,11 @@ theorem varBaseMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
       (CVar.eval_le ((hle₄.trans hle₅).trans hle₆) (hcurj 2 (by omega)))
     refine ⟨by rw [hw2Ok]; rfl, fun w2 st₇ hg2 hle₇ => ?_⟩
     obtain ⟨hs2e', -, -, hx3e', hy3e'⟩ := hg2 _ hw2Ok
-    rw [← Kimchi.Gate.VarBaseMul.chainBuild_s2] at hs2e'
-    rw [← Kimchi.Gate.VarBaseMul.chainBuild_x3] at hx3e'
-    rw [← Kimchi.Gate.VarBaseMul.chainBuild_y3] at hy3e'
+    obtain ⟨es2, ex2, ey2⟩ :=
+      Kimchi.Gate.VarBaseMul.chainBuild_step2 xv yv x0v y0v 0 bsF pref.length
+    rw [← es2] at hs2e'
+    rw [← ex2] at hx3e'
+    rw [← ey2] at hy3e'
     have hs2e := reads_fvar hs2e'
     have hx3e := reads_fvar hx3e'
     have hy3e := reads_fvar hy3e'
@@ -1318,9 +1290,11 @@ theorem varBaseMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
         (hcurj 3 (by omega)))
     refine ⟨by rw [hw3Ok]; rfl, fun w3 st₈ hg3 hle₈ => ?_⟩
     obtain ⟨hs3e', -, -, hx4e', hy4e'⟩ := hg3 _ hw3Ok
-    rw [← Kimchi.Gate.VarBaseMul.chainBuild_s3] at hs3e'
-    rw [← Kimchi.Gate.VarBaseMul.chainBuild_x4] at hx4e'
-    rw [← Kimchi.Gate.VarBaseMul.chainBuild_y4] at hy4e'
+    obtain ⟨es3, ex3, ey3⟩ :=
+      Kimchi.Gate.VarBaseMul.chainBuild_step3 xv yv x0v y0v 0 bsF pref.length
+    rw [← es3] at hs3e'
+    rw [← ex3] at hx4e'
+    rw [← ey3] at hy4e'
     have hs3e := reads_fvar hs3e'
     have hx4e := reads_fvar hx4e'
     have hy4e := reads_fvar hy4e'
@@ -1333,9 +1307,11 @@ theorem varBaseMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
         (hcurj 4 (by omega)))
     refine ⟨by rw [hw4Ok]; rfl, fun w4 st₉ hg4 hle₉ => ?_⟩
     obtain ⟨hs4e', -, -, hx5e', hy5e'⟩ := hg4 _ hw4Ok
-    rw [← Kimchi.Gate.VarBaseMul.chainBuild_s4] at hs4e'
-    rw [← Kimchi.Gate.VarBaseMul.chainBuild_x5] at hx5e'
-    rw [← Kimchi.Gate.VarBaseMul.chainBuild_y5] at hy5e'
+    obtain ⟨es4, ex4, ey4⟩ :=
+      Kimchi.Gate.VarBaseMul.chainBuild_step4 xv yv x0v y0v 0 bsF pref.length
+    rw [← es4] at hs4e'
+    rw [← ex4] at hx5e'
+    rw [← ey4] at hy5e'
     have hs4e := reads_fvar hs4e'
     have hx5e := reads_fvar hx5e'
     have hy5e := reads_fvar hy5e'
@@ -1370,7 +1346,7 @@ theorem varBaseMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
         = .ok (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
             pref.length) := by
       obtain ⟨hfxT, hfyT, hfb0, hfb1, hfb2, hfb3, hfb4⟩ :=
-        chainBuildV_fields xv yv x0v y0v 0 bsF pref.length
+        Kimchi.Gate.VarBaseMul.chainBuild_fields xv yv x0v y0v 0 bsF pref.length
       refine evalScale_ok_iff.mpr
         ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_,
           ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
@@ -1437,7 +1413,8 @@ theorem varBaseMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
       have hchain := Kimchi.Gate.VarBaseMul.chain_accN chunks
         (fun i => Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF i)
         hHolds (fun i _ => rfl)
-      rw [accN_chainBuildV, accN_chainBuildV, hrun,
+      rw [Kimchi.Gate.VarBaseMul.accN_chainBuild,
+        Kimchi.Gate.VarBaseMul.accN_chainBuild, hrun,
         show (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF 0).n = 0
           from rfl, mul_zero, zero_add,
         Kimchi.Gate.VarBaseMul.bitsRegister_eq_cast _ (fun x hx => by
@@ -1488,15 +1465,16 @@ theorem varBaseMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
       (Point.some _ _ hT) (2 * (nn : ℤ) + 2 ^ (5 * chunks) + 1)
       (Point.some_ne_zero hT) hHolds hT rfl
       (fun i _ => by
-        obtain ⟨hx1, hy1, -, -, -, -, -⟩ := chainBuildV_fields xv yv x0v y0v 0 bsF i
+        obtain ⟨hx1, hy1, -, -, -, -, -⟩ :=
+          Kimchi.Gate.VarBaseMul.chainBuild_fields xv yv x0v y0v 0 bsF i
         obtain ⟨hx0', hy0', -, -, -, -, -⟩ :=
-          chainBuildV_fields xv yv x0v y0v 0 bsF 0
+          Kimchi.Gate.VarBaseMul.chainBuild_fields xv yv x0v y0v 0 bsF 0
         rw [hx1, hy1, hx0', hy0']
         exact ⟨rfl, rfl⟩)
       (fun i _ => ⟨rfl, rfl⟩) hP0ns hP0eq d.two_ne d.odd
       hladder.symm hregpre
-    have hax := accX_chainBuildV xv yv x0v y0v 0 bsF chunks
-    have hay := accY_chainBuildV xv yv x0v y0v 0 bsF chunks
+    have hax := Kimchi.Gate.VarBaseMul.accX_chainBuild xv yv x0v y0v 0 bsF chunks
+    have hay := Kimchi.Gate.VarBaseMul.accY_chainBuild xv yv x0v y0v 0 bsF chunks
     have hfin : d.W.Nonsingular
         (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF chunks).x0
         (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF chunks).y0 := by

--- a/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
@@ -39,6 +39,10 @@ Deviations from the PS original (per `formal/docs/snarky-kimchi-alignment.md`):
 - PS allocates each bit step's five advice values through five separate `exists`;
   the port witnesses the quintet in one call — five fresh variables in the same
   order, so the variable ids agree.
+- PS walks a round's five bits with an inner `mapAccumM`; the port unrolls it into
+  five sequential `witness` calls. Same calls in the same order, so the emitted
+  circuit is untouched — but the loop rules cannot walk it, so each reading's law
+  pays for the five steps separately instead of once against an invariant.
 - `s1Sq` and `s2` are witnessed and never read back — dead allocations kept for
   OCaml variable-id parity, exactly as PS keeps them.
 - PS's type-level width bookkeeping (`FieldSizeInBits`, `Mul 5 nChunks bitsUsed`)
@@ -362,38 +366,17 @@ private theorem read_runBits [Field F] [DecidableEq F] {V : Valuation F} :
         simp]
     simp [roundBits, List.flatMap_append, ScaleRound.read]
 
-/-- Flattening the 5-bit windows of a list of exactly `5·c` entries recovers it. -/
-private theorem flatMap_window {α : Type} (dflt : α) :
-    ∀ (c : ℕ) (l : List α), l.length = 5 * c →
-      (List.range c).flatMap (fun i =>
-        [l.getD (5 * i) dflt, l.getD (5 * i + 1) dflt, l.getD (5 * i + 2) dflt,
-         l.getD (5 * i + 3) dflt, l.getD (5 * i + 4) dflt]) = l
-  | 0, l, hl => by
-    rw [show l = [] from List.eq_nil_of_length_eq_zero (by omega)]
-    rfl
-  | c + 1, a :: b :: d :: e :: f :: rest, hl => by
-    rw [List.range_succ_eq_map, List.flatMap_cons, List.flatMap_map]
-    have hshift : ∀ i, i ∈ List.range c →
-        [( a :: b :: d :: e :: f :: rest).getD (5 * (i + 1)) dflt,
-         (a :: b :: d :: e :: f :: rest).getD (5 * (i + 1) + 1) dflt,
-         (a :: b :: d :: e :: f :: rest).getD (5 * (i + 1) + 2) dflt,
-         (a :: b :: d :: e :: f :: rest).getD (5 * (i + 1) + 3) dflt,
-         (a :: b :: d :: e :: f :: rest).getD (5 * (i + 1) + 4) dflt]
-          = [rest.getD (5 * i) dflt, rest.getD (5 * i + 1) dflt,
-             rest.getD (5 * i + 2) dflt, rest.getD (5 * i + 3) dflt,
-             rest.getD (5 * i + 4) dflt] := by
-      intro i _
-      have h5 : ∀ j, (a :: b :: d :: e :: f :: rest).getD (5 * (i + 1) + j) dflt
-          = rest.getD (5 * i + j) dflt := by
-        intro j
-        rw [show 5 * (i + 1) + j = (5 * i + j) + 1 + 1 + 1 + 1 + 1 from by ring]
-        simp
-      rw [show (5 * (i + 1) : ℕ) = 5 * (i + 1) + 0 from rfl,
-        h5 0, h5 1, h5 2, h5 3, h5 4,
-        show (5 * i + 0 : ℕ) = 5 * i from rfl]
-    rw [List.flatMap_congr hshift,
-      flatMap_window dflt c rest (by simp at hl; omega)]
-    simp [List.getD]
+/-- Flattening the 5-bit windows of a list of exactly `5·c` entries recovers it —
+the gate model's window tiling (`flatMap_range_window`) read through `getD`. -/
+private theorem flatMap_window {α : Type} (dflt : α) (c : ℕ) (l : List α)
+    (hl : l.length = 5 * c) :
+    (List.range c).flatMap (fun i =>
+      [l.getD (5 * i) dflt, l.getD (5 * i + 1) dflt, l.getD (5 * i + 2) dflt,
+       l.getD (5 * i + 3) dflt, l.getD (5 * i + 4) dflt]) = l := by
+  rw [Kimchi.Gate.VarBaseMul.flatMap_range_window (fun i => l.getD i dflt) c]
+  refine List.ext_getElem (by simp [hl]) (fun i h1 h2 => ?_)
+  simp only [List.getElem_map, List.getElem_range]
+  rw [List.getD_eq_getElem _ _ (by simpa [hl] using h1)]
 
 open Kimchi.Gate.VarBaseMul in
 /-- A satisfied threading from the doubled-base init computes the ladder: the
@@ -1007,12 +990,6 @@ private theorem bitWit_ok [Field F] [DecidableEq F] {env : Assignments F}
         (Kimchi.Gate.VarBaseMul.stepBit bv xb yb xi yi).2.2) := by
   simp [bitWit, AsProver.readCVar, hxb, hyb, hxi, hyi, hb,
     Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
-
-/-- The `F`-leaf reading is the eval equation — the coercion the grant consumers
-apply (unification alone cannot unfold the instance projection against a
-metavariable-headed expected type). -/
-private theorem reads_fvar {F : Type} [Field F] {r : FVar F} {env : Assignments F}
-    {x : F} (h : WitnessReads.Reads (F := F) r env x) : r.eval env = .ok x := h
 
 open Kimchi.Gate.VarBaseMul (y_ne_zero_of_odd_order smul_ne_zero_of_lt) in
 /-- The gadget is complete, generic over the curve dictionary: the honest prover run

--- a/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
@@ -893,4 +893,733 @@ theorem scaleFast2'_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCurve F)
     rw [hsum, hvv, h1]
     simp [bit]
 
+/-! ## Completeness plumbing
+
+The prover-side reading of a scale round: `evalScale_ok_iff` splits the 26-cell read,
+the read survives table extension, and the advice computations read the threaded
+cells and compute the gate's canonical row — `nAccWit` its register update, `bitWit`
+its bit-step quintet from the gate model's `stepBit`. -/
+
+open Std.Do in
+/-- A round evaluates to a witness exactly when each cell reads as its field. -/
+private theorem evalScale_ok_iff [Field F] [DecidableEq F] {env : Assignments F}
+    {r : ScaleRound F} {w : Kimchi.Gate.VarBaseMul.Witness F} :
+    ScaleRound.eval env r = .ok w ↔
+      r.base.x.eval env = .ok w.xT ∧ r.base.y.eval env = .ok w.yT ∧
+      r.acc0.x.eval env = .ok w.x0 ∧ r.acc0.y.eval env = .ok w.y0 ∧
+      r.acc1.x.eval env = .ok w.x1 ∧ r.acc1.y.eval env = .ok w.y1 ∧
+      r.acc2.x.eval env = .ok w.x2 ∧ r.acc2.y.eval env = .ok w.y2 ∧
+      r.acc3.x.eval env = .ok w.x3 ∧ r.acc3.y.eval env = .ok w.y3 ∧
+      r.acc4.x.eval env = .ok w.x4 ∧ r.acc4.y.eval env = .ok w.y4 ∧
+      r.acc5.x.eval env = .ok w.x5 ∧ r.acc5.y.eval env = .ok w.y5 ∧
+      r.nPrev.eval env = .ok w.n ∧ r.nNext.eval env = .ok w.nPrime ∧
+      r.bit0.eval env = .ok w.b0 ∧ r.bit1.eval env = .ok w.b1 ∧
+      r.bit2.eval env = .ok w.b2 ∧ r.bit3.eval env = .ok w.b3 ∧
+      r.bit4.eval env = .ok w.b4 ∧
+      r.slope0.eval env = .ok w.s0 ∧ r.slope1.eval env = .ok w.s1 ∧
+      r.slope2.eval env = .ok w.s2 ∧ r.slope3.eval env = .ok w.s3 ∧
+      r.slope4.eval env = .ok w.s4 := by
+  constructor
+  · intro h
+    unfold ScaleRound.eval at h
+    obtain ⟨xT, hxT, h⟩ := bind_ok h
+    obtain ⟨yT, hyT, h⟩ := bind_ok h
+    obtain ⟨x0, hx0, h⟩ := bind_ok h
+    obtain ⟨y0, hy0, h⟩ := bind_ok h
+    obtain ⟨x1, hx1, h⟩ := bind_ok h
+    obtain ⟨y1, hy1, h⟩ := bind_ok h
+    obtain ⟨x2, hx2, h⟩ := bind_ok h
+    obtain ⟨y2, hy2, h⟩ := bind_ok h
+    obtain ⟨x3, hx3, h⟩ := bind_ok h
+    obtain ⟨y3, hy3, h⟩ := bind_ok h
+    obtain ⟨x4, hx4, h⟩ := bind_ok h
+    obtain ⟨y4, hy4, h⟩ := bind_ok h
+    obtain ⟨x5, hx5, h⟩ := bind_ok h
+    obtain ⟨y5, hy5, h⟩ := bind_ok h
+    obtain ⟨nv, hnv, h⟩ := bind_ok h
+    obtain ⟨nP, hnP, h⟩ := bind_ok h
+    obtain ⟨b0, hb0, h⟩ := bind_ok h
+    obtain ⟨b1, hb1, h⟩ := bind_ok h
+    obtain ⟨b2, hb2, h⟩ := bind_ok h
+    obtain ⟨b3, hb3, h⟩ := bind_ok h
+    obtain ⟨b4, hb4, h⟩ := bind_ok h
+    obtain ⟨s0, hs0, h⟩ := bind_ok h
+    obtain ⟨s1, hs1, h⟩ := bind_ok h
+    obtain ⟨s2, hs2, h⟩ := bind_ok h
+    obtain ⟨s3, hs3, h⟩ := bind_ok h
+    obtain ⟨s4, hs4, h⟩ := bind_ok h
+    simp only [Pure.pure, Except.pure, Except.ok.injEq] at h
+    subst h
+    exact ⟨hxT, hyT, hx0, hy0, hx1, hy1, hx2, hy2, hx3, hy3, hx4, hy4, hx5, hy5,
+      hnv, hnP, hb0, hb1, hb2, hb3, hb4, hs0, hs1, hs2, hs3, hs4⟩
+  · intro ⟨hxT, hyT, hx0, hy0, hx1, hy1, hx2, hy2, hx3, hy3, hx4, hy4, hx5, hy5,
+      hnv, hnP, hb0, hb1, hb2, hb3, hb4, hs0, hs1, hs2, hs3, hs4⟩
+    unfold ScaleRound.eval
+    rw [hxT, hyT, hx0, hy0, hx1, hy1, hx2, hy2, hx3, hy3, hx4, hy4, hx5, hy5,
+      hnv, hnP, hb0, hb1, hb2, hb3, hb4, hs0, hs1, hs2, hs3, hs4]
+    simp [Bind.bind, Except.bind, Pure.pure, Except.pure]
+
+/-- A round's read survives table extension. -/
+private theorem evalScale_le [Field F] [DecidableEq F] {env env' : Assignments F}
+    (hle : env.Le env') {r : ScaleRound F} {w : Kimchi.Gate.VarBaseMul.Witness F}
+    (h : ScaleRound.eval env r = .ok w) : ScaleRound.eval env' r = .ok w := by
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9, h10, h11, h12, h13, h14, h15, h16,
+    h17, h18, h19, h20, h21, h22, h23, h24, h25, h26⟩ := evalScale_ok_iff.mp h
+  exact evalScale_ok_iff.mpr ⟨CVar.eval_le hle h1, CVar.eval_le hle h2,
+    CVar.eval_le hle h3, CVar.eval_le hle h4, CVar.eval_le hle h5,
+    CVar.eval_le hle h6, CVar.eval_le hle h7, CVar.eval_le hle h8,
+    CVar.eval_le hle h9, CVar.eval_le hle h10, CVar.eval_le hle h11,
+    CVar.eval_le hle h12, CVar.eval_le hle h13, CVar.eval_le hle h14,
+    CVar.eval_le hle h15, CVar.eval_le hle h16, CVar.eval_le hle h17,
+    CVar.eval_le hle h18, CVar.eval_le hle h19, CVar.eval_le hle h20,
+    CVar.eval_le hle h21, CVar.eval_le hle h22, CVar.eval_le hle h23,
+    CVar.eval_le hle h24, CVar.eval_le hle h25, CVar.eval_le hle h26⟩
+
+/-- The register advice reads the threaded cells and computes the gate's
+`nPrime` fold. -/
+private theorem nAccWit_ok [Field F] [DecidableEq F] {env : Assignments F}
+    {nPrev : FVar F} {bs : Vector (FVar F) 5} {nv b0 b1 b2 b3 b4 : F}
+    (hnv : nPrev.eval env = .ok nv)
+    (hb0 : bs[0].eval env = .ok b0) (hb1 : bs[1].eval env = .ok b1)
+    (hb2 : bs[2].eval env = .ok b2) (hb3 : bs[3].eval env = .ok b3)
+    (hb4 : bs[4].eval env = .ok b4) :
+    nAccWit nPrev bs env
+      = .ok (b4 + 2 * (b3 + 2 * (b2 + 2 * (b1 + 2 * (b0 + 2 * nv))))) := by
+  simp [nAccWit, AsProver.readCVar, hnv, hb0, hb1, hb2, hb3, hb4,
+    Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
+
+/-- The bit-step advice reads the threaded cells and computes the gate model's
+`stepBit` quintet. -/
+private theorem bitWit_ok [Field F] [DecidableEq F] {env : Assignments F}
+    {t : AffinePoint (FVar F)} {b : FVar F} {acc : AffinePoint (FVar F)}
+    {xb yb xi yi bv : F}
+    (hxb : t.x.eval env = .ok xb) (hyb : t.y.eval env = .ok yb)
+    (hxi : acc.x.eval env = .ok xi) (hyi : acc.y.eval env = .ok yi)
+    (hb : b.eval env = .ok bv) :
+    bitWit t b acc env
+      = .ok ((Kimchi.Gate.VarBaseMul.stepBit bv xb yb xi yi).1,
+        (Kimchi.Gate.VarBaseMul.stepBit bv xb yb xi yi).1
+          * (Kimchi.Gate.VarBaseMul.stepBit bv xb yb xi yi).1,
+        2 * yi / (2 * xi + xb - (Kimchi.Gate.VarBaseMul.stepBit bv xb yb xi yi).1
+          * (Kimchi.Gate.VarBaseMul.stepBit bv xb yb xi yi).1)
+          - (Kimchi.Gate.VarBaseMul.stepBit bv xb yb xi yi).1,
+        (Kimchi.Gate.VarBaseMul.stepBit bv xb yb xi yi).2.1,
+        (Kimchi.Gate.VarBaseMul.stepBit bv xb yb xi yi).2.2) := by
+  simp [bitWit, AsProver.readCVar, hxb, hyb, hxi, hyi, hb,
+    Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
+
+/-- The walk's base and bit cells are the arguments, at every row. -/
+private theorem chainBuildV_fields [Field F] [DecidableEq F]
+    (xT yT x0 y0 n0 : F) (bs : ℕ → F) (m : ℕ) :
+    (Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs m).xT = xT
+    ∧ (Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs m).yT = yT
+    ∧ (Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs m).b0 = bs (5 * m)
+    ∧ (Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs m).b1 = bs (5 * m + 1)
+    ∧ (Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs m).b2 = bs (5 * m + 2)
+    ∧ (Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs m).b3 = bs (5 * m + 3)
+    ∧ (Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs m).b4 = bs (5 * m + 4) := by
+  cases m <;> exact ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+
+/-- `accX`/`accY`/`accN` at the walk are the next row's input cells. -/
+private theorem accX_chainBuildV [Field F] [DecidableEq F]
+    (xT yT x0 y0 n0 : F) (bs : ℕ → F) (m : ℕ) :
+    Kimchi.Gate.VarBaseMul.accX
+        (fun i => Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs i) m
+      = (Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs m).x0 := by
+  cases m <;> rfl
+
+private theorem accY_chainBuildV [Field F] [DecidableEq F]
+    (xT yT x0 y0 n0 : F) (bs : ℕ → F) (m : ℕ) :
+    Kimchi.Gate.VarBaseMul.accY
+        (fun i => Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs i) m
+      = (Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs m).y0 := by
+  cases m <;> rfl
+
+private theorem accN_chainBuildV [Field F] [DecidableEq F]
+    (xT yT x0 y0 n0 : F) (bs : ℕ → F) (m : ℕ) :
+    Kimchi.Gate.VarBaseMul.accN
+        (fun i => Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs i) m
+      = (Kimchi.Gate.VarBaseMul.chainBuild xT yT x0 y0 n0 bs m).n := by
+  cases m <;> rfl
+
+/-- The `F`-leaf reading is the eval equation — the coercion the grant consumers
+apply (unification alone cannot unfold the instance projection against a
+metavariable-headed expected type). -/
+private theorem reads_fvar {F : Type} [Field F] {r : FVar F} {env : Assignments F}
+    {x : F} (h : WitnessReads.Reads (F := F) r env x) : r.eval env = .ok x := h
+
+open Kimchi.Gate.VarBaseMul (y_ne_zero_of_odd_order smul_ne_zero_of_lt) in
+/-- The gadget is complete, generic over the curve dictionary: the honest prover run
+accepts on a readable on-curve base and a readable in-range faithful scalar whose
+`Type1` decode satisfies the ladder regime, and the returned point reads as the
+defining equation's honest side — `[fromShifted t]·g` at the scalar's canonical
+value. The regime precondition is per-scalar, exactly the fact the soundness law
+conditions on; at the deployed widths the subwrap arm discharges it for every chunk
+count below full width, and at full width it is the `Type1` forbidden-band check's
+contract. The loop invariant identifies the run with the honest walk `chainBuild`;
+the per-round check is the produce chain's (`chain_complete`), the init is the
+doubling `addFast` (`addFast_complete_spec`), and the register pin closes by the
+fold identity (`chain_accN` through `bitsVal_testBit`). -/
+theorem varBaseMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCurve F)
+    (n chunks : ℕ) (hn : 5 * chunks ≤ n)
+    (base' : AffinePoint (FVar F)) (scalar : Type1 (FVar F))
+    (Q : PostCond (VarBaseMulResult n F)
+      (.arg (ProverState F) (.except EvalError .pure))) :
+    ⦃Complete
+        (fun env =>
+          (scalar.val.eval env).isOk ∧ (base'.x.eval env).isOk ∧
+          (base'.y.eval env).isOk ∧
+          (∀ v, scalar.val.eval env = .ok v →
+            ToNat.toNat v < 2 ^ (5 * chunks) ∧ ((ToNat.toNat v : ℕ) : F) = v ∧
+            d.LadderRegime (5 * chunks)
+              (Type1.fromShifted (5 * chunks) ⟨(ToNat.toNat v : ℤ)⟩)) ∧
+          (∀ x y, base'.x.eval env = .ok x → base'.y.eval env = .ok y →
+            d.W.Nonsingular x y))
+        (fun env r env' => ∀ v xv yv, scalar.val.eval env = .ok v →
+          base'.x.eval env = .ok xv → base'.y.eval env = .ok yv →
+          ∀ hT : d.W.Nonsingular xv yv,
+          ∃ xS yS, r.g.x.eval env' = .ok xS ∧ r.g.y.eval env' = .ok yS ∧
+            ∃ hfin : d.W.Nonsingular xS yS,
+              Point.some _ _ hfin
+                = Type1.fromShifted (5 * chunks) ⟨(ToNat.toNat v : ℤ)⟩
+                    • Point.some _ _ hT)
+        Q⦄
+    (varBaseMul (c := KimchiProverC F) n chunks base' scalar)
+    ⦃Q⦄ := by
+  haveI : Fact (Nat.Prime d.W.order) := ⟨d.prime⟩
+  haveI : Fact (d.W.a₁ = 0 ∧ d.W.a₂ = 0 ∧ d.W.a₃ = 0) :=
+    ⟨⟨d.short.1, d.short.2.1, d.short.2.2.1⟩⟩
+  simp only [varBaseMul, mapAccumM]
+  mvcgen
+  rename_i st₀ hpre
+  obtain ⟨⟨hsok, hxok, hyok, hsc, hcurve⟩, hk⟩ := hpre
+  obtain ⟨v, hv⟩ := CVar.evalOk hsok
+  obtain ⟨xv, hxv⟩ := CVar.evalOk hxok
+  obtain ⟨yv, hyv⟩ := CVar.evalOk hyok
+  obtain ⟨hrange, hfaith, hregpre⟩ := hsc v hv
+  have hT : d.W.Nonsingular xv yv := hcurve _ _ hxv hyv
+  have hyne : yv ≠ 0 := y_ne_zero_of_odd_order d.W d.odd hT
+  -- the sealed base
+  refine ⟨⟨hxok, hyok⟩, fun base st₁ hseal hle₁ => ?_⟩
+  obtain ⟨hsx, hsy⟩ := hseal xv yv hxv hyv
+  mvcgen
+  -- the scalar's bits, in one witness
+  set nn := ToNat.toNat v with hndef
+  have hwit : lsbBitsWit n scalar.val st₁.env
+      = .ok (Vector.ofFn fun i => if nn.testBit i.1 then (1 : F) else 0) := by
+    simp [lsbBitsWit, AsProver.readCVar, CVar.eval_le hle₁ hv,
+      Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
+    rw [hndef]
+  refine ⟨by rw [hwit]; rfl, fun bits st₂ hgrant hle₂ => ?_⟩
+  have hread := hgrant _ hwit
+  mvcgen
+  -- the doubled init `P₀ = [2]·T`
+  have hsx₂ : base.x.eval st₂.env = .ok xv := CVar.eval_le hle₂ hsx
+  have hsy₂ : base.y.eval st₂.env = .ok yv := CVar.eval_le hle₂ hsy
+  refine AddFast.addFast_complete_spec .checkFinite d.W d.short d.two_ne base base _ _
+    ⟨⟨by rw [hsx₂]; rfl, by rw [hsy₂]; rfl, by rw [hsx₂]; rfl, by rw [hsy₂]; rfl,
+      fun x1 y1 x2 y2 he1 he2 he3 he4 => ?_⟩,
+     fun p st₃ hp hle₃ => ?_⟩
+  · rw [hsx₂] at he1; rw [hsy₂] at he2; rw [hsx₂] at he3; rw [hsy₂] at he4
+    injection he1 with he1; injection he2 with he2
+    injection he3 with he3; injection he4 with he4
+    subst he1 he2 he3 he4
+    refine ⟨hT.1, hT.1, hyne, fun _ => ?_⟩
+    rintro ⟨-, hyeq⟩
+    rw [show d.W.negY xv yv = -yv from by
+      simp [WeierstrassCurve.Affine.negY, d.short.1, d.short.2.2.1]] at hyeq
+    refine hyne ?_
+    have h2y : (2 : F) * yv = 0 := by linear_combination hyeq
+    exact (mul_eq_zero.mp h2y).resolve_left d.two_ne
+  obtain ⟨x0v, y0v, hx0e, hy0e, -, hP0ns, hsum⟩ :=
+    (hp xv yv xv yv hsx₂ hsy₂ hsx₂ hsy₂ hT hT).resolve_left (by
+      rintro ⟨-, hzero⟩
+      have h2P : (2 : ℤ) • Point.some _ _ hT = 0 := by rw [two_zsmul, hzero]
+      have hlt : (2 : ℤ) < (d.W.order : ℤ) := by
+        have h2le := d.prime.two_le
+        have hne2 := d.odd
+        have h3' : 3 ≤ d.W.order := by omega
+        exact_mod_cast h3'
+      exact smul_ne_zero_of_lt d.W (Point.some_ne_zero hT) (by norm_num) hlt h2P)
+  have hP0eq : Point.some _ _ hP0ns = (2 : ℤ) • Point.some _ _ hT := by
+    rw [← hsum]
+    module
+  -- the honest stream, its regime, and the produce chain's acceptance
+  set bsF : ℕ → F := fun j => if nn.testBit (5 * chunks - 1 - j) then (1 : F) else 0
+    with hbsF
+  have hbsb : ∀ j, j < 5 * chunks → bsF j = 0 ∨ bsF j = 1 := by
+    intro j _
+    rw [hbsF]
+    dsimp only
+    split
+    · exact Or.inr rfl
+    · exact Or.inl rfl
+  have hladder : Kimchi.Gate.VarBaseMul.ladderK bsF (5 * chunks)
+      = 2 * (nn : ℤ) + 2 ^ (5 * chunks) + 1 := by
+    rw [Kimchi.Gate.VarBaseMul.ladderK_eq_bitsVal bsF (5 * chunks) hbsb, hbsF,
+      Kimchi.Gate.VarBaseMul.bitsVal_testBit nn (5 * chunks) hrange]
+  have hregime' : 3 * 2 ^ (5 * chunks) ≤ d.W.order ∨
+      (2 ^ (5 * chunks - 1) < d.W.order ∧ d.W.order < 2 ^ (5 * chunks) ∧
+        d.W.order % 4 = 1 ∧
+        Kimchi.Gate.VarBaseMul.ladderK bsF (5 * chunks)
+          ∉ Kimchi.Gate.VarBaseMul.forbiddenValues d.W.order) := by
+    simp only [HasCurve.LadderRegime, Type1.fromShifted] at hregpre
+    rcases hregpre with h | ⟨h1, h2', h3, h4⟩
+    · exact Or.inl h
+    · exact Or.inr ⟨h1, h2', h3, by rw [hladder]; exact h4⟩
+  have hHolds : ∀ i, i < chunks →
+      Kimchi.Gate.VarBaseMul.Holds
+        (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF i) :=
+    Kimchi.Gate.VarBaseMul.chain_complete d.W d.two_ne d.odd chunks hT bsF hbsb 0
+      hP0ns hP0eq hregime'
+  mvcgen
+  case inv1 =>
+    exact ⇓ p s' => ⌜st₃.env.Le s'.env ∧
+      (p.2.fst.1.x.eval s'.env
+          = .ok (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              p.1.prefix.length).x0 ∧
+        p.2.fst.1.y.eval s'.env
+          = .ok (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              p.1.prefix.length).y0 ∧
+        p.2.fst.2.eval s'.env
+          = .ok (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              p.1.prefix.length).n) ∧
+      ∀ r ∈ p.2.snd, ∃ w, ScaleRound.eval s'.env r = .ok w ∧
+        Kimchi.Gate.VarBaseMul.Holds w⌝
+  case vc1.step =>
+    rename_i pref cur suff hsplit b s' hinv
+    obtain ⟨hLe, ⟨hxI, hyI, hnI⟩, hrounds⟩ := hinv
+    have hkrows : pref.length < chunks := by
+      have hlen := congrArg List.length hsplit
+      simp only [List.length_map, List.length_range, List.length_append,
+        List.length_cons] at hlen
+      omega
+    have hcur : cur = Vector.ofFn (fun j : Fin 5 =>
+        ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
+          (.const 0)) := by
+      have h1 : ((List.range chunks).map (fun i => Vector.ofFn (fun j : Fin 5 =>
+          ((bits.toList.take (5 * chunks)).reverse).getD (5 * i + j.1)
+            (.const 0))))[pref.length]'(by
+            simp only [List.length_map, List.length_range]
+            exact hkrows) = cur := by
+        simp only [hsplit]
+        rw [List.getElem_append_right (Nat.le_refl _)]
+        simp
+      rw [← h1, List.getElem_map, List.getElem_range]
+    subst hcur
+    -- the window's bits read as the honest stream
+    have hbit : ∀ j, j < 5 →
+        (((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j)
+            (.const 0) : FVar F).eval s'.env
+          = .ok (bsF (5 * pref.length + j)) := by
+      intro j hj
+      have hlen5 : (bits.toList.take (5 * chunks)).length = 5 * chunks := by
+        simp only [List.length_take, Vector.length_toList]
+        omega
+      have hgd : ((bits.toList.take (5 * chunks)).reverse).getD
+          (5 * pref.length + j) (.const 0)
+          = bits[5 * chunks - 1 - (5 * pref.length + j)]'(by omega) := by
+        rw [List.getD_eq_getElem?_getD, List.getElem?_reverse (by rw [hlen5]; omega),
+          hlen5, List.getElem?_take_of_lt (by omega),
+          List.getElem?_eq_getElem (by simp only [Vector.length_toList]; omega)]
+        simp [Vector.getElem_toList]
+      rw [hgd]
+      have hr := hread (5 * chunks - 1 - (5 * pref.length + j)) (by omega)
+      simp only [Vector.getElem_ofFn] at hr
+      rw [hbsF]
+      exact CVar.eval_le (hle₃.trans hLe) hr
+    have hcurj : ∀ (j : ℕ) (hj : j < 5),
+        ((Vector.ofFn (fun j : Fin 5 =>
+            ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
+              (.const 0)))[j]'hj).eval s'.env
+          = .ok (bsF (5 * pref.length + j)) := by
+      intro j hj
+      simp only [Vector.getElem_ofFn]
+      exact hbit j hj
+    -- shorthands for the row
+    have hxT' : base.x.eval s'.env = .ok xv :=
+      CVar.eval_le ((hle₂.trans hle₃).trans hLe) hsx
+    have hyT' : base.y.eval s'.env = .ok yv :=
+      CVar.eval_le ((hle₂.trans hle₃).trans hLe) hsy
+    have hcurj0 : ((Vector.ofFn (fun j : Fin 5 =>
+        ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
+          (.const 0)))[0]'(by omega)).eval s'.env
+        = .ok (bsF (5 * pref.length)) := hcurj 0 (by omega)
+    -- the register witness
+    have hnOk : nAccWit b.fst.2 (Vector.ofFn (fun j : Fin 5 =>
+        ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
+          (.const 0))) s'.env
+        = .ok ((Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+            pref.length).nPrime) := by
+      rw [nAccWit_ok hnI hcurj0 (hcurj 1 (by omega))
+        (hcurj 2 (by omega)) (hcurj 3 (by omega)) (hcurj 4 (by omega)),
+        Kimchi.Gate.VarBaseMul.chainBuild_nPrime]
+    refine ⟨by rw [hnOk]; rfl, fun nAcc st₄ hgN hle₄ => ?_⟩
+    have hnA : nAcc.eval st₄.env = .ok ((Kimchi.Gate.VarBaseMul.chainBuild
+        xv yv x0v y0v 0 bsF pref.length).nPrime) := hgN _ hnOk
+    mvcgen
+    -- the five bit steps: each quintet reads the previous accumulator and
+    -- computes `stepBit`, i.e. the walk's next fields
+    have hw0Ok : bitWit base ((Vector.ofFn (fun j : Fin 5 =>
+        ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
+          (.const 0)))[0]'(by omega)) b.fst.1 st₄.env
+        = .ok ((Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              pref.length).s0,
+            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              pref.length).s0
+              * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                pref.length).s0,
+            2 * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                pref.length).y0
+              / (2 * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                  pref.length).x0 + xv
+                - (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                    pref.length).s0
+                  * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                    pref.length).s0)
+              - (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                pref.length).s0,
+            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              pref.length).x1,
+            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              pref.length).y1) := by
+      rw [bitWit_ok (CVar.eval_le hle₄ hxT') (CVar.eval_le hle₄ hyT')
+        (CVar.eval_le hle₄ hxI) (CVar.eval_le hle₄ hyI)
+        (CVar.eval_le hle₄ hcurj0),
+        Kimchi.Gate.VarBaseMul.chainBuild_s0, Kimchi.Gate.VarBaseMul.chainBuild_x1,
+        Kimchi.Gate.VarBaseMul.chainBuild_y1]
+    refine ⟨by rw [hw0Ok]; rfl, fun w0 st₅ hg0 hle₅ => ?_⟩
+    obtain ⟨hs0e', -, -, hx1e', hy1e'⟩ := hg0 _ hw0Ok
+    have hs0e := reads_fvar hs0e'
+    have hx1e := reads_fvar hx1e'
+    have hy1e := reads_fvar hy1e'
+    mvcgen
+    have hw1Ok : bitWit base ((Vector.ofFn (fun j : Fin 5 =>
+        ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
+          (.const 0)))[1]'(by omega)) ⟨w0.2.2.2.1, w0.2.2.2.2⟩ st₅.env
+        = .ok ((Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              pref.length).s1,
+            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              pref.length).s1
+              * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                pref.length).s1,
+            2 * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                pref.length).y1
+              / (2 * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                  pref.length).x1 + xv
+                - (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                    pref.length).s1
+                  * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                    pref.length).s1)
+              - (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                pref.length).s1,
+            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              pref.length).x2,
+            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              pref.length).y2) := by
+      rw [bitWit_ok (acc := ⟨w0.2.2.2.1, w0.2.2.2.2⟩)
+        (CVar.eval_le (hle₄.trans hle₅) hxT')
+        (CVar.eval_le (hle₄.trans hle₅) hyT') hx1e hy1e
+        (CVar.eval_le (hle₄.trans hle₅) (hcurj 1 (by omega))),
+        Kimchi.Gate.VarBaseMul.chainBuild_s1, Kimchi.Gate.VarBaseMul.chainBuild_x2,
+        Kimchi.Gate.VarBaseMul.chainBuild_y2]
+    refine ⟨by rw [hw1Ok]; rfl, fun w1 st₆ hg1 hle₆ => ?_⟩
+    obtain ⟨hs1e', -, -, hx2e', hy2e'⟩ := hg1 _ hw1Ok
+    have hs1e := reads_fvar hs1e'
+    have hx2e := reads_fvar hx2e'
+    have hy2e := reads_fvar hy2e'
+    mvcgen
+    have hw2Ok : bitWit base ((Vector.ofFn (fun j : Fin 5 =>
+        ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
+          (.const 0)))[2]'(by omega)) ⟨w1.2.2.2.1, w1.2.2.2.2⟩ st₆.env
+        = .ok ((Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              pref.length).s2,
+            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              pref.length).s2
+              * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                pref.length).s2,
+            2 * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                pref.length).y2
+              / (2 * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                  pref.length).x2 + xv
+                - (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                    pref.length).s2
+                  * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                    pref.length).s2)
+              - (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                pref.length).s2,
+            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              pref.length).x3,
+            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              pref.length).y3) := by
+      rw [bitWit_ok (acc := ⟨w1.2.2.2.1, w1.2.2.2.2⟩)
+        (CVar.eval_le ((hle₄.trans hle₅).trans hle₆) hxT')
+        (CVar.eval_le ((hle₄.trans hle₅).trans hle₆) hyT')
+        hx2e hy2e
+        (CVar.eval_le ((hle₄.trans hle₅).trans hle₆) (hcurj 2 (by omega))),
+        Kimchi.Gate.VarBaseMul.chainBuild_s2, Kimchi.Gate.VarBaseMul.chainBuild_x3,
+        Kimchi.Gate.VarBaseMul.chainBuild_y3]
+    refine ⟨by rw [hw2Ok]; rfl, fun w2 st₇ hg2 hle₇ => ?_⟩
+    obtain ⟨hs2e', -, -, hx3e', hy3e'⟩ := hg2 _ hw2Ok
+    have hs2e := reads_fvar hs2e'
+    have hx3e := reads_fvar hx3e'
+    have hy3e := reads_fvar hy3e'
+    mvcgen
+    have hw3Ok : bitWit base ((Vector.ofFn (fun j : Fin 5 =>
+        ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
+          (.const 0)))[3]'(by omega)) ⟨w2.2.2.2.1, w2.2.2.2.2⟩ st₇.env
+        = .ok ((Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              pref.length).s3,
+            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              pref.length).s3
+              * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                pref.length).s3,
+            2 * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                pref.length).y3
+              / (2 * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                  pref.length).x3 + xv
+                - (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                    pref.length).s3
+                  * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                    pref.length).s3)
+              - (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                pref.length).s3,
+            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              pref.length).x4,
+            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              pref.length).y4) := by
+      rw [bitWit_ok (acc := ⟨w2.2.2.2.1, w2.2.2.2.2⟩)
+        (CVar.eval_le (((hle₄.trans hle₅).trans hle₆).trans hle₇) hxT')
+        (CVar.eval_le (((hle₄.trans hle₅).trans hle₆).trans hle₇) hyT')
+        hx3e hy3e
+        (CVar.eval_le (((hle₄.trans hle₅).trans hle₆).trans hle₇)
+          (hcurj 3 (by omega))),
+        Kimchi.Gate.VarBaseMul.chainBuild_s3, Kimchi.Gate.VarBaseMul.chainBuild_x4,
+        Kimchi.Gate.VarBaseMul.chainBuild_y4]
+    refine ⟨by rw [hw3Ok]; rfl, fun w3 st₈ hg3 hle₈ => ?_⟩
+    obtain ⟨hs3e', -, -, hx4e', hy4e'⟩ := hg3 _ hw3Ok
+    have hs3e := reads_fvar hs3e'
+    have hx4e := reads_fvar hx4e'
+    have hy4e := reads_fvar hy4e'
+    mvcgen
+    have hw4Ok : bitWit base ((Vector.ofFn (fun j : Fin 5 =>
+        ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
+          (.const 0)))[4]'(by omega)) ⟨w3.2.2.2.1, w3.2.2.2.2⟩ st₈.env
+        = .ok ((Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              pref.length).s4,
+            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              pref.length).s4
+              * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                pref.length).s4,
+            2 * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                pref.length).y4
+              / (2 * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                  pref.length).x4 + xv
+                - (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                    pref.length).s4
+                  * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                    pref.length).s4)
+              - (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+                pref.length).s4,
+            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              pref.length).x5,
+            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+              pref.length).y5) := by
+      rw [bitWit_ok (acc := ⟨w3.2.2.2.1, w3.2.2.2.2⟩)
+        (CVar.eval_le ((((hle₄.trans hle₅).trans hle₆).trans hle₇).trans hle₈) hxT')
+        (CVar.eval_le ((((hle₄.trans hle₅).trans hle₆).trans hle₇).trans hle₈) hyT')
+        hx4e hy4e
+        (CVar.eval_le ((((hle₄.trans hle₅).trans hle₆).trans hle₇).trans hle₈)
+          (hcurj 4 (by omega))),
+        Kimchi.Gate.VarBaseMul.chainBuild_s4, Kimchi.Gate.VarBaseMul.chainBuild_x5,
+        Kimchi.Gate.VarBaseMul.chainBuild_y5]
+    refine ⟨by rw [hw4Ok]; rfl, fun w4 st₉ hg4 hle₉ => ?_⟩
+    obtain ⟨hs4e', -, -, hx5e', hy5e'⟩ := hg4 _ hw4Ok
+    have hs4e := reads_fvar hs4e'
+    have hx5e := reads_fvar hx5e'
+    have hy5e := reads_fvar hy5e'
+    mvcgen
+    -- the collected round reads as the walk's row
+    have hleB : st₄.env.Le st₉.env :=
+      (((hle₅.trans hle₆).trans hle₇).trans hle₈).trans hle₉
+    have hleA : s'.env.Le st₉.env := hle₄.trans hleB
+    have hround : ScaleRound.eval st₉.env
+        { acc0 := b.fst.1,
+          acc1 := ⟨w0.2.2.2.1, w0.2.2.2.2⟩, acc2 := ⟨w1.2.2.2.1, w1.2.2.2.2⟩,
+          acc3 := ⟨w2.2.2.2.1, w2.2.2.2.2⟩, acc4 := ⟨w3.2.2.2.1, w3.2.2.2.2⟩,
+          acc5 := ⟨w4.2.2.2.1, w4.2.2.2.2⟩,
+          bit0 := (Vector.ofFn (fun j : Fin 5 =>
+            ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
+              (.const 0)))[0],
+          bit1 := (Vector.ofFn (fun j : Fin 5 =>
+            ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
+              (.const 0)))[1],
+          bit2 := (Vector.ofFn (fun j : Fin 5 =>
+            ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
+              (.const 0)))[2],
+          bit3 := (Vector.ofFn (fun j : Fin 5 =>
+            ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
+              (.const 0)))[3],
+          bit4 := (Vector.ofFn (fun j : Fin 5 =>
+            ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
+              (.const 0)))[4],
+          slope0 := w0.1, slope1 := w1.1, slope2 := w2.1, slope3 := w3.1,
+          slope4 := w4.1,
+          nPrev := b.fst.2, nNext := nAcc, base := base }
+        = .ok (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
+            pref.length) := by
+      obtain ⟨hfxT, hfyT, hfb0, hfb1, hfb2, hfb3, hfb4⟩ :=
+        chainBuildV_fields xv yv x0v y0v 0 bsF pref.length
+      refine evalScale_ok_iff.mpr
+        ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_,
+          ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+      · rw [hfxT]
+        exact CVar.eval_le hleA hxT'
+      · rw [hfyT]
+        exact CVar.eval_le hleA hyT'
+      · exact CVar.eval_le hleA hxI
+      · exact CVar.eval_le hleA hyI
+      · exact CVar.eval_le ((((hle₆.trans hle₇).trans hle₈).trans hle₉)) hx1e
+      · exact CVar.eval_le ((((hle₆.trans hle₇).trans hle₈).trans hle₉)) hy1e
+      · exact CVar.eval_le (((hle₇.trans hle₈).trans hle₉)) hx2e
+      · exact CVar.eval_le (((hle₇.trans hle₈).trans hle₉)) hy2e
+      · exact CVar.eval_le ((hle₈.trans hle₉)) hx3e
+      · exact CVar.eval_le ((hle₈.trans hle₉)) hy3e
+      · exact CVar.eval_le hle₉ hx4e
+      · exact CVar.eval_le hle₉ hy4e
+      · exact hx5e
+      · exact hy5e
+      · exact CVar.eval_le hleA hnI
+      · exact CVar.eval_le hleB hnA
+      · rw [hfb0]
+        exact CVar.eval_le hleA hcurj0
+      · rw [hfb1]
+        exact CVar.eval_le hleA (hcurj 1 (by omega))
+      · rw [hfb2]
+        exact CVar.eval_le hleA (hcurj 2 (by omega))
+      · rw [hfb3]
+        exact CVar.eval_le hleA (hcurj 3 (by omega))
+      · rw [hfb4]
+        exact CVar.eval_le hleA (hcurj 4 (by omega))
+      · exact CVar.eval_le ((((hle₆.trans hle₇).trans hle₈).trans hle₉)) hs0e
+      · exact CVar.eval_le (((hle₇.trans hle₈).trans hle₉)) hs1e
+      · exact CVar.eval_le ((hle₈.trans hle₉)) hs2e
+      · exact CVar.eval_le hle₉ hs3e
+      · exact hs4e
+    -- restore the invariant at the extended prefix
+    refine ⟨hLe.trans hleA, ⟨?_, ?_, ?_⟩, ?_⟩
+    · simp only [List.length_append, List.length_cons, List.length_nil]
+      rw [Kimchi.Gate.VarBaseMul.chainBuild_succ_x0]
+      exact hx5e
+    · simp only [List.length_append, List.length_cons, List.length_nil]
+      rw [Kimchi.Gate.VarBaseMul.chainBuild_succ_y0]
+      exact hy5e
+    · simp only [List.length_append, List.length_cons, List.length_nil]
+      rw [Kimchi.Gate.VarBaseMul.chainBuild_succ_n]
+      exact CVar.eval_le hleB hnA
+    · intro r hr
+      simp only [List.mem_append, List.mem_cons, List.not_mem_nil, or_false] at hr
+      rcases hr with hr | rfl
+      · obtain ⟨w, hev, hHw⟩ := hrounds r hr
+        exact ⟨w, evalScale_le hleA hev, hHw⟩
+      · exact ⟨_, hround, hHolds pref.length hkrows⟩
+  case vc2.vc1.vc1.vc1.refine_2.pre =>
+    refine ⟨Assignments.Le.refl st₃.env, ⟨hx0e, hy0e, rfl⟩, fun r hr => ?_⟩
+    exact absurd hr List.not_mem_nil
+  case vc3.vc1.vc1.vc1.refine_2.post.success =>
+    rename_i finp s' hinv
+    obtain ⟨hLe, ⟨hxP, hyP, hnP⟩, hrounds⟩ := hinv
+    simp only [List.length_map, List.length_range] at hxP hyP hnP hrounds
+    -- the register pin: the final register reads as the scalar
+    have hrun : Kimchi.Gate.VarBaseMul.runBits
+        (fun i => Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF i) chunks
+        = (List.range (5 * chunks)).map bsF := by
+      unfold Kimchi.Gate.VarBaseMul.runBits
+      rw [List.flatMap_congr (fun i _ => by
+        obtain ⟨-, -, hb0, hb1, hb2, hb3, hb4⟩ :=
+          chainBuildV_fields xv yv x0v y0v 0 bsF i
+        rw [hb0, hb1, hb2, hb3, hb4]),
+        Kimchi.Gate.VarBaseMul.flatMap_range_window]
+    have hreg : (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF chunks).n
+        = v := by
+      have hchain := Kimchi.Gate.VarBaseMul.chain_accN chunks
+        (fun i => Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF i)
+        hHolds (fun i _ => rfl)
+      rw [accN_chainBuildV, accN_chainBuildV, hrun,
+        show (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF 0).n = 0
+          from rfl, mul_zero, zero_add,
+        Kimchi.Gate.VarBaseMul.bitsRegister_eq_cast _ (fun x hx => by
+          obtain ⟨j, hjmem, rfl⟩ := List.mem_map.mp hx
+          exact hbsb j (List.mem_range.mp hjmem)),
+        hbsF, Kimchi.Gate.VarBaseMul.bitsVal_testBit nn (5 * chunks) hrange]
+        at hchain
+      rw [hchain]
+      push_cast
+      exact hfaith
+    have hsv' : scalar.val.eval s'.env = .ok v :=
+      CVar.eval_le ((hle₁.trans (hle₂.trans hle₃)).trans hLe) hv
+    -- the constraint: every collected round's read row holds
+    refine addConstraint_complete_spec (c := KimchiConstraint F)
+      (KimchiSystem.varBaseMul finp.snd) _ s' ⟨?_, fun u st₄ _ hle₄ => ?_⟩
+    · show KimchiConstraint.check (.varBaseMul finp.snd) s'.env = true
+      simp only [KimchiConstraint.check]
+      rw [List.all_eq_true]
+      intro r hr
+      obtain ⟨w, hev, hHw⟩ := hrounds r hr
+      rw [hev]
+      exact (Kimchi.Gate.VarBaseMul.ok_iff w).mpr hHw
+    mvcgen
+    -- the pin
+    refine ⟨⟨by rw [CVar.eval_le hle₄ hnP]; rfl, by rw [CVar.eval_le hle₄ hsv']; rfl,
+      fun rv sv hrv hsv => ?_⟩, fun u' st₅ hle₅ => ?_⟩
+    · rw [CVar.eval_le hle₄ hnP] at hrv
+      injection hrv with hrv
+      rw [CVar.eval_le hle₄ hsv'] at hsv
+      injection hsv with hsv
+      subst hrv hsv
+      exact hreg
+    simp only [wp, PredTrans.apply, prove]
+    intro hf
+    refine hk ⟨finp.fst.1, bits⟩ ⟨st₅.nv, st₅.env, hf⟩
+      (fun v' xv' yv' hv' hxv' hyv' hT' => ?_)
+      ((hle₁.trans (hle₂.trans hle₃)).trans (hLe.trans (hle₄.trans hle₅)))
+    rw [hv] at hv'
+    injection hv' with hv'
+    rw [hxv] at hxv'
+    injection hxv' with hxv'
+    rw [hyv] at hyv'
+    injection hyv' with hyv'
+    subst hv' hxv' hyv'
+    -- the point chain: `varBaseMul_off` at the honest walk
+    obtain ⟨hfin', hpt, -⟩ := Kimchi.Gate.VarBaseMul.varBaseMul_off d.W chunks
+      (fun i => Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF i)
+      (Point.some _ _ hT) (2 * (nn : ℤ) + 2 ^ (5 * chunks) + 1)
+      (Point.some_ne_zero hT) hHolds hT rfl
+      (fun i _ => by
+        obtain ⟨hx1, hy1, -, -, -, -, -⟩ := chainBuildV_fields xv yv x0v y0v 0 bsF i
+        obtain ⟨hx0', hy0', -, -, -, -, -⟩ :=
+          chainBuildV_fields xv yv x0v y0v 0 bsF 0
+        rw [hx1, hy1, hx0', hy0']
+        exact ⟨rfl, rfl⟩)
+      (fun i _ => ⟨rfl, rfl⟩) hP0ns hP0eq d.two_ne d.odd
+      (by
+        rw [Kimchi.Gate.VarBaseMul.gateLadder_eq_register,
+          Kimchi.Gate.VarBaseMul.gateRegister_eq_bitsVal, hrun, hbsF,
+          Kimchi.Gate.VarBaseMul.bitsVal_testBit nn (5 * chunks) hrange])
+      (by rw [← hladder]; exact hregime')
+    have hax := accX_chainBuildV xv yv x0v y0v 0 bsF chunks
+    have hay := accY_chainBuildV xv yv x0v y0v 0 bsF chunks
+    have hfin : d.W.Nonsingular
+        (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF chunks).x0
+        (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF chunks).y0 := by
+      rw [← hax, ← hay]
+      exact hfin'
+    exact ⟨(Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF chunks).x0,
+      (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF chunks).y0,
+      CVar.eval_le (hle₄.trans hle₅) hxP, CVar.eval_le (hle₄.trans hle₅) hyP,
+      hfin,
+      (Kimchi.Gate.EndoMul.some_congr d.W hfin hfin' hax.symm hay.symm).trans hpt⟩
+  case vc4.vc1.vc1.vc1.refine_2.post.except =>
+    exact ExceptConds.entails_false
+
 end Snarky.Kimchi

--- a/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
@@ -1052,7 +1052,7 @@ row back; registered, so `mvcgen` applies it once per iteration. -/
       = .ok (Kimchi.Gate.VarBaseMul.build xT yT x0 y0 nv b0 b1 b2 b3 b4).nPrime := by
     rw [nAccWit_ok hnv hb0 hb1 hb2 hb3 hb4, build_nPrime]
   refine ⟨by rw [hnOk]; rfl, fun nAcc st₁ hgN hle₁ => ?_⟩
-  have hnA := reads_fvar (hgN _ hnOk)
+  have hnA := (hgN _ hnOk)
   mvcgen
   -- the five bit steps, each reading the previous accumulator
   have hw0Ok := bitWit_ok (CVar.eval_le hle₁ hxT) (CVar.eval_le hle₁ hyT)
@@ -1065,9 +1065,9 @@ row back; registered, so `mvcgen` applies it once per iteration. -/
   rw [← es0] at hs0'
   rw [← ex0] at hx1'
   rw [← ey0] at hy1'
-  have hs0 := reads_fvar hs0'
-  have hx1 := reads_fvar hx1'
-  have hy1 := reads_fvar hy1'
+  have hs0 := hs0'
+  have hx1 := hx1'
+  have hy1 := hy1'
   mvcgen
   have hw1Ok := bitWit_ok (acc := ⟨w0.2.2.2.1, w0.2.2.2.2⟩)
     (CVar.eval_le (hle₁.trans hle₂) hxT) (CVar.eval_le (hle₁.trans hle₂) hyT)
@@ -1078,9 +1078,9 @@ row back; registered, so `mvcgen` applies it once per iteration. -/
   rw [← es1] at hs1'
   rw [← ex1] at hx2'
   rw [← ey1] at hy2'
-  have hs1 := reads_fvar hs1'
-  have hx2 := reads_fvar hx2'
-  have hy2 := reads_fvar hy2'
+  have hs1 := hs1'
+  have hx2 := hx2'
+  have hy2 := hy2'
   mvcgen
   have hw2Ok := bitWit_ok (acc := ⟨w1.2.2.2.1, w1.2.2.2.2⟩)
     (CVar.eval_le ((hle₁.trans hle₂).trans hle₃) hxT)
@@ -1092,9 +1092,9 @@ row back; registered, so `mvcgen` applies it once per iteration. -/
   rw [← es2] at hs2'
   rw [← ex2] at hx3'
   rw [← ey2] at hy3'
-  have hs2 := reads_fvar hs2'
-  have hx3 := reads_fvar hx3'
-  have hy3 := reads_fvar hy3'
+  have hs2 := hs2'
+  have hx3 := hx3'
+  have hy3 := hy3'
   mvcgen
   have hw3Ok := bitWit_ok (acc := ⟨w2.2.2.2.1, w2.2.2.2.2⟩)
     (CVar.eval_le (((hle₁.trans hle₂).trans hle₃).trans hle₄) hxT)
@@ -1106,9 +1106,9 @@ row back; registered, so `mvcgen` applies it once per iteration. -/
   rw [← es3] at hs3'
   rw [← ex3] at hx4'
   rw [← ey3] at hy4'
-  have hs3 := reads_fvar hs3'
-  have hx4 := reads_fvar hx4'
-  have hy4 := reads_fvar hy4'
+  have hs3 := hs3'
+  have hx4 := hx4'
+  have hy4 := hy4'
   mvcgen
   have hw4Ok := bitWit_ok (acc := ⟨w3.2.2.2.1, w3.2.2.2.2⟩)
     (CVar.eval_le ((((hle₁.trans hle₂).trans hle₃).trans hle₄).trans hle₅) hxT)
@@ -1121,9 +1121,9 @@ row back; registered, so `mvcgen` applies it once per iteration. -/
   rw [← es4] at hs4'
   rw [← ex4] at hx5'
   rw [← ey4] at hy5'
-  have hs4 := reads_fvar hs4'
-  have hx5 := reads_fvar hx5'
-  have hy5 := reads_fvar hy5'
+  have hs4 := hs4'
+  have hx5 := hx5'
+  have hy5 := hy5'
   mvcgen
   have hleA : st₀.env.Le st₆.env :=
     hle₁.trans ((((hle₂.trans hle₃).trans hle₄).trans hle₅).trans hle₆)

--- a/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
@@ -1275,181 +1275,67 @@ theorem varBaseMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
     mvcgen
     -- the five bit steps: each quintet reads the previous accumulator and
     -- computes `stepBit`, i.e. the walk's next fields
-    have hw0Ok : bitWit base ((Vector.ofFn (fun j : Fin 5 =>
-        ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
-          (.const 0)))[0]'(by omega)) b.fst.1 st₄.env
-        = .ok ((Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-              pref.length).s0,
-            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-              pref.length).s0
-              * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                pref.length).s0,
-            2 * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                pref.length).y0
-              / (2 * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                  pref.length).x0 + xv
-                - (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                    pref.length).s0
-                  * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                    pref.length).s0)
-              - (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                pref.length).s0,
-            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-              pref.length).x1,
-            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-              pref.length).y1) := by
-      rw [bitWit_ok (CVar.eval_le hle₄ hxT') (CVar.eval_le hle₄ hyT')
-        (CVar.eval_le hle₄ hxI) (CVar.eval_le hle₄ hyI)
-        (CVar.eval_le hle₄ hcurj0),
-        Kimchi.Gate.VarBaseMul.chainBuild_s0, Kimchi.Gate.VarBaseMul.chainBuild_x1,
-        Kimchi.Gate.VarBaseMul.chainBuild_y1]
+    have hw0Ok := bitWit_ok (CVar.eval_le hle₄ hxT') (CVar.eval_le hle₄ hyT')
+      (CVar.eval_le hle₄ hxI) (CVar.eval_le hle₄ hyI) (CVar.eval_le hle₄ hcurj0)
     refine ⟨by rw [hw0Ok]; rfl, fun w0 st₅ hg0 hle₅ => ?_⟩
     obtain ⟨hs0e', -, -, hx1e', hy1e'⟩ := hg0 _ hw0Ok
+    rw [← Kimchi.Gate.VarBaseMul.chainBuild_s0] at hs0e'
+    rw [← Kimchi.Gate.VarBaseMul.chainBuild_x1] at hx1e'
+    rw [← Kimchi.Gate.VarBaseMul.chainBuild_y1] at hy1e'
     have hs0e := reads_fvar hs0e'
     have hx1e := reads_fvar hx1e'
     have hy1e := reads_fvar hy1e'
     mvcgen
-    have hw1Ok : bitWit base ((Vector.ofFn (fun j : Fin 5 =>
-        ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
-          (.const 0)))[1]'(by omega)) ⟨w0.2.2.2.1, w0.2.2.2.2⟩ st₅.env
-        = .ok ((Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-              pref.length).s1,
-            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-              pref.length).s1
-              * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                pref.length).s1,
-            2 * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                pref.length).y1
-              / (2 * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                  pref.length).x1 + xv
-                - (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                    pref.length).s1
-                  * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                    pref.length).s1)
-              - (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                pref.length).s1,
-            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-              pref.length).x2,
-            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-              pref.length).y2) := by
-      rw [bitWit_ok (acc := ⟨w0.2.2.2.1, w0.2.2.2.2⟩)
-        (CVar.eval_le (hle₄.trans hle₅) hxT')
-        (CVar.eval_le (hle₄.trans hle₅) hyT') hx1e hy1e
-        (CVar.eval_le (hle₄.trans hle₅) (hcurj 1 (by omega))),
-        Kimchi.Gate.VarBaseMul.chainBuild_s1, Kimchi.Gate.VarBaseMul.chainBuild_x2,
-        Kimchi.Gate.VarBaseMul.chainBuild_y2]
+    have hw1Ok := bitWit_ok (acc := ⟨w0.2.2.2.1, w0.2.2.2.2⟩)
+      (CVar.eval_le (hle₄.trans hle₅) hxT') (CVar.eval_le (hle₄.trans hle₅) hyT')
+      hx1e hy1e (CVar.eval_le (hle₄.trans hle₅) (hcurj 1 (by omega)))
     refine ⟨by rw [hw1Ok]; rfl, fun w1 st₆ hg1 hle₆ => ?_⟩
     obtain ⟨hs1e', -, -, hx2e', hy2e'⟩ := hg1 _ hw1Ok
+    rw [← Kimchi.Gate.VarBaseMul.chainBuild_s1] at hs1e'
+    rw [← Kimchi.Gate.VarBaseMul.chainBuild_x2] at hx2e'
+    rw [← Kimchi.Gate.VarBaseMul.chainBuild_y2] at hy2e'
     have hs1e := reads_fvar hs1e'
     have hx2e := reads_fvar hx2e'
     have hy2e := reads_fvar hy2e'
     mvcgen
-    have hw2Ok : bitWit base ((Vector.ofFn (fun j : Fin 5 =>
-        ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
-          (.const 0)))[2]'(by omega)) ⟨w1.2.2.2.1, w1.2.2.2.2⟩ st₆.env
-        = .ok ((Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-              pref.length).s2,
-            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-              pref.length).s2
-              * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                pref.length).s2,
-            2 * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                pref.length).y2
-              / (2 * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                  pref.length).x2 + xv
-                - (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                    pref.length).s2
-                  * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                    pref.length).s2)
-              - (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                pref.length).s2,
-            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-              pref.length).x3,
-            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-              pref.length).y3) := by
-      rw [bitWit_ok (acc := ⟨w1.2.2.2.1, w1.2.2.2.2⟩)
-        (CVar.eval_le ((hle₄.trans hle₅).trans hle₆) hxT')
-        (CVar.eval_le ((hle₄.trans hle₅).trans hle₆) hyT')
-        hx2e hy2e
-        (CVar.eval_le ((hle₄.trans hle₅).trans hle₆) (hcurj 2 (by omega))),
-        Kimchi.Gate.VarBaseMul.chainBuild_s2, Kimchi.Gate.VarBaseMul.chainBuild_x3,
-        Kimchi.Gate.VarBaseMul.chainBuild_y3]
+    have hw2Ok := bitWit_ok (acc := ⟨w1.2.2.2.1, w1.2.2.2.2⟩)
+      (CVar.eval_le ((hle₄.trans hle₅).trans hle₆) hxT')
+      (CVar.eval_le ((hle₄.trans hle₅).trans hle₆) hyT') hx2e hy2e
+      (CVar.eval_le ((hle₄.trans hle₅).trans hle₆) (hcurj 2 (by omega)))
     refine ⟨by rw [hw2Ok]; rfl, fun w2 st₇ hg2 hle₇ => ?_⟩
     obtain ⟨hs2e', -, -, hx3e', hy3e'⟩ := hg2 _ hw2Ok
+    rw [← Kimchi.Gate.VarBaseMul.chainBuild_s2] at hs2e'
+    rw [← Kimchi.Gate.VarBaseMul.chainBuild_x3] at hx3e'
+    rw [← Kimchi.Gate.VarBaseMul.chainBuild_y3] at hy3e'
     have hs2e := reads_fvar hs2e'
     have hx3e := reads_fvar hx3e'
     have hy3e := reads_fvar hy3e'
     mvcgen
-    have hw3Ok : bitWit base ((Vector.ofFn (fun j : Fin 5 =>
-        ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
-          (.const 0)))[3]'(by omega)) ⟨w2.2.2.2.1, w2.2.2.2.2⟩ st₇.env
-        = .ok ((Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-              pref.length).s3,
-            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-              pref.length).s3
-              * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                pref.length).s3,
-            2 * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                pref.length).y3
-              / (2 * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                  pref.length).x3 + xv
-                - (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                    pref.length).s3
-                  * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                    pref.length).s3)
-              - (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                pref.length).s3,
-            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-              pref.length).x4,
-            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-              pref.length).y4) := by
-      rw [bitWit_ok (acc := ⟨w2.2.2.2.1, w2.2.2.2.2⟩)
-        (CVar.eval_le (((hle₄.trans hle₅).trans hle₆).trans hle₇) hxT')
-        (CVar.eval_le (((hle₄.trans hle₅).trans hle₆).trans hle₇) hyT')
-        hx3e hy3e
-        (CVar.eval_le (((hle₄.trans hle₅).trans hle₆).trans hle₇)
-          (hcurj 3 (by omega))),
-        Kimchi.Gate.VarBaseMul.chainBuild_s3, Kimchi.Gate.VarBaseMul.chainBuild_x4,
-        Kimchi.Gate.VarBaseMul.chainBuild_y4]
+    have hw3Ok := bitWit_ok (acc := ⟨w2.2.2.2.1, w2.2.2.2.2⟩)
+      (CVar.eval_le (((hle₄.trans hle₅).trans hle₆).trans hle₇) hxT')
+      (CVar.eval_le (((hle₄.trans hle₅).trans hle₆).trans hle₇) hyT') hx3e hy3e
+      (CVar.eval_le (((hle₄.trans hle₅).trans hle₆).trans hle₇)
+        (hcurj 3 (by omega)))
     refine ⟨by rw [hw3Ok]; rfl, fun w3 st₈ hg3 hle₈ => ?_⟩
     obtain ⟨hs3e', -, -, hx4e', hy4e'⟩ := hg3 _ hw3Ok
+    rw [← Kimchi.Gate.VarBaseMul.chainBuild_s3] at hs3e'
+    rw [← Kimchi.Gate.VarBaseMul.chainBuild_x4] at hx4e'
+    rw [← Kimchi.Gate.VarBaseMul.chainBuild_y4] at hy4e'
     have hs3e := reads_fvar hs3e'
     have hx4e := reads_fvar hx4e'
     have hy4e := reads_fvar hy4e'
     mvcgen
-    have hw4Ok : bitWit base ((Vector.ofFn (fun j : Fin 5 =>
-        ((bits.toList.take (5 * chunks)).reverse).getD (5 * pref.length + j.1)
-          (.const 0)))[4]'(by omega)) ⟨w3.2.2.2.1, w3.2.2.2.2⟩ st₈.env
-        = .ok ((Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-              pref.length).s4,
-            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-              pref.length).s4
-              * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                pref.length).s4,
-            2 * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                pref.length).y4
-              / (2 * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                  pref.length).x4 + xv
-                - (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                    pref.length).s4
-                  * (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                    pref.length).s4)
-              - (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-                pref.length).s4,
-            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-              pref.length).x5,
-            (Kimchi.Gate.VarBaseMul.chainBuild xv yv x0v y0v 0 bsF
-              pref.length).y5) := by
-      rw [bitWit_ok (acc := ⟨w3.2.2.2.1, w3.2.2.2.2⟩)
-        (CVar.eval_le ((((hle₄.trans hle₅).trans hle₆).trans hle₇).trans hle₈) hxT')
-        (CVar.eval_le ((((hle₄.trans hle₅).trans hle₆).trans hle₇).trans hle₈) hyT')
-        hx4e hy4e
-        (CVar.eval_le ((((hle₄.trans hle₅).trans hle₆).trans hle₇).trans hle₈)
-          (hcurj 4 (by omega))),
-        Kimchi.Gate.VarBaseMul.chainBuild_s4, Kimchi.Gate.VarBaseMul.chainBuild_x5,
-        Kimchi.Gate.VarBaseMul.chainBuild_y5]
+    have hw4Ok := bitWit_ok (acc := ⟨w3.2.2.2.1, w3.2.2.2.2⟩)
+      (CVar.eval_le ((((hle₄.trans hle₅).trans hle₆).trans hle₇).trans hle₈) hxT')
+      (CVar.eval_le ((((hle₄.trans hle₅).trans hle₆).trans hle₇).trans hle₈) hyT')
+      hx4e hy4e
+      (CVar.eval_le ((((hle₄.trans hle₅).trans hle₆).trans hle₇).trans hle₈)
+        (hcurj 4 (by omega)))
     refine ⟨by rw [hw4Ok]; rfl, fun w4 st₉ hg4 hle₉ => ?_⟩
     obtain ⟨hs4e', -, -, hx5e', hy5e'⟩ := hg4 _ hw4Ok
+    rw [← Kimchi.Gate.VarBaseMul.chainBuild_s4] at hs4e'
+    rw [← Kimchi.Gate.VarBaseMul.chainBuild_x5] at hx5e'
+    rw [← Kimchi.Gate.VarBaseMul.chainBuild_y5] at hy5e'
     have hs4e := reads_fvar hs4e'
     have hx5e := reads_fvar hx5e'
     have hy5e := reads_fvar hy5e'

--- a/formal/snarky/roots.txt
+++ b/formal/snarky/roots.txt
@@ -398,6 +398,7 @@ Snarky.Kimchi.EndoMul.endoMul_complete_spec
 Snarky.Kimchi.EndoMul.endoInv_spec
 Snarky.Kimchi.EndoMul.endoInv_complete_spec
 Snarky.Kimchi.varBaseMul_spec
+Snarky.Kimchi.varBaseMul_complete_spec
 Snarky.Kimchi.scaleFast1_spec
 Snarky.Kimchi.splitFieldVar_spec
 Snarky.Kimchi.scaleFast2_spec

--- a/formal/snarky/scripts/check_axioms.lean
+++ b/formal/snarky/scripts/check_axioms.lean
@@ -101,6 +101,7 @@ def roots : List Name :=
     `Snarky.Kimchi.EndoMul.endoInv_spec,
     `Snarky.Kimchi.EndoMul.endoInv_complete_spec,
     `Snarky.Kimchi.varBaseMul_spec,
+    `Snarky.Kimchi.varBaseMul_complete_spec,
     `Snarky.Kimchi.scaleFast1_spec,
     `Snarky.Kimchi.splitFieldVar_spec,
     `Snarky.Kimchi.scaleFast2_spec,


### PR DESCRIPTION
The completeness half of the VarBaseMul law pair, scoped to the core gadget (`varBaseMul` only; the `scaleFast*` wrapper completeness laws come separately).

## kimchi: the produce chain

The completeness mirror of EndoMul's produce chain, for the binary ladder (`Kimchi/Gate/Semantics/VarBaseMul.lean`):

- `chainBuild` threads the gate's canonical row (`build`) from the doubled init through a flat bit stream, five bits per row; `ladderK` is the stream's honest signed ladder (`k 0 = 2`, `k (j+1) = 2·k j + bitSign (bs j)`), decoding to Type1's `2·s + 2^L + 1` on boolean streams (`ladderK_eq_bitsVal`).
- `chain_complete`: under either regime — subwrap free, one-wrap with `ladderK bs (5m) ∉ forbiddenValues` — every generated row satisfies the gate. The non-degeneracy is **produced forward**: the regime prices all four degeneracy residues at every step through the existing kernel (`ladder_subwrap_nondegen` / `ladder_nondegen_tight`, consumed backward by the sound side), and `step_produce` derives each generated step's two secant denominators before certifying it — the x-condition from `k ≢ ±1`, the second denominator from the intermediate `I + Q ≠ ±I`, i.e. `2k ≢ ∓1`. The sound per-step advance then reads the output multiple back, so the only fresh geometry is one secant and the ±-bridge.
- Per-field row equations (`chainBuild_s0 … chainBuild_nPrime`, the successor threading) so a prover-side identification never normalizes `build`'s five-step let chain itself.
- `bitsVal_testBit` (MSB-first testBit reconstruction of a bounded scalar) and `flatMap_range_window` (five-bit windows tile the flat stream) join the bits vocabulary.

## snarky: `varBaseMul_complete_spec`

Gate-semantics-direct and constructive over the FIXED prover code: on a readable on-curve base and a readable in-range faithful scalar whose Type1 decode satisfies the ladder regime, the honest run accepts and the returned point reads as the defining equation's honest side, `[fromShifted t]·g` at the scalar's canonical value.

- The regime precondition is per-scalar, the same `HasCurve.LadderRegime` fact the sound law conditions on, at the honest decode `fromShifted ⟨toNat v⟩`. This conditionality is forced: a forbidden scalar's honest run genuinely fails (a secant denominator vanishes), so no completeness holds there — and it is exactly the contract of PS's Type1 `CheckedType` forbidden-values check. Below full width the subwrap arm discharges it for every scalar.
- Range + faithfulness are explicit hypotheses, not a `SizedF` tag — the PS argument is a bare `Type1 (FVar f)`.
- The walk identifies the run with `chainBuild`: each round's checker obligation closes by `chain_complete`, the init by the doubling `addFast`, the register pin by `chain_accN` through `bitsVal_testBit`, and the point by `varBaseMul_off` at the honest rows.

## Gates

Build clean; style OK; kimchi axiom gate 109 roots, snarky 128 roots (both reduce to the standard axiom set); dead-code sweep 0/2457.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QYZxnvZuHfK7cR4DYFHBA