### PR TITLE
The scaleFast completeness laws — wrappers ride the core, and the seams get repaired

### DIFF
--- a/formal/kimchi/Kimchi/Gate/Semantics/VarBaseMul.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/VarBaseMul.lean
@@ -1246,6 +1246,13 @@ conclude correctness — `varBaseMul_subwrap_correct` unconditionally below the 
 def forbiddenValues (order : ℕ) : Set ℤ :=
   {s | ∃ t ∈ Ladder.forbiddenResidues, (order : ℤ) ∣ (s - t)}
 
+/-- `1` is a forbidden residue: a scalar `≡ 1 (mod order)` is in the band. The
+membership an off-band caller inverts to keep its final accumulator away from the
+base (`[s]·T = T` forces `order ∣ s − 1`). -/
+theorem mem_forbiddenValues_of_dvd_sub_one (order : ℕ) {s : ℤ}
+    (h : (order : ℤ) ∣ (s - 1)) : s ∈ forbiddenValues order :=
+  ⟨1, by decide, h⟩
+
 /-- **Prime order ⇒ full order.** For a nonzero point `T` on a `short-Weierstrass curve`, a scalar
     multiple `m • T` vanishes iff `order ∣ m`. (`order` is prime and `order • T = 0`, so
     `addOrderOf T ∣ order`; nonzero `T` rules out `addOrderOf T = 1`, hence it equals

--- a/formal/snarky/Snarky/Backend/Assignments.lean
+++ b/formal/snarky/Snarky/Backend/Assignments.lean
@@ -192,11 +192,11 @@ theorem val_toValuation [Add F] [Mul F] [Zero F] {env : Assignments F} {x : CVar
   rw [eval_toAssignments] at h'
   injection h'
 
-/-- `add_` reads as the sum — the fold-evaluation lemma `eval_add_`, carried through
+/-- `add_` reads as the sum — the fold-evaluation lemma `eval_add_fold`, carried through
 the bridge to the total reading. -/
 @[circuitVal] theorem val_add_ [Add F] [Mul F] (a b : CVar F) (V : Valuation F) :
     (CVar.add_ a b).val V = a.val V + b.val V := by
-  have h := (CVar.eval_add_ a b V.toAssignments).trans
+  have h := (CVar.eval_add_fold a b V.toAssignments).trans
     (eval_toAssignments (CVar.add a b) V)
   rw [eval_toAssignments] at h
   injection h

--- a/formal/snarky/Snarky/Backend/WP.lean
+++ b/formal/snarky/Snarky/Backend/WP.lean
@@ -346,6 +346,19 @@ reason `Complete` records. -/
 def ReadsBit [Add F] [Mul F] [Zero F] [One F] (x : CVar F) (env : Assignments F) : Prop :=
   (x.eval env).isOk ∧ ∀ v, x.eval env = .ok v → v = 0 ∨ v = 1
 
+/-- The canonical producer fact introduces the reading: an operand that reads as
+`bit b` `ReadsBit` — how one gadget's grant becomes the next gadget's precondition. -/
+theorem ReadsBit.of_bit [Add F] [Mul F] [Zero F] [One F] {x : CVar F}
+    {env : Assignments F} {b : Bool} (h : x.eval env = .ok (bit b)) :
+    ReadsBit x env := by
+  refine ⟨by rw [h]; rfl, fun w hw => ?_⟩
+  rw [h] at hw
+  injection hw with hw
+  subst hw
+  cases b
+  · exact Or.inl rfl
+  · exact Or.inr rfl
+
 /-- Name the bit an operand reads as — the form a proof consumes, recovered inside the
 proof rather than quantified in the statement. -/
 theorem ReadsBit.exists_bit [Add F] [Mul F] [Zero F] [One F] {x : CVar F}
@@ -355,6 +368,13 @@ theorem ReadsBit.exists_bit [Add F] [Mul F] [Zero F] [One F] {x : CVar F}
   rcases hbit v hv with h0 | h1
   · exact ⟨false, by rw [hv, h0]; rfl⟩
   · exact ⟨true, by rw [hv, h1]; rfl⟩
+
+/-- The reading survives table extension. -/
+theorem ReadsBit.mono [Add F] [Mul F] [Zero F] [One F] {x : CVar F}
+    {env env' : Assignments F} (hle : env.Le env') (h : ReadsBit x env) :
+    ReadsBit x env' := by
+  obtain ⟨b, hb⟩ := h.exists_bit
+  exact .of_bit (CVar.eval_le hle hb)
 
 /-! ## Running a schematic spec
 

--- a/formal/snarky/Snarky/Circuit/CVar.lean
+++ b/formal/snarky/Snarky/Circuit/CVar.lean
@@ -145,9 +145,17 @@ The smart constructors pre-fold constants; these lemmas say the folds cannot cha
 successful evaluation — what connects gadget fast paths to the gadget laws. -/
 
 /-- `add_` evaluates like the raw constructor. -/
-theorem eval_add_ [Add F] [Mul F] (a b : CVar F) (env : Variable → Option F) :
+theorem eval_add_fold [Add F] [Mul F] (a b : CVar F) (env : Variable → Option F) :
     (add_ a b).eval env = (CVar.add a b).eval env := by
   cases a <;> cases b <;> rfl
+
+/-- `add_` evaluates to the sum. -/
+theorem eval_add_ [Add F] [Mul F] {a b : CVar F}
+    {env : Variable → Option F} {av bv : F}
+    (ha : a.eval env = .ok av) (hb : b.eval env = .ok bv) :
+    (add_ a b).eval env = .ok (av + bv) := by
+  rw [eval_add_fold]
+  simp [eval, ha, hb]
 
 /-- `scale_` evaluates to the scalar product. -/
 theorem eval_scale_ [Add F] [MulZeroOneClass F] [DecidableEq F] {x : CVar F}
@@ -169,7 +177,7 @@ theorem eval_sub_ [CommRing F] [DecidableEq F] {a b : CVar F}
   · next c₁ c₂ =>
     simp only [eval, Except.ok.injEq] at ha hb
     subst ha; subst hb; rfl
-  · rw [eval_add_]
+  · rw [eval_add_fold]
     have hs := eval_scale_ hb (-1)
     simp only [eval, ha, hs]
     congr 1

--- a/formal/snarky/Snarky/Circuit/DSL/Bits.lean
+++ b/formal/snarky/Snarky/Circuit/DSL/Bits.lean
@@ -108,7 +108,7 @@ private theorem packAux_eval {F : Type u} [Semiring F] [DecidableEq F]
       simp only [List.map_cons, List.cons.injEq] at hmap
       obtain ⟨hb, hrest⟩ := hmap
       refine ih bl (i + 1) _ _ hrest ?_
-      rw [CVar.eval_add_]
+      rw [CVar.eval_add_fold]
       have hs := CVar.eval_scale_ hb ((2 : F) ^ i)
       simp only [CVar.eval, hacc, hs]
 

--- a/formal/snarky/Snarky/Circuit/DSL/Boolean.lean
+++ b/formal/snarky/Snarky/Circuit/DSL/Boolean.lean
@@ -409,8 +409,7 @@ theorem sum_evalOk {F : Type} [Semiring F] [DecidableEq F] {env : Assignments F}
     obtain ⟨av, ha⟩ := CVar.evalOk hacc
     obtain ⟨bv, hb⟩ := CVar.evalOk (hall b (List.mem_cons_self ..))
     refine ih _ ?_ (fun x hx => hall x (List.mem_cons_of_mem _ hx))
-    rw [CVar.eval_add_]
-    simp only [CVar.eval, ha, hb]
+    rw [CVar.eval_add_ ha hb]
     rfl
 
 /-- Bit-reading operands read as SOME bit list — names the list a `ReadsBit`
@@ -748,12 +747,12 @@ private theorem xorCore_run {F c : Type} [Field F] [DecidableEq F]
     have hb' := CVar.eval_le hle hb
     have haa : (CVar.add_ (a.toCVar) (a.toCVar)).eval (env.extend nv (bit (ab ^^ bb)))
         = .ok ((bit ab : F) + bit ab) := by
-      rw [CVar.eval_add_]; simp [CVar.eval, ha']
+      exact CVar.eval_add_ ha' ha'
     have hvnv : (CVar.var nv).eval (env.extend nv (bit (ab ^^ bb)))
         = .ok (bit (ab ^^ bb)) := by simp [CVar.eval, Assignments.extend]
     have hab : (CVar.add_ (a.toCVar) (b.toCVar)).eval (env.extend nv (bit (ab ^^ bb)))
         = .ok ((bit ab : F) + bit bb) := by
-      rw [CVar.eval_add_]; simp [CVar.eval, ha', hb']
+      exact CVar.eval_add_ ha' hb'
     have hsub := CVar.eval_sub_ hab hvnv
     exact LawfulChecker.check_r1cs _ _ _ _ _ _ _ haa hb' hsub
       (by cases ab <;> cases bb <;> simp [bit])
@@ -1030,7 +1029,7 @@ private theorem select_mux_eval {F : Type} [Field F] [DecidableEq F] {bc : CVar 
   have htv : tv' = tv := by simpa [CVar.eval] using ht
   have hev : ev' = ev := by simpa [CVar.eval] using he
   rw [← htv, ← hev]
-  rw [CVar.eval_add_]
+  rw [CVar.eval_add_fold]
   have h₁ : (CVar.scale tv' bc).eval env = .ok (tv' * bit bb) := by
     simp [CVar.eval, hb]
   have h₂ := CVar.eval_scale_

--- a/formal/snarky/Snarky/Circuit/DSL/Field.lean
+++ b/formal/snarky/Snarky/Circuit/DSL/Field.lean
@@ -204,9 +204,8 @@ private theorem sum_go [AddMonoid F] [Mul F] {env : Assignments F} :
     | cons v vs =>
       simp only [List.map_cons, List.cons.injEq] at hmap
       obtain ⟨hx, hrest⟩ := hmap
-      have hstep : (CVar.add_ acc x).eval env = .ok (a + v) := by
-        rw [CVar.eval_add_]
-        simp only [CVar.eval, hacc, hx]
+      have hstep : (CVar.add_ acc x).eval env = .ok (a + v) :=
+        CVar.eval_add_ hacc hx
       simpa [add_assoc] using ih hrest hstep
 
 /-- `sum` evaluates to the sum of its operands' values: if each `xᵢ` evaluates to `vᵢ`

--- a/formal/snarky/Snarky/Kimchi/Circuit/AddComplete.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/AddComplete.lean
@@ -645,6 +645,69 @@ theorem addFast_complete_spec [Field F] [DecidableEq F]
     · exact Or.inl ⟨hinf1 ▸ hpost.2.2, hsum⟩
     · exact Or.inr ⟨_, _, hpost.1, hpost.2.1, hinf0 ▸ hpost.2.2, h3, hsum⟩
 
+open WeierstrassCurve.Affine in
+/-- The negated operand's reading, on a short curve: `(x, −y)` is nonsingular and is
+the group negation — the face a subtracting caller consumes. -/
+theorem neg_point_reading [Field F] (W : WeierstrassCurve.Affine F)
+    (ha : W.a₁ = 0 ∧ W.a₂ = 0 ∧ W.a₃ = 0) {xv yv : F} (hT : W.Nonsingular xv yv) :
+    ∃ hn : W.Nonsingular xv (-yv),
+      (Point.some _ _ hn : W.Point) = -Point.some _ _ hT := by
+  have hy : W.negY xv yv = -yv := by
+    rw [WeierstrassCurve.Affine.negY, ha.1, ha.2.2]
+    ring
+  have hn : W.Nonsingular xv (-yv) := hy ▸ (W.nonsingular_neg xv yv).mpr hT
+  refine ⟨hn, ?_⟩
+  rw [WeierstrassCurve.Affine.Point.neg_some]
+  simp only [hy]
+
+open Std.Do WeierstrassCurve.Affine in
+/-- `addFast`'s completeness at the group level, `checkFinite` mode: nonsingular
+readable operands with `y₁ ≠ 0` whose group sum is nonzero accept, and the result
+reads as the sum — `addFast_complete_spec` with the same-`x` branch analysis done
+once, the face the EC gadget walks consume. -/
+theorem addFast_complete_point_spec [Field F] [DecidableEq F]
+    (W : WeierstrassCurve.Affine F)
+    (ha : W.a₁ = 0 ∧ W.a₂ = 0 ∧ W.a₃ = 0 ∧ W.a₄ = 0) (htwo : (2 : F) ≠ 0)
+    (p1' p2' : AffinePoint (FVar F))
+    (Q : PostCond (AddResult F) (.arg (ProverState F) (.except EvalError .pure))) :
+    ⦃Complete
+        (fun env =>
+          (p1'.x.eval env).isOk ∧ (p1'.y.eval env).isOk ∧
+          (p2'.x.eval env).isOk ∧ (p2'.y.eval env).isOk ∧
+          (∀ x1 y1 x2 y2, p1'.x.eval env = .ok x1 → p1'.y.eval env = .ok y1 →
+            p2'.x.eval env = .ok x2 → p2'.y.eval env = .ok y2 →
+            ∃ (h1 : W.Nonsingular x1 y1) (h2 : W.Nonsingular x2 y2),
+              y1 ≠ 0 ∧ Point.some _ _ h1 + Point.some _ _ h2 ≠ 0))
+        (fun env (r : AddResult F) env' =>
+          ∀ x1 y1 x2 y2, p1'.x.eval env = .ok x1 → p1'.y.eval env = .ok y1 →
+            p2'.x.eval env = .ok x2 → p2'.y.eval env = .ok y2 →
+            ∀ (h1 : W.Nonsingular x1 y1) (h2 : W.Nonsingular x2 y2),
+              ∃ x3 y3, r.p.x.eval env' = .ok x3 ∧ r.p.y.eval env' = .ok y3 ∧
+                ∃ h3 : W.Nonsingular x3 y3,
+                  Point.some _ _ h1 + Point.some _ _ h2 = Point.some _ _ h3)
+        Q⦄
+    addFast (c := KimchiProverC F) .checkFinite p1' p2'
+    ⦃Q⦄ := by
+  intro st hpre
+  refine addFast_complete_spec .checkFinite W ha htwo p1' p2' Q st
+    ⟨⟨hpre.1.1, hpre.1.2.1, hpre.1.2.2.1, hpre.1.2.2.2.1,
+      fun x1 y1 x2 y2 he1 he2 he3 he4 => ?_⟩,
+     fun r st' hpost hle =>
+       hpre.2 r st' (fun x1 y1 x2 y2 he1 he2 he3 he4 h1 h2 => ?_) hle⟩
+  · obtain ⟨h1, h2, hy1ne, hsum⟩ := hpre.1.2.2.2.2 x1 y1 x2 y2 he1 he2 he3 he4
+    refine ⟨h1.1, h2.1, hy1ne, fun _ => ?_⟩
+    rintro ⟨rfl, hyeq⟩
+    subst hyeq
+    apply hsum
+    rw [show Point.some x1 (W.negY x1 y2) h1 = -Point.some x1 y2 h2 from by
+      rw [WeierstrassCurve.Affine.Point.neg_some]]
+    exact neg_add_cancel _
+  · obtain ⟨h1', h2', -, hsum⟩ := hpre.1.2.2.2.2 x1 y1 x2 y2 he1 he2 he3 he4
+    rcases hpost x1 y1 x2 y2 he1 he2 he3 he4 h1 h2 with
+      ⟨-, hzero⟩ | ⟨x3, y3, hx3, hy3, -, h3, hsum3⟩
+    · exact absurd hzero hsum
+    · exact ⟨x3, y3, hx3, hy3, h3, hsum3⟩
+
 end AddFast
 
 end Snarky.Kimchi

--- a/formal/snarky/Snarky/Kimchi/Circuit/AddComplete.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/AddComplete.lean
@@ -535,9 +535,10 @@ private theorem addFastTail_complete_spec [Field F] [DecidableEq F]
     · exact CVar.eval_le (hle05.trans hle₆) hinf
 
 /-- `addFast`'s honest run succeeds at the prover carrier: with the four operand
-coordinates readable, the operands on-curve (short shape), the first finite
-(`y ≠ 0`), and — under `checkFinite` — the sum finite, the checking interpreter at
-`KimchiProverC` accepts every row the gadget emits, and the outputs read as the sum
+coordinates readable, the operands nonsingular (short shape), the first finite
+(`y ≠ 0`), and — under `checkFinite` — the group sum nonzero, the checking
+interpreter at `KimchiProverC` accepts every row the gadget emits, and the outputs
+read as the sum
 in Mathlib's group — *either* the infinity flag reads `1` and the sum is `0`, *or*
 it reads `0` and the output coordinates are a nonsingular point equal to the sum
 (the accepted row satisfies the verified gate, so its `sound` characterizes what
@@ -555,8 +556,9 @@ theorem addFast_complete_spec [Field F] [DecidableEq F]
           (p2'.x.eval env).isOk ∧ (p2'.y.eval env).isOk ∧
           (∀ x1 y1 x2 y2, p1'.x.eval env = .ok x1 → p1'.y.eval env = .ok y1 →
             p2'.x.eval env = .ok x2 → p2'.y.eval env = .ok y2 →
-            W.Equation x1 y1 ∧ W.Equation x2 y2 ∧ y1 ≠ 0 ∧
-              (fin = .checkFinite → ¬(x1 = x2 ∧ y1 = W.negY x2 y2))))
+            ∃ (h1 : W.Nonsingular x1 y1) (h2 : W.Nonsingular x2 y2),
+              y1 ≠ 0 ∧ (fin = .checkFinite →
+                Point.some _ _ h1 + Point.some _ _ h2 ≠ 0)))
         (fun env (r : AddResult F) env' =>
           ∀ x1 y1 x2 y2, p1'.x.eval env = .ok x1 → p1'.y.eval env = .ok y1 →
             p2'.x.eval env = .ok x2 → p2'.y.eval env = .ok y2 →
@@ -578,7 +580,17 @@ theorem addFast_complete_spec [Field F] [DecidableEq F]
   obtain ⟨y1v, hy1⟩ := CVar.evalOk hy1ok
   obtain ⟨x2v, hx2⟩ := CVar.evalOk hx2ok
   obtain ⟨y2v, hy2⟩ := CVar.evalOk hy2ok
-  obtain ⟨hon1, hon2, hy1ne, hfin⟩ := hcond _ _ _ _ hx1 hy1 hx2 hy2
+  obtain ⟨h1n, h2n, hy1ne, hsumne⟩ := hcond _ _ _ _ hx1 hy1 hx2 hy2
+  have hon1 := h1n.1
+  have hon2 := h2n.1
+  have hfin : fin = .checkFinite → ¬(x1v = x2v ∧ y1v = W.negY x2v y2v) := by
+    intro hf
+    rintro ⟨rfl, hyeq⟩
+    subst hyeq
+    apply hsumne hf
+    rw [show Point.some x1v (W.negY x1v y2v) h1n = -Point.some x1v y2v h2n from by
+      rw [WeierstrassCurve.Affine.Point.neg_some]]
+    exact neg_add_cancel _
   refine ⟨⟨hx1ok, hy1ok⟩, fun p1 st₁ hp1 hle₁ => ?_⟩
   obtain ⟨hp1x, hp1y⟩ := hp1 _ _ hx1 hy1
   mvcgen
@@ -659,54 +671,6 @@ theorem neg_point_reading [Field F] (W : WeierstrassCurve.Affine F)
   refine ⟨hn, ?_⟩
   rw [WeierstrassCurve.Affine.Point.neg_some]
   simp only [hy]
-
-open Std.Do WeierstrassCurve.Affine in
-/-- `addFast`'s completeness at the group level, `checkFinite` mode: nonsingular
-readable operands with `y₁ ≠ 0` whose group sum is nonzero accept, and the result
-reads as the sum — `addFast_complete_spec` with the same-`x` branch analysis done
-once, the face the EC gadget walks consume. -/
-theorem addFast_complete_point_spec [Field F] [DecidableEq F]
-    (W : WeierstrassCurve.Affine F)
-    (ha : W.a₁ = 0 ∧ W.a₂ = 0 ∧ W.a₃ = 0 ∧ W.a₄ = 0) (htwo : (2 : F) ≠ 0)
-    (p1' p2' : AffinePoint (FVar F))
-    (Q : PostCond (AddResult F) (.arg (ProverState F) (.except EvalError .pure))) :
-    ⦃Complete
-        (fun env =>
-          (p1'.x.eval env).isOk ∧ (p1'.y.eval env).isOk ∧
-          (p2'.x.eval env).isOk ∧ (p2'.y.eval env).isOk ∧
-          (∀ x1 y1 x2 y2, p1'.x.eval env = .ok x1 → p1'.y.eval env = .ok y1 →
-            p2'.x.eval env = .ok x2 → p2'.y.eval env = .ok y2 →
-            ∃ (h1 : W.Nonsingular x1 y1) (h2 : W.Nonsingular x2 y2),
-              y1 ≠ 0 ∧ Point.some _ _ h1 + Point.some _ _ h2 ≠ 0))
-        (fun env (r : AddResult F) env' =>
-          ∀ x1 y1 x2 y2, p1'.x.eval env = .ok x1 → p1'.y.eval env = .ok y1 →
-            p2'.x.eval env = .ok x2 → p2'.y.eval env = .ok y2 →
-            ∀ (h1 : W.Nonsingular x1 y1) (h2 : W.Nonsingular x2 y2),
-              ∃ x3 y3, r.p.x.eval env' = .ok x3 ∧ r.p.y.eval env' = .ok y3 ∧
-                ∃ h3 : W.Nonsingular x3 y3,
-                  Point.some _ _ h1 + Point.some _ _ h2 = Point.some _ _ h3)
-        Q⦄
-    addFast (c := KimchiProverC F) .checkFinite p1' p2'
-    ⦃Q⦄ := by
-  intro st hpre
-  refine addFast_complete_spec .checkFinite W ha htwo p1' p2' Q st
-    ⟨⟨hpre.1.1, hpre.1.2.1, hpre.1.2.2.1, hpre.1.2.2.2.1,
-      fun x1 y1 x2 y2 he1 he2 he3 he4 => ?_⟩,
-     fun r st' hpost hle =>
-       hpre.2 r st' (fun x1 y1 x2 y2 he1 he2 he3 he4 h1 h2 => ?_) hle⟩
-  · obtain ⟨h1, h2, hy1ne, hsum⟩ := hpre.1.2.2.2.2 x1 y1 x2 y2 he1 he2 he3 he4
-    refine ⟨h1.1, h2.1, hy1ne, fun _ => ?_⟩
-    rintro ⟨rfl, hyeq⟩
-    subst hyeq
-    apply hsum
-    rw [show Point.some x1 (W.negY x1 y2) h1 = -Point.some x1 y2 h2 from by
-      rw [WeierstrassCurve.Affine.Point.neg_some]]
-    exact neg_add_cancel _
-  · obtain ⟨h1', h2', -, hsum⟩ := hpre.1.2.2.2.2 x1 y1 x2 y2 he1 he2 he3 he4
-    rcases hpost x1 y1 x2 y2 he1 he2 he3 he4 h1 h2 with
-      ⟨-, hzero⟩ | ⟨x3, y3, hx3, hy3, -, h3, hsum3⟩
-    · exact absurd hzero hsum
-    · exact ⟨x3, y3, hx3, hy3, h3, hsum3⟩
 
 end AddFast
 

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
@@ -942,6 +942,10 @@ theorem endoMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F
   have hTne : Point.some _ _ hT ≠ 0 := Point.some_ne_zero hT
   have hx02 : t.x.eval st₂.env = .ok xv := CVar.eval_le (hle₁.trans hle₂) hxv
   have hy02 : t.y.eval st₂.env = .ok yv := CVar.eval_le (hle₁.trans hle₂) hyv
+  have hTφne : Point.some _ _ hT + Point.some _ _ hφT ≠ 0 := by
+    intro hzero
+    rw [heig hT hφT] at hzero
+    exact hlam1 (Point.some _ _ hT) hTne (by rw [← hzero]; module)
   refine AddFast.addFast_complete_spec .checkFinite W ha h2 t ⟨phix, t.y⟩ _ _
     ⟨⟨by rw [hx02]; rfl, by rw [hy02]; rfl, by rw [hphix]; rfl, by rw [hy02]; rfl,
       fun x1 y1 x2 y2 he1 he2 he3 he4 => ?_⟩,
@@ -950,20 +954,22 @@ theorem endoMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F
     injection he1 with he1; injection he2 with he2
     injection he3 with he3; injection he4 with he4
     subst he1 he2 he3 he4
-    refine ⟨hT.1, hφT.1, hyne, fun _ => ?_⟩
-    rintro ⟨-, hyeq⟩
-    rw [show W.negY (eb * xv) yv = -yv from by
-      simp [WeierstrassCurve.Affine.negY, ha.1, ha.2.2.1]] at hyeq
-    refine hyne ?_
-    have h2y : (2 : F) * yv = 0 := by linear_combination hyeq
-    exact (mul_eq_zero.mp h2y).resolve_left h2
+    exact ⟨hT, hφT, hyne, fun _ => hTφne⟩
   obtain ⟨x1v, y1v, hx1e, hy1e, -, hP1, hsum1⟩ :=
     (hp1 xv yv (eb * xv) yv hx02 hy02 hphix hy02 hT hφT).resolve_left (by
       rintro ⟨-, hzero⟩
-      rw [heig hT hφT] at hzero
-      exact hlam1 (Point.some _ _ hT) hTne (by rw [← hzero]; module))
+      exact hTφne hzero)
   have hy1ne : y1v ≠ 0 := y_ne_zero_of_odd_order W hodd hP1
   mvcgen
+  have h2P1ne : Point.some _ _ hP1 + Point.some _ _ hP1 ≠ 0 := by
+    intro hzero
+    have h2P : (2 : ℤ) • Point.some _ _ hP1 = 0 := by
+      rw [two_zsmul, hzero]
+    have hlt : (2 : ℤ) < (W.order : ℤ) := by
+      have hp2' := (Fact.out : Nat.Prime W.order).two_le
+      have h3' : 3 ≤ W.order := by omega
+      exact_mod_cast h3'
+    exact smul_ne_zero_of_lt W (Point.some_ne_zero hP1) (by norm_num) hlt h2P
   refine AddFast.addFast_complete_spec .checkFinite W ha h2 p1.p p1.p _ _
     ⟨⟨by rw [hx1e]; rfl, by rw [hy1e]; rfl, by rw [hx1e]; rfl, by rw [hy1e]; rfl,
       fun x1 y1 x2 y2 he1 he2 he3 he4 => ?_⟩,
@@ -972,23 +978,11 @@ theorem endoMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F
     injection he1 with he1; injection he2 with he2
     injection he3 with he3; injection he4 with he4
     subst he1 he2 he3 he4
-    refine ⟨hP1.1, hP1.1, hy1ne, fun _ => ?_⟩
-    rintro ⟨-, hyeq⟩
-    rw [show W.negY x1v y1v = -y1v from by
-      simp [WeierstrassCurve.Affine.negY, ha.1, ha.2.2.1]] at hyeq
-    refine hy1ne ?_
-    have h2y : (2 : F) * y1v = 0 := by linear_combination hyeq
-    exact (mul_eq_zero.mp h2y).resolve_left h2
+    exact ⟨hP1, hP1, hy1ne, fun _ => h2P1ne⟩
   obtain ⟨x0v, y0v, hx0e, hy0e, -, hP0ns, hsum2⟩ :=
     (hp2 x1v y1v x1v y1v hx1e hy1e hx1e hy1e hP1 hP1).resolve_left (by
       rintro ⟨-, hzero⟩
-      have h2P : (2 : ℤ) • Point.some _ _ hP1 = 0 := by
-        rw [two_zsmul, hzero]
-      have hlt : (2 : ℤ) < (W.order : ℤ) := by
-        have hp2' := (Fact.out : Nat.Prime W.order).two_le
-        have h3' : 3 ≤ W.order := by omega
-        exact_mod_cast h3'
-      exact smul_ne_zero_of_lt W (Point.some_ne_zero hP1) (by norm_num) hlt h2P)
+      exact h2P1ne hzero)
   have hP0 : Point.some _ _ hP0ns
       = (2 : ℤ) • Point.some _ _ hT + (2 : ℤ) • Point.some _ _ hφT := by
     rw [← hsum2, ← hsum1]

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
@@ -1474,8 +1474,8 @@ theorem endoInv_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F
     linear_combination h
   have hrhs : (CVar.add_ (CVar.add_ x3 (CVar.scale_ d.W.a₄ rp.1)) (CVar.const d.W.a₆)).eval
       st₃.env = .ok (px * px * px + d.W.a₄ * px + d.W.a₆) := by
-    rw [CVar.eval_add_]
-    simp only [CVar.eval, CVar.eval_add_, hx3, CVar.eval_scale_ hrpx₃ d.W.a₄]
+    rw [CVar.eval_add_fold]
+    simp only [CVar.eval, CVar.eval_add_fold, hx3, CVar.eval_scale_ hrpx₃ d.W.a₄]
   mvcgen
   refine ⟨⟨by rw [hrpy₃]; rfl, by rw [hrhs]; rfl, ?_⟩, fun u₄ st₄ hle₄ => ?_⟩
   · intro yv' rhv' hyv' hrhv'

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
@@ -795,7 +795,7 @@ theorem toField_complete_spec [Field F] [DecidableEq F] [ToNat F]
       have hev : ev = e := by
         simp only [CVar.eval] at he
         exact (Except.ok.inj he).symm
-      rw [CVar.eval_add_]
+      rw [CVar.eval_add_fold]
       simp only [CVar.eval, CVar.eval_scale_ hA2 e, hB2, Except.ok.injEq,
         Kimchi.Gate.EndoScalar.toField, hev]
       ring
@@ -815,7 +815,7 @@ theorem toField_complete_spec [Field F] [DecidableEq F] [ToNat F]
       injection he' with he'
       subst he'
       have hB3 := CVar.eval_le (hle₂.trans hle₃) hB
-      rw [CVar.eval_add_]
+      rw [CVar.eval_add_fold]
       simp only [CVar.eval, hB3, hpv, Except.ok.injEq,
         Kimchi.Gate.EndoScalar.toField]
       ring

--- a/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
@@ -1556,6 +1556,27 @@ private theorem readsBit_le [Field F] [DecidableEq F] {x : CVar F}
   · exact Or.inl rfl
   · exact Or.inr rfl
 
+/-- The ladder's granted bits above the half's width read zero: `testBit` vanishes
+above a value's width. -/
+private theorem dropped_bits_zero [Field F] [DecidableEq F] {env : Assignments F}
+    {n sDiv2Bits : ℕ} {bits : Vector (FVar F) n} {x : ℕ} (hx : x < 2 ^ sDiv2Bits)
+    (hbits : ∀ (i : ℕ) (hi : i < n),
+      (bits[i]'hi).eval env = .ok (if x.testBit i then (1 : F) else 0)) :
+    ∀ b ∈ bits.toList.drop sDiv2Bits, b.eval env = .ok 0 := by
+  intro bpin hbpin
+  obtain ⟨k, hk', hEq⟩ := List.mem_iff_getElem.mp hbpin
+  have hkn : sDiv2Bits + k < n := by
+    have hlen : (bits.toList.drop sDiv2Bits).length = n - sDiv2Bits := by
+      simp [List.length_drop]
+    omega
+  rw [← hEq, List.getElem_drop, Vector.getElem_toList]
+  have hbfalse : x.testBit (sDiv2Bits + k) = false := by
+    apply Nat.testBit_lt_two_pow
+    calc x < 2 ^ sDiv2Bits := hx
+      _ ≤ 2 ^ (sDiv2Bits + k) := Nat.pow_le_pow_right (by norm_num) (by omega)
+  rw [hbits (sDiv2Bits + k) hkn, hbfalse]
+  rfl
+
 /-- The regime keeps the honest decode off the base: `fromShifted t ≢ 1 (mod order)`
 — subwrap by size (the window sits strictly inside `(0, order)`), one-wrap because
 `1` is a forbidden residue. What makes `scaleFast2`'s parity correction — the
@@ -1639,22 +1660,7 @@ theorem scaleFast2_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
     exact ⟨lt_of_lt_of_le hrange (Nat.pow_le_pow_right (by norm_num) hd),
       hfaith, hreg⟩
   obtain ⟨xg, yg, hgx, hgy, hfin, hpt⟩ := hrpt v xv yv hv hxv hyv hT
-  have hbits := hrbits v hv
-  -- the high-bit pins: every dropped bit reads zero (the half is below `2^sDiv2Bits`)
-  have hpins : ∀ b ∈ r.lsbBits.toList.drop sDiv2Bits, b.eval st'.env = .ok 0 := by
-    intro bpin hbpin
-    obtain ⟨k, hk', hEq⟩ := List.mem_iff_getElem.mp hbpin
-    have hkn : sDiv2Bits + k < n := by
-      have hlen : (r.lsbBits.toList.drop sDiv2Bits).length = n - sDiv2Bits := by
-        simp [List.length_drop]
-      omega
-    rw [← hEq, List.getElem_drop, Vector.getElem_toList]
-    have hbfalse : (ToNat.toNat v).testBit (sDiv2Bits + k) = false := by
-      apply Nat.testBit_lt_two_pow
-      calc ToNat.toNat v < 2 ^ sDiv2Bits := hrange
-        _ ≤ 2 ^ (sDiv2Bits + k) := Nat.pow_le_pow_right (by norm_num) (by omega)
-    rw [hbits (sDiv2Bits + k) hkn, hbfalse]
-    rfl
+  have hpins := dropped_bits_zero hrange (hrbits v hv)
   mvcgen
   case inv1 =>
     exact ⇓ p s' => ⌜st'.env.Le s'.env⌝
@@ -1682,16 +1688,21 @@ theorem scaleFast2_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
       rw [show (-yv) = (-1 : F) * yv from by ring]
       exact CVar.eval_scale_ (CVar.eval_le (hle.trans hle') hyv) (-1)
     have hgyne : yg ≠ 0 := y_ne_zero_of_odd_order d.W d.odd hfin
-    have hnegT : d.W.Nonsingular xv (-yv) := by
-      have h := (d.W.nonsingular_neg xv yv).mpr hT
-      rwa [show d.W.negY xv yv = -yv from by
-        rw [WeierstrassCurve.Affine.negY, d.short.1, d.short.2.2.1]; ring] at h
-    have hnegPt : (Point.some _ _ hnegT : d.W.Point) = -Point.some _ _ hT := by
-      rw [WeierstrassCurve.Affine.Point.neg_some]
-      exact Kimchi.Gate.EndoMul.some_congr d.W hnegT _ rfl (by
-        rw [WeierstrassCurve.Affine.negY, d.short.1, d.short.2.2.1]; ring)
+    obtain ⟨hnegT, hnegPt⟩ := AddFast.neg_point_reading d.W
+      ⟨d.short.1, d.short.2.1, d.short.2.2.1⟩ hT
+    have hsumne : Point.some _ _ hfin + Point.some _ _ hnegT ≠ 0 := by
+      rw [hpt, hnegPt]
+      intro h0
+      apply hs1
+      refine (zsmul_eq_zero_iff_order_dvd d.W (Point.some_ne_zero hT) _).1 ?_
+      calc (2 * (ToNat.toNat v : ℤ) + 2 ^ (5 * chunks)) • Point.some _ _ hT
+          = Type1.fromShifted (5 * chunks) ⟨(ToNat.toNat v : ℤ)⟩
+              • Point.some _ _ hT + -Point.some _ _ hT := by
+            simp only [Type1.fromShifted]
+            module
+        _ = 0 := h0
     mvcgen
-    refine AddFast.addFast_complete_spec .checkFinite d.W d.short d.two_ne
+    refine AddFast.addFast_complete_point_spec d.W d.short d.two_ne
       r.g ⟨base.x, CVar.negate_ base.y⟩ _ _
       ⟨⟨by rw [hgx']; rfl, by rw [hgy']; rfl, by rw [hbx']; rfl, by rw [hny]; rfl,
         fun x1 y1 x2 y2 he1 he2 he3 he4 => ?_⟩,
@@ -1700,35 +1711,9 @@ theorem scaleFast2_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
       injection he1 with he1; injection he2 with he2
       injection he3 with he3; injection he4 with he4
       subst he1 he2 he3 he4
-      refine ⟨hfin.1, hnegT.1, hgyne, fun _ => ?_⟩
-      rintro ⟨hxeq, hyeq⟩
-      rw [show d.W.negY xv (-yv) = yv from by
-        rw [WeierstrassCurve.Affine.negY, d.short.1, d.short.2.2.1]; ring] at hyeq
-      have hgT : Point.some _ _ hfin = Point.some _ _ hT :=
-        Kimchi.Gate.EndoMul.some_congr d.W hfin hT hxeq hyeq
-      apply hs1
-      have hsT : Type1.fromShifted (5 * chunks) ⟨(ToNat.toNat v : ℤ)⟩
-          • Point.some _ _ hT = Point.some _ _ hT := hpt.symm.trans hgT
-      have h0 : (2 * (ToNat.toNat v : ℤ) + 2 ^ (5 * chunks)) • Point.some _ _ hT
-          = 0 := by
-        have hexp : (2 * (ToNat.toNat v : ℤ) + 2 ^ (5 * chunks)) • Point.some _ _ hT
-            = Type1.fromShifted (5 * chunks) ⟨(ToNat.toNat v : ℤ)⟩
-                • Point.some _ _ hT - Point.some _ _ hT := by
-          simp only [Type1.fromShifted]
-          module
-        rw [hexp, hsT, sub_self]
-      exact (zsmul_eq_zero_iff_order_dvd d.W (Point.some_ne_zero hT) _).1 h0
-    obtain ⟨xq, yq, hqx, hqy, -, hqns, hqsum⟩ :=
-      (hq xg yg xv (-yv) hgx' hgy' hbx' hny hfin hnegT).resolve_left (by
-        rintro ⟨-, hzero⟩
-        apply hs1
-        have hexp : (2 * (ToNat.toNat v : ℤ) + 2 ^ (5 * chunks)) • Point.some _ _ hT
-            = Point.some _ _ hfin + Point.some _ _ hnegT := by
-          rw [hpt, hnegPt]
-          simp only [Type1.fromShifted]
-          module
-        rw [hzero] at hexp
-        exact (zsmul_eq_zero_iff_order_dvd d.W (Point.some_ne_zero hT) _).1 hexp)
+      exact ⟨hfin, hnegT, hgyne, hsumne⟩
+    obtain ⟨xq, yq, hqx, hqy, hqns, hqsum⟩ :=
+      hq xg yg xv (-yv) hgx' hgy' hbx' hny hfin hnegT
     have hqpt : (Point.some _ _ hqns : d.W.Point)
         = (2 * (ToNat.toNat v : ℤ) + 2 ^ (5 * chunks)) • Point.some _ _ hT := by
       rw [← hqsum, hpt, hnegPt]

--- a/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
@@ -1235,6 +1235,15 @@ theorem varBaseMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
   -- the doubled init `P₀ = [2]·T`
   have hsx₂ : base.x.eval st₂.env = .ok xv := CVar.eval_le hle₂ hsx
   have hsy₂ : base.y.eval st₂.env = .ok yv := CVar.eval_le hle₂ hsy
+  have h2Tne : Point.some _ _ hT + Point.some _ _ hT ≠ 0 := by
+    intro hzero
+    have h2P : (2 : ℤ) • Point.some _ _ hT = 0 := by rw [two_zsmul, hzero]
+    have hlt : (2 : ℤ) < (d.W.order : ℤ) := by
+      have h2le := d.prime.two_le
+      have hne2 := d.odd
+      have h3' : 3 ≤ d.W.order := by omega
+      exact_mod_cast h3'
+    exact smul_ne_zero_of_lt d.W (Point.some_ne_zero hT) (by norm_num) hlt h2P
   refine AddFast.addFast_complete_spec .checkFinite d.W d.short d.two_ne base base _ _
     ⟨⟨by rw [hsx₂]; rfl, by rw [hsy₂]; rfl, by rw [hsx₂]; rfl, by rw [hsy₂]; rfl,
       fun x1 y1 x2 y2 he1 he2 he3 he4 => ?_⟩,
@@ -1243,23 +1252,11 @@ theorem varBaseMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
     injection he1 with he1; injection he2 with he2
     injection he3 with he3; injection he4 with he4
     subst he1 he2 he3 he4
-    refine ⟨hT.1, hT.1, hyne, fun _ => ?_⟩
-    rintro ⟨-, hyeq⟩
-    rw [show d.W.negY xv yv = -yv from by
-      simp [WeierstrassCurve.Affine.negY, d.short.1, d.short.2.2.1]] at hyeq
-    refine hyne ?_
-    have h2y : (2 : F) * yv = 0 := by linear_combination hyeq
-    exact (mul_eq_zero.mp h2y).resolve_left d.two_ne
+    exact ⟨hT, hT, hyne, fun _ => h2Tne⟩
   obtain ⟨x0v, y0v, hx0e, hy0e, -, hP0ns, hsum⟩ :=
     (hp xv yv xv yv hsx₂ hsy₂ hsx₂ hsy₂ hT hT).resolve_left (by
       rintro ⟨-, hzero⟩
-      have h2P : (2 : ℤ) • Point.some _ _ hT = 0 := by rw [two_zsmul, hzero]
-      have hlt : (2 : ℤ) < (d.W.order : ℤ) := by
-        have h2le := d.prime.two_le
-        have hne2 := d.odd
-        have h3' : 3 ≤ d.W.order := by omega
-        exact_mod_cast h3'
-      exact smul_ne_zero_of_lt d.W (Point.some_ne_zero hT) (by norm_num) hlt h2P)
+      exact h2Tne hzero)
   have hP0eq : Point.some _ _ hP0ns = (2 : ℤ) • Point.some _ _ hT := by
     rw [← hsum]
     module
@@ -1702,7 +1699,7 @@ theorem scaleFast2_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
             module
         _ = 0 := h0
     mvcgen
-    refine AddFast.addFast_complete_point_spec d.W d.short d.two_ne
+    refine AddFast.addFast_complete_spec .checkFinite d.W d.short d.two_ne
       r.g ⟨base.x, CVar.negate_ base.y⟩ _ _
       ⟨⟨by rw [hgx']; rfl, by rw [hgy']; rfl, by rw [hbx']; rfl, by rw [hny]; rfl,
         fun x1 y1 x2 y2 he1 he2 he3 he4 => ?_⟩,
@@ -1711,9 +1708,11 @@ theorem scaleFast2_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
       injection he1 with he1; injection he2 with he2
       injection he3 with he3; injection he4 with he4
       subst he1 he2 he3 he4
-      exact ⟨hfin, hnegT, hgyne, hsumne⟩
-    obtain ⟨xq, yq, hqx, hqy, hqns, hqsum⟩ :=
-      hq xg yg xv (-yv) hgx' hgy' hbx' hny hfin hnegT
+      exact ⟨hfin, hnegT, hgyne, fun _ => hsumne⟩
+    obtain ⟨xq, yq, hqx, hqy, -, hqns, hqsum⟩ :=
+      (hq xg yg xv (-yv) hgx' hgy' hbx' hny hfin hnegT).resolve_left (by
+        rintro ⟨-, hzero⟩
+        exact hsumne hzero)
     have hqpt : (Point.some _ _ hqns : d.W.Point)
         = (2 * (ToNat.toNat v : ℤ) + 2 ^ (5 * chunks)) • Point.some _ _ hT := by
       rw [← hqsum, hpt, hnegPt]

--- a/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
@@ -1516,4 +1516,41 @@ theorem varBaseMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
   case vc4.vc1.vc1.vc1.refine_2.post.except =>
     exact ExceptConds.entails_false
 
+/-- `scaleFast1` is complete — the honest side of the defining equation
+`scaleFast1 g a ~ scalarMul (fromShifted a) g`: on the same readable, in-range,
+faithful, regime-satisfying scalar and readable on-curve base, the honest run
+accepts and the returned point is `[fromShifted t]·g` at the scalar's canonical
+value. `varBaseMul_complete_spec`'s point promise at the result, the bits dropped. -/
+theorem scaleFast1_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCurve F)
+    (n chunks : ℕ) (hn : 5 * chunks ≤ n)
+    (p : AffinePoint (FVar F)) (t : Type1 (FVar F))
+    (Q : PostCond (AffinePoint (FVar F))
+      (.arg (ProverState F) (.except EvalError .pure))) :
+    ⦃Complete
+        (fun env =>
+          (t.val.eval env).isOk ∧ (p.x.eval env).isOk ∧ (p.y.eval env).isOk ∧
+          (∀ v, t.val.eval env = .ok v →
+            ToNat.toNat v < 2 ^ (5 * chunks) ∧ ((ToNat.toNat v : ℕ) : F) = v ∧
+            d.LadderRegime (5 * chunks)
+              (Type1.fromShifted (5 * chunks) ⟨(ToNat.toNat v : ℤ)⟩)) ∧
+          (∀ x y, p.x.eval env = .ok x → p.y.eval env = .ok y →
+            d.W.Nonsingular x y))
+        (fun env r env' => ∀ v xv yv, t.val.eval env = .ok v →
+          p.x.eval env = .ok xv → p.y.eval env = .ok yv →
+          ∀ hT : d.W.Nonsingular xv yv,
+          ∃ xS yS, r.x.eval env' = .ok xS ∧ r.y.eval env' = .ok yS ∧
+            ∃ hfin : d.W.Nonsingular xS yS,
+              Point.some _ _ hfin
+                = Type1.fromShifted (5 * chunks) ⟨(ToNat.toNat v : ℤ)⟩
+                    • Point.some _ _ hT)
+        Q⦄
+    (scaleFast1 (c := KimchiProverC F) n chunks p t)
+    ⦃Q⦄ := by
+  simp only [scaleFast1]
+  mvcgen [varBaseMul_complete_spec]
+  rename_i st hpre
+  refine ⟨hpre.1, fun r st' hrbits hrpt hle => ?_⟩
+  mvcgen
+  exact hpre.2 r.g st' hrpt hle
+
 end Snarky.Kimchi

--- a/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
@@ -1540,19 +1540,6 @@ theorem scaleFast1_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
   mvcgen
   exact hpre.2 r.g st' hrpt hle
 
-/-- A bit reading survives table extension. -/
-private theorem readsBit_le [Field F] [DecidableEq F] {x : CVar F}
-    {env env' : Assignments F} (hle : env.Le env') (h : ReadsBit x env) :
-    ReadsBit x env' := by
-  obtain ⟨b, hb⟩ := h.exists_bit
-  refine ⟨by rw [CVar.eval_le hle hb]; rfl, fun w hw => ?_⟩
-  rw [CVar.eval_le hle hb] at hw
-  injection hw with hw
-  subst hw
-  cases b
-  · exact Or.inl rfl
-  · exact Or.inr rfl
-
 /-- The ladder's granted bits above the half's width read zero: `testBit` vanishes
 above a value's width. -/
 private theorem dropped_bits_zero [Field F] [DecidableEq F] {env : Assignments F}
@@ -1720,14 +1707,14 @@ theorem scaleFast2_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
       module
     -- the point conditional selects coordinatewise, `y` before `x`
     mvcgen
-    refine ⟨⟨readsBit_le ((hle.trans hle').trans hle₃) hbit,
+    refine ⟨⟨ReadsBit.mono ((hle.trans hle').trans hle₃) hbit,
       by rw [CVar.eval_le hle₃ hgy']; rfl, by rw [hqy]; rfl⟩,
       fun ysel sty hyg hley => ?_⟩
     have hyv' := hyg bb yg yq
       (CVar.eval_le ((hle.trans hle').trans hle₃) hb)
       (CVar.eval_le hle₃ hgy') hqy
     mvcgen
-    refine ⟨⟨readsBit_le (((hle.trans hle').trans hle₃).trans hley) hbit,
+    refine ⟨⟨ReadsBit.mono (((hle.trans hle').trans hle₃).trans hley) hbit,
       by rw [CVar.eval_le (hle₃.trans hley) hgx']; rfl,
       by rw [CVar.eval_le hley hqx]; rfl⟩,
       fun xsel stx hxg hlex => ?_⟩
@@ -1765,5 +1752,123 @@ theorem scaleFast2_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
       exact hpt
   case post.except =>
     exact ExceptConds.entails_false
+
+open Std.Do in
+/-- `splitFieldVar`'s honest run: on a readable operand in odd characteristic the
+recombination assert accepts — `2·((s − sOdd)/2) + sOdd = s` needs only `2 ≠ 0`, for
+ANY parity bit — and the returned pair reads as the parity split. -/
+@[spec] theorem splitFieldVar_complete_spec [Field F] [DecidableEq F] [ToNat F]
+    (s : FVar F)
+    (Q : PostCond (FVar F × BoolVar F)
+      (.arg (ProverState F) (.except EvalError .pure))) :
+    ⦃Complete
+        (fun env => (s.eval env).isOk ∧ (2 : F) ≠ 0)
+        (fun env r env' => ∀ v, s.eval env = .ok v →
+          r.1.eval env' = .ok ((splitField v).1) ∧
+          (↑r.2 : CVar F).eval env' = .ok (bit (splitField v).2))
+        Q⦄
+    (splitFieldVar (c := KimchiProverC F) s)
+    ⦃Q⦄ := by
+  simp only [splitFieldVar]
+  mvcgen
+  rename_i st hpre
+  obtain ⟨⟨hsok, h2⟩, hk⟩ := hpre
+  obtain ⟨v, hv⟩ := CVar.evalOk hsok
+  have hwit : splitFieldWit s st.env = .ok (splitField v) := by
+    simp [splitFieldWit, AsProver.readCVar, hv,
+      Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
+  refine ⟨by rw [hwit]; rfl, fun r st₁ hgrant hle₁ => ?_⟩
+  obtain ⟨hhalf', hodd'⟩ := hgrant _ hwit
+  have hhalf : r.1.eval st₁.env = .ok ((splitField v).1) := hhalf'
+  have hodd : (↑r.2 : CVar F).eval st₁.env = .ok (bit (splitField v).2) := hodd'
+  have hsum : (CVar.add_ (CVar.scale_ 2 r.1) ↑r.2).eval st₁.env
+      = .ok (2 * (splitField v).1 + bit (splitField v).2) :=
+    CVar.eval_add_ (CVar.eval_scale_ hhalf 2) hodd
+  mvcgen
+  refine ⟨⟨by rw [CVar.eval_le hle₁ hv]; rfl, by rw [hsum]; rfl,
+    fun xv yv hx hy => ?_⟩, fun u st₂ hle₂ => ?_⟩
+  · rw [CVar.eval_le hle₁ hv] at hx
+    rw [hsum] at hy
+    injection hx with hx
+    injection hy with hy
+    subst hx hy
+    by_cases hoddc : (ToNat.toNat v) % 2 = 1 <;>
+      simp only [splitField, bit, hoddc, if_true, if_false, reduceIte] <;>
+      field_simp <;>
+      simp
+  mvcgen
+  exact hk r st₂ (fun v' hv' => by
+    rw [hv] at hv'
+    injection hv' with hv'
+    subst hv'
+    exact ⟨CVar.eval_le hle₂ hhalf, CVar.eval_le hle₂ hodd⟩) (hle₁.trans hle₂)
+
+/-- `scaleFast2'` is complete — the honest side of the defining equation
+`scaleFast2' g s ~ [s + 2^(5·chunks)]·g`, `s` read through its parity split: the
+split's half must be in range, faithful, and regime-satisfying (its `Type1` decode
+feeds the inner ladder), and the returned point is the `SplitField` decode's
+multiple at the honest split. -/
+theorem scaleFast2'_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCurve F)
+    (n chunks sDiv2Bits : ℕ) (hn : 5 * chunks ≤ n) (hd : sDiv2Bits ≤ 5 * chunks)
+    (base : AffinePoint (FVar F)) (sc : FVar F)
+    (Q : PostCond (AffinePoint (FVar F))
+      (.arg (ProverState F) (.except EvalError .pure))) :
+    ⦃Complete
+        (fun env =>
+          (sc.eval env).isOk ∧ (base.x.eval env).isOk ∧ (base.y.eval env).isOk ∧
+          (∀ v, sc.eval env = .ok v →
+            ToNat.toNat ((splitField v).1) < 2 ^ sDiv2Bits ∧
+            ((ToNat.toNat ((splitField v).1) : ℕ) : F) = (splitField v).1 ∧
+            d.LadderRegime (5 * chunks)
+              (Type1.fromShifted (5 * chunks)
+                ⟨(ToNat.toNat ((splitField v).1) : ℤ)⟩)) ∧
+          (∀ x y, base.x.eval env = .ok x → base.y.eval env = .ok y →
+            d.W.Nonsingular x y))
+        (fun env r env' => ∀ v xv yv, sc.eval env = .ok v →
+          base.x.eval env = .ok xv → base.y.eval env = .ok yv →
+          ∀ hT : d.W.Nonsingular xv yv,
+          ∃ xS yS, r.x.eval env' = .ok xS ∧ r.y.eval env' = .ok yS ∧
+            ∃ hres : d.W.Nonsingular xS yS,
+              Point.some _ _ hres
+                = SplitField.fromShifted (5 * chunks)
+                    ⟨(ToNat.toNat ((splitField v).1) : ℤ), (splitField v).2⟩
+                      • Point.some _ _ hT)
+        Q⦄
+    (scaleFast2' (c := KimchiProverC F) n chunks sDiv2Bits base sc)
+    ⦃Q⦄ := by
+  simp only [scaleFast2']
+  mvcgen [scaleFast2_complete_spec, splitFieldVar_complete_spec]
+  rename_i st hpre
+  obtain ⟨⟨hsok, hxok, hyok, hsc, hcurve⟩, hk⟩ := hpre
+  obtain ⟨v, hv⟩ := CVar.evalOk hsok
+  obtain ⟨xv, hxv⟩ := CVar.evalOk hxok
+  obtain ⟨yv, hyv⟩ := CVar.evalOk hyok
+  refine ⟨⟨hsok, d.two_ne⟩, fun pr st' hsplit hle => ?_⟩
+  obtain ⟨hhalf, hodd⟩ := hsplit v hv
+  mvcgen [scaleFast2_complete_spec]
+  refine ⟨⟨by rw [hhalf]; rfl, ReadsBit.of_bit hodd,
+    by rw [CVar.eval_le hle hxv]; rfl, by rw [CVar.eval_le hle hyv]; rfl,
+    fun v' hv' => ?_, fun x y hx hy => ?_⟩,
+    fun r st'' hpt hle' => ?_⟩
+  · rw [hhalf] at hv'
+    injection hv' with hv'
+    subst hv'
+    exact hsc v hv
+  · rw [CVar.eval_le hle hxv] at hx
+    rw [CVar.eval_le hle hyv] at hy
+    injection hx with hx
+    injection hy with hy
+    subst hx hy
+    exact hcurve _ _ hxv hyv
+  refine hk r st'' (fun v' xv' yv' hv' hxv' hyv' hT => ?_) (hle.trans hle')
+  rw [hv] at hv'
+  injection hv' with hv'
+  rw [hxv] at hxv'
+  injection hxv' with hxv'
+  rw [hyv] at hyv'
+  injection hyv' with hyv'
+  subst hv' hxv' hyv'
+  exact hpt ((splitField v).1) xv yv hhalf
+    (CVar.eval_le hle hxv) (CVar.eval_le hle hyv) hT ((splitField v).2) hodd
 
 end Snarky.Kimchi

--- a/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
@@ -159,7 +159,8 @@ def scaleFast2 [Field F] [DecidableEq F] [ToNat F] [BasicSystem F c]
     [KimchiSystem F c] (n chunks sDiv2Bits : ℕ) (base : AffinePoint (FVar F))
     (sDiv2 : FVar F) (sOdd : BoolVar F) : CircuitM F c (AffinePoint (FVar F)) := do
   let r ← varBaseMul n chunks base ⟨sDiv2⟩
-  (r.lsbBits.toList.drop sDiv2Bits).forM fun bit => assertEqual bit (.const 0)
+  for bit in r.lsbBits.toList.drop sDiv2Bits do
+    assertEqual bit (.const 0)
   -- the else branch first (PS `if_ sOdd g =<< …`): `g − base` via the pure negation
   let negBase : AffinePoint (FVar F) := ⟨base.x, CVar.negate_ base.y⟩
   let q ← addFast .checkFinite r.g negBase
@@ -702,34 +703,6 @@ theorem scaleFast1_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCurve F)
   push_cast
   ring
 
-open Std.Do in
-/-- Pinning a list of variables to the zero constant reads them all as zero —
-`scaleFast2`'s high-bit pins, one `assertEqual` per variable. -/
-private theorem forM_pinZero_spec [Field F] [DecidableEq F]
-    (l : List (FVar F)) (Q : PostCond PUnit (.arg (BuilderState F) .pure)) :
-    ⦃Sound (fun V (_ : PUnit) => ∀ b ∈ l, b.val V = 0) Q⦄
-    ((l.forM fun bit => assertEqual bit (.const 0)) :
-      CircuitM F (KimchiConstraint F) PUnit)
-    ⦃Q⦄ := by
-  induction l generalizing Q with
-  | nil =>
-    mvcgen
-    intro s hpre
-    simp only [List.forM_eq_forM, List.forM_nil]
-    mvcgen
-    exact hpre ⟨⟩ _ (by simp)
-  | cons b t ih =>
-    mvcgen
-    intro s hpre
-    simp only [List.forM_eq_forM, List.forM_cons]
-    mvcgen
-    intro _ nv hpin
-    exact ih _ _ fun _ nv2 hrest =>
-      hpre ⟨⟩ _ fun x hx => by
-        rcases List.mem_cons.mp hx with rfl | hx
-        · simpa using hpin
-        · exact hrest x hx
-
 open Kimchi.Gate.VarBaseMul (bitsRegister bitsVal bitsVal_lt bitsVal_drop_of_zeros
   bitsRegister_eq_cast y_ne_zero_of_odd_order) in
 /-- `scaleFast2` is sound — the PS defining equation
@@ -763,86 +736,103 @@ theorem scaleFast2_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCurve F)
   refine varBaseMul_spec d n chunks hn base ⟨sDiv2⟩ _ _ ?_
   intro r nv hr
   mvcgen
-  refine forM_pinZero_spec (r.lsbBits.toList.drop sDiv2Bits) _ _ ?_
-  intro _ nvp hzeros
-  mvcgen
-  refine AddFast.addFast_checkFinite_spec d.W d.short d.two_ne r.g
-    ⟨base.x, CVar.negate_ base.y⟩ _ _ ?_
-  intro q nvq hq
-  mvcgen
-  intro y _ hysel
-  mvcgen
-  intro x _ hxsel
-  mvcgen
-  refine hpre ⟨x, y⟩ _ ?_
-  intro hT bb hbb
-  obtain ⟨bl, hbool, hblen, hsrc, hregF, hpfn⟩ := hr hT
-  -- the pins force the decode's leading window to zero
-  have hzeros' : ∀ b ∈ bl.take (5 * chunks - sDiv2Bits), b = 0 := by
-    intro b hb
-    rw [hsrc, ← List.map_take] at hb
-    obtain ⟨fv, hfv, rfl⟩ := List.mem_map.mp hb
-    apply hzeros
-    rw [List.take_reverse,
-      show (r.lsbBits.toList.take (5 * chunks)).length - (5 * chunks - sDiv2Bits)
-          = sDiv2Bits from by
-        simp only [List.length_take, Vector.length_toList]
-        omega,
-      List.mem_reverse, List.drop_take] at hfv
-    exact List.mem_of_mem_take hfv
-  have hvlt : bitsVal bl < 2 ^ sDiv2Bits ∧ 0 ≤ bitsVal bl := by
-    rw [bitsVal_drop_of_zeros bl (5 * chunks - sDiv2Bits) hzeros']
-    have hb' : ∀ b ∈ bl.drop (5 * chunks - sDiv2Bits), b = 0 ∨ b = 1 :=
-      fun b hb => hbool b (List.mem_of_mem_drop hb)
-    have hlt := bitsVal_lt _ hb'
-    rwa [List.length_drop, hblen,
-      show 5 * chunks - (5 * chunks - sDiv2Bits) = sDiv2Bits from by omega] at hlt
-  refine ⟨bitsVal bl, hvlt.2, hvlt.1, ?_, fun hregime => ?_⟩
-  · rw [hregF, bitsRegister_eq_cast bl hbool]
-  · obtain ⟨hg, hgpt⟩ := hpfn hregime
-    simp only [Type1.fromShifted] at hgpt
-    have hnegv : (CVar.negate_ base.y).val s.V = -(base.y.val s.V) := by
-      simp [CVar.negate_, CVar.val_scale_]
-    have hnegT : d.W.Nonsingular (base.x.val s.V) ((CVar.negate_ base.y).val s.V) := by
-      rw [hnegv]
-      have hneg := (d.W.nonsingular_neg (base.x.val s.V) (base.y.val s.V)).mpr hT
-      rwa [show d.W.negY (base.x.val s.V) (base.y.val s.V) = -(base.y.val s.V) from by
-        rw [WeierstrassCurve.Affine.negY, d.short.1, d.short.2.2.1]
-        ring] at hneg
-    have hy : r.g.y.val s.V ≠ 0 := y_ne_zero_of_odd_order d.W d.odd hg
-    obtain ⟨hqns, hqsum⟩ := hq hg hnegT hy
-    have hnegPt : (Point.some _ _ hnegT : d.W.Point) = -Point.some _ _ hT := by
-      rw [WeierstrassCurve.Affine.Point.neg_some]
-      exact Kimchi.Gate.EndoMul.some_congr d.W hnegT _ rfl (by
-        rw [hnegv, WeierstrassCurve.Affine.negY, d.short.1, d.short.2.2.1]
-        ring)
-    have hqpt : (Point.some _ _ hqns : d.W.Point)
-        = (2 * bitsVal bl + 2 ^ (5 * chunks)) • Point.some _ _ hT := by
-      rw [← hqsum, hgpt, hnegPt]
-      module
-    have hxv := hxsel bb hbb
-    have hyv := hysel bb hbb
-    cases bb
-    · have hres : d.W.Nonsingular (x.val s.V) (y.val s.V) := by
-        rw [hxv, hyv]
-        simpa [selectPure] using hqns
-      refine ⟨hres, ?_⟩
-      rw [show SplitField.fromShifted (5 * chunks) (⟨bitsVal bl, false⟩ : SplitField ℤ Bool)
-          = 2 * bitsVal bl + 2 ^ (5 * chunks) from by
-        simp [SplitField.fromShifted]]
-      refine (Kimchi.Gate.EndoMul.some_congr d.W hres hqns ?_ ?_).trans hqpt
-      · rw [hxv]; simp [selectPure]
-      · rw [hyv]; simp [selectPure]
-    · have hres : d.W.Nonsingular (x.val s.V) (y.val s.V) := by
-        rw [hxv, hyv]
-        simpa [selectPure] using hg
-      refine ⟨hres, ?_⟩
-      rw [show SplitField.fromShifted (5 * chunks) (⟨bitsVal bl, true⟩ : SplitField ℤ Bool)
-          = 2 * bitsVal bl + 2 ^ (5 * chunks) + 1 from by
-        simp [SplitField.fromShifted]; ring]
-      refine (Kimchi.Gate.EndoMul.some_congr d.W hres hg ?_ ?_).trans hgpt
-      · rw [hxv]; simp [selectPure]
-      · rw [hyv]; simp [selectPure]
+  case inv1 =>
+    exact ⇓ p s' => ⌜s'.V = s.V ∧ ∀ b ∈ p.1.prefix, b.val s.V = 0⌝
+  case step =>
+    rename_i pref cur suff hsplit u st' hinv
+    intro _ nv hpin
+    mvcgen
+    refine ⟨hinv.1, fun b hb => ?_⟩
+    rcases List.mem_append.mp hb with hb | hb
+    · exact hinv.2 b hb
+    · rw [List.mem_singleton.mp hb, ← hinv.1]
+      simpa using hpin
+  case pre => exact ⟨rfl, by simp⟩
+  case post.success =>
+    rename_i u st' hinv
+    obtain ⟨hV, hzeros⟩ := hinv
+    mvcgen
+    refine AddFast.addFast_checkFinite_spec d.W d.short d.two_ne r.g
+      ⟨base.x, CVar.negate_ base.y⟩ _ _ ?_
+    intro q nvq hq
+    rw [hV] at hq
+    mvcgen
+    intro y _ hysel
+    rw [hV] at hysel
+    mvcgen
+    intro x _ hxsel
+    rw [hV] at hxsel
+    mvcgen
+    rw [hV]
+    refine hpre ⟨x, y⟩ _ ?_
+    intro hT bb hbb
+    obtain ⟨bl, hbool, hblen, hsrc, hregF, hpfn⟩ := hr hT
+    -- the pins force the decode's leading window to zero
+    have hzeros' : ∀ b ∈ bl.take (5 * chunks - sDiv2Bits), b = 0 := by
+      intro b hb
+      rw [hsrc, ← List.map_take] at hb
+      obtain ⟨fv, hfv, rfl⟩ := List.mem_map.mp hb
+      apply hzeros
+      rw [List.take_reverse,
+        show (r.lsbBits.toList.take (5 * chunks)).length - (5 * chunks - sDiv2Bits)
+            = sDiv2Bits from by
+          simp only [List.length_take, Vector.length_toList]
+          omega,
+        List.mem_reverse, List.drop_take] at hfv
+      exact List.mem_of_mem_take hfv
+    have hvlt : bitsVal bl < 2 ^ sDiv2Bits ∧ 0 ≤ bitsVal bl := by
+      rw [bitsVal_drop_of_zeros bl (5 * chunks - sDiv2Bits) hzeros']
+      have hb' : ∀ b ∈ bl.drop (5 * chunks - sDiv2Bits), b = 0 ∨ b = 1 :=
+        fun b hb => hbool b (List.mem_of_mem_drop hb)
+      have hlt := bitsVal_lt _ hb'
+      rwa [List.length_drop, hblen,
+        show 5 * chunks - (5 * chunks - sDiv2Bits) = sDiv2Bits from by omega] at hlt
+    refine ⟨bitsVal bl, hvlt.2, hvlt.1, ?_, fun hregime => ?_⟩
+    · rw [hregF, bitsRegister_eq_cast bl hbool]
+    · obtain ⟨hg, hgpt⟩ := hpfn hregime
+      simp only [Type1.fromShifted] at hgpt
+      have hnegv : (CVar.negate_ base.y).val s.V = -(base.y.val s.V) := by
+        simp [CVar.negate_, CVar.val_scale_]
+      have hnegT : d.W.Nonsingular (base.x.val s.V) ((CVar.negate_ base.y).val s.V) := by
+        rw [hnegv]
+        have hneg := (d.W.nonsingular_neg (base.x.val s.V) (base.y.val s.V)).mpr hT
+        rwa [show d.W.negY (base.x.val s.V) (base.y.val s.V) = -(base.y.val s.V) from by
+          rw [WeierstrassCurve.Affine.negY, d.short.1, d.short.2.2.1]
+          ring] at hneg
+      have hy : r.g.y.val s.V ≠ 0 := y_ne_zero_of_odd_order d.W d.odd hg
+      obtain ⟨hqns, hqsum⟩ := hq hg hnegT hy
+      have hnegPt : (Point.some _ _ hnegT : d.W.Point) = -Point.some _ _ hT := by
+        rw [WeierstrassCurve.Affine.Point.neg_some]
+        exact Kimchi.Gate.EndoMul.some_congr d.W hnegT _ rfl (by
+          rw [hnegv, WeierstrassCurve.Affine.negY, d.short.1, d.short.2.2.1]
+          ring)
+      have hqpt : (Point.some _ _ hqns : d.W.Point)
+          = (2 * bitsVal bl + 2 ^ (5 * chunks)) • Point.some _ _ hT := by
+        rw [← hqsum, hgpt, hnegPt]
+        module
+      have hxv := hxsel bb hbb
+      have hyv := hysel bb hbb
+      cases bb
+      · have hres : d.W.Nonsingular (x.val s.V) (y.val s.V) := by
+          rw [hxv, hyv]
+          simpa [selectPure] using hqns
+        refine ⟨hres, ?_⟩
+        rw [show SplitField.fromShifted (5 * chunks) (⟨bitsVal bl, false⟩ : SplitField ℤ Bool)
+            = 2 * bitsVal bl + 2 ^ (5 * chunks) from by
+          simp [SplitField.fromShifted]]
+        refine (Kimchi.Gate.EndoMul.some_congr d.W hres hqns ?_ ?_).trans hqpt
+        · rw [hxv]; simp [selectPure]
+        · rw [hyv]; simp [selectPure]
+      · have hres : d.W.Nonsingular (x.val s.V) (y.val s.V) := by
+          rw [hxv, hyv]
+          simpa [selectPure] using hg
+        refine ⟨hres, ?_⟩
+        rw [show SplitField.fromShifted (5 * chunks) (⟨bitsVal bl, true⟩ : SplitField ℤ Bool)
+            = 2 * bitsVal bl + 2 ^ (5 * chunks) + 1 from by
+          simp [SplitField.fromShifted]; ring]
+        refine (Kimchi.Gate.EndoMul.some_congr d.W hres hg ?_ ?_).trans hgpt
+        · rw [hxv]; simp [selectPure]
+        · rw [hyv]; simp [selectPure]
 
 open Kimchi.Gate.VarBaseMul (bitsRegister bitsVal) in
 /-- `scaleFast2'` is sound — `scaleFast2' g s ~ [s + 2^(5·chunks)]·g`, `s` read
@@ -1552,5 +1542,244 @@ theorem scaleFast1_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCur
   refine ⟨hpre.1, fun r st' hrbits hrpt hle => ?_⟩
   mvcgen
   exact hpre.2 r.g st' hrpt hle
+
+/-- A bit reading survives table extension. -/
+private theorem readsBit_le [Field F] [DecidableEq F] {x : CVar F}
+    {env env' : Assignments F} (hle : env.Le env') (h : ReadsBit x env) :
+    ReadsBit x env' := by
+  obtain ⟨b, hb⟩ := h.exists_bit
+  refine ⟨by rw [CVar.eval_le hle hb]; rfl, fun w hw => ?_⟩
+  rw [CVar.eval_le hle hb] at hw
+  injection hw with hw
+  subst hw
+  cases b
+  · exact Or.inl rfl
+  · exact Or.inr rfl
+
+/-- The regime keeps the honest decode off the base: `fromShifted t ≢ 1 (mod order)`
+— subwrap by size (the window sits strictly inside `(0, order)`), one-wrap because
+`1` is a forbidden residue. What makes `scaleFast2`'s parity correction — the
+incomplete subtraction of the base — well-defined on the honest run. -/
+private theorem regime_off_base [Field F] [DecidableEq F] (d : HasCurve F)
+    {L : ℕ} {t : ℤ} (ht0 : 0 ≤ t) (htlt : t < 2 ^ L)
+    (hreg : d.LadderRegime L (Type1.fromShifted L ⟨t⟩)) :
+    ¬ ((d.W.order : ℤ) ∣ (2 * t + 2 ^ L)) := by
+  intro hdvd
+  rcases hreg with hsub | ⟨-, -, -, hnf⟩
+  · have hpos : (0 : ℤ) < 2 ^ L := by positivity
+    have hord : (3 : ℤ) * 2 ^ L ≤ (d.W.order : ℤ) := by exact_mod_cast hsub
+    have hle' := Int.le_of_dvd (by linarith) hdvd
+    linarith
+  · refine hnf (Kimchi.Gate.VarBaseMul.mem_forbiddenValues_of_dvd_sub_one
+      d.W.order ?_)
+    rw [show Type1.fromShifted L (⟨t⟩ : Type1 ℤ) - 1 = 2 * t + 2 ^ L from by
+      simp [Type1.fromShifted]]
+    exact hdvd
+
+open Kimchi.Gate.VarBaseMul (y_ne_zero_of_odd_order zsmul_eq_zero_iff_order_dvd) in
+/-- `scaleFast2` is complete — the honest side of the PS defining equation
+`scaleFast2 g (sDiv2, sOdd) ~ [fromShifted (sDiv2, sOdd)]·g`: on a readable on-curve
+base, a readable in-range faithful half whose `Type1` decode satisfies the inner
+ladder's regime, and a parity flag reading a genuine bit, the honest run accepts and
+the returned point is the `SplitField` decode's multiple. The regime also keeps the
+ladder result off the base (`s ≢ 1`, subwrap by size, one-wrap because `1` is a
+forbidden residue), which is what makes the parity correction's incomplete
+subtraction well-defined — the completeness-side counterpart of the sound law's
+`tne` self-enforcement. -/
+theorem scaleFast2_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasCurve F)
+    (n chunks sDiv2Bits : ℕ) (hn : 5 * chunks ≤ n) (hd : sDiv2Bits ≤ 5 * chunks)
+    (base : AffinePoint (FVar F)) (sDiv2 : FVar F) (sOdd : BoolVar F)
+    (Q : PostCond (AffinePoint (FVar F))
+      (.arg (ProverState F) (.except EvalError .pure))) :
+    ⦃Complete
+        (fun env =>
+          (sDiv2.eval env).isOk ∧ ReadsBit (↑sOdd : CVar F) env ∧
+          (base.x.eval env).isOk ∧ (base.y.eval env).isOk ∧
+          (∀ v, sDiv2.eval env = .ok v →
+            ToNat.toNat v < 2 ^ sDiv2Bits ∧ ((ToNat.toNat v : ℕ) : F) = v ∧
+            d.LadderRegime (5 * chunks)
+              (Type1.fromShifted (5 * chunks) ⟨(ToNat.toNat v : ℤ)⟩)) ∧
+          (∀ x y, base.x.eval env = .ok x → base.y.eval env = .ok y →
+            d.W.Nonsingular x y))
+        (fun env r env' => ∀ v xv yv, sDiv2.eval env = .ok v →
+          base.x.eval env = .ok xv → base.y.eval env = .ok yv →
+          ∀ hT : d.W.Nonsingular xv yv,
+          ∀ bb : Bool, (↑sOdd : CVar F).eval env = .ok (bit bb) →
+          ∃ xS yS, r.x.eval env' = .ok xS ∧ r.y.eval env' = .ok yS ∧
+            ∃ hres : d.W.Nonsingular xS yS,
+              Point.some _ _ hres
+                = SplitField.fromShifted (5 * chunks) ⟨(ToNat.toNat v : ℤ), bb⟩
+                    • Point.some _ _ hT)
+        Q⦄
+    (scaleFast2 (c := KimchiProverC F) n chunks sDiv2Bits base sDiv2 sOdd)
+    ⦃Q⦄ := by
+  haveI : Fact (Nat.Prime d.W.order) := ⟨d.prime⟩
+  haveI : Fact (d.W.a₁ = 0 ∧ d.W.a₂ = 0 ∧ d.W.a₃ = 0) :=
+    ⟨⟨d.short.1, d.short.2.1, d.short.2.2.1⟩⟩
+  simp only [scaleFast2]
+  mvcgen [varBaseMul_complete_spec]
+  rename_i st hpre
+  obtain ⟨⟨hsok, hbit, hxok, hyok, hsc, hcurve⟩, hk⟩ := hpre
+  obtain ⟨v, hv⟩ := CVar.evalOk hsok
+  obtain ⟨xv, hxv⟩ := CVar.evalOk hxok
+  obtain ⟨yv, hyv⟩ := CVar.evalOk hyok
+  obtain ⟨hrange, hfaith, hreg⟩ := hsc v hv
+  obtain ⟨bb, hb⟩ := hbit.exists_bit
+  have hT : d.W.Nonsingular xv yv := hcurve _ _ hxv hyv
+  have hvlt : (ToNat.toNat v : ℤ) < 2 ^ (5 * chunks) := by
+    exact_mod_cast lt_of_lt_of_le hrange (Nat.pow_le_pow_right (by norm_num) hd)
+  have hs1 : ¬ ((d.W.order : ℤ) ∣ (2 * (ToNat.toNat v : ℤ) + 2 ^ (5 * chunks))) :=
+    regime_off_base d (Int.natCast_nonneg _) hvlt hreg
+  -- the inner ladder
+  refine ⟨⟨hsok, hxok, hyok, fun v' hv' => ?_, hcurve⟩,
+    fun r st' hrbits hrpt hle => ?_⟩
+  · rw [hv] at hv'
+    injection hv' with hv'
+    subst hv'
+    exact ⟨lt_of_lt_of_le hrange (Nat.pow_le_pow_right (by norm_num) hd),
+      hfaith, hreg⟩
+  obtain ⟨xg, yg, hgx, hgy, hfin, hpt⟩ := hrpt v xv yv hv hxv hyv hT
+  have hbits := hrbits v hv
+  -- the high-bit pins: every dropped bit reads zero (the half is below `2^sDiv2Bits`)
+  have hpins : ∀ b ∈ r.lsbBits.toList.drop sDiv2Bits, b.eval st'.env = .ok 0 := by
+    intro bpin hbpin
+    obtain ⟨k, hk', hEq⟩ := List.mem_iff_getElem.mp hbpin
+    have hkn : sDiv2Bits + k < n := by
+      have hlen : (r.lsbBits.toList.drop sDiv2Bits).length = n - sDiv2Bits := by
+        simp [List.length_drop]
+      omega
+    rw [← hEq, List.getElem_drop, Vector.getElem_toList]
+    have hbfalse : (ToNat.toNat v).testBit (sDiv2Bits + k) = false := by
+      apply Nat.testBit_lt_two_pow
+      calc ToNat.toNat v < 2 ^ sDiv2Bits := hrange
+        _ ≤ 2 ^ (sDiv2Bits + k) := Nat.pow_le_pow_right (by norm_num) (by omega)
+    rw [hbits (sDiv2Bits + k) hkn, hbfalse]
+    rfl
+  mvcgen
+  case inv1 =>
+    exact ⇓ p s' => ⌜st'.env.Le s'.env⌝
+  case step =>
+    rename_i pref cur suff hsplit u s' hinv
+    have hcur : cur ∈ r.lsbBits.toList.drop sDiv2Bits := by
+      rw [hsplit]
+      exact List.mem_append_right _ List.mem_cons_self
+    refine ⟨⟨by rw [CVar.eval_le hinv (hpins cur hcur)]; rfl, by rfl,
+      fun xv' yv' hx' hy' => ?_⟩, fun u' s'' hle'' => ?_⟩
+    · rw [CVar.eval_le hinv (hpins cur hcur)] at hx'
+      injection hx' with hx'
+      injection hy' with hy'
+      rw [← hx', ← hy']
+    · mvcgen
+      exact hinv.trans hle''
+  case pre => exact Assignments.Le.refl st'.env
+  case post.success =>
+    rename_i u st'' hle'
+    -- the correction addition: `g − T` via the pure negation
+    have hgx' := CVar.eval_le hle' hgx
+    have hgy' := CVar.eval_le hle' hgy
+    have hbx' : base.x.eval st''.env = .ok xv := CVar.eval_le (hle.trans hle') hxv
+    have hny : (CVar.negate_ base.y).eval st''.env = .ok (-yv) := by
+      rw [show (-yv) = (-1 : F) * yv from by ring]
+      exact CVar.eval_scale_ (CVar.eval_le (hle.trans hle') hyv) (-1)
+    have hgyne : yg ≠ 0 := y_ne_zero_of_odd_order d.W d.odd hfin
+    have hnegT : d.W.Nonsingular xv (-yv) := by
+      have h := (d.W.nonsingular_neg xv yv).mpr hT
+      rwa [show d.W.negY xv yv = -yv from by
+        rw [WeierstrassCurve.Affine.negY, d.short.1, d.short.2.2.1]; ring] at h
+    have hnegPt : (Point.some _ _ hnegT : d.W.Point) = -Point.some _ _ hT := by
+      rw [WeierstrassCurve.Affine.Point.neg_some]
+      exact Kimchi.Gate.EndoMul.some_congr d.W hnegT _ rfl (by
+        rw [WeierstrassCurve.Affine.negY, d.short.1, d.short.2.2.1]; ring)
+    mvcgen
+    refine AddFast.addFast_complete_spec .checkFinite d.W d.short d.two_ne
+      r.g ⟨base.x, CVar.negate_ base.y⟩ _ _
+      ⟨⟨by rw [hgx']; rfl, by rw [hgy']; rfl, by rw [hbx']; rfl, by rw [hny]; rfl,
+        fun x1 y1 x2 y2 he1 he2 he3 he4 => ?_⟩,
+       fun q st₃ hq hle₃ => ?_⟩
+    · rw [hgx'] at he1; rw [hgy'] at he2; rw [hbx'] at he3; rw [hny] at he4
+      injection he1 with he1; injection he2 with he2
+      injection he3 with he3; injection he4 with he4
+      subst he1 he2 he3 he4
+      refine ⟨hfin.1, hnegT.1, hgyne, fun _ => ?_⟩
+      rintro ⟨hxeq, hyeq⟩
+      rw [show d.W.negY xv (-yv) = yv from by
+        rw [WeierstrassCurve.Affine.negY, d.short.1, d.short.2.2.1]; ring] at hyeq
+      have hgT : Point.some _ _ hfin = Point.some _ _ hT :=
+        Kimchi.Gate.EndoMul.some_congr d.W hfin hT hxeq hyeq
+      apply hs1
+      have hsT : Type1.fromShifted (5 * chunks) ⟨(ToNat.toNat v : ℤ)⟩
+          • Point.some _ _ hT = Point.some _ _ hT := hpt.symm.trans hgT
+      have h0 : (2 * (ToNat.toNat v : ℤ) + 2 ^ (5 * chunks)) • Point.some _ _ hT
+          = 0 := by
+        have hexp : (2 * (ToNat.toNat v : ℤ) + 2 ^ (5 * chunks)) • Point.some _ _ hT
+            = Type1.fromShifted (5 * chunks) ⟨(ToNat.toNat v : ℤ)⟩
+                • Point.some _ _ hT - Point.some _ _ hT := by
+          simp only [Type1.fromShifted]
+          module
+        rw [hexp, hsT, sub_self]
+      exact (zsmul_eq_zero_iff_order_dvd d.W (Point.some_ne_zero hT) _).1 h0
+    obtain ⟨xq, yq, hqx, hqy, -, hqns, hqsum⟩ :=
+      (hq xg yg xv (-yv) hgx' hgy' hbx' hny hfin hnegT).resolve_left (by
+        rintro ⟨-, hzero⟩
+        apply hs1
+        have hexp : (2 * (ToNat.toNat v : ℤ) + 2 ^ (5 * chunks)) • Point.some _ _ hT
+            = Point.some _ _ hfin + Point.some _ _ hnegT := by
+          rw [hpt, hnegPt]
+          simp only [Type1.fromShifted]
+          module
+        rw [hzero] at hexp
+        exact (zsmul_eq_zero_iff_order_dvd d.W (Point.some_ne_zero hT) _).1 hexp)
+    have hqpt : (Point.some _ _ hqns : d.W.Point)
+        = (2 * (ToNat.toNat v : ℤ) + 2 ^ (5 * chunks)) • Point.some _ _ hT := by
+      rw [← hqsum, hpt, hnegPt]
+      simp only [Type1.fromShifted]
+      module
+    -- the point conditional selects coordinatewise, `y` before `x`
+    mvcgen
+    refine ⟨⟨readsBit_le ((hle.trans hle').trans hle₃) hbit,
+      by rw [CVar.eval_le hle₃ hgy']; rfl, by rw [hqy]; rfl⟩,
+      fun ysel sty hyg hley => ?_⟩
+    have hyv' := hyg bb yg yq
+      (CVar.eval_le ((hle.trans hle').trans hle₃) hb)
+      (CVar.eval_le hle₃ hgy') hqy
+    mvcgen
+    refine ⟨⟨readsBit_le (((hle.trans hle').trans hle₃).trans hley) hbit,
+      by rw [CVar.eval_le (hle₃.trans hley) hgx']; rfl,
+      by rw [CVar.eval_le hley hqx]; rfl⟩,
+      fun xsel stx hxg hlex => ?_⟩
+    have hxv' := hxg bb xg xq
+      (CVar.eval_le (((hle.trans hle').trans hle₃).trans hley) hb)
+      (CVar.eval_le (hle₃.trans hley) hgx') (CVar.eval_le hley hqx)
+    mvcgen
+    refine hk ⟨xsel, ysel⟩ stx
+      (fun v' xv' yv' hv' hxv' hyv' hT' bb' hb' => ?_)
+      ((((hle.trans hle').trans hle₃).trans hley).trans hlex)
+    rw [hv] at hv'
+    injection hv' with hv'
+    rw [hxv] at hxv'
+    injection hxv' with hxv'
+    rw [hyv] at hyv'
+    injection hyv' with hyv'
+    subst hv' hxv' hyv'
+    rw [hb] at hb'
+    injection hb' with hb'
+    obtain rfl := bit_inj one_ne_zero hb'
+    cases bb
+    · refine ⟨xq, yq, by simpa [selectPure] using hxv',
+        by simpa [selectPure] using CVar.eval_le hlex hyv', hqns, ?_⟩
+      rw [show SplitField.fromShifted (5 * chunks)
+          (⟨(ToNat.toNat v : ℤ), false⟩ : SplitField ℤ Bool)
+          = 2 * (ToNat.toNat v : ℤ) + 2 ^ (5 * chunks) from by
+        simp [SplitField.fromShifted]]
+      exact hqpt
+    · refine ⟨xg, yg, by simpa [selectPure] using hxv',
+        by simpa [selectPure] using CVar.eval_le hlex hyv', hfin, ?_⟩
+      rw [show SplitField.fromShifted (5 * chunks)
+          (⟨(ToNat.toNat v : ℤ), true⟩ : SplitField ℤ Bool)
+          = Type1.fromShifted (5 * chunks) (⟨(ToNat.toNat v : ℤ)⟩ : Type1 ℤ) from by
+        simp [SplitField.fromShifted, Type1.fromShifted]; ring]
+      exact hpt
+  case post.except =>
+    exact ExceptConds.entails_false
 
 end Snarky.Kimchi

--- a/formal/snarky/roots.txt
+++ b/formal/snarky/roots.txt
@@ -399,6 +399,7 @@ Snarky.Kimchi.EndoMul.endoInv_spec
 Snarky.Kimchi.EndoMul.endoInv_complete_spec
 Snarky.Kimchi.varBaseMul_spec
 Snarky.Kimchi.varBaseMul_complete_spec
+Snarky.Kimchi.scaleFast1_complete_spec
 Snarky.Kimchi.scaleFast1_spec
 Snarky.Kimchi.splitFieldVar_spec
 Snarky.Kimchi.scaleFast2_spec

--- a/formal/snarky/roots.txt
+++ b/formal/snarky/roots.txt
@@ -400,6 +400,7 @@ Snarky.Kimchi.EndoMul.endoInv_complete_spec
 Snarky.Kimchi.varBaseMul_spec
 Snarky.Kimchi.varBaseMul_complete_spec
 Snarky.Kimchi.scaleFast1_complete_spec
+Snarky.Kimchi.scaleFast2_complete_spec
 Snarky.Kimchi.scaleFast1_spec
 Snarky.Kimchi.splitFieldVar_spec
 Snarky.Kimchi.scaleFast2_spec

--- a/formal/snarky/roots.txt
+++ b/formal/snarky/roots.txt
@@ -401,6 +401,8 @@ Snarky.Kimchi.varBaseMul_spec
 Snarky.Kimchi.varBaseMul_complete_spec
 Snarky.Kimchi.scaleFast1_complete_spec
 Snarky.Kimchi.scaleFast2_complete_spec
+Snarky.Kimchi.scaleFast2'_complete_spec
+Snarky.Kimchi.splitFieldVar_complete_spec
 Snarky.Kimchi.scaleFast1_spec
 Snarky.Kimchi.splitFieldVar_spec
 Snarky.Kimchi.scaleFast2_spec

--- a/formal/snarky/scripts/check_axioms.lean
+++ b/formal/snarky/scripts/check_axioms.lean
@@ -102,6 +102,7 @@ def roots : List Name :=
     `Snarky.Kimchi.EndoMul.endoInv_complete_spec,
     `Snarky.Kimchi.varBaseMul_spec,
     `Snarky.Kimchi.varBaseMul_complete_spec,
+    `Snarky.Kimchi.scaleFast1_complete_spec,
     `Snarky.Kimchi.scaleFast1_spec,
     `Snarky.Kimchi.splitFieldVar_spec,
     `Snarky.Kimchi.scaleFast2_spec,

--- a/formal/snarky/scripts/check_axioms.lean
+++ b/formal/snarky/scripts/check_axioms.lean
@@ -103,6 +103,7 @@ def roots : List Name :=
     `Snarky.Kimchi.varBaseMul_spec,
     `Snarky.Kimchi.varBaseMul_complete_spec,
     `Snarky.Kimchi.scaleFast1_complete_spec,
+    `Snarky.Kimchi.scaleFast2_complete_spec,
     `Snarky.Kimchi.scaleFast1_spec,
     `Snarky.Kimchi.splitFieldVar_spec,
     `Snarky.Kimchi.scaleFast2_spec,

--- a/formal/snarky/scripts/check_axioms.lean
+++ b/formal/snarky/scripts/check_axioms.lean
@@ -104,6 +104,8 @@ def roots : List Name :=
     `Snarky.Kimchi.varBaseMul_complete_spec,
     `Snarky.Kimchi.scaleFast1_complete_spec,
     `Snarky.Kimchi.scaleFast2_complete_spec,
+    `Snarky.Kimchi.scaleFast2'_complete_spec,
+    `Snarky.Kimchi.splitFieldVar_complete_spec,
     `Snarky.Kimchi.scaleFast1_spec,
     `Snarky.Kimchi.splitFieldVar_spec,
     `Snarky.Kimchi.scaleFast2_spec,


### PR DESCRIPTION
The completeness laws for all three `varBaseMul` wrappers, each stated as the honest side of its PS defining equation over the curve dictionary — plus the interface repairs the review pressure exposed: every place a composition walk needed inline work traced to an underspecified component interface, and each is fixed at its home rather than worked around.

## The laws

- **`scaleFast1_complete_spec`** — `scaleFast1 g a ~ [fromShifted a]·g` at the scalar's canonical value: `varBaseMul_complete_spec`'s point promise at the result, the bits dropped. Six tactic lines: `mvcgen` consumes the dictionary-carrying core law from the registry (the `d` metavariable pins itself when the leftover precondition closes against the hypothesis).
- **`scaleFast2_complete_spec`** — `scaleFast2 g (sDiv2, sOdd) ~ [fromShifted (sDiv2, sOdd)]·g`, the `SplitField` decode at the honest split: in-range faithful half whose Type1 decode satisfies the inner ladder's regime, parity flag a genuine bit. The one fresh fact is quarantined (`regime_off_base`): the regime keeps the honest decode off the base — subwrap by size, one-wrap because `1` is a forbidden residue (`mem_forbiddenValues_of_dvd_sub_one`, kimchi) — which makes the parity correction's incomplete subtraction well-defined, the completeness-side counterpart of the sound law's `tne` self-enforcement.
- **`splitFieldVar_complete_spec`** (registered) — the recombination assert accepts in odd characteristic (`2·((s − b)/2) + b = s` needs only `2 ≠ 0`, for any parity bit) and the pair reads as the split.
- **`scaleFast2'_complete_spec`** — the defining equation `scaleFast2' g s ~ [s + 2^(5·chunks)]·g` at the honest split; the char-2 obligation is discharged by the dictionary's own `two_ne`.

## The interface repairs

- **Gadget loops speak `forIn`.** The pin loop moves from `List.forM` to `for … in` — the same op tree (pure yields emit nothing; CS oracle stays 30/30) but a loop `Std.Do` actually has spec lemmas for (`Spec.forIn_list`; there are no `forM` lemmas at all). Both hand-rolled `forM` induction lemmas are deleted; the sound walk carries the pins in a one-line accumulating invariant, the complete walk in an env-monotonicity invariant.
- **One `addFast` completeness spec, stated at the group it computes in.** The precondition is now nonsingular operands, `y₁ ≠ 0`, and (under `checkFinite`) a nonzero group sum; the coordinate vocabulary the old statement leaked (`W.Equation`, the `¬(x₁ = x₂ ∧ y₁ = negY x₂ y₂)` same-x branch) moves inside the proof, per the doctrine that specs state the intended EC operation and never the field equations. Mode-generality and the infinity-flag outcome survive unchanged. All three callers (the varBaseMul doubling init, endoMul's two pinned additions, scaleFast2's correction) shed their inline branch geometry: each names its nonzero-sum fact once and hands it to both the precondition and the infinity-branch resolution. `neg_point_reading` is the negated operand's face.
- **`ReadsBit` gains its missing introduction and monotonicity** (`of_bit`, `mono`, beside the definition): a producer's grant — `eval = .ok (bit b)` — becomes a consumer's `ReadsBit` precondition in one name instead of an inline construction at every seam.
- **`CVar.eval_add_` becomes compositional**, matching `eval_scale_`/`eval_sub_` (the fold-normalization survives as `eval_add_fold`); five call sites across four files shrink to single applications.

## Gates

Full build clean; style OK; snarky axiom gate 132 roots, kimchi gate green (both reduce to the standard axiom set); dead-code sweep 0; CS-equality oracle 30/30 (the `forIn` respelling is byte-neutral).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QYZxnvZuHfK7cR4DYFHBA