### PR TITLE
The law-interface audit — weak postconditions repaired at their homes

### DIFF
--- a/formal/kimchi/Kimchi/Gate/Semantics/EndoScalar.lean
+++ b/formal/kimchi/Kimchi/Gate/Semantics/EndoScalar.lean
@@ -203,6 +203,13 @@ def decomposeB (crumbs : List F) : F := decomposeFold (fun x => dPoly x) crumbs
     input challenge. -/
 def nReconstruct (crumbs : List F) : F := crumbs.foldl (fun n x => 4 * n + x) 0
 
+/-- Zero crumbs decompose to the inits: the empty fold is its seed. -/
+@[simp] theorem decomposeA_nil : decomposeA (F := F) [] = 2 := rfl
+
+@[simp] theorem decomposeB_nil : decomposeB (F := F) [] = 2 := rfl
+
+@[simp] theorem nReconstruct_nil : nReconstruct (F := F) [] = 0 := rfl
+
 /-- The effective scalar the gate outputs: `a·λ + b` (`λ` the endomorphism
     eigenvalue). This is the pure `to_field` of the challenge. -/
 def toField (crumbs : List F) (lam : F) : F :=
@@ -477,6 +484,8 @@ theorem chainCrumbs_chainBuild (rows : ℕ → List F) (m : ℕ) :
 def crumbsOf : ℕ → ℕ → List F
   | 0, _ => []
   | c + 1, k => crumbsOf c (k / 4) ++ [((k % 4 : ℕ) : F)]
+
+@[simp] theorem crumbsOf_zero (k : ℕ) : crumbsOf (F := F) 0 k = [] := rfl
 
 /-- `crumbsOf` has exactly the width asked for, which is what lets it fill whole
     `EndoScalar` rows. -/

--- a/formal/kimchi/roots.txt
+++ b/formal/kimchi/roots.txt
@@ -51,6 +51,11 @@ Kimchi.Gate.VarBaseMul.varBaseMul_scaleFast2
 -- per-gate `sound`/`complete` are live through `endoScalar_unique`/`chain_complete`.
 Kimchi.Gate.EndoScalar.chain_toField
 Kimchi.Gate.EndoScalar.chain_complete
+-- zero-crumb decompositions: simp-set surface (consumed by simpa in snarky walks)
+Kimchi.Gate.EndoScalar.crumbsOf_zero
+Kimchi.Gate.EndoScalar.decomposeA_nil
+Kimchi.Gate.EndoScalar.decomposeB_nil
+Kimchi.Gate.EndoScalar.nReconstruct_nil
 Kimchi.Gate.EndoScalar.endoScalar_unique
 
 -- The 128-bit range check (`RangeCheck.purs`'s `rangeCheck128 = void ∘ EndoScalar.toField @8`):

--- a/formal/snarky/Snarky/Backend/Assignments.lean
+++ b/formal/snarky/Snarky/Backend/Assignments.lean
@@ -238,4 +238,22 @@ theorem mapM_eval_le [Add F] [Mul F] {env env' : Assignments F}
         simp [List.mapM_cons, CVar.eval_le hle he, mapM_eval_le hle hr, Bind.bind,
           Except.bind, Pure.pure, Except.pure, h]
 
+/-- Elementwise reads assemble into a `mapM`-evaluation — the introduction the bulk
+witness grants feed. -/
+theorem mapM_eval_ok [Add F] [Mul F] {env : Assignments F} :
+    ∀ {xs : List (CVar F)} {vs : List F}, xs.length = vs.length →
+      (∀ j (hj : j < xs.length) (hj' : j < vs.length), xs[j].eval env = .ok vs[j]) →
+      xs.mapM (CVar.eval · env) = .ok vs
+  | [], [], _, _ => rfl
+  | [], _ :: _, hlen, _ => by simp at hlen
+  | _ :: _, [], hlen, _ => by simp at hlen
+  | x :: xs, v :: vs, hlen, hj => by
+    have h0 := hj 0 (by simp) (by simp)
+    simp only [List.getElem_cons_zero] at h0
+    have ih := mapM_eval_ok (env := env) (xs := xs) (vs := vs) (by simpa using hlen)
+      (fun j hj1 hj2 => by
+        have := hj (j + 1) (by simpa using hj1) (by simpa using hj2)
+        simpa only [List.getElem_cons_succ] using this)
+    simp [List.mapM_cons, h0, ih, Bind.bind, Except.bind, Pure.pure, Except.pure]
+
 end Snarky

--- a/formal/snarky/Snarky/Circuit/DSL/Monad.lean
+++ b/formal/snarky/Snarky/Circuit/DSL/Monad.lean
@@ -63,6 +63,24 @@ namespace AsProver
 def readCVar [Add F] [Mul F] (x : CVar F) : AsProver F F :=
   fun env => x.eval env
 
+/-- The prover-side list read is the elementwise read. -/
+theorem readAll_ok [Add F] [Mul F] {env : Assignments F} :
+    ∀ {xs : List (CVar F)} {vs : List F},
+      xs.mapM (CVar.eval · env) = .ok vs →
+      (xs.mapM readCVar) env = .ok vs
+  | [], vs, h => h
+  | x :: xs, vs, h => by
+    cases he : x.eval env with
+    | error e => simp [List.mapM_cons, he, Bind.bind, Except.bind] at h
+    | ok y =>
+      cases hr : xs.mapM (CVar.eval · env) with
+      | error e => simp [List.mapM_cons, he, hr, Bind.bind, Except.bind] at h
+      | ok ys =>
+        simp only [List.mapM_cons, he, hr, Bind.bind, Except.bind, Pure.pure,
+          Except.pure] at h
+        simp [List.mapM_cons, readCVar, he, readAll_ok hr, Bind.bind,
+          ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure, h]
+
 /-- Fail with a message (PS `throwAsProver`). -/
 def throw (msg : String) : AsProver F α :=
   fun _ => .error (.custom msg)

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
@@ -97,6 +97,22 @@ private def rowWit [Field F] [DecidableEq F] (eb : F) (t : AffinePoint (FVar F))
   let w := Kimchi.Gate.EndoMul.build eb xt yt xp yp n b1 b2 b3 b4
   pure (w.inv, w.nPrime, w.xR, w.yR, w.xS, w.yS, w.s1, w.s3)
 
+/-- One `endoMul` window round (the loop body, named): witness the row's advice
+octet and assemble the `EndoMulRound` record, returning the round and the advanced
+`(accumulator, register)` state. -/
+def endoMulRound [Field F] [DecidableEq F] [BasicSystem F c]
+    (eb : F) (t : AffinePoint (FVar F)) (st : AffinePoint (FVar F) × FVar F)
+    (bs : Vector (FVar F) 4) :
+    CircuitM F c (EndoMulRound F × (AffinePoint (FVar F) × FVar F)) := do
+  let w ← witness (val := F × F × F × F × F × F × F × F) (rowWit eb t bs st)
+  let s : AffinePoint (FVar F) := ⟨w.2.2.2.2.1, w.2.2.2.2.2.1⟩
+  pure (({ t, p := st.1, r := ⟨w.2.2.1, w.2.2.2.1⟩, s,
+           s1 := w.2.2.2.2.2.2.1, s3 := w.2.2.2.2.2.2.2,
+           nAcc := st.2, nAccNext := w.2.1,
+           bit0 := bs[0], bit1 := bs[1], bit2 := bs[2], bit3 := bs[3],
+           inv := w.1 } : EndoMulRound F),
+        (s, w.2.1))
+
 /-- The endomorphism-optimized scalar multiplication (PS `endo`; OCaml
 `Pickles.Step_main_inputs.Ops.endo`): witness the MSB-first bits, seal `β·x` and
 build `acc = [2](g + φ(g))` with two `addFast`s, run the `rounds` window rounds
@@ -110,17 +126,7 @@ def endoMul [Field F] [DecidableEq F] [ToNat F] [BasicSystem F c] [KimchiSystem 
   let phix ← sealVar (CVar.scale_ eb g.x)
   let p1 ← addFast .checkFinite g ⟨phix, g.y⟩
   let p2 ← addFast .checkFinite p1.p p1.p
-  let (state, fin) ← mapAccumM
-    (fun (st : AffinePoint (FVar F) × FVar F) (bs : Vector (FVar F) 4) => do
-      let w ← witness (val := F × F × F × F × F × F × F × F) (rowWit eb g bs st)
-      let s : AffinePoint (FVar F) := ⟨w.2.2.2.2.1, w.2.2.2.2.2.1⟩
-      pure (({ t := g, p := st.1, r := ⟨w.2.2.1, w.2.2.2.1⟩, s,
-               s1 := w.2.2.2.2.2.2.1, s3 := w.2.2.2.2.2.2.2,
-               nAcc := st.2, nAccNext := w.2.1,
-               bit0 := bs[0], bit1 := bs[1], bit2 := bs[2], bit3 := bs[3],
-               inv := w.1 } : EndoMulRound F),
-            (s, w.2.1)))
-    (p2.p, .const 0) bits.toList
+  let (state, fin) ← mapAccumM (endoMulRound eb g) (p2.p, .const 0) bits.toList
   assertEqual fin.2 scalar.val
   addConstraint (KimchiSystem.endoMul { state, s := fin.1, nAcc := fin.2, endo := eb })
   pure fin.1
@@ -613,7 +619,7 @@ theorem endoMul_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F)
   obtain ⟨W, eb, lam, ha, -, hprime, hodd, h2, h3, heig, hφns, hoff, -, -, -⟩ := d
   haveI : Fact (Nat.Prime W.order) := ⟨hprime⟩
   haveI : Fact (W.a₁ = 0 ∧ W.a₂ = 0 ∧ W.a₃ = 0) := ⟨⟨ha.1, ha.2.1, ha.2.2.1⟩⟩
-  simp only [endoMul, mapAccumM]
+  simp only [endoMul, endoMulRound, mapAccumM]
   mvcgen
   rename_i s hpre
   intro bits _
@@ -820,6 +826,91 @@ private theorem rowWit_ok [Field F] [DecidableEq F] {env : Assignments F}
              (Kimchi.Gate.EndoMul.build eb xt yt xp yp n b1 b2 b3 b4).s3) := by
   simp [rowWit, AsProver.readCVar, hxt, hyt, hxp, hyp, hn, hb1, hb2, hb3, hb4,
     Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
+
+open Std.Do in
+/-- **One round is the gate's canonical row.** On readable base, accumulator,
+register, and bit cells, the honest round accepts and its collected `EndoMulRound`
+reads as `build` at exactly those values — with the successor-supplied output cells
+being that row's `xS`/`yS`/`nPrime`, which the returned state also reads as. Stated
+over the gate model's row rather than any particular walk, so the caller's loop
+supplies only the reads and gets the row back; registered, so `mvcgen` applies it
+once per iteration. -/
+@[spec] theorem endoMulRound_complete_spec [Field F] [DecidableEq F]
+    (eb : F) (t : AffinePoint (FVar F)) (st : AffinePoint (FVar F) × FVar F)
+    (bs : Vector (FVar F) 4)
+    (Q : PostCond (EndoMulRound F × (AffinePoint (FVar F) × FVar F))
+      (.arg (ProverState F) (.except EvalError .pure))) :
+    ⦃Complete
+        (fun env => (t.x.eval env).isOk ∧ (t.y.eval env).isOk ∧
+          (st.1.x.eval env).isOk ∧ (st.1.y.eval env).isOk ∧ (st.2.eval env).isOk ∧
+          ∀ (j : ℕ) (hj : j < 4), ((bs[j]'hj).eval env).isOk)
+        (fun env r env' => ∀ xt yt xp yp nv b1 b2 b3 b4,
+          t.x.eval env = .ok xt → t.y.eval env = .ok yt →
+          st.1.x.eval env = .ok xp → st.1.y.eval env = .ok yp →
+          st.2.eval env = .ok nv →
+          bs[0].eval env = .ok b1 → bs[1].eval env = .ok b2 →
+          bs[2].eval env = .ok b3 → bs[3].eval env = .ok b4 →
+          EndoMulRound.evalWith env' r.1
+              (Kimchi.Gate.EndoMul.build eb xt yt xp yp nv b1 b2 b3 b4).xS
+              (Kimchi.Gate.EndoMul.build eb xt yt xp yp nv b1 b2 b3 b4).yS
+              (Kimchi.Gate.EndoMul.build eb xt yt xp yp nv b1 b2 b3 b4).nPrime
+            = .ok (Kimchi.Gate.EndoMul.build eb xt yt xp yp nv b1 b2 b3 b4)
+          ∧ r.1.p = st.1 ∧ r.1.nAcc = st.2
+          ∧ r.2.1.x.eval env'
+              = .ok (Kimchi.Gate.EndoMul.build eb xt yt xp yp nv b1 b2 b3 b4).xS
+          ∧ r.2.1.y.eval env'
+              = .ok (Kimchi.Gate.EndoMul.build eb xt yt xp yp nv b1 b2 b3 b4).yS
+          ∧ r.2.2.eval env'
+              = .ok (Kimchi.Gate.EndoMul.build eb xt yt xp yp nv b1 b2 b3 b4).nPrime)
+        Q⦄
+    (endoMulRound (c := KimchiProverC F) eb t st bs)
+    ⦃Q⦄ := by
+  simp only [endoMulRound]
+  mvcgen
+  rename_i st₀ hpre
+  obtain ⟨⟨htxk, htyk, hpxk, hpyk, hnk, hbk⟩, hk⟩ := hpre
+  obtain ⟨xt, hxt⟩ := CVar.evalOk htxk
+  obtain ⟨yt, hyt⟩ := CVar.evalOk htyk
+  obtain ⟨xp, hxp⟩ := CVar.evalOk hpxk
+  obtain ⟨yp, hyp⟩ := CVar.evalOk hpyk
+  obtain ⟨nv, hnv⟩ := CVar.evalOk hnk
+  obtain ⟨b1, hb1⟩ := CVar.evalOk (hbk 0 (by omega))
+  obtain ⟨b2, hb2⟩ := CVar.evalOk (hbk 1 (by omega))
+  obtain ⟨b3, hb3⟩ := CVar.evalOk (hbk 2 (by omega))
+  obtain ⟨b4, hb4⟩ := CVar.evalOk (hbk 3 (by omega))
+  have hrow := rowWit_ok (eb := eb) hxt hyt hxp hyp hnv hb1 hb2 hb3 hb4
+  refine ⟨by rw [hrow]; rfl, fun w st₁ hgrant hle₁ => ?_⟩
+  have hw := hgrant _ hrow
+  mvcgen
+  refine hk _ st₁ (fun xt' yt' xp' yp' nv' b1' b2' b3' b4'
+      hxt' hyt' hxp' hyp' hnv' hb1' hb2' hb3' hb4' => ?_) hle₁
+  rw [hxt] at hxt'
+  injection hxt' with hxt'
+  rw [hyt] at hyt'
+  injection hyt' with hyt'
+  rw [hxp] at hxp'
+  injection hxp' with hxp'
+  rw [hyp] at hyp'
+  injection hyp' with hyp'
+  rw [hnv] at hnv'
+  injection hnv' with hnv'
+  rw [hb1] at hb1'
+  injection hb1' with hb1'
+  rw [hb2] at hb2'
+  injection hb2' with hb2'
+  rw [hb3] at hb3'
+  injection hb3' with hb3'
+  rw [hb4] at hb4'
+  injection hb4' with hb4'
+  subst hxt' hyt' hxp' hyp' hnv' hb1' hb2' hb3' hb4'
+  refine ⟨?_, rfl, rfl, hw.2.2.2.2.1, hw.2.2.2.2.2.1, hw.2.1⟩
+  exact evalWith_ok_iff.mpr
+    ⟨CVar.eval_le hle₁ hxt, CVar.eval_le hle₁ hyt, CVar.eval_le hle₁ hxp,
+     CVar.eval_le hle₁ hyp, CVar.eval_le hle₁ hnv,
+     CVar.eval_le hle₁ hb1, CVar.eval_le hle₁ hb2,
+     CVar.eval_le hle₁ hb3, CVar.eval_le hle₁ hb4,
+     hw.2.2.2.2.2.2.1, hw.2.2.1, hw.2.2.2.1, hw.2.2.2.2.2.2.2, hw.1,
+     rfl, rfl, rfl⟩
 
 /-- `accX`/`accY`/`accN` at the walk are the next row's input cells. -/
 private theorem accX_chainBuild [Field F] [DecidableEq F]
@@ -1061,66 +1152,27 @@ theorem endoMul_complete_spec [Field F] [DecidableEq F] [ToNat F] (d : HasEndo F
         hread pref.length hkrows j hj
       have hr2 := CVar.eval_le (hle₂.trans (hle₃.trans (hle₄.trans hLe))) hr'
       simpa [Vector.getElem_ofFn] using hr2
-    have hrow := rowWit_ok (eb := eb)
-      (CVar.eval_le ((hle₁.trans (hle₂.trans (hle₃.trans hle₄))).trans hLe) hxv)
-      (CVar.eval_le ((hle₁.trans (hle₂.trans (hle₃.trans hle₄))).trans hLe) hyv)
-      hxP hyP hnP (hbit 0 (by omega)) (hbit 1 (by omega))
+    have htx := CVar.eval_le ((hle₁.trans (hle₂.trans (hle₃.trans hle₄))).trans hLe) hxv
+    have hty := CVar.eval_le ((hle₁.trans (hle₂.trans (hle₃.trans hle₄))).trans hLe) hyv
+    -- the round's own law does the rest
+    refine ⟨⟨by rw [htx]; rfl, by rw [hty]; rfl, by rw [hxP]; rfl,
+      by rw [hyP]; rfl, by rw [hnP]; rfl,
+      fun j hj => by rw [hbit j hj]; rfl⟩, fun r st' hpost hle' => ?_⟩
+    obtain ⟨hev, hpEq, hnEq, hsx, hsy, hsn⟩ := hpost xv yv _ _ _ _ _ _ _
+      htx hty hxP hyP hnP (hbit 0 (by omega)) (hbit 1 (by omega))
       (hbit 2 (by omega)) (hbit 3 (by omega))
-    rw [show Kimchi.Gate.EndoMul.build eb xv yv
-        (Kimchi.Gate.EndoMul.chainBuild eb xv yv x0v y0v 0 bsv pref.length).xP
-        (Kimchi.Gate.EndoMul.chainBuild eb xv yv x0v y0v 0 bsv pref.length).yP
-        (Kimchi.Gate.EndoMul.chainBuild eb xv yv x0v y0v 0 bsv pref.length).n
-        (if n.testBit (4 * rounds - 1 - (4 * pref.length + 0)) then (1 : F) else 0)
-        (if n.testBit (4 * rounds - 1 - (4 * pref.length + 1)) then (1 : F) else 0)
-        (if n.testBit (4 * rounds - 1 - (4 * pref.length + 2)) then (1 : F) else 0)
-        (if n.testBit (4 * rounds - 1 - (4 * pref.length + 3)) then (1 : F) else 0)
-      = Kimchi.Gate.EndoMul.chainBuild eb xv yv x0v y0v 0 bsv pref.length from
-        (Kimchi.Gate.EndoMul.chainBuild_eta eb xv yv x0v y0v 0 bsv
-          pref.length).symm] at hrow
-    refine ⟨by rw [hrow]; rfl, fun w st' hgrant' hle' => ?_⟩
-    have hw := hgrant' _ hrow
-    mvcgen
-    have hround : EndoMulRound.evalWith st'.env
-        { t := t, p := b.fst.1, r := ⟨w.2.2.1, w.2.2.2.1⟩,
-          s := ⟨w.2.2.2.2.1, w.2.2.2.2.2.1⟩,
-          s1 := w.2.2.2.2.2.2.1, s3 := w.2.2.2.2.2.2.2,
-          nAcc := b.fst.2, nAccNext := w.2.1,
-          bit0 := (bits[pref.length]'hkrows)[0],
-          bit1 := (bits[pref.length]'hkrows)[1],
-          bit2 := (bits[pref.length]'hkrows)[2],
-          bit3 := (bits[pref.length]'hkrows)[3],
-          inv := w.1 }
-        (Kimchi.Gate.EndoMul.chainBuild eb xv yv x0v y0v 0 bsv pref.length).xS
-        (Kimchi.Gate.EndoMul.chainBuild eb xv yv x0v y0v 0 bsv pref.length).yS
-        (Kimchi.Gate.EndoMul.chainBuild eb xv yv x0v y0v 0 bsv pref.length).nPrime
-        = .ok (Kimchi.Gate.EndoMul.chainBuild eb xv yv x0v y0v 0 bsv pref.length) := by
-      obtain ⟨hxT', hyT', hb1', hb2', hb3', hb4'⟩ :=
-        chainBuild_fields eb xv yv x0v y0v 0 bsv pref.length
-      refine evalWith_ok_iff.mpr
-        ⟨?_, ?_, CVar.eval_le hle' hxP, CVar.eval_le hle' hyP,
-          CVar.eval_le hle' hnP, ?_, ?_, ?_, ?_, hw.2.2.2.2.2.2.1,
-          hw.2.2.1, hw.2.2.2.1, hw.2.2.2.2.2.2.2, hw.1, rfl, rfl, rfl⟩
-      · rw [hxT']
-        exact CVar.eval_le
-          (((hle₁.trans (hle₂.trans (hle₃.trans hle₄))).trans hLe).trans hle') hxv
-      · rw [hyT']
-        exact CVar.eval_le
-          (((hle₁.trans (hle₂.trans (hle₃.trans hle₄))).trans hLe).trans hle') hyv
-      · rw [hb1']
-        exact CVar.eval_le hle' (hbit 0 (by omega))
-      · rw [hb2']
-        exact CVar.eval_le hle' (hbit 1 (by omega))
-      · rw [hb3']
-        exact CVar.eval_le hle' (hbit 2 (by omega))
-      · rw [hb4']
-        exact CVar.eval_le hle' (hbit 3 (by omega))
+    rw [← Kimchi.Gate.EndoMul.chainBuild_eta eb xv yv x0v y0v 0 bsv pref.length]
+      at hev hsx hsy hsn
+    intro _
     refine ⟨hLe.trans hle', ?_, ?_⟩
     · simp only [List.length_append, List.length_cons, List.length_nil]
-      exact ⟨hw.2.2.2.2.1, hw.2.2.2.2.2.1, hw.2.1⟩
+      exact ⟨hsx, hsy, hsn⟩
     · simp only [List.length_append, List.length_cons, List.length_nil]
       exact chainOk_snoc (chainOk_le hle' hchk)
-        (CVar.eval_le hle' hxP) (CVar.eval_le hle' hyP) (CVar.eval_le hle' hnP)
-        hround ((Kimchi.Gate.EndoMul.ok_iff eb _).mpr (hHolds pref.length hkrows))
+        (by rw [hpEq]; exact CVar.eval_le hle' hxP)
+        (by rw [hpEq]; exact CVar.eval_le hle' hyP)
+        (by rw [hnEq]; exact CVar.eval_le hle' hnP)
+        hev ((Kimchi.Gate.EndoMul.ok_iff eb _).mpr (hHolds pref.length hkrows))
   case vc2.vc1.vc1.vc1.vc1.refine_2.refine_2.pre =>
     exact ⟨Assignments.Le.refl st₄.env, ⟨hx0e, hy0e, rfl⟩, rfl⟩
   case vc3.vc1.vc1.vc1.vc1.refine_2.refine_2.post.success =>

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
@@ -484,41 +484,6 @@ private theorem chainBuild_crumbs [Field F] (rows' : ℕ → List F) (i : ℕ) :
     (Kimchi.Gate.EndoScalar.chainBuild rows' i).crumbs = rows' i := by
   cases i <;> rfl
 
-/-- Element reads assemble into the list read. -/
-private theorem mapM_eval_ok [Add F] [Mul F] {env : Assignments F} :
-    ∀ {xs : List (FVar F)} {vs : List F}, xs.length = vs.length →
-      (∀ j (hj : j < xs.length) (hj' : j < vs.length), xs[j].eval env = .ok vs[j]) →
-      xs.mapM (CVar.eval · env) = .ok vs
-  | [], [], _, _ => rfl
-  | [], _ :: _, hlen, _ => by simp at hlen
-  | _ :: _, [], hlen, _ => by simp at hlen
-  | x :: xs, v :: vs, hlen, hj => by
-    have h0 := hj 0 (by simp) (by simp)
-    simp only [List.getElem_cons_zero] at h0
-    have ih := mapM_eval_ok (env := env) (xs := xs) (vs := vs) (by simpa using hlen)
-      (fun j hj1 hj2 => by
-        have := hj (j + 1) (by simpa using hj1) (by simpa using hj2)
-        simpa only [List.getElem_cons_succ] using this)
-    simp [List.mapM_cons, h0, ih, Bind.bind, Except.bind, Pure.pure, Except.pure]
-
-/-- The prover-side list read is the elementwise read. -/
-private theorem readAll_ok [Add F] [Mul F] {env : Assignments F} :
-    ∀ {xs : List (FVar F)} {vs : List F},
-      xs.mapM (CVar.eval · env) = .ok vs →
-      (xs.mapM AsProver.readCVar) env = .ok vs
-  | [], vs, h => h
-  | x :: xs, vs, h => by
-    cases he : x.eval env with
-    | error e => simp [List.mapM_cons, he, Bind.bind, Except.bind] at h
-    | ok y =>
-      cases hr : xs.mapM (CVar.eval · env) with
-      | error e => simp [List.mapM_cons, he, hr, Bind.bind, Except.bind] at h
-      | ok ys =>
-        simp only [List.mapM_cons, he, hr, Bind.bind, Except.bind, Pure.pure,
-          Except.pure] at h
-        simp [List.mapM_cons, AsProver.readCVar, he, readAll_ok hr, Bind.bind,
-          ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure, h]
-
 /-- A round evaluates to a witness exactly when each register and the crumb list
 read as its fields. -/
 private theorem round_eval_ok_iff [Field F] [DecidableEq F] {env : Assignments F}
@@ -581,7 +546,7 @@ private theorem rowWit_ok [Field F] [DecidableEq F] {env : Assignments F}
       = .ok ((Kimchi.Gate.EndoScalar.build a b n vs).a8,
              (Kimchi.Gate.EndoScalar.build a b n vs).b8,
              (Kimchi.Gate.EndoScalar.build a b n vs).n8) := by
-  simp [rowWit, AsProver.readCVar, ha, hb, hn, readAll_ok hxs, Bind.bind, ReaderT.bind,
+  simp [rowWit, AsProver.readCVar, ha, hb, hn, AsProver.readAll_ok hxs, Bind.bind, ReaderT.bind,
     Except.bind, Pure.pure, ReaderT.pure, Except.pure]
 
 open Std.Do in
@@ -694,29 +659,8 @@ theorem toFieldChecked'_complete_spec [Field F] [DecidableEq F] [ToNat F]
     subst hv'
     cases rows with
     | zero =>
-      refine ⟨?_, ?_, ?_⟩ <;>
-        · refine CVar.eval_le hle₂ ?_
-          first
-            | (rw [show Kimchi.Gate.EndoScalar.decomposeA
-                    (Kimchi.Gate.EndoScalar.crumbsOf (F := F) (8 * 0)
-                      (ToNat.toNat vv)) = 2 from by
-                  simp [Kimchi.Gate.EndoScalar.crumbsOf,
-                    Kimchi.Gate.EndoScalar.decomposeA,
-                    Kimchi.Gate.EndoScalar.decomposeFold]]
-               exact hA)
-            | (rw [show Kimchi.Gate.EndoScalar.decomposeB
-                    (Kimchi.Gate.EndoScalar.crumbsOf (F := F) (8 * 0)
-                      (ToNat.toNat vv)) = 2 from by
-                  simp [Kimchi.Gate.EndoScalar.crumbsOf,
-                    Kimchi.Gate.EndoScalar.decomposeB,
-                    Kimchi.Gate.EndoScalar.decomposeFold]]
-               exact hB)
-            | (rw [show Kimchi.Gate.EndoScalar.nReconstruct
-                    (Kimchi.Gate.EndoScalar.crumbsOf (F := F) (8 * 0)
-                      (ToNat.toNat vv)) = 0 from by
-                  simp [Kimchi.Gate.EndoScalar.crumbsOf,
-                    Kimchi.Gate.EndoScalar.nReconstruct]]
-               exact hN)
+      exact ⟨CVar.eval_le hle₂ (by simpa using hA),
+        CVar.eval_le hle₂ (by simpa using hB), CVar.eval_le hle₂ (by simpa using hN)⟩
     | succ m =>
       obtain ⟨hH, c1, c2, c3, s1, s2, s3, -⟩ :=
         Kimchi.Gate.EndoScalar.chain_complete m

--- a/formal/snarky/Snarky/Kimchi/Circuit/Poseidon.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/Poseidon.lean
@@ -248,6 +248,37 @@ private theorem evalStates_ok [Field F] [DecidableEq F] {env : Assignments F} :
     simp [evalStates, h1, h2, h3, ih, Bind.bind, Except.bind, Pure.pure, Except.pure]
 
 open Std.Do in
+/-- The rounds trajectory checks: a state list whose entries are the round
+function's iterates satisfies the checker's window fold. The fold speaks
+window-indexed `getD` cells; the trajectory speaks the round function — this is the
+honest witness's face of the checker, converted once. -/
+private theorem chainHolds_rounds [Field F] [DecidableEq F] (p : Poseidon.Params F)
+    (s0 : F × F × F) :
+    chainHolds (mdsOf p.mds) p.roundConstants.toList 0
+      (s0 :: (List.ofFn fun i : Fin 55 =>
+        rounds (mdsOfParams p) (paramsRc p) (i.1 + 1) s0)) := by
+  refine chainHolds_of_succ 0 _ ?_
+  intro j hj1 hj0
+  have hgetD : ∀ (m : ℕ) (hm : m < 56),
+      (s0 :: (List.ofFn fun i : Fin 55 =>
+          rounds (mdsOfParams p) (paramsRc p) (i.1 + 1) s0))[m]'(by simp; omega)
+        = rounds (mdsOfParams p) (paramsRc p) m s0 := by
+    intro m hm
+    cases m with
+    | zero => rfl
+    | succ i => simp only [List.getElem_cons_succ, List.getElem_ofFn]
+  simp only [List.length_cons, List.length_ofFn] at hj1
+  rw [hgetD (j + 1) (by omega), hgetD j (by omega)]
+  rw [show (5 * 0 + j) = j by omega]
+  have hgd : p.roundConstants.toList.getD j (0, 0, 0)
+      = Kimchi.Gate.Poseidon.paramsRc p j := by
+    simp [Kimchi.Gate.Poseidon.paramsRc, List.getD_eq_getElem?_getD,
+      Array.getD_eq_getD_getElem?]
+  rw [hgd]
+  rfl
+
+
+open Std.Do in
 /-- The gadget is complete: the honest prover run accepts on any readable input
 state — no domain conditions — and the output state reads back as
 `Poseidon.blockCipher` of the input values. -/
@@ -309,31 +340,7 @@ theorem poseidon_complete_spec [Field F] [DecidableEq F] (p : Poseidon.Params F)
         have h := helem i (by omega)
         simp only [List.getElem_cons_succ, Vector.getElem_toList, List.getElem_ofFn]
         exact h
-    have hchain : chainHolds (mdsOf p.mds) p.roundConstants.toList 0
-        ((av, bv, cv) ::
-          (List.ofFn fun i : Fin 55 =>
-            rounds (mdsOfParams p) (paramsRc p) (i.1 + 1) (av, bv, cv))) := by
-      refine chainHolds_of_succ 0 _ ?_
-      intro j hj1 hj0
-      have hgetD : ∀ (m : ℕ) (hm : m < 56),
-          ((av, bv, cv) ::
-            (List.ofFn fun i : Fin 55 =>
-              rounds (mdsOfParams p) (paramsRc p) (i.1 + 1) (av, bv, cv)))[m]'(
-              by simp; omega)
-            = rounds (mdsOfParams p) (paramsRc p) m (av, bv, cv) := by
-        intro m hm
-        cases m with
-        | zero => rfl
-        | succ i => simp only [List.getElem_cons_succ, List.getElem_ofFn]
-      simp only [List.length_cons, List.length_ofFn] at hj1
-      rw [hgetD (j + 1) (by omega), hgetD j (by omega)]
-      rw [show (5 * 0 + j) = j by omega]
-      have hgd : p.roundConstants.toList.getD j (0, 0, 0)
-          = Kimchi.Gate.Poseidon.paramsRc p j := by
-        simp [Kimchi.Gate.Poseidon.paramsRc, List.getD_eq_getElem?_getD,
-          Array.getD_eq_getD_getElem?]
-      rw [hgd]
-      rfl
+    have hchain := chainHolds_rounds p (av, bv, cv)
     simp only [KimchiConstraint.check, hstates]
     exact (chainOk_iff 0 _).mpr hchain
   · simp only [wp, PredTrans.apply, prove]


### PR DESCRIPTION
An audit of the older soundness/completeness walks (EndoScalar, EndoMul, Poseidon) against the defect taxonomy the scaleFast arc established: walk length that traces to underspecified component interfaces — postconditions too weak or spelled in the wrong vocabulary, generic facts kept file-local, loop bodies not named — rather than to mathematics. Four findings executed; one withdrawn with reasoning.

## B1 — the bulk-read lemmas move to the DSL layer

`mapM_eval_ok` (elementwise reads assemble into the list read) joins `mapM_eval_le` beside the `Assignments` vocabulary, and `readAll_ok` (the prover-side list read is the elementwise read) lands next to `AsProver.readCVar`. Both were private to the EndoScalar walk, but every bulk-witness gadget needs them: file-local copies of generic facts are API holes.

## B2 — the zero-row case becomes simp

kimchi gains the zero-crumb decompositions (`crumbsOf_zero`, the fold seeds `decomposeA_nil`/`decomposeB_nil`, `nReconstruct_nil`), rooted as simp-set surface; `toFieldChecked'_complete_spec`'s 28-line inline `rows = 0` computation collapses to three `simpa` applications.

## C1 — the Poseidon checker learns its trajectory face

The checker's `chainHolds` speaks window-indexed `getD` cells, while the honest witness's natural fact is that the state list IS the rounds trajectory — so the completeness walk paid ~35 lines converting one into the other. `chainHolds_rounds` does the conversion once; the walk keeps a single application, and any future sponge-level consumer inherits it.

## A1 — the endoMul window round is a named gadget with its own law

The `scaleRound` pattern: the loop body becomes `endoMulRound` (byte-neutral, CS oracle 30/30), and its registered completeness law states once what the walk previously assembled per iteration — on readable cells the honest round accepts, the collected record `evalWith`-reads as `build` at exactly those values, and the returned state reads as that row's `xS`/`yS`/`nPrime`. `endoMul_complete_spec` drops from 347 to 314 lines with the row identification now reusable. The extraction surfaced a fresh instance of the seam principle: an *opaque* round result must expose the structural facts a literal record gave for free (`r.p`/`r.nAcc` are the state's cells) — the successor-chain `snoc` consumes them, so the round law's post carries them.

## A2 — withdrawn

The Prop-form `chainOk` invariant was scoped on the assumption that the Bool surgery lived in the walk; post-A1 the walk pays one `chainOk_snoc` per step, and a Prop-form invariant needs its own monotonicity/append lemmas of the same size as the trio it would delete. The successor fold's real cost is only removable by restating the EndoMul checker's round reading pair-adjacent, which touches the merged sound side — held.

## Gates

Full build clean; style OK; snarky 128 roots, kimchi 108 roots; dead-code sweep 0 (the simp-only zero-crumb lemmas rooted as simp-set surface per the invisible-consumer rule); CS-equality oracle 30/30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QYZxnvZuHfK7cR4DYFHBA