### PR TITLE
Seam coherence — kimchiOps runs its two seams in lockstep

### DIFF
--- a/formal/snarky/Snarky/Backend/Compile.lean
+++ b/formal/snarky/Snarky/Backend/Compile.lean
@@ -1,4 +1,5 @@
 import Snarky.Circuit.DSL.Assert
+import Snarky.Backend.Ops
 
 /-!
 # Compiling and solving whole circuits
@@ -244,3 +245,84 @@ theorem solve_complete [A : CircuitType F a avar] [CheckedType F (Basic F) avar]
               · have := hle₃ (A.size + j) _ (hextlook j (by omega))
                 rw [this]
                 simp [hM]
+
+omit [Zero F] [One F] in
+/-- The public slots decode at ANY extending backend: a successful `proveWith` run of
+`compileBody` returns a table reading the input at the input slots (the seed
+survives) and the decoded output at the output slots (the back-fill wrote them, and
+the tail only extends). `solve_complete` states the base-`prove` instance alongside
+its constraint clause; backends whose prover seams check nothing (kimchi) consume
+this form. -/
+theorem proveWith_compileBody_slots {g σ : Type u} {ops : BackendOps F g c σ}
+    [BasicSystem F c] [A : CircuitType F a avar] [CheckedType F c avar] [B : CircuitType F b bvar]
+    (hp : ops.ProveExtends)
+    {main : avar → CircuitM F c bvar} {input : a} {outVal : b}
+    {env₀ : Assignments F} {p : Proved F bvar}
+    (hseed : Assignments.empty.extendPairs
+        ((allocRange 0 A.size).toList.zip (A.valueToFields input).toList) = .ok env₀)
+    (hrun : proveWith ops (compileBody (a := a) (b := b) main)
+        (A.size + B.size) env₀ = .ok p)
+    (hread : readVar (val := b) p.result p.assignments = .ok outVal) :
+    (∀ i (hi : i < A.size), p.assignments i = some ((A.valueToFields input)[i])) ∧
+      ∀ j (hj : j < B.size),
+        p.assignments (A.size + j) = some ((B.valueToFields outVal)[j]) := by
+  set L := (A.valueToFields input).toList with hL
+  have hlenL : L.length = A.size := by simp [hL]
+  rw [allocRange_toList, ← hlenL] at hseed
+  have hseedlook := (extendPairs_range'_lookup L 0 hseed).1
+  rw [show p = ⟨p.result, p.nextVar, p.assignments⟩ from rfl] at hrun
+  have hle₀ := (proveWith_extends hp hrun).1
+  simp only [compileBody] at hrun
+  rw [proveWith_bind] at hrun
+  obtain ⟨s₁, hrun₁, hrun⟩ := bind_ok hrun
+  rw [proveWith_bind] at hrun
+  obtain ⟨s₂, hrun₂, hrun⟩ := bind_ok hrun
+  have hslots : (allocRange A.size B.size).toList.find?
+      (s₂.nextVar ≤ ·) = none := by
+    refine List.find?_eq_none.mpr fun v hv => ?_
+    have hlt := (mem_allocRange hv).2
+    have h₁ := (proveWith_extends hp hrun₁).2
+    have h₂ := (proveWith_extends hp hrun₂).2
+    simp only [decide_eq_true_eq]
+    omega
+  rw [proveWith_bind] at hrun
+  obtain ⟨s₃, hassign, hrun⟩ := bind_ok hrun
+  simp only [assignVars, proveWith, outputWit, hslots] at hassign
+  split at hassign
+  · cases hassign
+  next xs hwit =>
+    split at hassign
+    · cases hassign
+    next env₃ hext =>
+      cases hwitread : readVar (val := b) s₂.result s₂.assignments with
+      | error e => rw [hwitread] at hwit; cases hwit
+      | ok ov =>
+        rw [hwitread] at hwit
+        simp only [Except.map, Except.ok.injEq] at hwit
+        subst hwit
+        set M := (B.valueToFields ov).toList with hM
+        have hlenM : M.length = B.size := by simp [hM]
+        rw [allocRange_toList, ← hlenM] at hext
+        have hextlook := (extendPairs_range'_lookup M A.size hext).1
+        simp only [Except.ok.injEq] at hassign
+        subst hassign
+        have hle₃ : env₃.Le p.assignments := (proveWith_extends hp hrun).1
+        have hle₂ : s₂.assignments.Le p.assignments :=
+          (Assignments.le_extendPairs hext).trans hle₃
+        have hres : s₂.result = p.result := by
+          rw [proveWith_bind] at hrun
+          obtain ⟨s₄, -, hpure⟩ := bind_ok hrun
+          simp only [proveWith, Except.ok.injEq, Proved.mk.injEq] at hpure
+          exact hpure.1
+        rw [hres] at hwitread
+        rw [readVar_le hle₂ hwitread] at hread
+        cases hread
+        refine ⟨fun i hi => ?_, fun j hj => ?_⟩
+        · have hlook := hseedlook i (by omega)
+          rw [Nat.zero_add] at hlook
+          have hfin := hle₀ i _ hlook
+          rw [hfin]
+          simp [hL]
+        · have hfin := hle₃ (A.size + j) _ (hextlook j (by omega))
+          rw [hfin]
+          simp [hM]

--- a/formal/snarky/Snarky/Backend/Compile.lean
+++ b/formal/snarky/Snarky/Backend/Compile.lean
@@ -144,108 +144,6 @@ private theorem extendPairs_range'_lookup :
 
 variable [Add F] [Mul F] [Zero F] [One F] [DecidableEq F]
 
-/-- A successful `solve` produces an assignment that satisfies
-every constraint `compile` emits, holds the input's encoding at the input slots, and
-holds the returned output's encoding at the output slots. Stated over the reference
-`Basic F` backend, whose `holds` is monotone (`Basic.holds_mono`).
-
-Constraint satisfaction is `prove_complete` for the shared program; the slot decodes
-chase the run: the seed fills the input slots and prover runs only extend
-(`prove_assignments_le`), and the back-fill's `extendPairs` fills the output slots with
-the encoding of the value `readVar` sees mid-run — carried to the returned output by
-`readVar_le`. Stepped through in the body. -/
-theorem solve_complete [A : CircuitType F a avar] [CheckedType F (Basic F) avar]
-    [B : CircuitType F b bvar] {main : avar → CircuitM F (Basic F) bvar} {input : a}
-    {outVal : b} {env : Assignments F}
-    (h : solve (b := b) Basic.holds main input = .ok (outVal, env)) :
-    (∀ con ∈ (compile (a := a) (b := b) main).constraints, con.holds env = true) ∧
-      ((∀ i (hi : i < A.size), env i = some ((A.valueToFields input)[i])) ∧
-        ∀ j (hj : j < B.size), env (A.size + j) = some ((B.valueToFields outVal)[j])) := by
-  unfold solve at h
-  split at h
-  · cases h
-  next env₀ hseed =>
-    split at h
-    · cases h
-    next p hrun =>
-      split at h
-      · cases h
-      next out' hread =>
-        simp only [Except.ok.injEq, Prod.mk.injEq] at h
-        obtain ⟨rfl, rfl⟩ := h
-        -- The seed's slot facts, behind an opaque list so the range' lemma applies.
-        set L := (A.valueToFields input).toList with hL
-        have hlenL : L.length = A.size := by simp [hL]
-        rw [allocRange_toList, ← hlenL] at hseed
-        have hseedlook := (extendPairs_range'_lookup L 0 hseed).1
-        -- The whole-run facts, before the equation is decomposed.
-        have hmono : ∀ (con : Basic F) {e e' : Assignments F},
-            e.Le e' → con.holds e = true → con.holds e' = true :=
-          fun _ => Basic.holds_mono
-        rw [show p = ⟨p.result, p.nextVar, p.assignments⟩ from rfl] at hrun
-        have hsat := prove_complete hmono hrun
-        have hle₀ := prove_assignments_le hrun
-        -- Decompose the run at the program's binds.
-        simp only [compileBody] at hrun
-        rw [prove_bind] at hrun
-        obtain ⟨s₁, hrun₁, hrun⟩ := bind_ok hrun
-        rw [prove_bind] at hrun
-        obtain ⟨s₂, hrun₂, hrun⟩ := bind_ok hrun
-        -- The back-fill targets the preallocated output slots, and the counter has
-        -- only advanced since they were reserved — so the assign guard is satisfied.
-        have hslots : (allocRange A.size B.size).toList.find?
-            (s₂.nextVar ≤ ·) = none := by
-          refine List.find?_eq_none.mpr fun v hv => ?_
-          have hlt := (mem_allocRange hv).2
-          have h₁ := prove_nextVar_le hrun₁
-          have h₂ := prove_nextVar_le hrun₂
-          simp only [decide_eq_true_eq]
-          omega
-        rw [prove_bind] at hrun
-        obtain ⟨s₃, hassign, hrun⟩ := bind_ok hrun
-        -- The back-fill stage: recover the mid-run output read and the slot fills.
-        simp only [assignVars, prove, outputWit, hslots] at hassign
-        split at hassign
-        · cases hassign
-        next xs hwit =>
-          split at hassign
-          · cases hassign
-          next env₃ hext =>
-            cases hwitread : readVar (val := b) s₂.result s₂.assignments with
-            | error e => rw [hwitread] at hwit; cases hwit
-            | ok ov =>
-              rw [hwitread] at hwit
-              simp only [Except.map, Except.ok.injEq] at hwit
-              subst hwit
-              set M := (B.valueToFields ov).toList with hM
-              have hlenM : M.length = B.size := by simp [hM]
-              rw [allocRange_toList, ← hlenM] at hext
-              have hextlook := (extendPairs_range'_lookup M A.size hext).1
-              -- The tail stages only extend the assignment.
-              simp only [Except.ok.injEq] at hassign
-              subst hassign
-              have hle₃ : env₃.Le p.assignments := prove_assignments_le hrun
-              have hle₂ : s₂.assignments.Le p.assignments :=
-                (Assignments.le_extendPairs hext).trans hle₃
-              -- The mid-run read survives to the end, so `ov` IS the decoded output.
-              have hres : s₂.result = p.result := by
-                rw [prove_bind] at hrun
-                obtain ⟨s₄, -, hpure⟩ := bind_ok hrun
-                simp only [prove, Except.ok.injEq, Proved.mk.injEq] at hpure
-                exact hpure.1
-              rw [hres] at hwitread
-              rw [readVar_le hle₂ hwitread] at hread
-              cases hread
-              refine ⟨hsat, fun i hi => ?_, fun j hj => ?_⟩
-              · have := hseedlook i (by omega)
-                rw [Nat.zero_add] at this
-                have := hle₀ i _ this
-                rw [this]
-                simp [hL]
-              · have := hle₃ (A.size + j) _ (hextlook j (by omega))
-                rw [this]
-                simp [hM]
-
 omit [Zero F] [One F] in
 /-- The public slots decode at ANY extending backend: a successful `proveWith` run of
 `compileBody` returns a table reading the input at the input slots (the seed
@@ -326,3 +224,40 @@ theorem proveWith_compileBody_slots {g σ : Type u} {ops : BackendOps F g c σ}
         · have hfin := hle₃ (A.size + j) _ (hextlook j (by omega))
           rw [hfin]
           simp [hM]
+
+/-- A successful `solve` produces an assignment that satisfies
+every constraint `compile` emits, holds the input's encoding at the input slots, and
+holds the returned output's encoding at the output slots. Stated over the reference
+`Basic F` backend, whose `holds` is monotone (`Basic.holds_mono`).
+
+Constraint satisfaction is `prove_complete` for the shared program — the checking
+prover's own clause, with no backend-generic counterpart; the slot decodes are
+`proveWith_compileBody_slots` at the base ops (`prove` is `proveWith` at
+`checkedOps`, which extends). -/
+theorem solve_complete [A : CircuitType F a avar] [CheckedType F (Basic F) avar]
+    [B : CircuitType F b bvar] {main : avar → CircuitM F (Basic F) bvar} {input : a}
+    {outVal : b} {env : Assignments F}
+    (h : solve (b := b) Basic.holds main input = .ok (outVal, env)) :
+    (∀ con ∈ (compile (a := a) (b := b) main).constraints, con.holds env = true) ∧
+      ((∀ i (hi : i < A.size), env i = some ((A.valueToFields input)[i])) ∧
+        ∀ j (hj : j < B.size), env (A.size + j) = some ((B.valueToFields outVal)[j])) := by
+  unfold solve at h
+  split at h
+  · cases h
+  next env₀ hseed =>
+    split at h
+    · cases h
+    next p hrun =>
+      split at h
+      · cases h
+      next out' hread =>
+        simp only [Except.ok.injEq, Prod.mk.injEq] at h
+        obtain ⟨rfl, rfl⟩ := h
+        have hmono : ∀ (con : Basic F) {e e' : Assignments F},
+            e.Le e' → con.holds e = true → con.holds e' = true :=
+          fun _ => Basic.holds_mono
+        rw [show p = ⟨p.result, p.nextVar, p.assignments⟩ from rfl] at hrun
+        have hsat := prove_complete hmono hrun
+        rw [← proveWith_checkedOps] at hrun
+        exact ⟨hsat, proveWith_compileBody_slots (checkedOps_proveExtends _)
+          hseed hrun hread⟩

--- a/formal/snarky/Snarky/Backend/Ops.lean
+++ b/formal/snarky/Snarky/Backend/Ops.lean
@@ -84,6 +84,12 @@ def finalizeWith (ops : BackendOps F g c σ) (b : BuiltWith g σ α) : BuiltWith
   | (none, s') => { b with aux := s' }
   | (some gate, s') => { b with constraints := b.constraints ++ [gate], aux := s' }
 
+/-- Finalization only flushes queued rows: the counter is untouched. -/
+theorem finalizeWith_nextVar (ops : BackendOps F g c σ) (b : BuiltWith g σ α) :
+    (finalizeWith ops b).nextVar = b.nextVar := by
+  unfold finalizeWith
+  rcases ops.finalize b.aux with ⟨_ | gate, s'⟩ <;> rfl
+
 /-- Interpret a circuit as a prover run through a backend's ops (PS
 `runCircuitProver`): witness handling and the assignment guard mirror `prove`; each
 constraint runs the backend's prover seam against the shared counter and table. -/

--- a/formal/snarky/Snarky/Kimchi/Backend/Compile.lean
+++ b/formal/snarky/Snarky/Kimchi/Backend/Compile.lean
@@ -22,7 +22,7 @@ variable {F : Type} {a b avar bvar : Type}
 
 /-- Compile a circuit at the kimchi backend (the base `compile` at `kimchiOps`,
 queue flushed). -/
-private def kimchiCompile [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F]
+def kimchiCompile [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F]
     [DecidableEq F] [A : CircuitType F a avar]
     [CheckedType F (KimchiConstraint F) avar] [B : CircuitType F b bvar]
     (main : avar → CircuitM F (KimchiConstraint F) bvar) :
@@ -61,5 +61,55 @@ def kimchiGateData [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F]
   let rows := built.constraints.flatMap (toKimchiRows (F := F))
   makeGateData ((allocRange 0 (A.size + B.size)).toList) rows
     built.aux.wireState.unionFind
+
+/-! ## Seam coherence at the pipeline level
+
+The ops-record discharge (`kimchiOps_lockstep`/`kimchiOps_proveExtends`,
+`Constraint.lean`), read at this module's own entry points through the generic
+whole-program theorems. -/
+
+/-- **Compile/solve allocation agreement at the kimchi backend**: a successful
+prover run of the compiled body pins the compilation's counter — `kimchiCompile` and
+the run behind `kimchiSolve` number their variables identically, so every variable
+id the emitted rows can mention is an index the prover numbered.
+`buildWith_proveWith_nextVar` at `kimchiOps_lockstep`, through the
+counter-transparent queue flush. -/
+theorem kimchiCompile_solve_nextVar [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F]
+    [Neg F] [DecidableEq F] [A : CircuitType F a avar]
+    [CheckedType F (KimchiConstraint F) avar] [B : CircuitType F b bvar]
+    (main : avar → CircuitM F (KimchiConstraint F) bvar) {env₀ : Assignments F}
+    {p : Proved F bvar}
+    (h : proveWith kimchiOps (compileBody (a := a) (b := b) main)
+        (A.size + B.size) env₀ = .ok p) :
+    (kimchiCompile (a := a) (b := b) main).nextVar = p.nextVar := by
+  unfold kimchiCompile
+  rw [finalizeWith_nextVar]
+  exact buildWith_proveWith_nextVar kimchiOps_lockstep h initialAuxState
+
+/-- A successful kimchi solve only extends the seeded table: the public-input
+seeding survives into the returned assignments. `proveWith_extends` at
+`kimchiOps_proveExtends`. -/
+theorem kimchiSolve_extends [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F]
+    [Neg F] [DecidableEq F] [A : CircuitType F a avar]
+    [CheckedType F (KimchiConstraint F) avar] [B : CircuitType F b bvar]
+    (main : avar → CircuitM F (KimchiConstraint F) bvar) (input : a)
+    {out : b} {env env₀ : Assignments F}
+    (hseed : Assignments.empty.extendPairs
+        ((allocRange 0 A.size).toList.zip (A.valueToFields input).toList)
+        = .ok env₀)
+    (h : kimchiSolve (a := a) (b := b) main input = .ok (out, env)) :
+    env₀.Le env := by
+  unfold kimchiSolve at h
+  rw [hseed] at h
+  dsimp only at h
+  rcases hp : proveWith kimchiOps (compileBody (a := a) (b := b) main)
+      (A.size + B.size) env₀ with e | p <;> rw [hp] at h
+  · cases h
+  · dsimp only at h
+    rcases hr : readVar (val := b) p.result p.assignments with e | outv <;>
+      rw [hr] at h
+    · cases h
+    · cases h
+      exact (proveWith_extends kimchiOps_proveExtends hp).1
 
 end Snarky.Kimchi

--- a/formal/snarky/Snarky/Kimchi/Backend/Compile.lean
+++ b/formal/snarky/Snarky/Kimchi/Backend/Compile.lean
@@ -86,30 +86,34 @@ theorem kimchiCompile_solve_nextVar [Add F] [Mul F] [Sub F] [Div F] [Zero F] [On
   rw [finalizeWith_nextVar]
   exact buildWith_proveWith_nextVar kimchiOps_lockstep h initialAuxState
 
-/-- A successful kimchi solve only extends the seeded table: the public-input
-seeding survives into the returned assignments. `proveWith_extends` at
-`kimchiOps_proveExtends`. -/
-theorem kimchiSolve_extends [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F]
+/-- **The kimchi solve decodes its public slots** — the kimchi counterpart of the
+base `solve_complete`'s slot clause: a successful solve returns a table reading the
+given input at the input slots and the returned output at the output slots. The seed
+survives the run and the output back-fill wrote the slots the wiring ties to the
+circuit's result — `proveWith_compileBody_slots` at `kimchiOps_proveExtends`. -/
+theorem kimchiSolve_publicSlots [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F]
     [Neg F] [DecidableEq F] [A : CircuitType F a avar]
     [CheckedType F (KimchiConstraint F) avar] [B : CircuitType F b bvar]
     (main : avar → CircuitM F (KimchiConstraint F) bvar) (input : a)
-    {out : b} {env env₀ : Assignments F}
-    (hseed : Assignments.empty.extendPairs
-        ((allocRange 0 A.size).toList.zip (A.valueToFields input).toList)
-        = .ok env₀)
-    (h : kimchiSolve (a := a) (b := b) main input = .ok (out, env)) :
-    env₀.Le env := by
+    {outVal : b} {env : Assignments F}
+    (h : kimchiSolve (a := a) (b := b) main input = .ok (outVal, env)) :
+    (∀ i (hi : i < A.size), env i = some ((A.valueToFields input)[i])) ∧
+      ∀ j (hj : j < B.size),
+        env (A.size + j) = some ((B.valueToFields outVal)[j]) := by
   unfold kimchiSolve at h
-  rw [hseed] at h
-  dsimp only at h
-  rcases hp : proveWith kimchiOps (compileBody (a := a) (b := b) main)
-      (A.size + B.size) env₀ with e | p <;> rw [hp] at h
+  rcases hseed : Assignments.empty.extendPairs
+      ((allocRange 0 A.size).toList.zip (A.valueToFields input).toList)
+    with e | env₀ <;> rw [hseed] at h
   · cases h
   · dsimp only at h
-    rcases hr : readVar (val := b) p.result p.assignments with e | outv <;>
-      rw [hr] at h
+    rcases hp : proveWith kimchiOps (compileBody (a := a) (b := b) main)
+        (A.size + B.size) env₀ with e | p <;> rw [hp] at h
     · cases h
-    · cases h
-      exact (proveWith_extends kimchiOps_proveExtends hp).1
+    · dsimp only at h
+      rcases hr : readVar (val := b) p.result p.assignments with e | outv <;>
+        rw [hr] at h
+      · cases h
+      · cases h
+        exact proveWith_compileBody_slots kimchiOps_proveExtends hseed hp hr
 
 end Snarky.Kimchi

--- a/formal/snarky/Snarky/Kimchi/Constraint.lean
+++ b/formal/snarky/Snarky/Kimchi/Constraint.lean
@@ -43,16 +43,17 @@ Deviations from the PS original (per `formal/docs/snarky-kimchi-alignment.md`):
   kimchi constraint emits rows, not a checkable predicate, and validation is the row
   laws plus the fixture seam. This diverges from the base `prove`'s deliberate
   checking strengthening; the closest kimchi analogue of `prove_complete` is the
-  ops-coherence lockstep, undischarged here (closing paragraph).
+  ops-coherence lockstep, discharged below (closing paragraph).
 - Labels are not threaded (the base embedding's `labelOp` is inert).
 
 The composition laws come for free from the generic interpreter
 (`buildWith_bind`/`proveWith_bind`), and the cross-seam laws are stated there as the
 ops-coherence facts `BackendOps.Lockstep`/`BackendOps.ProveExtends` with their
 whole-program consequences (`buildWith_proveWith_nextVar`/`proveWith_extends`).
-They are not discharged for `kimchiOps` here: doing so is per-gate content — both
-instances of `KimchiConstraint.reduce` must branch identically and advance the
-counter identically.
+Both are discharged for `kimchiOps` at the end of this module
+(`kimchiOps_lockstep`/`kimchiOps_proveExtends`): the one shared dispatch runs its two
+seams in lockstep (`KimchiConstraint.reduce_seam`), composed from the per-gate walks
+beside each reducer through the `Seam` vocabulary (`Constraint/Reduction`).
 -/
 
 namespace Snarky.Kimchi
@@ -172,5 +173,64 @@ def kimchiOps [Add F] [Mul F] [Sub F] [Zero F] [One F] [Neg F] [Div F]
   finalize aux :=
     ((finalizeGateQueue aux.queuedGenericGate).map .plonk,
      { aux with queuedGenericGate := none })
+
+/-! ## Seam coherence: the dispatch and the ops-record discharge -/
+
+/-- `reducePad` is a seam: seven pinned operands, one row. -/
+private theorem reducePad_seam [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F]
+    [Neg F] [DecidableEq F] (vs : Vector (FVar F) 7) :
+    Seam (reducePad (m := PlonkBuilder F) vs) (reducePad (m := PlonkProver F) vs) := by
+  unfold reducePad
+  repeat first
+    | exact Seam.pure _
+    | refine Seam.bind (reduceToVariable_seam _) fun _ => ?_
+
+/-- The one shared dispatch runs its two seams in lockstep: `KimchiConstraint.reduce`
+is a seam, arm by arm from the per-gate walks. -/
+theorem KimchiConstraint.reduce_seam [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F]
+    [Neg F] [DecidableEq F] (con : KimchiConstraint F) :
+    Seam (KimchiConstraint.reduce (m := PlonkBuilder F) con)
+      (KimchiConstraint.reduce (m := PlonkProver F) con) := by
+  rcases con with c | c | c | c | c | c | vs <;> simp only [KimchiConstraint.reduce]
+  · refine Seam.bind (_root_.Snarky.Kimchi.reduce_seam c) fun _ => ?_
+    exact Seam.pure _
+  · exact Seam.map _ (AddComplete.reduce_seam c)
+  · exact Seam.map _ (PoseidonConstraint.reduce_seam c)
+  · exact Seam.map _ (VarBaseMul.reduce_seam c)
+  · exact Seam.map _ (EndoScalar.reduce_seam c)
+  · exact Seam.map _ (EndoMul.reduce_seam c)
+  · exact Seam.map _ (reducePad_seam vs)
+
+/-- The kimchi backend's per-constraint counter lockstep: a successful prover seam
+pins the builder seam's counter, for every auxiliary state — the two instantiations
+of the one dispatch advance the shared counter identically
+(`KimchiConstraint.reduce_seam`). -/
+theorem kimchiOps_lockstep [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F]
+    [DecidableEq F] : (kimchiOps (F := F)).Lockstep := by
+  intro con n env n' env' aux h
+  simp only [kimchiOps] at h ⊢
+  rcases hp : reduceAsProver ⟨n, env⟩ (KimchiConstraint.reduce con) with e | ⟨a, sP'⟩ <;>
+    rw [hp] at h
+  · cases h
+  · obtain ⟨rfl, -⟩ : sP'.nextVariable = n' ∧ sP'.assignments = env' := by
+      simpa using h
+    obtain ⟨-, hn, -, -⟩ := KimchiConstraint.reduce_seam con hp ⟨[], n, aux⟩ rfl
+    exact hn
+
+/-- The kimchi backend's per-constraint prover extension: a successful prover seam
+only extends the witness table — the guarded write — and never retreats the
+counter. -/
+theorem kimchiOps_proveExtends [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F]
+    [Neg F] [DecidableEq F] : (kimchiOps (F := F)).ProveExtends := by
+  intro con n env n' env' h
+  simp only [kimchiOps] at h
+  rcases hp : reduceAsProver ⟨n, env⟩ (KimchiConstraint.reduce con) with e | ⟨a, sP'⟩ <;>
+    rw [hp] at h
+  · cases h
+  · obtain ⟨rfl, rfl⟩ : sP'.nextVariable = n' ∧ sP'.assignments = env' := by
+      simpa using h
+    obtain ⟨-, -, hle, hmono⟩ :=
+      KimchiConstraint.reduce_seam con hp ⟨[], n, initialAuxState⟩ rfl
+    exact ⟨hle, hmono⟩
 
 end Snarky.Kimchi

--- a/formal/snarky/Snarky/Kimchi/Constraint/AddComplete.lean
+++ b/formal/snarky/Snarky/Kimchi/Constraint/AddComplete.lean
@@ -94,4 +94,26 @@ def AddComplete.reduce [Add F] [Mul F] [Zero F] [One F] [Neg F] [DecidableEq F]
                      some x21Inv] ++ List.replicate 4 none⟩, by simp⟩,
           coeffs := [] }⟩
 
+/-- `reduceAffinePoint` is a seam. -/
+private theorem reduceAffinePoint_seam [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F]
+    [DecidableEq F]
+    (p : AffinePoint (FVar F)) :
+    Seam (reduceAffinePoint (m := PlonkBuilder F) p)
+      (reduceAffinePoint (m := PlonkProver F) p) := by
+  unfold reduceAffinePoint
+  repeat first
+    | exact Seam.pure _
+    | refine Seam.bind (reduceToVariable_seam _) fun _ => ?_
+
+/-- The complete-addition reducer is a seam: eleven pinned operands, one row. -/
+theorem AddComplete.reduce_seam [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F]
+    [DecidableEq F] (c : AddComplete F) :
+    Seam (AddComplete.reduce (m := PlonkBuilder F) c)
+      (AddComplete.reduce (m := PlonkProver F) c) := by
+  unfold AddComplete.reduce
+  repeat first
+    | exact Seam.pure _
+    | refine Seam.bind (reduceAffinePoint_seam _) fun _ => ?_
+    | refine Seam.bind (reduceToVariable_seam _) fun _ => ?_
+
 end Snarky.Kimchi

--- a/formal/snarky/Snarky/Kimchi/Constraint/EndoMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Constraint/EndoMul.lean
@@ -141,4 +141,42 @@ def EndoMul.reduce [Add F] [Mul F] [Zero F] [One F] [Neg F] [DecidableEq F]
   let rows ← EndoMul.reduceRounds c.state
   pure (rows ++ [EndoMul.finalZeroRow xs ys nAcc])
 
+/-- The round reducer is a seam: fourteen pinned operands, one row. -/
+private theorem EndoMulRound.reduce_seam [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F]
+    [DecidableEq F] (c : EndoMulRound F) :
+    Seam (EndoMulRound.reduce (m := PlonkBuilder F) c)
+      (EndoMulRound.reduce (m := PlonkProver F) c) := by
+  unfold EndoMulRound.reduce
+  repeat first
+    | exact Seam.pure _
+    | refine Seam.bind (reduceToVariable_seam _) fun _ => ?_
+
+/-- `reduceRounds` is a seam: the structural fold composes. -/
+private theorem EndoMul.reduceRounds_seam [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F]
+    [DecidableEq F]
+    (cs : List (EndoMulRound F)) :
+    Seam (EndoMul.reduceRounds (m := PlonkBuilder F) cs)
+      (EndoMul.reduceRounds (m := PlonkProver F) cs) := by
+  induction cs with
+  | nil =>
+    simp only [EndoMul.reduceRounds]
+    exact Seam.pure _
+  | cons c cs ih =>
+    simp only [EndoMul.reduceRounds]
+    refine Seam.bind (EndoMulRound.reduce_seam c) fun _ => ?_
+    refine Seam.bind ih fun _ => ?_
+    exact Seam.pure _
+
+/-- The endomorphism-multiplication reducer is a seam: the final accumulator and
+scalar first, then the rounds, then the trailing row, purely. -/
+theorem EndoMul.reduce_seam [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F]
+    [DecidableEq F] (c : EndoMul F) :
+    Seam (EndoMul.reduce (m := PlonkBuilder F) c)
+      (EndoMul.reduce (m := PlonkProver F) c) := by
+  unfold EndoMul.reduce
+  repeat first
+    | exact Seam.pure _
+    | refine Seam.bind (reduceToVariable_seam _) fun _ => ?_
+    | refine Seam.bind (EndoMul.reduceRounds_seam _) fun _ => ?_
+
 end Snarky.Kimchi

--- a/formal/snarky/Snarky/Kimchi/Constraint/EndoScalar.lean
+++ b/formal/snarky/Snarky/Kimchi/Constraint/EndoScalar.lean
@@ -94,4 +94,30 @@ def EndoScalar.reduce [Add F] [Mul F] [Zero F] [One F] [Neg F] [DecidableEq F]
     let rest ← EndoScalar.reduce cs
     pure (row :: rest)
 
+/-- The round reducer is a seam: fourteen pinned operands, one row. -/
+private theorem EndoScalarRound.reduce_seam [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F]
+    [DecidableEq F]
+    (c : EndoScalarRound F) :
+    Seam (EndoScalarRound.reduce (m := PlonkBuilder F) c)
+      (EndoScalarRound.reduce (m := PlonkProver F) c) := by
+  unfold EndoScalarRound.reduce
+  repeat first
+    | exact Seam.pure _
+    | refine Seam.bind (reduceToVariable_seam _) fun _ => ?_
+
+/-- The challenge-decomposition reducer is a seam: the roundwise fold composes. -/
+theorem EndoScalar.reduce_seam [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F]
+    [DecidableEq F] (c : EndoScalar F) :
+    Seam (EndoScalar.reduce (m := PlonkBuilder F) c)
+      (EndoScalar.reduce (m := PlonkProver F) c) := by
+  induction c with
+  | nil =>
+    simp only [EndoScalar.reduce]
+    exact Seam.pure _
+  | cons c cs ih =>
+    simp only [EndoScalar.reduce]
+    refine Seam.bind (EndoScalarRound.reduce_seam c) fun _ => ?_
+    refine Seam.bind ih fun _ => ?_
+    exact Seam.pure _
+
 end Snarky.Kimchi

--- a/formal/snarky/Snarky/Kimchi/Constraint/GenericPlonk.lean
+++ b/formal/snarky/Snarky/Kimchi/Constraint/GenericPlonk.lean
@@ -123,4 +123,29 @@ def reduce [Add F] [Mul F] [Sub F] [Zero F] [One F] [Neg F] [DecidableEq F] [Mon
         { cl := -x.2, vl := some v, cr := 0, vr := some v, co := 0, vo := none,
           m := x.2 * x.2, c := 0 }
 
+/-- The `Basic` reducer is a seam: the branches consume reduced results, which agree,
+and every tail is counter-inert. -/
+theorem reduce_seam [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F]
+    [DecidableEq F] (c : Basic F) :
+    Seam (reduce (m := PlonkBuilder F) c) (reduce (m := PlonkProver F) c) := by
+  rcases c with ⟨l, r, o⟩ | ⟨a, b⟩ | ⟨a, b⟩ | v <;> simp only [reduce]
+  · refine Seam.bind (reduceAffineExpression_seam _) fun l' => ?_
+    refine Seam.bind (reduceAffineExpression_seam _) fun r' => ?_
+    refine Seam.bind (reduceAffineExpression_seam _) fun o' => ?_
+    rcases l'.1 with _ | vl <;> rcases r'.1 with _ | vr <;> rcases o'.1 with _ | vo
+    all_goals try exact addGeneric_seam _
+    exact Seam.ite (fun _ => Seam.pure _) fun _ => addGeneric_seam _
+  · refine Seam.bind (reduceAffineExpression_seam _) fun l' => ?_
+    refine Seam.bind (reduceAffineExpression_seam _) fun r' => ?_
+    exact addEquals_seam _
+  · refine Seam.bind (reduceAffineExpression_seam _) fun x => ?_
+    refine Seam.bind (reduceAffineExpression_seam _) fun y => ?_
+    rcases x.1 with _ | x1 <;> rcases y.1 with _ | x2
+    all_goals try exact addGeneric_seam _
+    exact Seam.ite (fun _ => Seam.pure _) fun _ => addGeneric_seam _
+  · refine Seam.bind (reduceAffineExpression_seam _) fun x => ?_
+    rcases x.1 with _ | xv
+    · exact Seam.ite (fun _ => Seam.pure _) fun _ => addGeneric_seam _
+    · exact addGeneric_seam _
+
 end Snarky.Kimchi

--- a/formal/snarky/Snarky/Kimchi/Constraint/Poseidon.lean
+++ b/formal/snarky/Snarky/Kimchi/Constraint/Poseidon.lean
@@ -121,4 +121,41 @@ def PoseidonConstraint.reduce [Add F] [Mul F] [Zero F] [One F] [Neg F] [Decidabl
   let vs ← reduceStates c.state
   pure (rowsFromStates (fun i => c.rc.getD i (0, 0, 0)) 0 vs)
 
+/-- `reduceState` is a seam. -/
+private theorem reduceState_seam [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F]
+    [DecidableEq F]
+    (t : FVar F × FVar F × FVar F) :
+    Seam (reduceState (m := PlonkBuilder F) t)
+      (reduceState (m := PlonkProver F) t) := by
+  unfold reduceState
+  repeat first
+    | exact Seam.pure _
+    | refine Seam.bind (reduceToVariable_seam _) fun _ => ?_
+
+/-- `reduceStates` is a seam: the structural fold composes. -/
+private theorem reduceStates_seam [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F]
+    [DecidableEq F]
+    (ts : List (FVar F × FVar F × FVar F)) :
+    Seam (reduceStates (m := PlonkBuilder F) ts)
+      (reduceStates (m := PlonkProver F) ts) := by
+  induction ts with
+  | nil =>
+    simp only [reduceStates]
+    exact Seam.pure _
+  | cons t ts ih =>
+    simp only [reduceStates]
+    refine Seam.bind (reduceState_seam t) fun _ => ?_
+    refine Seam.bind ih fun _ => ?_
+    exact Seam.pure _
+
+/-- The Poseidon reducer is a seam: pin the states, then assemble rows purely. -/
+theorem PoseidonConstraint.reduce_seam [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F]
+    [DecidableEq F]
+    (c : PoseidonConstraint F) :
+    Seam (PoseidonConstraint.reduce (m := PlonkBuilder F) c)
+      (PoseidonConstraint.reduce (m := PlonkProver F) c) := by
+  unfold PoseidonConstraint.reduce
+  refine Seam.bind (reduceStates_seam _) fun _ => ?_
+  exact Seam.pure _
+
 end Snarky.Kimchi

--- a/formal/snarky/Snarky/Kimchi/Constraint/Reduction.lean
+++ b/formal/snarky/Snarky/Kimchi/Constraint/Reduction.lean
@@ -390,7 +390,7 @@ is unconditional because `extendPairs` is guarded — success implies no overwri
 
 /-- The builder's allocation op, applied: return the current counter, advance it,
 touch the union-find, record the internal variable. -/
-private theorem createInternalB_apply (s : BuilderReductionState F) :
+theorem createInternalB_apply (s : BuilderReductionState F) :
     createInternalB s
       = (s.nextVariable,
           { s with
@@ -493,7 +493,7 @@ theorem PlonkBuilder.pure_apply {α : Type} (a : α) (s : BuilderReductionState 
     (pure a : PlonkBuilder F α) s = (a, s) := rfl
 
 /-- The class ops at the builder instance, named (`simp` fodder for the walks). -/
-private theorem createInternal_builder [Zero F] [Neg F] [Sub F] [Div F] [DecidableEq F]
+theorem createInternal_builder [Zero F] [Neg F] [Sub F] [Div F] [DecidableEq F]
     (e : AffineExpression F) :
     createInternalVariable (m := PlonkBuilder F) e = createInternalB := rfl
 
@@ -505,17 +505,13 @@ private theorem addEquals_builder [Zero F] [Neg F] [Sub F] [Div F] [DecidableEq 
     (c : EqualsConstraint F) :
     addEqualsConstraint (m := PlonkBuilder F) c = addEqualsB c := rfl
 
-/-- The class ops at the prover instance, named: allocation is `createInternalP`, the
-row-emitting ops are inert. -/
-private theorem createInternal_prover [Add F] [Mul F] [Zero F]
-    (e : AffineExpression F) :
-    createInternalVariable (m := PlonkProver F) e = createInternalP e := rfl
-
-private theorem addGeneric_prover [Add F] [Mul F] [Zero F]
+/-- The row-emitting ops at the prover instance are inert. -/
+theorem addGeneric_prover [Add F] [Mul F] [Zero F]
     (c : GenericPlonkConstraint F) :
     addGenericPlonkConstraint (m := PlonkProver F) c = pure () := rfl
 
-private theorem addEquals_prover [Add F] [Mul F] [Zero F] (c : EqualsConstraint F) :
+/-- The equality op at the prover instance is inert. -/
+theorem addEquals_prover [Add F] [Mul F] [Zero F] (c : EqualsConstraint F) :
     addEqualsConstraint (m := PlonkProver F) c = pure () := rfl
 
 /-! ## Seam coherence: the composable pairing

--- a/formal/snarky/Snarky/Kimchi/Constraint/Reduction.lean
+++ b/formal/snarky/Snarky/Kimchi/Constraint/Reduction.lean
@@ -518,6 +518,89 @@ private theorem addGeneric_prover [Add F] [Mul F] [Zero F]
 private theorem addEquals_prover [Add F] [Mul F] [Zero F] (c : EqualsConstraint F) :
     addEqualsConstraint (m := PlonkProver F) c = pure () := rfl
 
+/-! ## Seam coherence: the composable pairing
+
+The gate reducers are `reduceToVariable` chains and structural folds, so their walks
+compose rather than re-walk: `Seam` pairs a builder run with a prover run and is
+preserved by `pure`, `bind`, and `map`; the leaves are the reduction algorithms and
+the two row-emitting ops. The per-gate walks live beside their reducers and consume
+this vocabulary. -/
+
+/-- The paired-run property the per-gate walks compose: whenever the prover run
+succeeds, the builder run from any state at the same counter returns the same result
+and lands at the prover's final counter, and the prover's table only grew. -/
+def Seam {α : Type} (xB : PlonkBuilder F α) (xP : PlonkProver F α) : Prop :=
+  ∀ {sP sP' : ProverReductionState F} {a : α}, xP sP = .ok (a, sP') →
+    ∀ sB : BuilderReductionState F, sB.nextVariable = sP.nextVariable →
+      (xB sB).1 = a ∧ (xB sB).2.nextVariable = sP'.nextVariable ∧
+      sP.assignments.Le sP'.assignments ∧ sP.nextVariable ≤ sP'.nextVariable
+
+/-- `pure` is a seam. -/
+protected theorem Seam.pure {α : Type} (a : α) :
+    Seam (pure a : PlonkBuilder F α) (pure a) := by
+  intro sP sP' a' h sB hn
+  simp only [PlonkProver.pure_apply, Except.ok.injEq, Prod.mk.injEq] at h
+  obtain ⟨rfl, rfl⟩ := h
+  exact ⟨rfl, hn, Assignments.Le.refl _, Nat.le_refl _⟩
+
+/-- Seams compose over `bind`: the prefix's result agreement feeds the
+continuation. -/
+protected theorem Seam.bind {α β : Type} {xB : PlonkBuilder F α}
+    {xP : PlonkProver F α} {fB : α → PlonkBuilder F β} {fP : α → PlonkProver F β}
+    (hx : Seam xB xP) (hf : ∀ a, Seam (fB a) (fP a)) :
+    Seam (xB >>= fB) (xP >>= fP) := by
+  intro sP sP' b h sB hn
+  rw [PlonkProver.bind_ok] at h
+  obtain ⟨a, sP₁, h₁, h₂⟩ := h
+  obtain ⟨ha, hn₁, hle₁, hm₁⟩ := hx h₁ sB hn
+  obtain ⟨hb, hn₂, hle₂, hm₂⟩ := hf a h₂ (xB sB).2 hn₁
+  rw [PlonkBuilder.bind_apply, ha]
+  exact ⟨hb, hn₂, hle₁.trans hle₂, hm₁.trans hm₂⟩
+
+/-- Seams compose over `map`. -/
+protected theorem Seam.map {α β : Type} {xB : PlonkBuilder F α}
+    {xP : PlonkProver F α} (f : α → β) (hx : Seam xB xP) :
+    Seam (f <$> xB) (f <$> xP) := by
+  rw [← bind_pure_comp, ← bind_pure_comp]
+  exact hx.bind fun a => Seam.pure (f a)
+
+/-- Seams compose over a shared conditional. -/
+protected theorem Seam.ite {α : Type} {c : Prop} [Decidable c]
+    {xB yB : PlonkBuilder F α} {xP yP : PlonkProver F α}
+    (hx : c → Seam xB xP) (hy : ¬c → Seam yB yP) :
+    Seam (if c then xB else yB) (if c then xP else yP) := by
+  by_cases h : c
+  · rw [if_pos h, if_pos h]
+    exact hx h
+  · rw [if_neg h, if_neg h]
+    exact hy h
+
+/-- The generic-constraint op is a seam: inert for the prover, counter-inert for the
+builder. -/
+theorem addGeneric_seam [Add F] [Mul F] [Zero F] [Neg F] [Sub F] [Div F]
+    [DecidableEq F] (g : GenericPlonkConstraint F) :
+    Seam (addGenericPlonkConstraint (m := PlonkBuilder F) g)
+      (addGenericPlonkConstraint (m := PlonkProver F) g) := by
+  intro sP sP' u h sB hn
+  simp only [addGeneric_prover, PlonkProver.pure_apply, Except.ok.injEq,
+    Prod.mk.injEq] at h
+  obtain ⟨-, rfl⟩ := h
+  refine ⟨rfl, ?_, Assignments.Le.refl _, Nat.le_refl _⟩
+  rw [addGeneric_builder, addGenericB_nextVariable, hn]
+
+/-- The equality op is a seam: inert for the prover, counter-inert for the
+builder. -/
+theorem addEquals_seam [Add F] [Mul F] [Zero F] [Neg F] [Sub F] [Div F]
+    [DecidableEq F] (e : EqualsConstraint F) :
+    Seam (addEqualsConstraint (m := PlonkBuilder F) e)
+      (addEqualsConstraint (m := PlonkProver F) e) := by
+  intro sP sP' u h sB hn
+  simp only [addEquals_prover, PlonkProver.pure_apply, Except.ok.injEq,
+    Prod.mk.injEq] at h
+  obtain ⟨-, rfl⟩ := h
+  refine ⟨rfl, ?_, Assignments.Le.refl _, Nat.le_refl _⟩
+  rw [addEquals_builder, addEqualsB_nextVariable, hn]
+
 variable [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F] [DecidableEq F]
 
 /-- `completelyReduce` in lockstep: same result, same final counter, table only
@@ -667,5 +750,20 @@ theorem reduceToVariable_lockstep {x : CVar F}
       · simp only [PlonkBuilder.bind_apply, createInternal_builder,
           createInternalB_apply, addGeneric_builder, PlonkBuilder.pure_apply,
           addGenericB_nextVariable, ihn, hn₂]
+
+/-- `reduceToVariable` is a seam (`reduceToVariable_lockstep`, repackaged). -/
+theorem reduceToVariable_seam (x : CVar F) :
+    Seam (reduceToVariable (m := PlonkBuilder F) x)
+      (reduceToVariable (m := PlonkProver F) x) := by
+  intro sP sP' a h sB hn
+  exact reduceToVariable_lockstep h sB hn
+
+/-- `reduceAffineExpression` is a seam (`reduceAffineExpression_lockstep`,
+repackaged): the `Basic` reducer branches on its results, which agree. -/
+theorem reduceAffineExpression_seam (ae : AffineExpression F) :
+    Seam (reduceAffineExpression (m := PlonkBuilder F) ae)
+      (reduceAffineExpression (m := PlonkProver F) ae) := by
+  intro sP sP' a h sB hn
+  exact reduceAffineExpression_lockstep h sB hn
 
 end Snarky.Kimchi

--- a/formal/snarky/Snarky/Kimchi/Constraint/Reduction.lean
+++ b/formal/snarky/Snarky/Kimchi/Constraint/Reduction.lean
@@ -68,6 +68,9 @@ The builder's batching queues an incoming constraint and packs pairs into
 emitted constraints and the faithfulness of the reduction are deliberately not stated
 in this package.
 
+The seam-coherence section at the end states per-op bookkeeping only: which ops move
+the shared counter, and that the prover's guarded write only extends the table.
+
 The PS package has no QuickCheck rows for this module — its tests exercise the
 circuit layer, and the fixture corpus is the oracle; the byte-equality seam replays
 it against this port.
@@ -96,7 +99,7 @@ structure EqualsConstraint (F : Type u) where
 
 /-- The reduction-op vocabulary (PS `class PlonkReductionM`): allocate an internal
 variable for an affine expression, emit a generic constraint, assert a two-sided
-equality. The builder, the prover, and the law-vehicle trace interpret it below. -/
+equality. The builder and the prover interpret it below. -/
 class PlonkReductionM (F : Type) (m : Type → Type) where
   /-- Allocate a fresh variable standing for the given affine expression (the prover
   assigns it the expression's value; the builder only advances the counter). -/
@@ -376,5 +379,80 @@ the evaluation error out. -/
 def reduceAsProver (s : ProverReductionState F) (x : PlonkProver F α) :
     Except EvalError (α × ProverReductionState F) :=
   x.run s
+
+/-! ## Seam coherence: the op-level facts
+
+Only `createInternalVariable` moves the shared counter — by exactly one, on both
+sides. The other builder ops touch rows, the gate queue, the union-find, and the
+constant cache; the other prover ops are inert. Stated here per op: the builder's
+counter behavior, total, and the prover op's success inversion, whose table extension
+is unconditional because `extendPairs` is guarded — success implies no overwrite. -/
+
+/-- The builder's allocation op, applied: return the current counter, advance it,
+touch the union-find, record the internal variable. -/
+private theorem createInternalB_apply (s : BuilderReductionState F) :
+    createInternalB s
+      = (s.nextVariable,
+          { s with
+            nextVariable := s.nextVariable + 1,
+            aux.wireState.unionFind :=
+              (s.aux.wireState.unionFind.find s.nextVariable).2,
+            aux.wireState.internalVariables :=
+              s.nextVariable :: s.aux.wireState.internalVariables }) := rfl
+
+/-- The builder's generic-constraint op never moves the counter: it queues or packs. -/
+private theorem addGenericB_nextVariable (c : GenericPlonkConstraint F)
+    (s : BuilderReductionState F) :
+    (addGenericB c s).2.nextVariable = s.nextVariable := by
+  rcases hq : s.aux.queuedGenericGate with _ | g <;>
+    simp [addGenericB, handleGateBatching, hq]
+
+/-- The builder's equality op never moves the counter: every branch of the guard
+cascade wires, caches, batches, or no-ops. -/
+private theorem addEqualsB_nextVariable [Zero F] [Neg F] [Sub F] [Div F]
+    [DecidableEq F] (c : EqualsConstraint F) (s : BuilderReductionState F) :
+    (addEqualsB c s).2.nextVariable = s.nextVariable := by
+  rcases c with ⟨cl, vl, cr, vr⟩
+  dsimp only [addEqualsB]
+  split
+  · rfl
+  rcases vl with _ | l <;> rcases vr with _ | r <;> dsimp only
+  · -- constant against constant
+    split
+    · rfl
+    · exact addGenericB_nextVariable ..
+  · -- constant against a variable
+    split
+    · exact addGenericB_nextVariable ..
+    · dsimp only [Bind.bind, StateT.bind, get, getThe, MonadStateOf.get, StateT.get]
+      rcases _hc : s.aux.wireState.cachedConstants.lookup (cl / cr) with _ | cached
+      · exact addGenericB_nextVariable ..
+      · rfl
+  · -- a variable against a constant
+    split
+    · exact addGenericB_nextVariable ..
+    · dsimp only [Bind.bind, StateT.bind, get, getThe, MonadStateOf.get, StateT.get]
+      rcases _hc : s.aux.wireState.cachedConstants.lookup (cr / cl) with _ | cached
+      · exact addGenericB_nextVariable ..
+      · rfl
+  · -- two variables: wire or constrain
+    split
+    · rfl
+    · exact addGenericB_nextVariable ..
+
+/-- The prover's allocation op, inverted at success: it returns the borrowed counter,
+advances it by one, and only extends the table (the guarded write). -/
+private theorem createInternalP_ok [Add F] [Mul F] [Zero F] {e : AffineExpression F}
+    {n : Variable} {env : Assignments F} {a : Variable} {s' : ProverReductionState F}
+    (h : createInternalP e ⟨n, env⟩ = .ok (a, s')) :
+    a = n ∧ s'.nextVariable = n + 1 ∧ env.Le s'.assignments := by
+  unfold createInternalP at h
+  split at h
+  · cases h
+  split at h
+  · cases h
+  next env' hext =>
+    cases h
+    exact ⟨rfl, rfl, Assignments.le_extendPairs hext⟩
 
 end Snarky.Kimchi

--- a/formal/snarky/Snarky/Kimchi/Constraint/Reduction.lean
+++ b/formal/snarky/Snarky/Kimchi/Constraint/Reduction.lean
@@ -455,4 +455,217 @@ private theorem createInternalP_ok [Add F] [Mul F] [Zero F] {e : AffineExpressio
     cases h
     exact ⟨rfl, rfl, Assignments.le_extendPairs hext⟩
 
+/-! ## Seam coherence: the generic algorithms
+
+The paired-run walks: a successful prover run of each reduction algorithm pins the
+builder run from any state at the same counter — same result, same final counter —
+and only extends the prover's table. Result agreement is load-bearing: downstream
+branching consumes returned variables, so the branches agree exactly when the
+counters do. -/
+
+/-- Invert one prover bind: a successful sequenced run factors through a successful
+prefix. -/
+theorem PlonkProver.bind_ok {α β : Type} {x : PlonkProver F α}
+    {f : α → PlonkProver F β} {s s' : ProverReductionState F} {b : β} :
+    (x >>= f) s = .ok (b, s') ↔
+      ∃ a s₁, x s = .ok (a, s₁) ∧ f a s₁ = .ok (b, s') := by
+  constructor
+  · intro h
+    rcases hx : x s with e | ⟨a, s₁⟩ <;>
+      simp only [Bind.bind, StateT.bind, hx, Except.bind] at h
+    · cases h
+    · exact ⟨a, s₁, rfl, h⟩
+  · rintro ⟨a, s₁, hx, hf⟩
+    simp only [Bind.bind, StateT.bind, hx, Except.bind]
+    exact hf
+
+/-- The prover's `pure`, applied. -/
+theorem PlonkProver.pure_apply {α : Type} (a : α) (s : ProverReductionState F) :
+    (pure a : PlonkProver F α) s = .ok (a, s) := rfl
+
+/-- Step one builder bind: the state monad sequences by application. -/
+theorem PlonkBuilder.bind_apply {α β : Type} (x : PlonkBuilder F α)
+    (f : α → PlonkBuilder F β) (s : BuilderReductionState F) :
+    (x >>= f) s = f (x s).1 (x s).2 := rfl
+
+/-- The builder's `pure`, applied. -/
+theorem PlonkBuilder.pure_apply {α : Type} (a : α) (s : BuilderReductionState F) :
+    (pure a : PlonkBuilder F α) s = (a, s) := rfl
+
+/-- The class ops at the builder instance, named (`simp` fodder for the walks). -/
+private theorem createInternal_builder [Zero F] [Neg F] [Sub F] [Div F] [DecidableEq F]
+    (e : AffineExpression F) :
+    createInternalVariable (m := PlonkBuilder F) e = createInternalB := rfl
+
+private theorem addGeneric_builder [Zero F] [Neg F] [Sub F] [Div F] [DecidableEq F]
+    (c : GenericPlonkConstraint F) :
+    addGenericPlonkConstraint (m := PlonkBuilder F) c = addGenericB c := rfl
+
+private theorem addEquals_builder [Zero F] [Neg F] [Sub F] [Div F] [DecidableEq F]
+    (c : EqualsConstraint F) :
+    addEqualsConstraint (m := PlonkBuilder F) c = addEqualsB c := rfl
+
+/-- The class ops at the prover instance, named: allocation is `createInternalP`, the
+row-emitting ops are inert. -/
+private theorem createInternal_prover [Add F] [Mul F] [Zero F]
+    (e : AffineExpression F) :
+    createInternalVariable (m := PlonkProver F) e = createInternalP e := rfl
+
+private theorem addGeneric_prover [Add F] [Mul F] [Zero F]
+    (c : GenericPlonkConstraint F) :
+    addGenericPlonkConstraint (m := PlonkProver F) c = pure () := rfl
+
+private theorem addEquals_prover [Add F] [Mul F] [Zero F] (c : EqualsConstraint F) :
+    addEqualsConstraint (m := PlonkProver F) c = pure () := rfl
+
+variable [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F] [DecidableEq F]
+
+/-- `completelyReduce` in lockstep: same result, same final counter, table only
+grown. -/
+private theorem completelyReduce_lockstep {single : Variable × F}
+    {ts : List (Variable × F)} {sP sP' : ProverReductionState F} {a : Variable × F}
+    (h : completelyReduce (m := PlonkProver F) single ts sP = .ok (a, sP'))
+    (sB : BuilderReductionState F) (hn : sB.nextVariable = sP.nextVariable) :
+    (completelyReduce (m := PlonkBuilder F) single ts sB).1 = a ∧
+    (completelyReduce (m := PlonkBuilder F) single ts sB).2.nextVariable
+      = sP'.nextVariable ∧
+    sP.assignments.Le sP'.assignments ∧ sP.nextVariable ≤ sP'.nextVariable := by
+  induction ts generalizing single sP sB a sP' with
+  | nil =>
+    simp only [completelyReduce, PlonkProver.pure_apply, Except.ok.injEq,
+      Prod.mk.injEq] at h
+    obtain ⟨rfl, rfl⟩ := h
+    exact ⟨rfl, hn, Assignments.Le.refl _, Nat.le_refl _⟩
+  | cons next rest ih =>
+    simp only [completelyReduce] at h ⊢
+    rw [PlonkProver.bind_ok] at h
+    obtain ⟨r, sP₁, h₁, h⟩ := h
+    rw [PlonkProver.bind_ok] at h
+    obtain ⟨vo, sP₂, h₂, h⟩ := h
+    rw [PlonkProver.bind_ok] at h
+    obtain ⟨u, sP₃, h₃, h⟩ := h
+    simp only [addGeneric_prover, PlonkProver.pure_apply, Except.ok.injEq,
+      Prod.mk.injEq] at h₃ h
+    obtain ⟨rfl, rfl⟩ := h
+    obtain ⟨-, rfl⟩ := h₃
+    obtain ⟨-, ihn, ihle, ihmono⟩ := ih h₁ sB hn
+    obtain ⟨rfl, hn₂, hle₂⟩ := createInternalP_ok h₂
+    refine ⟨?_, ?_, ihle.trans hle₂, by rw [hn₂]; exact Nat.le_succ_of_le ihmono⟩
+    · simp only [PlonkBuilder.bind_apply, createInternal_builder,
+        createInternalB_apply, addGeneric_builder, PlonkBuilder.pure_apply, ihn]
+    · simp only [PlonkBuilder.bind_apply, createInternal_builder,
+        createInternalB_apply, addGeneric_builder, PlonkBuilder.pure_apply,
+        addGenericB_nextVariable, ihn, hn₂]
+
+/-- `reduceAffineExpression` in lockstep. -/
+private theorem reduceAffineExpression_lockstep {ae : AffineExpression F}
+    {sP sP' : ProverReductionState F} {a : Option Variable × F}
+    (h : reduceAffineExpression (m := PlonkProver F) ae sP = .ok (a, sP'))
+    (sB : BuilderReductionState F) (hn : sB.nextVariable = sP.nextVariable) :
+    (reduceAffineExpression (m := PlonkBuilder F) ae sB).1 = a ∧
+    (reduceAffineExpression (m := PlonkBuilder F) ae sB).2.nextVariable
+      = sP'.nextVariable ∧
+    sP.assignments.Le sP'.assignments ∧ sP.nextVariable ≤ sP'.nextVariable := by
+  rcases hts : ae.terms with _ | ⟨head, _ | ⟨first, rest⟩⟩ <;>
+    simp only [reduceAffineExpression, hts] at h ⊢
+  · simp only [PlonkProver.pure_apply, Except.ok.injEq, Prod.mk.injEq] at h
+    obtain ⟨rfl, rfl⟩ := h
+    exact ⟨rfl, hn, Assignments.Le.refl _, Nat.le_refl _⟩
+  · rcases hc : ae.constant with _ | c <;> simp only [hc] at h ⊢
+    · simp only [PlonkProver.pure_apply, Except.ok.injEq, Prod.mk.injEq] at h
+      obtain ⟨rfl, rfl⟩ := h
+      exact ⟨rfl, hn, Assignments.Le.refl _, Nat.le_refl _⟩
+    · by_cases h0 : c = 0
+      · rw [if_pos h0] at h ⊢
+        simp only [PlonkProver.pure_apply, Except.ok.injEq, Prod.mk.injEq] at h
+        obtain ⟨rfl, rfl⟩ := h
+        exact ⟨rfl, hn, Assignments.Le.refl _, Nat.le_refl _⟩
+      · rw [if_neg h0] at h ⊢
+        rw [PlonkProver.bind_ok] at h
+        obtain ⟨vo, sP₁, h₁, h⟩ := h
+        rw [PlonkProver.bind_ok] at h
+        obtain ⟨u, sP₂, h₂, h⟩ := h
+        simp only [addGeneric_prover, PlonkProver.pure_apply, Except.ok.injEq,
+          Prod.mk.injEq] at h₂ h
+        obtain ⟨rfl, rfl⟩ := h
+        obtain ⟨-, rfl⟩ := h₂
+        obtain ⟨rfl, hn₁, hle₁⟩ := createInternalP_ok h₁
+        refine ⟨?_, ?_, hle₁, by rw [hn₁]; exact Nat.le_succ _⟩
+        · simp only [PlonkBuilder.bind_apply, createInternal_builder,
+            createInternalB_apply, addGeneric_builder, PlonkBuilder.pure_apply, hn]
+        · simp only [PlonkBuilder.bind_apply, createInternal_builder,
+            createInternalB_apply, addGeneric_builder, PlonkBuilder.pure_apply,
+            addGenericB_nextVariable, hn, hn₁]
+  · rw [PlonkProver.bind_ok] at h
+    obtain ⟨r, sP₁, h₁, h⟩ := h
+    rw [PlonkProver.bind_ok] at h
+    obtain ⟨vo, sP₂, h₂, h⟩ := h
+    rw [PlonkProver.bind_ok] at h
+    obtain ⟨u, sP₃, h₃, h⟩ := h
+    simp only [addGeneric_prover, PlonkProver.pure_apply, Except.ok.injEq,
+      Prod.mk.injEq] at h₃ h
+    obtain ⟨rfl, rfl⟩ := h
+    obtain ⟨-, rfl⟩ := h₃
+    obtain ⟨-, ihn, ihle, ihmono⟩ := completelyReduce_lockstep h₁ sB hn
+    obtain ⟨rfl, hn₂, hle₂⟩ := createInternalP_ok h₂
+    refine ⟨?_, ?_, ihle.trans hle₂, by rw [hn₂]; exact Nat.le_succ_of_le ihmono⟩
+    · simp only [PlonkBuilder.bind_apply, createInternal_builder,
+        createInternalB_apply, addGeneric_builder, PlonkBuilder.pure_apply, ihn]
+    · simp only [PlonkBuilder.bind_apply, createInternal_builder,
+        createInternalB_apply, addGeneric_builder, PlonkBuilder.pure_apply,
+        addGenericB_nextVariable, ihn, hn₂]
+
+/-- `reduceToVariable` in lockstep: the walks' one public boundary — same variable,
+same final counter, table only grown. -/
+theorem reduceToVariable_lockstep {x : CVar F}
+    {sP sP' : ProverReductionState F} {v : Variable}
+    (h : reduceToVariable (m := PlonkProver F) x sP = .ok (v, sP'))
+    (sB : BuilderReductionState F) (hn : sB.nextVariable = sP.nextVariable) :
+    (reduceToVariable (m := PlonkBuilder F) x sB).1 = v ∧
+    (reduceToVariable (m := PlonkBuilder F) x sB).2.nextVariable
+      = sP'.nextVariable ∧
+    sP.assignments.Le sP'.assignments ∧ sP.nextVariable ≤ sP'.nextVariable := by
+  simp only [reduceToVariable] at h ⊢
+  rw [PlonkProver.bind_ok] at h
+  obtain ⟨r, sP₁, h₁, h⟩ := h
+  obtain ⟨ihr, ihn, ihle, ihmono⟩ := reduceAffineExpression_lockstep h₁ sB hn
+  simp only [PlonkBuilder.bind_apply, ihr]
+  rcases hr : r.1 with _ | rv <;> rw [hr] at h <;> dsimp only at h ⊢
+  · rw [PlonkProver.bind_ok] at h
+    obtain ⟨vl, sP₂, h₂, h⟩ := h
+    rw [PlonkProver.bind_ok] at h
+    obtain ⟨u, sP₃, h₃, h⟩ := h
+    simp only [addEquals_prover, PlonkProver.pure_apply, Except.ok.injEq,
+      Prod.mk.injEq] at h₃ h
+    obtain ⟨rfl, rfl⟩ := h
+    obtain ⟨-, rfl⟩ := h₃
+    obtain ⟨rfl, hn₂, hle₂⟩ := createInternalP_ok h₂
+    refine ⟨?_, ?_, ihle.trans hle₂, by rw [hn₂]; exact Nat.le_succ_of_le ihmono⟩
+    · simp only [PlonkBuilder.bind_apply, createInternal_builder,
+        createInternalB_apply, addEquals_builder, PlonkBuilder.pure_apply, ihn]
+    · simp only [PlonkBuilder.bind_apply, createInternal_builder,
+        createInternalB_apply, addEquals_builder, PlonkBuilder.pure_apply,
+        addEqualsB_nextVariable, ihn, hn₂]
+  · by_cases h1 : r.2 = 1
+    · rw [if_pos h1] at h ⊢
+      simp only [PlonkProver.pure_apply, Except.ok.injEq, Prod.mk.injEq] at h
+      obtain ⟨rfl, rfl⟩ := h
+      exact ⟨rfl, ihn, ihle, ihmono⟩
+    · rw [if_neg h1] at h ⊢
+      rw [PlonkProver.bind_ok] at h
+      obtain ⟨cv, sP₂, h₂, h⟩ := h
+      rw [PlonkProver.bind_ok] at h
+      obtain ⟨u, sP₃, h₃, h⟩ := h
+      simp only [addGeneric_prover, PlonkProver.pure_apply, Except.ok.injEq,
+        Prod.mk.injEq] at h₃ h
+      obtain ⟨rfl, rfl⟩ := h
+      obtain ⟨-, rfl⟩ := h₃
+      obtain ⟨rfl, hn₂, hle₂⟩ := createInternalP_ok h₂
+      refine ⟨?_, ?_, ihle.trans hle₂, by rw [hn₂]; exact Nat.le_succ_of_le ihmono⟩
+      · simp only [PlonkBuilder.bind_apply, createInternal_builder,
+          createInternalB_apply, addGeneric_builder, PlonkBuilder.pure_apply, ihn]
+      · simp only [PlonkBuilder.bind_apply, createInternal_builder,
+          createInternalB_apply, addGeneric_builder, PlonkBuilder.pure_apply,
+          addGenericB_nextVariable, ihn, hn₂]
+
 end Snarky.Kimchi

--- a/formal/snarky/Snarky/Kimchi/Constraint/VarBaseMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Constraint/VarBaseMul.lean
@@ -146,4 +146,29 @@ def VarBaseMul.reduce [Add F] [Mul F] [Zero F] [One F] [Neg F] [DecidableEq F]
     let rest ← VarBaseMul.reduce cs
     pure (pair :: rest)
 
+/-- The round reducer is a seam: twenty-six pinned operands, one row pair. -/
+private theorem ScaleRound.reduce_seam [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F]
+    [DecidableEq F] (c : ScaleRound F) :
+    Seam (ScaleRound.reduce (m := PlonkBuilder F) c)
+      (ScaleRound.reduce (m := PlonkProver F) c) := by
+  unfold ScaleRound.reduce
+  repeat first
+    | exact Seam.pure _
+    | refine Seam.bind (reduceToVariable_seam _) fun _ => ?_
+
+/-- The scalar-multiplication reducer is a seam: the roundwise fold composes. -/
+theorem VarBaseMul.reduce_seam [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F]
+    [DecidableEq F] (c : VarBaseMul F) :
+    Seam (VarBaseMul.reduce (m := PlonkBuilder F) c)
+      (VarBaseMul.reduce (m := PlonkProver F) c) := by
+  induction c with
+  | nil =>
+    simp only [VarBaseMul.reduce]
+    exact Seam.pure _
+  | cons c cs ih =>
+    simp only [VarBaseMul.reduce]
+    refine Seam.bind (ScaleRound.reduce_seam c) fun _ => ?_
+    refine Seam.bind ih fun _ => ?_
+    exact Seam.pure _
+
 end Snarky.Kimchi

--- a/formal/snarky/roots.txt
+++ b/formal/snarky/roots.txt
@@ -121,6 +121,7 @@ Snarky.buildWith_proveWith_nextVar
 Snarky.proveWith_extends
 Snarky.checkedOps_lockstep
 Snarky.checkedOps_proveExtends
+Snarky.finalizeWith_nextVar
 
 -- The D12 gadget laws (beside their gadgets, Circuit/DSL/{Field,Boolean}.lean): every
 -- assignment satisfying a gadget's
@@ -190,6 +191,7 @@ Snarky.unpack_complete_spec
 Snarky.compile
 Snarky.solve
 Snarky.solve_complete
+Snarky.proveWith_compileBody_slots
 Snarky.readVar_le
 
 -- The DSL primitive surface (Circuit/DSL/Monad.lean): the PS Snarky-monad exports not
@@ -294,6 +296,16 @@ Snarky.Kimchi.ToKimchiRows
 -- The reduction layer (Snarky/Kimchi/Constraint/Reduction.lean): the op vocabulary,
 -- the two reduction algorithms, and the builder/prover instances.
 Snarky.Kimchi.PlonkReductionM
+
+-- Seam-walk simp fodder (Constraint/Reduction.lean): rfl-lemmas the walks consume
+-- through simp, which applies them definitionally — no proof term records them, so
+-- they are rooted as simp-set surface.
+Snarky.Kimchi.PlonkBuilder.pure_apply
+Snarky.Kimchi.PlonkProver.pure_apply
+Snarky.Kimchi.createInternalB_apply
+Snarky.Kimchi.createInternal_builder
+Snarky.Kimchi.addGeneric_prover
+Snarky.Kimchi.addEquals_prover
 Snarky.Kimchi.reduceAffineExpression
 Snarky.Kimchi.reduceToVariable
 Snarky.Kimchi.reduceAsBuilder
@@ -361,6 +373,11 @@ Snarky.Kimchi.instReprAssembledGate
 -- consumer is scripts/check_cs_equality.lean, invisible to any constant walk.
 Snarky.Kimchi.kimchiSolve
 Snarky.Kimchi.kimchiGateData
+Snarky.Kimchi.kimchiCompile
+Snarky.Kimchi.kimchiOps_lockstep
+Snarky.Kimchi.kimchiOps_proveExtends
+Snarky.Kimchi.kimchiCompile_solve_nextVar
+Snarky.Kimchi.kimchiSolve_publicSlots
 -- script-surface:end
 
 -- The complete-addition gadget (Snarky/Kimchi/Circuit/AddComplete.lean) and the

--- a/formal/snarky/scripts/check_axioms.lean
+++ b/formal/snarky/scripts/check_axioms.lean
@@ -20,6 +20,7 @@ import Snarky.Kimchi.Circuit.EndoScalar
 import Snarky.Kimchi.Circuit.EndoMul
 import Snarky.Kimchi.Circuit.VarBaseMul
 import Snarky.Kimchi.Circuit.GroupMap
+import Snarky.Kimchi.Backend.Compile
 import Lean.Elab.Command
 
 open Lean Lean.Elab.Command
@@ -137,6 +138,11 @@ def roots : List Name :=
     `Snarky.Example.cubic_sound,
     `Snarky.Example.cubic_complete,
     `Snarky.solve_complete,
+    `Snarky.proveWith_compileBody_slots,
+    `Snarky.Kimchi.kimchiOps_lockstep,
+    `Snarky.Kimchi.kimchiOps_proveExtends,
+    `Snarky.Kimchi.kimchiCompile_solve_nextVar,
+    `Snarky.Kimchi.kimchiSolve_publicSlots,
     `Snarky.readVar_le,
     `Snarky.CVar.reduce_eval,
     `Snarky.fvar_value_roundTrip,


### PR DESCRIPTION
Closes the last proof gap from the snarky-kimchi port audit: the ops-coherence obligation `Constraint.lean`'s docstring has carried since the backend landed — `BackendOps.Lockstep` and `BackendOps.ProveExtends` were stated generically with their whole-program consequences, discharged for the base `checkedOps`, and open for `kimchiOps`.

## What is proved

At the kimchi backend, one constraint is not one row: both seams run the one class-polymorphic dispatch `KimchiConstraint.reduce`, whose reduction ops allocate (`reduceToVariable` on a compound `CVar` mints an internal variable and queues a generic gate; the gate reducers emit whole row blocks). The discharge shows the two instantiations agree:

- **`kimchiOps_lockstep`** — a successful prover seam pins the builder seam's counter, for every auxiliary state: the compiled gate rows and the prover's table number their variables identically, per constraint.
- **`kimchiOps_proveExtends`** — the prover seam only extends the witness table (the guarded write) and never retreats the counter.

The generic whole-program theorems then instantiate for free, and the branch states the payoff at the pipeline's own entry points:

- **`kimchiCompile_solve_nextVar`** — a successful prover run of the compiled body pins the compilation's counter: `kimchiCompile` and the run behind `kimchiSolve` allocate identically, so every variable id the emitted rows can mention is an index the prover numbered.
- **`kimchiSolve_publicSlots`** — the kimchi counterpart of the base `solve_complete`'s slot clause: a successful solve returns a table reading the given input at the input slots and the returned output at the output slots (the seed survives; the output back-fill wrote the slots the wiring ties to the circuit's result).
- **`proveWith_compileBody_slots`** — the slot decode proved once, at ANY `ProveExtends` backend, beside `compileBody`. The base `solve_complete` now rides it (its fifty-line slot walk deleted): its remaining own content is the checking prover's constraint clause, which has no backend-generic counterpart by design — the kimchi prover seam checks nothing, validation being the row laws plus the fixture seam.

## How

Bottom-up, one review step per commit:

1. **Op-level facts** (`Reduction.lean`): only `createInternalVariable` moves the shared counter — by exactly one, on both sides; the equality op's guard cascade walked branch by branch; the prover's write is unconditional-`Le` because `extendPairs` errors on an occupied key.
2. **The generic algorithms in lockstep**: `completelyReduce` / `reduceAffineExpression` / `reduceToVariable` paired walks — result agreement carried inductively, because downstream branching consumes returned variables and the branches agree exactly when the counters do.
3. **`Seam`, and the per-gate walks**: the paired-run property made composable (`Seam.pure`/`bind`/`map`/`ite` mirror the monad structure the reducers are written in). Each gate walk then lives beside its reducer and collapses to a few lines — the 11-to-26-operand chains are a two-alternative `repeat` loop, the roundwise folds six-line inductions, and the branchy `Basic` reducer closes leaf-by-leaf on result agreement.
4. **The dispatch and the discharge** (`Constraint.lean`), plus the entry-point corollaries and the `solve_complete` dedup.

## Gates

- snarky axiom gate: **146 roots** reduce to the standard three
- deadcode: **549 roots resolved, 0 dead** (seam-walk simp fodder rooted as simp-set surface — rfl-lemmas simp applies definitionally leave no proof-term trace)
- style green; full build green; CS-equality oracle green at 31 circuits — the branch changes no executable definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QYZxnvZuHfK7cR4DYFHBA