### PR TITLE
snarky: AsProver as syntax (backport S1)

### DIFF
--- a/formal/snarky/Snarky/Backend/Builder.lean
+++ b/formal/snarky/Snarky/Backend/Builder.lean
@@ -104,9 +104,9 @@ def eraseWitness : CircuitM F c α → CircuitM F c α
   | .freshOp k => .freshOp fun v => eraseWitness (k v)
   | .addConstraintOp con k => .addConstraintOp con (eraseWitness k)
   | .existsOp n _ k =>
-    .existsOp n (fun _ => .error (.custom "erased")) fun vs => eraseWitness (k vs)
+    .existsOp n (AsProver.throw "erased") fun vs => eraseWitness (k vs)
   | .assignOp vs _ k =>
-    .assignOp vs (fun _ => .error (.custom "erased")) (eraseWitness k)
+    .assignOp vs (AsProver.throw "erased") (eraseWitness k)
   | .labelOp s k => .labelOp s (eraseWitness k)
 
 /-- Witness-independence of the builder: `build` factors through `eraseWitness` —

--- a/formal/snarky/Snarky/Backend/Compile.lean
+++ b/formal/snarky/Snarky/Backend/Compile.lean
@@ -48,7 +48,7 @@ private def assertEqPairs [DecidableEq F] [BasicSystem F c] :
 field elements — PS `map valueToFields (read out)`. -/
 private def outputWit [Add F] [Mul F] [B : CircuitType F b bvar] (out : bvar) :
     AsProver F (Vector F B.size) :=
-  fun env => (readVar (val := b) out env).map B.valueToFields
+  B.valueToFields <$> readVar (val := b) out
 
 /-- The public-input bundle every compiled circuit binds, over slots `0 … A.size−1`.
 Whole-circuit statements read the input through this bundle (`readVal`/`Reads`),
@@ -96,7 +96,7 @@ def solve [Add F] [Mul F] [DecidableEq F] [BasicSystem F c]
     match prove holds (compileBody (a := a) (b := b) main) (A.size + B.size) env₀ with
     | .error e => .error e
     | .ok p =>
-      match readVar (val := b) p.result p.assignments with
+      match (readVar (val := b) p.result).run p.assignments with
       | .error e => .error e
       | .ok outVal => .ok (outVal, p.assignments)
 
@@ -273,7 +273,7 @@ theorem proveWith_compileBody_slots {g σ : Type u} {ops : BackendOps F g c σ}
         ((allocRange 0 A.size).toList.zip (A.valueToFields input).toList) = .ok env₀)
     (hrun : proveWith ops (compileBody (a := a) (b := b) main)
         (A.size + B.size) env₀ = .ok p)
-    (hread : readVar (val := b) p.result p.assignments = .ok outVal) :
+    (hread : (readVar (val := b) p.result).run p.assignments = .ok outVal) :
     (∀ i (hi : i < A.size), p.assignments i = some ((A.valueToFields input)[i])) ∧
       ∀ j (hj : j < B.size),
         p.assignments (A.size + j) = some ((B.valueToFields outVal)[j]) := by
@@ -298,18 +298,19 @@ theorem proveWith_compileBody_slots {g σ : Type u} {ops : BackendOps F g c σ}
     omega
   rw [proveWith_bind] at hrun
   obtain ⟨s₃, hassign, hrun⟩ := bind_ok hrun
-  simp only [assignVars, proveWith, outputWit, hslots] at hassign
+  simp only [assignVars, proveWith, outputWit, hslots, AsProver.map_eq, AsProver.run_bind]
+    at hassign
   split at hassign
   · cases hassign
   next xs hwit =>
     split at hassign
     · cases hassign
     next env₃ hext =>
-      cases hwitread : readVar (val := b) s₂.result s₂.assignments with
+      cases hwitread : (readVar (val := b) s₂.result).run s₂.assignments with
       | error e => rw [hwitread] at hwit; cases hwit
       | ok ov =>
         rw [hwitread] at hwit
-        simp only [Except.map, Except.ok.injEq] at hwit
+        simp only [Except.bind, AsProver.run_pure, Except.ok.injEq] at hwit
         subst hwit
         set M := (B.valueToFields ov).toList with hM
         have hlenM : M.length = B.size := by simp [hM]

--- a/formal/snarky/Snarky/Backend/Ops.lean
+++ b/formal/snarky/Snarky/Backend/Ops.lean
@@ -102,7 +102,7 @@ def proveWith (ops : BackendOps F g c σ) :
     | .error e => .error e
     | .ok (nv', env') => proveWith ops k nv' env'
   | .existsOp n wit k, nv, env =>
-    match wit env with
+    match wit.run env with
     | .error e => .error e
     | .ok xs =>
       match env.extendPairs ((allocRange nv n).toList.zip xs.toList) with
@@ -112,7 +112,7 @@ def proveWith (ops : BackendOps F g c σ) :
     match vs.toList.find? (nv ≤ ·) with
     | some v => .error (.conflict v)
     | none =>
-      match wit env with
+      match wit.run env with
       | .error e => .error e
       | .ok xs =>
         match env.extendPairs (vs.toList.zip xs.toList) with
@@ -162,7 +162,7 @@ theorem proveWith_checkedOps (holds : c → Assignments F → Bool)
     · simp only [if_neg h]
   | existsOp n wit k ih =>
     simp only [proveWith, prove]
-    cases hw : wit env with
+    cases hw : wit.run env with
     | error e => rfl
     | ok xs =>
       simp only []
@@ -175,7 +175,7 @@ theorem proveWith_checkedOps (holds : c → Assignments F → Bool)
     | some v => rfl
     | none =>
       simp only []
-      cases hw : wit env with
+      cases hw : wit.run env with
       | error e => rfl
       | ok xs =>
         simp only []

--- a/formal/snarky/Snarky/Backend/Prover.lean
+++ b/formal/snarky/Snarky/Backend/Prover.lean
@@ -80,7 +80,7 @@ def prove (holds : c → Assignments F → Bool) :
     if holds con env then prove holds k nv env
     else .error .unsatisfiedConstraint
   | .existsOp n wit k, nv, env =>
-    match wit env with
+    match wit.run env with
     | .error e => .error e
     | .ok xs =>
       match env.extendPairs ((allocRange nv n).toList.zip xs.toList) with
@@ -90,7 +90,7 @@ def prove (holds : c → Assignments F → Bool) :
     match vs.toList.find? (nv ≤ ·) with
     | some v => .error (.conflict v)
     | none =>
-      match wit env with
+      match wit.run env with
       | .error e => .error e
       | .ok xs =>
         match env.extendPairs (vs.toList.zip xs.toList) with
@@ -143,7 +143,7 @@ one constraint, return it: the run succeeds and assigns the witnessed value at `
 whenever the witness computation succeeds and the constraint accepts the result. -/
 theorem prove_witnessCore {holds : c → Assignments F → Bool} {w : AsProver F F}
     {mk : CVar F → c} {nv : Nat} {env : Assignments F} {v : F}
-    (hw : w env = .ok v) (hfresh : env.FreshFrom nv)
+    (hw : w.run env = .ok v) (hfresh : env.FreshFrom nv)
     (hch : holds (mk (.var nv)) (env.extend nv v) = true) :
     prove holds (do
         let z ← witness (val := F) w
@@ -151,14 +151,16 @@ theorem prove_witnessCore {holds : c → Assignments F → Bool} {w : AsProver F
         pure z) nv env
       = .ok ⟨.var nv, nv + 1, env.extend nv v⟩ := by
   have hnv : env nv = none := hfresh nv (Nat.le_refl nv)
-  have hwit : (w env).map (CircuitType.valueToFields (F := F) (val := F))
-      = .ok ⟨#[v], rfl⟩ := by rw [hw]; rfl
+  have hwit : (CircuitType.valueToFields (F := F) (val := F) <$> w).run env
+      = .ok ⟨#[v], rfl⟩ := by
+    simp only [AsProver.map_eq, AsProver.run_bind, hw, Except.bind]
+    rfl
   have hext : env.extendPairs
       ((allocRange nv 1).toList.zip (⟨#[v], rfl⟩ : Vector F 1).toList)
       = .ok (env.extend nv v) := by
     show env.extendPairs [(nv, v)] = .ok _
     simp [Assignments.extendPairs, hnv]
-  show prove holds (.existsOp 1 (fun e => (w e).map _) _) nv env = _
+  show prove holds (.existsOp 1 (_ <$> w) _) nv env = _
   simp only [prove, hwit, hext]
   show prove holds (.addConstraintOp (mk (.var nv)) (.pure (CVar.var nv))) (nv + 1)
     (env.extend nv v) = _

--- a/formal/snarky/Snarky/Backend/WP.lean
+++ b/formal/snarky/Snarky/Backend/WP.lean
@@ -806,19 +806,20 @@ shape). -/
     [CheckedType F (Prover c) var] [Checker F c] [LawfulCheckedType F c val var]
     [WitnessReads F val var] (w : AsProver F val)
     (Q : PostCond var (.arg (ProverState F) (.except EvalError .pure))) :
-    ⦃Complete (fun env => (w env).isOk)
-        (fun env (r : var) env' => ∀ v, w env = .ok v →
+    ⦃Complete (fun env => (w.run env).isOk)
+        (fun env (r : var) env' => ∀ v, w.run env = .ok v →
           WitnessReads.Reads (F := F) r env' v) Q⦄
     (witness (val := val) w : CircuitM F (Prover c) var)
     ⦃Q⦄ := by
   intro st hpre
   obtain ⟨hok, hk⟩ := hpre
-  obtain ⟨v, hw⟩ : ∃ v, w st.env = .ok v := by
-    cases hwe : w st.env with
+  obtain ⟨v, hw⟩ : ∃ v, w.run st.env = .ok v := by
+    cases hwe : w.run st.env with
     | error e => rw [hwe] at hok; cases hok
     | ok v => exact ⟨v, rfl⟩
-  have hwit : (w st.env).map (CircuitType.valueToFields (F := F) (val := val))
-      = .ok (CircuitType.valueToFields (F := F) (var := var) v) := by rw [hw]; rfl
+  have hwit : (CircuitType.valueToFields (F := F) (val := val) <$> w).run st.env
+      = .ok (CircuitType.valueToFields (F := F) (var := var) v) := by
+    simp [hw, Except.bind]
   obtain ⟨env₁, hext, hle₁, hfr₁, hread⟩ :=
     extendPairs_consecutive
       (CircuitType.valueToFields (F := F) (var := var) v).toList st.nv st.env st.fresh
@@ -846,7 +847,7 @@ shape). -/
     exact mapM_eval_range' hle'' _ st.nv hread
   rw [show (witness (val := val) w : CircuitM F (Prover c) var)
       = ((CircuitM.existsOp (CircuitType.size F val)
-            (fun e => (w e).map (CircuitType.valueToFields (F := F) (val := val)))
+            (CircuitType.valueToFields (F := F) (val := val) <$> w)
             (fun vs => CircuitM.pure vs) : CircuitM F (Prover c) _) >>=
           fun vs =>
             (CheckedType.check (c := Prover c)

--- a/formal/snarky/Snarky/Circuit/DSL/Bits.lean
+++ b/formal/snarky/Snarky/Circuit/DSL/Bits.lean
@@ -327,11 +327,11 @@ the results are the operand's binary digits. -/
     intro i Q st' hpre'
     obtain ⟨hok', hk'⟩ := hpre'
     obtain ⟨vv', hv'⟩ := CVar.evalOk hok'
-    have hw : unpackWit v i.val st'.env = .ok ((ToNat.toNat vv').testBit i.val) := by
-      simp [unpackWit, AsProver.readCVar, hv', Bind.bind, ReaderT.bind, Except.bind,
-        Pure.pure, ReaderT.pure, Except.pure]
+    have hw : (unpackWit v i.val).run st'.env = .ok ((ToNat.toNat vv').testBit i.val) := by
+      simp [unpackWit, hv', Bind.bind, Except.bind,
+        Pure.pure]
     refine witness_complete_spec (val := Bool) _ _ st'
-      ⟨show (unpackWit v i.val st'.env).isOk = true by rw [hw]; rfl,
+      ⟨show ((unpackWit v i.val).run st'.env).isOk = true by rw [hw]; rfl,
         fun r st'' hr hle => ?_⟩
     refine hk' r st'' (fun vv'' hv'' => ?_) hle
     rw [hv'] at hv''
@@ -347,7 +347,7 @@ the results are the operand's binary digits. -/
       CVar.eval_le h23 (hpost vv' (CVar.eval_le h01 hv₀))) _ st
     ⟨fun _ => hokv, fun bits st₁ hbits hle₁ => ?_⟩
   -- after the loop: the packing row accepts, and the caller reads the digits
-  simp only [WPMonad.wp_bind, PredTrans.apply_Bind_bind]
+  dsimp only
   have hv₁ : v.eval st₁.env = .ok vv := CVar.eval_le hle₁ hv
   have hbitEval : ∀ i (hi : i < n), (bits[i].toCVar).eval st₁.env
       = .ok (bit ((ToNat.toNat vv).testBit i)) := by

--- a/formal/snarky/Snarky/Circuit/DSL/Boolean.lean
+++ b/formal/snarky/Snarky/Circuit/DSL/Boolean.lean
@@ -719,12 +719,11 @@ private theorem xorCore_run {F c : Type} [Field F] [DecidableEq F]
     split
     · next h => rw [h, hnv] at hv; cases hv
     · exact hv
-  have hwit : (xorWit a b env).map
-      (CircuitType.valueToFields (F := F) (val := UnChecked Bool))
+  have hwit : (CircuitType.valueToFields (F := F) (val := UnChecked Bool) <$> xorWit a b).run env
       = .ok ⟨#[bit (ab ^^ bb)], rfl⟩ := by
     cases hab : ab <;> cases hbb : bb <;>
-      simp [xorWit, AsProver.readCVar, ha, hb, hab, hbb, Bind.bind, ReaderT.bind,
-        Except.bind, Pure.pure, ReaderT.pure, Except.pure, Except.map,
+      simp [xorWit, ha, hb, hab, hbb, Bind.bind,
+        Except.bind, Pure.pure,
         CircuitType.valueToFields, bit, one_ne_zero]
   have hext : env.extendPairs
       ((allocRange nv 1).toList.zip
@@ -750,7 +749,7 @@ private theorem xorCore_run {F c : Type} [Field F] [DecidableEq F]
     exact LawfulChecker.check_r1cs _ _ _ _ _ _ _ haa hb' hsub
       (by cases ab <;> cases bb <;> simp [bit])
   show prove (Checker.holds (F := F) (c := c))
-    (.existsOp 1 (fun e => (xorWit a b e).map _) _) nv env = _
+    (.existsOp 1 (_ <$> xorWit a b) _) nv env = _
   simp only [prove, hwit, hext]
   show prove (Checker.holds (F := F) (c := c))
     (.addConstraintOp (BasicSystem.r1cs (c := c) (CVar.add_ a.toCVar a.toCVar) b.toCVar
@@ -987,9 +986,9 @@ private theorem selectCore_run {F c : Type} [Field F] [DecidableEq F]
     split
     · next h => rw [h, hnv] at hv; cases hv
     · exact hv
-  have hw : selectWit b t e env = .ok (if bb then tv else ev) := by
+  have hw : (selectWit b t e).run env = .ok (if bb then tv else ev) := by
     cases bb <;>
-      simp [selectWit, AsProver.readCVar, hb, ht, he, Bind.bind, ReaderT.bind,
+      simp [selectWit, hb, ht, he, Bind.bind,
         Except.bind, bit]
   have hch : Checker.holds (F := F) (c := c)
       (BasicSystem.r1cs b.toCVar (CVar.sub_ t e) (CVar.sub_ (.var nv) e))

--- a/formal/snarky/Snarky/Circuit/DSL/Field.lean
+++ b/formal/snarky/Snarky/Circuit/DSL/Field.lean
@@ -253,9 +253,8 @@ private theorem equalsCore_run {F c : Type} [Field F] [DecidableEq F]
     [BasicSystem F c] [Checker F c] [LawfulChecker F c] {z : CVar F}
     {nv : Nat} {env : Assignments F} {zv v₁ v₂ : F} (hz : z.eval env = .ok zv)
     (hfresh : env.FreshFrom nv)
-    (hwit : (equalsWit z env).map
-        (CircuitType.valueToFields (F := F) (val := UnChecked Bool × F))
-      = .ok ⟨#[v₁, v₂], rfl⟩)
+    (hwit : (CircuitType.valueToFields (F := F) (val := UnChecked Bool × F) <$> equalsWit z).run
+        env = .ok ⟨#[v₁, v₂], rfl⟩)
     (hc₁ : v₁ * zv = 0) (hc₂ : v₂ * zv = 1 - v₁) :
     prove (Checker.holds (F := F) (c := c)) (equalsCore (c := c) z) nv env
       = .ok ⟨.unchecked (.var nv), nv + 2, (env.extend nv v₁).extend (nv + 1) v₂⟩ := by
@@ -293,7 +292,7 @@ private theorem equalsCore_run {F c : Type} [Field F] [DecidableEq F]
     exact LawfulChecker.check_r1cs _ _ _ _ _ _ _ (by simp [CVar.eval, henv₂nv1])
       hzeval₂ hsub hc₂
   show prove (Checker.holds (F := F) (c := c))
-    (.existsOp 2 (fun e => (equalsWit z e).map _) _) nv env = _
+    (.existsOp 2 (_ <$> equalsWit z) _) nv env = _
   simp only [prove, hwit, hext]
   show prove (Checker.holds (F := F) (c := c))
     (.addConstraintOp (BasicSystem.r1cs (c := c) (.var nv) z (.const 0))
@@ -313,12 +312,11 @@ private theorem equalsCore_complete {F c : Type} [Field F] [DecidableEq F]
       out.result.toCVar.eval out.assignments = .ok (if zv = 0 then 1 else 0) ∧
       out.assignments.FreshFrom out.nextVar := by
   obtain ⟨hc₁, hc₂⟩ := equals_checks (F := F) zv
-  have hwit : (equalsWit z env).map
-      (CircuitType.valueToFields (F := F) (val := UnChecked Bool × F))
-      = .ok ⟨#[if zv = 0 then 1 else 0, if zv = 0 then 0 else zv⁻¹], rfl⟩ := by
+  have hwit : (CircuitType.valueToFields (F := F) (val := UnChecked Bool × F) <$> equalsWit z).run
+      env = .ok ⟨#[if zv = 0 then 1 else 0, if zv = 0 then 0 else zv⁻¹], rfl⟩ := by
     by_cases hzv : zv = 0 <;>
-      simp [equalsWit, AsProver.readCVar, hz, hzv, Bind.bind, ReaderT.bind, Except.bind,
-        Pure.pure, ReaderT.pure, Except.pure, Except.map, CircuitType.valueToFields, bit]
+      simp [equalsWit, hz, hzv, Bind.bind, Except.bind,
+        Pure.pure, CircuitType.valueToFields, bit]
   refine ⟨_, equalsCore_run hz hfresh hwit hc₁ hc₂, ?_, ?_⟩
   · show (CVar.var nv).eval _ = _
     simp [CVar.eval, Assignments.extend]
@@ -487,9 +485,9 @@ private theorem mulCore_run {F c : Type} [Add F] [Mul F] [Zero F] [One F] [Decid
     split
     · next h => rw [h, hnv] at hv; cases hv
     · exact hv
-  have hw : mulWit x y env = .ok (xv * yv) := by
-    simp [mulWit, AsProver.readCVar, hx, hy, Bind.bind, ReaderT.bind, Except.bind,
-      Pure.pure, ReaderT.pure, Except.pure]
+  have hw : (mulWit x y).run env = .ok (xv * yv) := by
+    simp [mulWit, hx, hy, Bind.bind, Except.bind,
+      Pure.pure]
   have hch : Checker.holds (F := F) (c := c) (BasicSystem.r1cs x y (.var nv))
       (env.extend nv (xv * yv)) = true :=
     LawfulChecker.check_r1cs _ _ _ _ _ _ _ (CVar.eval_le hle hx) (CVar.eval_le hle hy)
@@ -512,9 +510,9 @@ private theorem invCore_run {F c : Type} [Field F] [DecidableEq F]
     split
     · next h => rw [h, hnv] at hv; cases hv
     · exact hv
-  have hw : invWit x env = .ok xv⁻¹ := by
-    simp [invWit, AsProver.readCVar, hx, hxv, Bind.bind, ReaderT.bind, Except.bind,
-      Pure.pure, ReaderT.pure, Except.pure]
+  have hw : (invWit x).run env = .ok xv⁻¹ := by
+    simp [invWit, hx, hxv, Bind.bind, Except.bind,
+      Pure.pure]
   have hch : Checker.holds (F := F) (c := c) (BasicSystem.r1cs x (.var nv) (.const 1))
       (env.extend nv xv⁻¹) = true :=
     LawfulChecker.check_r1cs _ _ _ _ _ _ _ (CVar.eval_le hle hx)
@@ -677,9 +675,9 @@ private theorem squareCore_run {F c : Type} [Add F] [Mul F] [Zero F] [One F]
     split
     · next h => rw [h, hnv] at hv; cases hv
     · exact hv
-  have hw : squareWit x env = .ok (xv * xv) := by
-    simp [squareWit, AsProver.readCVar, hx, Bind.bind, ReaderT.bind, Except.bind,
-      Pure.pure, ReaderT.pure, Except.pure]
+  have hw : (squareWit x).run env = .ok (xv * xv) := by
+    simp [squareWit, hx, Bind.bind, Except.bind,
+      Pure.pure]
   have hch : Checker.holds (F := F) (c := c) (BasicSystem.square x (.var nv))
       (env.extend nv (xv * xv)) = true :=
     LawfulChecker.check_square _ _ _ _ _ (CVar.eval_le hle hx)

--- a/formal/snarky/Snarky/Circuit/DSL/Monad.lean
+++ b/formal/snarky/Snarky/Circuit/DSL/Monad.lean
@@ -51,43 +51,156 @@ namespace Snarky
 
 /-! ## Witness (prover-side) computations -/
 
-/-- A prover-only witness computation: read the current assignments, produce a value or
-fail (PS `AsProver f r a`, minus the advice row). `ReaderT`/`Except` supply the `Monad` and
-`LawfulMonad` instances. -/
-abbrev AsProver (F : Type u) : Type u → Type u :=
-  ReaderT (Assignments F) (Except EvalError)
+/-- A prover-only witness computation, as syntax (PS `AsProver f r a`, minus the advice
+row): return a value, read a variable from the current assignments and continue with
+its value, or fail. A computation can read the table and nothing else — there is no
+instruction that observes a failed read and carries on — which is PS's surface
+(`readCVar`, `throwAsProver`, the monad) and nothing more. `run` is its evaluation
+against a table. -/
+inductive AsProver (F : Type u) : Type u → Type u where
+  /-- Return `a`. -/
+  | pure {α : Type u} (a : α) : AsProver F α
+  /-- Read variable `v`'s value, then run `k` on it. -/
+  | read {α : Type u} (v : Variable) (k : F → AsProver F α) : AsProver F α
+  /-- Fail with `e`. -/
+  | fail {α : Type u} (e : EvalError) : AsProver F α
 
 namespace AsProver
 
-/-- Read the value of an affine expression from the current assignments (PS `readCVar`). -/
-def readCVar [Add F] [Mul F] (x : CVar F) : AsProver F F :=
-  fun env => x.eval env
+variable {F : Type u} {α β : Type u}
 
-/-- The prover-side list read is the elementwise read. -/
-theorem readAll_ok [Add F] [Mul F] {env : Assignments F} :
-    ∀ {xs : List (CVar F)} {vs : List F},
-      xs.mapM (CVar.eval · env) = .ok vs →
-      (xs.mapM readCVar) env = .ok vs
-  | [], vs, h => h
-  | x :: xs, vs, h => by
-    cases he : x.eval env with
-    | error e => simp [List.mapM_cons, he, Bind.bind, Except.bind] at h
-    | ok y =>
-      cases hr : xs.mapM (CVar.eval · env) with
-      | error e => simp [List.mapM_cons, he, hr, Bind.bind, Except.bind] at h
-      | ok ys =>
-        simp only [List.mapM_cons, he, hr, Bind.bind, Except.bind, Pure.pure,
-          Except.pure] at h
-        simp [List.mapM_cons, readCVar, he, readAll_ok hr, Bind.bind,
-          ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure, h]
+/-- Sequencing: run the first computation, then `f` on its result. -/
+protected def bind : AsProver F α → (α → AsProver F β) → AsProver F β
+  | .pure a, f => f a
+  | .read v k, f => .read v fun x => AsProver.bind (k x) f
+  | .fail e, _ => .fail e
+
+instance : Monad (AsProver F) where
+  pure := .pure
+  bind := AsProver.bind
+
+/-- A `do`-block over `AsProver` normalises to its constructors: these equations push
+`pure`, `>>=` and `<$>` through to `.pure`, `.read` and `.fail`, so that anything
+defined on the constructors computes on a block written with `do`. -/
+@[simp] theorem pure_eq (a : α) : (Pure.pure a : AsProver F α) = .pure a := rfl
+
+@[simp] theorem bind_eq (x : AsProver F α) (f : α → AsProver F β) :
+    x >>= f = AsProver.bind x f := rfl
+
+@[simp] theorem map_eq (f : α → β) (x : AsProver F α) :
+    f <$> x = AsProver.bind x fun a => .pure (f a) := rfl
+
+@[simp] theorem bind_pure (a : α) (f : α → AsProver F β) :
+    AsProver.bind (.pure a) f = f a := rfl
+
+@[simp] theorem bind_read (v : Variable) (k : F → AsProver F α) (f : α → AsProver F β) :
+    AsProver.bind (.read v k) f = .read v fun x => AsProver.bind (k x) f := rfl
+
+@[simp] theorem bind_fail (e : EvalError) (f : α → AsProver F β) :
+    AsProver.bind (.fail e : AsProver F α) f = .fail e := rfl
+
+private theorem bind_pure' (x : AsProver F α) : AsProver.bind x .pure = x := by
+  induction x with
+  | pure a => rfl
+  | read v k ih => simp only [AsProver.bind]; exact congrArg _ (funext ih)
+  | fail e => rfl
+
+private theorem bind_assoc' (x : AsProver F α) (f : α → AsProver F β)
+    (g : β → AsProver F γ) :
+    AsProver.bind (AsProver.bind x f) g = AsProver.bind x fun a => AsProver.bind (f a) g := by
+  induction x with
+  | pure a => rfl
+  | read v k ih => simp only [AsProver.bind]; exact congrArg _ (funext ih)
+  | fail e => rfl
+
+instance : LawfulMonad (AsProver F) :=
+  LawfulMonad.mk' _ (id_map := bind_pure') (pure_bind := fun _ _ => rfl)
+    (bind_assoc := bind_assoc')
+
+/-- Read the value of an affine expression from the current assignments (PS
+`readCVar`): read its variables and combine — the prover's evaluation of the term. -/
+def readCVar [Add F] [Mul F] : CVar F → AsProver F F
+  | .var v => .read v .pure
+  | .const k => .pure k
+  | .add a b => do
+    let x ← readCVar a
+    let y ← readCVar b
+    pure (x + y)
+  | .scale k y => do
+    let x ← readCVar y
+    pure (k * x)
 
 /-- Fail with a message (PS `throwAsProver`). -/
-def throw (msg : String) : AsProver F α :=
-  fun _ => .error (.custom msg)
+def throw (msg : String) : AsProver F α := .fail (.custom msg)
 
-/-- Run a witness computation against an assignment (PS `runAsProver`, minus `Effect`). -/
-def run (p : AsProver F α) (env : Assignments F) : Except EvalError α :=
-  p env
+/-- Run a witness computation against an assignment (PS `runAsProver`, minus `Effect`):
+a read of an assigned variable continues with its value; one of an unassigned
+variable, or a `fail`, ends the run. -/
+def run : AsProver F α → Assignments F → Except EvalError α
+  | .pure a, _ => .ok a
+  | .read v k, env =>
+    match env v with
+    | some x => (k x).run env
+    | none => .error (.unassigned v)
+  | .fail e, _ => .error e
+
+/-- `run` computes by its three equations and the sequencing law; a `do`-block reaches
+them through the normal forms above. -/
+@[simp] theorem run_pure (a : α) (env : Assignments F) :
+    (AsProver.pure a : AsProver F α).run env = .ok a := rfl
+
+@[simp] theorem run_read (v : Variable) (k : F → AsProver F α) (env : Assignments F) :
+    (AsProver.read v k).run env = match env v with
+      | some x => (k x).run env
+      | none => .error (.unassigned v) := by
+  rcases h : env v with _ | x <;> simp [run, h]
+
+@[simp] theorem run_fail (e : EvalError) (env : Assignments F) :
+    (AsProver.fail e : AsProver F α).run env = .error e := rfl
+
+@[simp] theorem run_bind (x : AsProver F α) (f : α → AsProver F β) (env : Assignments F) :
+    (AsProver.bind x f).run env = (x.run env).bind fun a => (f a).run env := by
+  induction x with
+  | pure a => rfl
+  | read v k ih =>
+    simp only [AsProver.bind, run]
+    cases env v with
+    | none => rfl
+    | some x => exact ih x
+  | fail e => rfl
+
+/-- Reading an affine expression is evaluating it. -/
+@[simp] theorem run_readCVar [Add F] [Mul F] (x : CVar F) (env : Assignments F) :
+    (readCVar x).run env = x.eval env := by
+  induction x with
+  | var v =>
+    simp only [readCVar, run_read, run_pure, CVar.eval]
+    rcases env v with _ | x <;> rfl
+  | const k => rfl
+  | add a b iha ihb =>
+    simp only [readCVar, bind_eq, run_bind, iha, ihb, run_pure, CVar.eval]
+    rcases a.eval env with e | x
+    · rfl
+    · rcases b.eval env with e | y <;> rfl
+  | scale k y ih =>
+    simp only [readCVar, bind_eq, run_bind, ih, run_pure, CVar.eval]
+    rcases y.eval env with e | x <;> rfl
+
+/-- The prover-side list read is the elementwise read. -/
+theorem run_mapM_readCVar [Add F] [Mul F] (env : Assignments F) :
+    ∀ xs : List (CVar F), (xs.mapM readCVar).run env = xs.mapM (CVar.eval · env)
+  | [] => rfl
+  | x :: xs => by
+    simp only [List.mapM_cons, bind_eq, pure_eq, run_bind, run_readCVar, run_pure,
+      run_mapM_readCVar env xs]
+    rcases x.eval env with e | v
+    · rfl
+    · rcases xs.mapM (CVar.eval · env) with e | vs <;> rfl
+
+/-- A successful elementwise read is a successful list read. -/
+theorem readAll_ok [Add F] [Mul F] {env : Assignments F} {xs : List (CVar F)} {vs : List F}
+    (h : xs.mapM (CVar.eval · env) = .ok vs) : (xs.mapM readCVar).run env = .ok vs := by
+  rw [run_mapM_readCVar]; exact h
 
 end AsProver
 
@@ -245,7 +358,7 @@ execute `compute`, whose output is — in the NP sense — the witness justifyin
 existential. Renamed because `exists` is Lean's `∃` keyword. -/
 def witness [inst : CircuitType F val var] [CheckedType F c var]
     (compute : AsProver F val) : CircuitM F c var :=
-  .existsOp inst.size (fun env => (compute env).map inst.valueToFields) fun vs => do
+  .existsOp inst.size (inst.valueToFields <$> compute) fun vs => do
     let v := inst.fieldsToVar (mapVec CVar.var vs)
     CheckedType.check (c := c) v
     pure v
@@ -253,25 +366,25 @@ def witness [inst : CircuitType F val var] [CheckedType F c var]
 /-- Read a typed variable bundle back to its value during a prover run (PS `read`). The
 length check is dynamic (it always succeeds) to keep the definition kernel-reducible
 without a `mapM`-length lemma. -/
-def readVar [Add F] [Mul F] [inst : CircuitType F val var] (v : var) : AsProver F val :=
-  fun env => do
-    let fields ← (inst.varToFields v).toList.mapM (CVar.eval · env)
-    if h : fields.length = inst.size then
-      pure (inst.fieldsToValue ⟨⟨fields⟩, by simpa using h⟩)
-    else
-      .error (.custom "readVar: size mismatch")
+def readVar [Add F] [Mul F] [inst : CircuitType F val var] (v : var) : AsProver F val := do
+  let fields ← (inst.varToFields v).toList.mapM AsProver.readCVar
+  if h : fields.length = inst.size then
+    pure (inst.fieldsToValue ⟨⟨fields⟩, by simpa using h⟩)
+  else
+    AsProver.throw "readVar: size mismatch"
 
 /-- Successful `readVar`s are stable under assignment extension — the bundle form of
 `CVar.eval_le`. -/
 theorem readVar_le [Add F] [Mul F] [inst : CircuitType F val var] {v : var}
     {env env' : Assignments F} (hle : env.Le env') {x : val}
-    (h : readVar (F := F) v env = .ok x) : readVar (F := F) v env' = .ok x := by
-  unfold readVar at h ⊢
+    (h : (readVar (F := F) v).run env = .ok x) : (readVar (F := F) v).run env' = .ok x := by
+  simp only [readVar, AsProver.bind_eq, AsProver.run_bind, AsProver.run_mapM_readCVar] at h ⊢
   cases hm : (inst.varToFields v).toList.mapM (CVar.eval · env) with
   | error e => rw [hm] at h; cases h
   | ok fields =>
     rw [hm] at h
     rw [mapM_eval_le hle hm]
-    exact h
+    simp only [Except.bind] at h ⊢
+    split at h <;> split <;> simp_all [AsProver.throw]
 
 end Snarky

--- a/formal/snarky/Snarky/Circuit/DSL/Utils.lean
+++ b/formal/snarky/Snarky/Circuit/DSL/Utils.lean
@@ -68,8 +68,8 @@ private theorem sealCore_run {F c : Type} [Add F] [Mul F] [Zero F] [One F]
     split
     · next h => rw [h, hnv] at hv; cases hv
     · exact hv
-  have hw : AsProver.readCVar x env = .ok xv := by
-    simpa [AsProver.readCVar] using hx
+  have hw : (AsProver.readCVar x).run env = .ok xv := by
+    simpa using hx
   have hch : Checker.holds (F := F) (c := c) (BasicSystem.equal x (.var nv))
       (env.extend nv xv) = true :=
     LawfulChecker.check_equal _ _ _ _ (CVar.eval_le hle hx)

--- a/formal/snarky/Snarky/DSL.lean
+++ b/formal/snarky/Snarky/DSL.lean
@@ -33,7 +33,7 @@ returning later as a `deriving` handler if wanted.
 | --- | --- | --- |
 | `Snarky(..)` | `CircuitM` | the deep embedding — THE sanctioned deviation (`DSL/Monad`) |
 | `CircuitOps(..)` | `CircuitM` constructors | one constructor per ops-record field |
-| `AsProver(..)` | `AsProver` | reader-except stack; advice row dropped |
+| `AsProver(..)` | `AsProver` | syntax (`pure`/`read`/`fail`), evaluated by `run`; no advice row |
 | `AsProverCtx(..)`, `liftAdvice`, `runAdvice` | — | the advice row, dropped |
 | `liftEffectSnarky`, `mkWitnessTable` | — | `Effect` machinery, no pure-embedding analogue |
 | `runAsProver` | `AsProver.run` | |

--- a/formal/snarky/Snarky/Kimchi/Backend/Compile.lean
+++ b/formal/snarky/Snarky/Kimchi/Backend/Compile.lean
@@ -46,7 +46,7 @@ def kimchiSolve [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F] [Neg F]
         (A.size + B.size) env₀ with
     | .error e => .error e
     | .ok p =>
-      match readVar (val := b) p.result p.assignments with
+      match (readVar (val := b) p.result).run p.assignments with
       | .error e => .error e
       | .ok outVal => .ok (outVal, p.assignments)
 
@@ -110,7 +110,7 @@ theorem kimchiSolve_publicSlots [Add F] [Mul F] [Sub F] [Div F] [Zero F] [One F]
         (A.size + B.size) env₀ with e | p <;> rw [hp] at h
     · cases h
     · dsimp only at h
-      rcases hr : readVar (val := b) p.result p.assignments with e | outv <;>
+      rcases hr : (readVar (val := b) p.result).run p.assignments with e | outv <;>
         rw [hr] at h
       · cases h
       · cases h

--- a/formal/snarky/Snarky/Kimchi/Circuit/AddComplete.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/AddComplete.lean
@@ -372,15 +372,15 @@ itself (the field is nontrivial). -/
 private theorem readVar_bool_of_eval [Field F] [DecidableEq F]
     {v : BoolVar F} {env : Assignments F} {b : Bool}
     (h : (↑v : CVar F).eval env = .ok (bit b)) :
-    readVar (val := Bool) v env = .ok b := by
+    (readVar (val := Bool) v).run env = .ok b := by
   cases b with
   | false =>
     simp [readVar, h, Bind.bind, Except.bind, bit, CircuitType.fieldsToValue,
-      CircuitType.varToFields, Pure.pure, Except.pure]
+      CircuitType.varToFields, Pure.pure]
     rfl
   | true =>
     simp [readVar, h, Bind.bind, Except.bind, bit, CircuitType.fieldsToValue,
-      CircuitType.varToFields, Pure.pure, Except.pure, one_ne_zero]
+      CircuitType.varToFields, Pure.pure, one_ne_zero]
     rfl
 
 open Std.Do in
@@ -412,49 +412,49 @@ private theorem addFastTail_complete_spec [Field F] [DecidableEq F]
   mvcgen
   rename_i st hpre
   obtain ⟨⟨hp1x, hp1y, hp2x, hp2y, hsx, hinf⟩, hk⟩ := hpre
-  have hinfZw : infZWit p1 p2 sameX st.env
+  have hinfZw : (infZWit p1 p2 sameX).run st.env
       = .ok (if y1v = y2v then 0 else if x1v = x2v then (y2v - y1v)⁻¹ else 0) := by
     by_cases hy : y1v = y2v <;> by_cases hx : x1v = x2v <;>
-      simp [infZWit, AsProver.readCVar, hp1y, hp2y, readVar_bool_of_eval hsx, hy, hx,
-        Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
+      simp [infZWit, hp1y, hp2y, readVar_bool_of_eval hsx, hy, hx,
+        Bind.bind, Except.bind, Pure.pure]
   refine ⟨by rw [hinfZw]; rfl, fun infZ st₁ hr₁ hle₁ => ?_⟩
   have hinfZ : _ = _ := hr₁ _ hinfZw
   mvcgen
-  have hx21w : x21InvWit p1 p2 sameX st₁.env
+  have hx21w : (x21InvWit p1 p2 sameX).run st₁.env
       = .ok (if x1v = x2v then 0 else (x2v - x1v)⁻¹) := by
     by_cases hx : x1v = x2v <;>
-      simp [x21InvWit, AsProver.readCVar, CVar.eval_le hle₁ hp1x,
+      simp [x21InvWit, CVar.eval_le hle₁ hp1x,
         CVar.eval_le hle₁ hp2x, readVar_bool_of_eval (CVar.eval_le hle₁ hsx), hx,
-        Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
+        Bind.bind, Except.bind, Pure.pure]
   refine ⟨by rw [hx21w]; rfl, fun x21Inv st₂ hr₂ hle₂ => ?_⟩
   have hx21 : _ = _ := hr₂ _ hx21w
   have hle02 := hle₁.trans hle₂
   mvcgen
-  have hsw : slopeWit p1 p2 sameX st₂.env
+  have hsw : (slopeWit p1 p2 sameX).run st₂.env
       = .ok (if x1v = x2v then 3 * x1v * x1v / (2 * y1v)
           else (y2v - y1v) / (x2v - x1v)) := by
     by_cases hx : x1v = x2v <;>
-      simp [slopeWit, AsProver.readCVar, CVar.eval_le hle02 hp1x,
+      simp [slopeWit, CVar.eval_le hle02 hp1x,
         CVar.eval_le hle02 hp1y, CVar.eval_le hle02 hp2x, CVar.eval_le hle02 hp2y,
         readVar_bool_of_eval (CVar.eval_le hle02 hsx), hx,
-        Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
+        Bind.bind, Except.bind, Pure.pure]
   refine ⟨by rw [hsw]; rfl, fun s st₃ hr₃ hle₃ => ?_⟩
   have hs : _ = _ := hr₃ _ hsw
   have hle03 := hle02.trans hle₃
   mvcgen
-  have hx3w : x3Wit p1 p2 s st₃.env
+  have hx3w : (x3Wit p1 p2 s).run st₃.env
       = .ok ((if x1v = x2v then 3 * x1v * x1v / (2 * y1v)
             else (y2v - y1v) / (x2v - x1v)) *
           (if x1v = x2v then 3 * x1v * x1v / (2 * y1v)
             else (y2v - y1v) / (x2v - x1v)) - (x1v + x2v)) := by
-    simp [x3Wit, AsProver.readCVar, hs, CVar.eval_le hle03 hp1x,
+    simp [x3Wit, hs, CVar.eval_le hle03 hp1x,
       CVar.eval_le hle03 hp2x,
-      Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
+      Bind.bind, Except.bind, Pure.pure]
   refine ⟨by rw [hx3w]; rfl, fun x3 st₄ hr₄ hle₄ => ?_⟩
   have hx3 : _ = _ := hr₄ _ hx3w
   have hle04 := hle03.trans hle₄
   mvcgen
-  have hy3w : y3Wit p1 s x3 st₄.env
+  have hy3w : (y3Wit p1 s x3).run st₄.env
       = .ok ((if x1v = x2v then 3 * x1v * x1v / (2 * y1v)
             else (y2v - y1v) / (x2v - x1v)) *
           (x1v -
@@ -462,9 +462,9 @@ private theorem addFastTail_complete_spec [Field F] [DecidableEq F]
               else (y2v - y1v) / (x2v - x1v)) *
             (if x1v = x2v then 3 * x1v * x1v / (2 * y1v)
               else (y2v - y1v) / (x2v - x1v)) - (x1v + x2v))) - y1v) := by
-    simp [y3Wit, AsProver.readCVar, CVar.eval_le hle₄ hs, hx3,
+    simp [y3Wit, CVar.eval_le hle₄ hs, hx3,
       CVar.eval_le hle04 hp1x, CVar.eval_le hle04 hp1y,
-      Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
+      Bind.bind, Except.bind, Pure.pure]
   refine ⟨by rw [hy3w]; rfl, fun y3 st₅ hr₅ hle₅ => ?_⟩
   have hy3 : _ = _ := hr₅ _ hy3w
   have hle05 := hle04.trans hle₅
@@ -555,11 +555,10 @@ theorem addFast_complete_spec [Field F] [DecidableEq F] [d : HasCurve F]
     fun p2 st₂ hp2 hle₂ => ?_⟩
   obtain ⟨hp2x, hp2y⟩ := hp2 _ _ (CVar.eval_le hle₁ hx2) (CVar.eval_le hle₁ hy2)
   mvcgen
-  have hsw : (UnChecked.mk <$> sameXWit p1 p2) st₂.env
+  have hsw : (UnChecked.mk <$> sameXWit p1 p2).run st₂.env
       = .ok ⟨decide (x1v = x2v)⟩ := by
-    simp [sameXWit, AsProver.readCVar, CVar.eval_le hle₂ hp1x, hp2x,
-      Functor.map, Bind.bind, ReaderT.bind, Except.bind, Except.map,
-      Pure.pure, ReaderT.pure, Except.pure]
+    simp [sameXWit, CVar.eval_le hle₂ hp1x, hp2x,
+      Functor.map, Bind.bind, Except.bind, Pure.pure]
   refine ⟨by rw [hsw]; rfl, fun sameXU st₃ hsxr hle₃ => ?_⟩
   have hsx : _ = _ := hsxr _ hsw
   cases fin with
@@ -584,12 +583,11 @@ theorem addFast_complete_spec [Field F] [DecidableEq F] [d : HasCurve F]
     · exact Or.inr ⟨_, _, hpost.1, hpost.2.1, hpost.2.2, h3, hsum⟩
   | dontCheckFinite =>
     mvcgen
-    have hiw : (UnChecked.mk <$> infWit p1 p2 sameXU.val) st₃.env
+    have hiw : (UnChecked.mk <$> infWit p1 p2 sameXU.val).run st₃.env
         = .ok ⟨decide (x1v = x2v) && !decide (y1v = y2v)⟩ := by
-      simp [infWit, AsProver.readCVar, readVar_bool_of_eval hsx,
+      simp [infWit, readVar_bool_of_eval hsx,
         CVar.eval_le (hle₂.trans hle₃) hp1y, CVar.eval_le hle₃ hp2y,
-        Functor.map, Bind.bind, ReaderT.bind, Except.bind, Except.map,
-        Pure.pure, ReaderT.pure, Except.pure]
+        Functor.map, Bind.bind, Except.bind, Pure.pure]
     refine ⟨by rw [hiw]; rfl, fun infU st₄ hinfr hle₄ => ?_⟩
     have hinfb : _ = _ := hinfr _ hiw
     mvcgen

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoMul.lean
@@ -893,7 +893,7 @@ private theorem rowWit_ok [Field F] [DecidableEq F] {env : Assignments F}
     (hn : st.2.eval env = .ok n)
     (hb1 : bs[0].eval env = .ok b1) (hb2 : bs[1].eval env = .ok b2)
     (hb3 : bs[2].eval env = .ok b3) (hb4 : bs[3].eval env = .ok b4) :
-    rowWit eb t bs st env
+    (rowWit eb t bs st).run env
       = .ok ((Kimchi.Gate.EndoMul.build eb xt yt xp yp n b1 b2 b3 b4).inv,
              (Kimchi.Gate.EndoMul.build eb xt yt xp yp n b1 b2 b3 b4).nPrime,
              (Kimchi.Gate.EndoMul.build eb xt yt xp yp n b1 b2 b3 b4).xR,
@@ -902,8 +902,8 @@ private theorem rowWit_ok [Field F] [DecidableEq F] {env : Assignments F}
              (Kimchi.Gate.EndoMul.build eb xt yt xp yp n b1 b2 b3 b4).yS,
              (Kimchi.Gate.EndoMul.build eb xt yt xp yp n b1 b2 b3 b4).s1,
              (Kimchi.Gate.EndoMul.build eb xt yt xp yp n b1 b2 b3 b4).s3) := by
-  simp [rowWit, AsProver.readCVar, hxt, hyt, hxp, hyp, hn, hb1, hb2, hb3, hb4,
-    Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
+  simp [rowWit, hxt, hyt, hxp, hyp, hn, hb1, hb2, hb3, hb4,
+    Bind.bind, Except.bind, Pure.pure]
 
 open Std.Do in
 /-- **One round is the gate's canonical row.** On readable base, accumulator,
@@ -1100,12 +1100,12 @@ chain is the two pinned additions (`addFast_complete_spec`), and the register pi
   have hφT : W.Nonsingular (eb * xv) yv := hφns hT
   have hyne : yv ≠ 0 := y_ne_zero_of_odd_order W hodd hT
   -- the bulk bit witness
-  have hwit : bitsWit rounds scalar.val st₀.env
+  have hwit : (bitsWit rounds scalar.val).run st₀.env
       = .ok (Vector.ofFn fun r => Vector.ofFn fun j =>
           if (ToNat.toNat v).testBit (4 * rounds - 1 - (4 * r.1 + j.1))
           then 1 else 0) := by
-    simp [bitsWit, AsProver.readCVar, hv, Bind.bind, ReaderT.bind, Except.bind,
-      Pure.pure, ReaderT.pure, Except.pure]
+    simp [bitsWit, hv, Bind.bind, Except.bind,
+      Pure.pure]
   refine ⟨by rw [hwit]; rfl, fun bits st₁ hgrant hle₁ => ?_⟩
   have hread := hgrant _ hwit
   mvcgen
@@ -1553,11 +1553,11 @@ theorem endoInv_complete_spec [Field F] [DecidableEq F] [ToNat F] [LawfulToNat F
     | zero => exact absurd hp hsmul_ne
     | some px py hpns => exact ⟨px, py, hpns, rfl⟩
   -- the honest witness computes exactly the advice pair
-  have hread : endoInvWit d.W d.W.order d.prime ((d.lam : ZMod d.W.order)) t scalar.val
-      st₀.env
+  have hread : (endoInvWit d.W d.W.order d.prime ((d.lam : ZMod d.W.order)) t
+      scalar.val).run st₀.env
       = .ok (px, py) := by
-    simp only [endoInvWit, AsProver.readCVar, hv, hxv, hyv, Bind.bind, ReaderT.bind,
-      Except.bind, Pure.pure]
+    simp only [endoInvWit, hv, hxv, hyv, AsProver.bind_eq, AsProver.run_bind,
+      AsProver.run_readCVar, AsProver.pure_eq, Except.bind]
     rw [dif_pos hg, ← heff, ← hkdef, hG.symm, hpteq]
     rfl
   refine ⟨by rw [hread]; rfl, fun rp st₁ hgrantW hle₁ => ?_⟩

--- a/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/EndoScalar.lean
@@ -518,12 +518,12 @@ private theorem rowWit_ok [Field F] [DecidableEq F] {env : Assignments F}
     (ha : st.1.eval env = .ok a) (hb : st.2.1.eval env = .ok b)
     (hn : st.2.2.eval env = .ok n)
     (hxs : xs.toList.mapM (CVar.eval · env) = .ok vs) :
-    rowWit xs st env
+    (rowWit xs st).run env
       = .ok ((Kimchi.Gate.EndoScalar.build a b n vs).a8,
              (Kimchi.Gate.EndoScalar.build a b n vs).b8,
              (Kimchi.Gate.EndoScalar.build a b n vs).n8) := by
-  simp [rowWit, AsProver.readCVar, ha, hb, hn, AsProver.readAll_ok hxs, Bind.bind, ReaderT.bind,
-    Except.bind, Pure.pure, ReaderT.pure, Except.pure]
+  simp [rowWit, ha, hb, hn, AsProver.readAll_ok hxs, Bind.bind,
+    Except.bind, Pure.pure]
 
 open Std.Do in
 /-- The gate emitter is complete: the honest prover run accepts on any readable
@@ -548,10 +548,10 @@ theorem toFieldChecked'_complete_spec [Field F] [DecidableEq F] [ToNat F]
   rename_i st₀ hpre
   obtain ⟨hoks, hk⟩ := hpre
   obtain ⟨vv, hv⟩ := CVar.evalOk hoks
-  have hwit : crumbsWit rows scalar st₀.env
+  have hwit : (crumbsWit rows scalar).run st₀.env
       = .ok (crumbVals rows (ToNat.toNat vv)) := by
-    simp [crumbsWit, AsProver.readCVar, hv, Bind.bind, ReaderT.bind, Except.bind,
-      Pure.pure, ReaderT.pure, Except.pure]
+    simp [crumbsWit, hv, Bind.bind, Except.bind,
+      Pure.pure]
   refine ⟨by rw [hwit]; rfl, fun crumbVars st₁ hgrant hle₁ => ?_⟩
   have hread := hgrant _ hwit
   mvcgen

--- a/formal/snarky/Snarky/Kimchi/Circuit/GroupMap.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/GroupMap.lean
@@ -226,10 +226,8 @@ private theorem sqrtFlagged_complete_spec [Field F] [DecidableEq F] {c : Type}
   rename_i st hpre
   obtain ⟨⟨hokx, htw⟩, hk⟩ := hpre
   obtain ⟨xv, hx⟩ := CVar.evalOk hokx
-  have hw₁ : isQRWit sqrtF x st.env = .ok (sqrtF xv).isSome := by
-    rw [show isQRWit sqrtF x st.env
-        = (fun v => (sqrtF v).isSome) <$> CVar.eval x st.env from rfl, hx]
-    rfl
+  have hw₁ : (isQRWit sqrtF x).run st.env = .ok (sqrtF xv).isSome := by
+    simp [isQRWit, hx, Except.bind]
   refine ⟨by rw [hw₁]; rfl, fun isQR st₁ hrd₁ hle₁ => ?_⟩
   have hb₁ : (↑isQR : CVar F).eval st₁.env = .ok (bit (sqrtF xv).isSome) := hrd₁ _ hw₁
   have hx₁ : x.eval st₁.env = .ok xv := CVar.eval_le hle₁ hx
@@ -239,11 +237,9 @@ private theorem sqrtFlagged_complete_spec [Field F] [DecidableEq F] {c : Type}
   have hsel : xOrMx.eval st₂.env
       = .ok (if (sqrtF xv).isSome then xv else nonResidue * xv) := by
     simpa [selectPure] using hrd₂ _ _ _ hb₁ hx₁ (CVar.eval_scale_ hx₁ nonResidue)
-  have hw₂ : sqrtWit sqrtF xOrMx st₂.env
+  have hw₂ : (sqrtWit sqrtF xOrMx).run st₂.env
       = .ok ((sqrtF (if (sqrtF xv).isSome then xv else nonResidue * xv)).getD 0) := by
-    rw [show sqrtWit sqrtF xOrMx st₂.env
-        = (fun v => (sqrtF v).getD 0) <$> CVar.eval xOrMx st₂.env from rfl, hsel]
-    rfl
+    simp [sqrtWit, hsel, Except.bind]
   mvcgen
   refine ⟨by rw [hw₂]; rfl, fun sqrtVal st₃ hrd₃ hle₃ => ?_⟩
   have hy₃ : sqrtVal.eval st₃.env

--- a/formal/snarky/Snarky/Kimchi/Circuit/Poseidon.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/Poseidon.lean
@@ -299,10 +299,10 @@ theorem poseidon_complete_spec [Field F] [DecidableEq F] (p : Poseidon.Params F)
   obtain ⟨av, ha⟩ := CVar.evalOk haok
   obtain ⟨bv, hb⟩ := CVar.evalOk hbok
   obtain ⟨cv, hc⟩ := CVar.evalOk hcok
-  have hwit : roundOutputsWit p s st.env
+  have hwit : (roundOutputsWit p s).run st.env
       = .ok (Vector.ofFn fun i => rounds (mdsOfParams p) (paramsRc p) (i.1 + 1) (av, bv, cv)) := by
-    simp [roundOutputsWit, AsProver.readCVar, ha, hb, hc, Bind.bind, ReaderT.bind,
-      Except.bind, Pure.pure, ReaderT.pure, Except.pure]
+    simp [roundOutputsWit, ha, hb, hc, Bind.bind,
+      Except.bind, Pure.pure]
   refine ⟨by rw [hwit]; rfl, fun outs st₁ hgrant hle₁ => ?_⟩
   have hread := hgrant _ hwit
   have helem : ∀ (i : ℕ) (hi : i < 55),

--- a/formal/snarky/Snarky/Kimchi/Circuit/RangeCheck.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/RangeCheck.lean
@@ -193,11 +193,10 @@ theorem lowest128Bits'_complete_spec [Field F] [DecidableEq F] [ToNat F] [Lawful
             : F) := by push_cast; ring
       _ = ((ToNat.toNat vv : ℕ) : F) := by rw [h1]
       _ = vv := hfaith
-  have hwit : (UnChecked.mk <$> lowestWit x) st.env
+  have hwit : (UnChecked.mk <$> lowestWit x).run st.env
       = .ok ⟨(((ToNat.toNat vv % 2 ^ 128 : ℕ) : F),
           ((ToNat.toNat vv / 2 ^ 128 : ℕ) : F))⟩ := by
-    simp [lowestWit, AsProver.readCVar, hv, Functor.map, Bind.bind, ReaderT.bind,
-      Except.bind, Except.map, Pure.pure, ReaderT.pure, Except.pure]
+    simp [lowestWit, hv, Functor.map, Bind.bind, Except.bind, Pure.pure]
   refine ⟨by rw [hwit]; rfl, fun lohi st₁ hgrant hle₁ => ?_⟩
   obtain ⟨hlo, hhi⟩ := hgrant _ hwit
   mvcgen [EndoScalar.toField_complete_spec]

--- a/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
+++ b/formal/snarky/Snarky/Kimchi/Circuit/VarBaseMul.lean
@@ -944,10 +944,10 @@ private theorem nAccWit_ok [Field F] [DecidableEq F] {env : Assignments F}
     (hb0 : bs[0].eval env = .ok b0) (hb1 : bs[1].eval env = .ok b1)
     (hb2 : bs[2].eval env = .ok b2) (hb3 : bs[3].eval env = .ok b3)
     (hb4 : bs[4].eval env = .ok b4) :
-    nAccWit nPrev bs env
+    (nAccWit nPrev bs).run env
       = .ok (b4 + 2 * (b3 + 2 * (b2 + 2 * (b1 + 2 * (b0 + 2 * nv))))) := by
-  simp [nAccWit, AsProver.readCVar, hnv, hb0, hb1, hb2, hb3, hb4,
-    Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
+  simp [nAccWit, hnv, hb0, hb1, hb2, hb3, hb4,
+    Bind.bind, Except.bind, Pure.pure]
 
 /-- The bit-step advice reads the threaded cells and computes the gate model's
 `stepBit` quintet. -/
@@ -957,7 +957,7 @@ private theorem bitWit_ok [Field F] [DecidableEq F] {env : Assignments F}
     (hxb : t.x.eval env = .ok xb) (hyb : t.y.eval env = .ok yb)
     (hxi : acc.x.eval env = .ok xi) (hyi : acc.y.eval env = .ok yi)
     (hb : b.eval env = .ok bv) :
-    bitWit t b acc env
+    (bitWit t b acc).run env
       = .ok ((Kimchi.Gate.VarBaseMul.stepBit bv xb yb xi yi).1,
         (Kimchi.Gate.VarBaseMul.stepBit bv xb yb xi yi).1
           * (Kimchi.Gate.VarBaseMul.stepBit bv xb yb xi yi).1,
@@ -966,8 +966,8 @@ private theorem bitWit_ok [Field F] [DecidableEq F] {env : Assignments F}
           - (Kimchi.Gate.VarBaseMul.stepBit bv xb yb xi yi).1,
         (Kimchi.Gate.VarBaseMul.stepBit bv xb yb xi yi).2.1,
         (Kimchi.Gate.VarBaseMul.stepBit bv xb yb xi yi).2.2) := by
-  simp [bitWit, AsProver.readCVar, hxb, hyb, hxi, hyi, hb,
-    Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
+  simp [bitWit, hxb, hyb, hxi, hyi, hb,
+    Bind.bind, Except.bind, Pure.pure]
 
 open Std.Do in
 open Kimchi.Gate.VarBaseMul (build_fields build_nPrime
@@ -1020,7 +1020,7 @@ row back; registered, so `mvcgen` applies it once per iteration. -/
   obtain ⟨b3, hb3⟩ := CVar.evalOk (hbk 3 (by omega))
   obtain ⟨b4, hb4⟩ := CVar.evalOk (hbk 4 (by omega))
   -- the register advice computes the row's `nPrime`
-  have hnOk : nAccWit st.2 bs st₀.env
+  have hnOk : (nAccWit st.2 bs).run st₀.env
       = .ok (Kimchi.Gate.VarBaseMul.build xT yT x0 y0 nv b0 b1 b2 b3 b4).nPrime := by
     rw [nAccWit_ok hnv hb0 hb1 hb2 hb3 hb4, build_nPrime]
   refine ⟨by rw [hnOk]; rfl, fun nAcc st₁ hgN hle₁ => ?_⟩
@@ -1208,10 +1208,10 @@ fold identity (`chain_accN` through `natLsbVal_testBit_msbStream`). -/
   mvcgen
   -- the scalar's bits, in one witness
   set nn := ToNat.toNat v with hndef
-  have hwit : lsbBitsWit n scalar.val st₁.env
+  have hwit : (lsbBitsWit n scalar.val).run st₁.env
       = .ok (Vector.ofFn fun i => if nn.testBit i.1 then (1 : F) else 0) := by
-    simp [lsbBitsWit, AsProver.readCVar, CVar.eval_le hle₁ hv,
-      Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
+    simp [lsbBitsWit, CVar.eval_le hle₁ hv,
+      Bind.bind, Except.bind, Pure.pure]
     rw [hndef]
   refine ⟨by rw [hwit]; rfl, fun bits st₂ hgrant hle₂ => ?_⟩
   have hread := hgrant _ hwit
@@ -1757,9 +1757,9 @@ ANY parity bit — and the returned pair reads as the parity split. -/
   rename_i st hpre
   obtain ⟨⟨hsok, h2⟩, hk⟩ := hpre
   obtain ⟨v, hv⟩ := CVar.evalOk hsok
-  have hwit : splitFieldWit s st.env = .ok (splitField v) := by
-    simp [splitFieldWit, AsProver.readCVar, hv,
-      Bind.bind, ReaderT.bind, Except.bind, Pure.pure, ReaderT.pure, Except.pure]
+  have hwit : (splitFieldWit s).run st.env = .ok (splitField v) := by
+    simp [splitFieldWit, hv,
+      Bind.bind, Except.bind, Pure.pure]
   refine ⟨by rw [hwit]; rfl, fun r st₁ hgrant hle₁ => ?_⟩
   obtain ⟨hhalf', hodd'⟩ := hgrant _ hwit
   have hhalf : r.1.eval st₁.env = .ok ((splitField v).1) := hhalf'
@@ -1776,7 +1776,7 @@ ANY parity bit — and the returned pair reads as the parity split. -/
     injection hy with hy
     subst hx hy
     by_cases hoddc : (ToNat.toNat v) % 2 = 1 <;>
-      simp only [splitField, bit, hoddc, if_true, if_false, reduceIte] <;>
+      simp only [splitField, bit, hoddc, if_true, if_false] <;>
       field_simp <;>
       simp
   mvcgen

--- a/formal/snarky/roots.txt
+++ b/formal/snarky/roots.txt
@@ -45,6 +45,21 @@ Snarky.equalsPure
 Snarky.neqPure
 Snarky.selectPure
 
+-- The witness-block normal forms and run equations (Circuit/DSL/Monad.lean): a
+-- do-block over `AsProver` normalises to its constructors and `run` computes on them,
+-- consumed by simp — rooted as simp-set surface.
+Snarky.AsProver.pure_eq
+Snarky.AsProver.bind_eq
+Snarky.AsProver.map_eq
+Snarky.AsProver.bind_pure
+Snarky.AsProver.bind_read
+Snarky.AsProver.bind_fail
+Snarky.AsProver.run_pure
+Snarky.AsProver.run_read
+Snarky.AsProver.run_fail
+Snarky.AsProver.run_bind
+Snarky.AsProver.run_readCVar
+
 -- The alignment bridge: complete a run's table to a valuation, and tie an honest run
 -- to the soundness relation (Backend/{Assignments,WP}.lean).
 Snarky.Assignments.toValuation


### PR DESCRIPTION
Backport plan S1 (`formal/docs/completeness-backport-plan.md`, branch `completeness-backport-plan`): the course's `Wit` deep embedding (`martyall/wp` `04707b3`), carried into `Snarky.AsProver`.

## What changes

`Circuit/DSL/Monad.lean`: `AsProver` is an inductive — `pure a`, `read v k` (a *variable*, as in the course), `fail e` — with `bind` by structural recursion, `Monad`/`LawfulMonad`, and `run : AsProver F α → Assignments F → Except EvalError α`. `readCVar` reads an affine term's variables and combines them (so `run` needs no field instances; `run_readCVar : (readCVar x).run env = x.eval env`). `throw msg := .fail (.custom msg)`. The `@[simp]` surface: `pure_eq`, `bind_eq`, `map_eq`, `bind_pure`, `bind_read`, `bind_fail`, `run_pure`, `run_read`, `run_fail`, `run_bind`, `run_readCVar`, rooted in `roots.txt` as simp-set surface. `readVar` (the typed bundle read) is the same do-block over the new monad; `readAll_ok` is a corollary of `run_mapM_readCVar`.

Interpreters (`prove`, `proveWith`) run a block by `wit.run env`; `witness` lifts the encoder by `<$>`; `eraseWitness` erases to `AsProver.throw`. Every witness-evaluation lemma in the gadget files is stated at `.run` (the `ReaderT.bind/pure` simp tokens are gone; `Bind.bind`/`Except.bind`/`Pure.pure` stay where they unfold `Except`). `witness_complete_spec`'s pre/post read `w.run env`.

Why: PS's `AsProver f r a = AsProverCtx → Effect a` technically admits interception through the raw constructor and `MonadEffect`, but no witness block does it and no catch is exported; the inductive is exactly the sanctioned surface. It is the precondition for S3 (`run_eq_eval`: a scoped block cannot fail).

No completeness law changes statement beyond `w env` → `w.run env`; no proof grew.

## Gates

`lake build Snarky Schnorr` clean (no warnings); `snarky/scripts/check_axioms.sh` (187 roots) and `schnorr/scripts/check_axioms.sh` (12) ✓; deadcode gate 0 dead; `lake lint` ✓; `check-style.sh` ✓. `make lean-shake` reports `kimchi/Kimchi/Bits.lean` (remove `Mathlib.Tactic.Ring`, add `Mathlib.Algebra.Group.Nat.Defs`) — a kimchi file this branch does not touch; it changed on the `sound-native` stack, so that belongs with #314/`sound-native`.

Stacked on `sound-native`.
