### PR TITLE
snarky: freshOp leaves the modeled fragment (backport S2)

### DIFF
--- a/formal/snarky/Snarky/Backend/Builder.lean
+++ b/formal/snarky/Snarky/Backend/Builder.lean
@@ -29,7 +29,7 @@ variable {F c : Type u}
 
 /-- The `n` variables `start, start+1, …, start+n-1` — sequential allocation.
 Interpreter plumbing, not a DSL allocation interface: circuits allocate via
-`fresh`/`existsVars`/`witness` and never see a counter. The explicit `start` is the
+`existsVars`/`witness` and never see a counter. The explicit `start` is the
 pure rendering of PS `allocVars`'s threaded `CircuitBuilderState`. -/
 def allocRange (start n : Nat) : Vector Variable n :=
   Vector.ofFn fun i => start + i.val
@@ -57,7 +57,6 @@ the result, the final counter, and the constraints in emission order. Witness pa
 never inspected — see `build_eq_of_eraseWitness` below. -/
 def build : CircuitM F c α → Nat → Built c α
   | .pure a, n => ⟨a, n, []⟩
-  | .freshOp k, n => build (k n) (n + 1)
   | .addConstraintOp con k, n =>
     let r := build k n
     ⟨r.result, r.nextVar, con :: r.constraints⟩
@@ -86,7 +85,6 @@ theorem build_bind (m : CircuitM F c α) (f : α → CircuitM F c β) (nv : Nat)
   show build (CircuitM.bind m f) nv = _
   induction m generalizing nv with
   | pure a => rfl
-  | freshOp k ih => exact ih ..
   | addConstraintOp con k ih =>
     simp only [CircuitM.bind, build, ih, List.cons_append]
   | existsOp n wit k ih => exact ih ..
@@ -101,7 +99,6 @@ failing one. Two circuits differ only in their witness code exactly when their e
 are equal — for literal circuit terms that equality is `rfl`. -/
 def eraseWitness : CircuitM F c α → CircuitM F c α
   | .pure a => .pure a
-  | .freshOp k => .freshOp fun v => eraseWitness (k v)
   | .addConstraintOp con k => .addConstraintOp con (eraseWitness k)
   | .existsOp n _ k =>
     .existsOp n (AsProver.throw "erased") fun vs => eraseWitness (k vs)
@@ -116,7 +113,6 @@ nodes. -/
 theorem build_eraseWitness (m : CircuitM F c α) : ∀ n, build (eraseWitness m) n = build m n := by
   induction m with
   | pure a => intro n; rfl
-  | freshOp k ih => intro n; simp only [eraseWitness, build]; exact ih n (n + 1)
   | addConstraintOp con k ih => intro n; simp only [eraseWitness, build, ih n]
   | existsOp k wit K ih => intro n; simp only [eraseWitness, build]; exact ih _ (n + k)
   | assignOp vs wit k ih => intro n; simp only [eraseWitness, build]; exact ih n

--- a/formal/snarky/Snarky/Backend/Ops.lean
+++ b/formal/snarky/Snarky/Backend/Ops.lean
@@ -68,7 +68,6 @@ builder seam against the shared counter and state. -/
 def buildWith (ops : BackendOps F g c σ) :
     CircuitM F c α → Nat → σ → BuiltWith g σ α
   | .pure a, n, s => ⟨a, n, [], s⟩
-  | .freshOp k, n, s => buildWith ops (k n) (n + 1) s
   | .addConstraintOp con k, n, s =>
     let red := ops.appendConstraint con n s
     let r := buildWith ops k red.2.1 red.2.2
@@ -96,7 +95,6 @@ constraint runs the backend's prover seam against the shared counter and table. 
 def proveWith (ops : BackendOps F g c σ) :
     CircuitM F c α → Nat → Assignments F → Except EvalError (Proved F α)
   | .pure a, nv, env => .ok ⟨a, nv, env⟩
-  | .freshOp k, nv, env => proveWith ops (k nv) (nv + 1) env
   | .addConstraintOp con k, nv, env =>
     match ops.proveConstraint con nv env with
     | .error e => .error e
@@ -137,7 +135,6 @@ theorem buildWith_checkedOps (holds : c → Assignments F → Bool)
       ⟨(build m n).result, (build m n).nextVar, (build m n).constraints, ⟨⟩⟩ := by
   induction m generalizing n with
   | pure a => rfl
-  | freshOp k ih => exact ih ..
   | addConstraintOp con k ih =>
     have h1 : (checkedOps (F := F) holds).appendConstraint con n PUnit.unit =
         ([con], n, PUnit.unit) := rfl
@@ -152,7 +149,6 @@ theorem proveWith_checkedOps (holds : c → Assignments F → Bool)
     proveWith (checkedOps holds) m nv env = prove holds m nv env := by
   induction m generalizing nv env with
   | pure a => rfl
-  | freshOp k ih => exact ih ..
   | addConstraintOp con k ih =>
     have h1 : (checkedOps (F := F) holds).proveConstraint con nv env =
         if holds con env then .ok (nv, env) else .error .unsatisfiedConstraint := rfl
@@ -217,7 +213,6 @@ theorem buildWith_proveWith_nextVar {ops : BackendOps F g c σ} (hl : ops.Lockst
     (buildWith ops m nv s).nextVar = p.nextVar := by
   induction m generalizing nv env s with
   | pure a => cases h; rfl
-  | freshOp k ih => exact ih _ h s
   | addConstraintOp con k ih =>
     simp only [proveWith] at h
     split at h
@@ -255,9 +250,6 @@ theorem proveWith_extends {ops : BackendOps F g c σ} (hp : ops.ProveExtends)
   | pure a =>
     cases h
     exact ⟨Assignments.Le.refl _, Nat.le_refl _⟩
-  | freshOp k ih =>
-    obtain ⟨hle, hn⟩ := ih _ h
-    exact ⟨hle, Nat.le_of_succ_le hn⟩
   | addConstraintOp con k ih =>
     simp only [proveWith] at h
     split at h
@@ -327,7 +319,6 @@ theorem buildWith_bind (ops : BackendOps F g c σ) (m : CircuitM F c α)
   show buildWith ops (CircuitM.bind m f) nv s = _
   induction m generalizing nv s with
   | pure a => rfl
-  | freshOp k ih => exact ih ..
   | addConstraintOp con k ih =>
     simp only [CircuitM.bind, buildWith, ih, List.append_assoc]
   | existsOp n wit k ih => exact ih ..
@@ -344,7 +335,6 @@ theorem proveWith_bind (ops : BackendOps F g c σ) (m : CircuitM F c α)
   show proveWith ops (CircuitM.bind m f) nv env = _
   induction m generalizing nv env with
   | pure a => rfl
-  | freshOp k ih => exact ih ..
   | addConstraintOp con k ih =>
     simp only [CircuitM.bind, proveWith]
     split

--- a/formal/snarky/Snarky/Backend/Prover.lean
+++ b/formal/snarky/Snarky/Backend/Prover.lean
@@ -75,7 +75,6 @@ when added. -/
 def prove (holds : c → Assignments F → Bool) :
     CircuitM F c α → Nat → Assignments F → Except EvalError (Proved F α)
   | .pure a, nv, env => .ok ⟨a, nv, env⟩
-  | .freshOp k, nv, env => prove holds (k nv) (nv + 1) env
   | .addConstraintOp con k, nv, env =>
     if holds con env then prove holds k nv env
     else .error .unsatisfiedConstraint
@@ -114,7 +113,6 @@ theorem prove_bind (holds : c → Assignments F → Bool) (m : CircuitM F c α)
   show prove holds (CircuitM.bind m f) nv env = _
   induction m generalizing nv env with
   | pure a => rfl
-  | freshOp k ih => exact ih ..
   | addConstraintOp con k ih =>
     simp only [CircuitM.bind, prove]
     split
@@ -178,9 +176,6 @@ theorem prove_assignments_le {holds : c → Assignments F → Bool} {m : Circuit
     simp only [prove, Except.ok.injEq, Proved.mk.injEq] at h
     obtain ⟨-, -, rfl⟩ := h
     exact Assignments.Le.refl _
-  | freshOp k ih =>
-    simp only [prove] at h
-    exact ih _ h
   | addConstraintOp con k ih =>
     simp only [prove] at h
     split at h
@@ -216,7 +211,6 @@ theorem prove_nextVar_le {holds : c → Assignments F → Bool} {m : CircuitM F 
   | pure a =>
     simp only [prove, Except.ok.injEq, Proved.mk.injEq] at h
     omega
-  | freshOp k ih => exact Nat.le_of_succ_le (ih _ h)
   | addConstraintOp con k ih =>
     simp only [prove] at h
     split at h
@@ -253,7 +247,6 @@ theorem prove_freshFrom {holds : c → Assignments F → Bool} {m : CircuitM F c
     simp only [prove, Except.ok.injEq, Proved.mk.injEq] at h
     obtain ⟨-, hnv, henv⟩ := h
     exact hnv ▸ henv ▸ hfresh
-  | freshOp k ih => exact ih _ (fun v hv => hfresh v (by omega)) h
   | addConstraintOp con k ih =>
     simp only [prove] at h
     split at h
@@ -332,10 +325,6 @@ theorem prove_build_agrees {holds : c → Assignments F → Bool} {m : CircuitM 
     simp only [prove, Except.ok.injEq, Proved.mk.injEq] at h
     obtain ⟨rfl, rfl, -⟩ := h
     exact ⟨rfl, rfl⟩
-  | freshOp k ih =>
-    simp only [prove] at h
-    simp only [build]
-    exact ih _ h
   | addConstraintOp con k ih =>
     simp only [prove] at h
     simp only [build]
@@ -382,10 +371,6 @@ theorem prove_complete {holds : c → Assignments F → Bool}
   | pure a =>
     intro con hcon
     simp [build] at hcon
-  | freshOp k ih =>
-    simp only [prove] at h
-    simp only [build]
-    exact ih _ h
   | addConstraintOp con' k ih =>
     simp only [prove] at h
     split at h

--- a/formal/snarky/Snarky/Circuit/DSL/Monad.lean
+++ b/formal/snarky/Snarky/Circuit/DSL/Monad.lean
@@ -9,7 +9,7 @@ import Snarky.Vec
 
 Port of `Snarky.Circuit.DSL.Monad` (packages/snarky/src/Snarky/Circuit/DSL/Monad.purs):
 the witness monad `AsProver`, the circuit monad `CircuitM`, the core operations
-(`fresh`, `addConstraint`, `existsVars`/`witness`, `assignVars`, `label`, `readVar`),
+(`addConstraint`, `existsVars`/`witness`, `assignVars`, `label`, `readVar`),
 and the `CheckedType` class with its base instances.
 
 ## The one deliberate architectural deviation
@@ -208,12 +208,11 @@ end AsProver
 
 /-- A circuit computation over field `F` and constraint type `c`, returning `α` — the
 deep-embedded counterpart of PS `Snarky f c r a`. Constructors mirror the `CircuitOps`
-record fields. -/
+record fields that library code reaches; `freshOp` (allocate without a value) is
+outside the fragment, since every allocation is an `exists`. -/
 inductive CircuitM (F c : Type u) (α : Type v) : Type (max u v) where
   /-- Return a value (the monad's `pure`). -/
   | pure (a : α)
-  /-- Allocate a fresh variable (PS `freshOp`). -/
-  | freshOp (k : Variable → CircuitM F c α)
   /-- Emit a constraint (PS `addConstraintOp`). -/
   | addConstraintOp (con : c) (k : CircuitM F c α)
   /-- Allocate `n` fresh variables, to be assigned by the witness computation `wit` during
@@ -234,7 +233,6 @@ variable {F c : Type u}
 it is a structural recursion, which is what makes the interpreter proofs inductions. -/
 protected def bind : CircuitM F c α → (α → CircuitM F c β) → CircuitM F c β
   | .pure a, f => f a
-  | .freshOp k, f => .freshOp fun v => (k v).bind f
   | .addConstraintOp con k, f => .addConstraintOp con (k.bind f)
   | .existsOp n wit k, f => .existsOp n wit fun vs => (k vs).bind f
   | .assignOp vs wit k, f => .assignOp vs wit (k.bind f)
@@ -249,7 +247,6 @@ instance : Monad (CircuitM F c) where
 protected theorem bind_pure (m : CircuitM F c α) : m.bind CircuitM.pure = m := by
   induction m with
   | pure a => rfl
-  | freshOp k ih => simp only [CircuitM.bind]; exact congrArg _ (funext ih)
   | addConstraintOp con k ih => simp only [CircuitM.bind]; exact congrArg _ ih
   | existsOp n wit k ih => simp only [CircuitM.bind]; exact congrArg _ (funext ih)
   | assignOp vs wit k ih => simp only [CircuitM.bind]; exact congrArg _ ih
@@ -260,7 +257,6 @@ protected theorem bind_assoc (m : CircuitM F c α) (f : α → CircuitM F c β)
     (m.bind f).bind g = m.bind fun a => (f a).bind g := by
   induction m with
   | pure a => rfl
-  | freshOp k ih => simp only [CircuitM.bind]; exact congrArg _ (funext ih)
   | addConstraintOp con k ih => simp only [CircuitM.bind]; exact congrArg _ ih
   | existsOp n wit k ih => simp only [CircuitM.bind]; exact congrArg _ (funext ih)
   | assignOp vs wit k ih => simp only [CircuitM.bind]; exact congrArg _ ih
@@ -277,10 +273,6 @@ end CircuitM
 /-! ## The core operations -/
 
 variable {F c : Type u}
-
-/-- Allocate one fresh variable (PS `fresh`). -/
-def fresh : CircuitM F c Variable :=
-  .freshOp .pure
 
 /-- Emit one constraint (PS `addConstraint`). Returns `PUnit` rather than `Unit` so it can
 sit in `do`-blocks at any universe. -/

--- a/formal/snarky/Snarky/DSL.lean
+++ b/formal/snarky/Snarky/DSL.lean
@@ -41,7 +41,8 @@ returning later as a `deriving` handler if wanted.
 | `read` | `readVar` | `read` is core's `MonadReader` primitive |
 | `readCVar` | `AsProver.readCVar` | |
 | `exists` | `witness` | `exists` is a Lean keyword |
-| `fresh`, `addConstraint`, `assignVars`, `label` | same | |
+| `addConstraint`, `assignVars`, `label` | same | |
+| `fresh` | — | outside the fragment: nothing allocates without a value (allocation is `exists`) |
 | `check` (class `CheckedType`) | `CheckedType.check` | |
 | `mul_`, `inv_`, `div_` | `mul`, `inv`, `div` | in `DSL/Field` (PS parks them in Monad) |
 | `not_`, `and_`, `or_` | `not`, `and`, `or` | shadow core's Bool functions; types resolve |

--- a/formal/snarky/roots.txt
+++ b/formal/snarky/roots.txt
@@ -270,7 +270,6 @@ Snarky.readVar_le
 -- The DSL primitive surface (Circuit/DSL/Monad.lean): the PS Snarky-monad exports not
 -- already pulled in by the laws above, and the Lean-only monad laws
 -- (`bind_assoc`/`bind_pure` ride along inside the instance).
-Snarky.fresh
 Snarky.existsVars
 Snarky.label
 Snarky.AsProver.run


### PR DESCRIPTION
Backport plan S2. `CircuitM.freshOp` (allocate a variable without a value) and its wrapper `fresh` leave the modeled fragment.

**Evidence.** In the Lean tree `freshOp` occurred only in its constructor, the `fresh` wrapper, the interpreters' cases and the generic inductions — no gadget, seam or script ever emitted it (`← fresh` appears nowhere). In PS, the DSL's `fresh` (`Monad.purs:298`) has no caller in `snarky`, `snarky-kimchi`, `poseidon`, `random-oracle`, `schnorr` or `pickles`; allocation is `exists`, which computes before it allocates. The functionality is subsumed, so parity with the ops record carries no weight.

**Change.** The constructor, `fresh`, the `CircuitM.bind` case and one case in each of the ten interpreter inductions (`build`, `prove`, `buildWith`, `proveWith`, the bind/assoc laws, `eraseWitness`, `prove_assignments_le`, `prove_nextVar_le`, `prove_freshFrom`, `prove_build_agrees`, `prove_complete`, `proveWith_*`) are deleted; `Snarky.fresh` leaves `roots.txt`; the parity table (`DSL.lean`) records `fresh` as outside the fragment; the `CircuitM` docstring says so. `assignOp` stays — `compileBody`'s output back-fill uses it.

**Gates.** `lake build Snarky Schnorr` clean; axioms (snarky, schnorr) ✓; deadcode 0; lint ✓; style ✓. (`make lean-shake`: the pre-existing `kimchi/Kimchi/Bits.lean` complaint from the `sound-native` stack, untouched here.)

Stacked on #315 (S1).
