### PR TITLE
snarky: scope as membership, the total reading, scoped witness blocks (backport S3)

### DIFF
--- a/formal/snarky/Snarky/Backend/Assignments.lean
+++ b/formal/snarky/Snarky/Backend/Assignments.lean
@@ -106,6 +106,93 @@ theorem le_extend_self {a : Assignments F} {nv : Nat} (h : a.FreshFrom nv) (x : 
     a.Le (a.extend nv x) :=
   le_extend (h nv (Nat.le_refl nv)) x
 
+/-- Writing at the counter and advancing it keeps the table fresh. -/
+theorem FreshFrom.extend {a : Assignments F} {nv : Nat} (h : a.FreshFrom nv) (x : F) :
+    (a.extend nv x).FreshFrom (nv + 1) := by
+  intro v hv
+  simp only [Assignments.extend]
+  rw [if_neg (show v ≠ nv by omega)]
+  exact h v (by omega)
+
+/-! ## Consecutive allocation
+
+An `existsOp` writes its values at consecutive slots from the counter. `extendList` is
+that write as a function — the table after, not an `Except` — and the laws below are
+what a run equation reads off it: the batch's slots hold their values, every other
+slot is as before, the table stays fresh past the batch and only grew. -/
+
+/-- Write `xs` at the slots `nv, nv + 1, …`. -/
+def extendList (a : Assignments F) (nv : Nat) : List F → Assignments F
+  | [] => a
+  | x :: xs => (a.extend nv x).extendList (nv + 1) xs
+
+/-- Below the batch, nothing changes. -/
+theorem extendList_below :
+    ∀ {xs : List F} {a : Assignments F} {nv v : Nat}, v < nv → a.extendList nv xs v = a v
+  | [], _, _, _, _ => rfl
+  | x :: xs, a, nv, v, hv => by
+    simp only [extendList]
+    rw [extendList_below (by omega)]
+    simp [Assignments.extend, Nat.ne_of_lt hv]
+
+/-- At or past the batch's end, nothing changes. -/
+theorem extendList_above :
+    ∀ {xs : List F} {a : Assignments F} {nv v : Nat}, nv + xs.length ≤ v →
+      a.extendList nv xs v = a v
+  | [], _, _, _, _ => rfl
+  | x :: xs, a, nv, v, hv => by
+    simp only [extendList, List.length_cons] at hv ⊢
+    rw [extendList_above (by omega)]
+    simp [Assignments.extend, show v ≠ nv by omega]
+
+/-- Slot `i` of the batch holds its value. -/
+theorem extendList_get :
+    ∀ {xs : List F} {a : Assignments F} {nv i : Nat} (hi : i < xs.length),
+      a.extendList nv xs (nv + i) = some xs[i]
+  | [], _, _, _, hi => absurd hi (Nat.not_lt_zero _)
+  | x :: xs, a, nv, 0, _ => by
+    simp only [extendList]
+    rw [extendList_below (by omega)]
+    simp [Assignments.extend]
+  | x :: xs, a, nv, i + 1, hi => by
+    simp only [extendList]
+    rw [show nv + (i + 1) = (nv + 1) + i by omega]
+    simpa using extendList_get (xs := xs) (a := a.extend nv x) (nv := nv + 1) (by simpa using hi)
+
+/-- The table stays fresh past the batch. -/
+theorem FreshFrom.extendList {a : Assignments F} {nv : Nat} (h : a.FreshFrom nv) (xs : List F) :
+    (a.extendList nv xs).FreshFrom (nv + xs.length) := by
+  intro v hv
+  rw [extendList_above hv]
+  exact h v (by omega)
+
+/-- A fresh batch only grows the table. -/
+theorem FreshFrom.le_extendList {a : Assignments F} {nv : Nat} (h : a.FreshFrom nv)
+    (xs : List F) : a.Le (a.extendList nv xs) := by
+  intro v x hv
+  have hlt : v < nv := by
+    by_contra hge
+    rw [h v (Nat.le_of_not_lt hge)] at hv
+    cases hv
+  rw [extendList_below hlt]
+  exact hv
+
+/-- The guarded batch write at fresh consecutive slots is the functional one. -/
+theorem extendPairs_extendList :
+    ∀ {xs : List F} {a : Assignments F} {nv : Nat}, a.FreshFrom nv →
+      a.extendPairs ((List.range' nv xs.length).zip xs) = .ok (a.extendList nv xs)
+  | [], _, _, _ => rfl
+  | x :: xs, a, nv, h => by
+    simp only [List.length_cons, List.range'_succ, List.zip_cons_cons, extendPairs, extendList]
+    rw [h nv (Nat.le_refl nv)]
+    exact extendPairs_extendList (h.extend x)
+
+/-- An assigned slot holds its completed reading. -/
+theorem toValuation_eq [Zero F] {a : Assignments F} {v : Variable} (h : (a v).isSome) :
+    a v = some (a.toValuation v) := by
+  obtain ⟨x, hx⟩ := Option.isSome_iff_exists.mp h
+  simp [Assignments.toValuation, hx]
+
 theorem le_extendPairs {a a' : Assignments F} :
     ∀ {l : List (Variable × F)}, a.extendPairs l = .ok a' → a.Le a' := by
   intro l

--- a/formal/snarky/Snarky/Backend/Prover.lean
+++ b/formal/snarky/Snarky/Backend/Prover.lean
@@ -293,8 +293,9 @@ it, and `prove_freshFrom` supplies it for every successor state, so the statemen
 downstream never mention freshness again. -/
 
 /-- A prover state: the allocation counter, the table, and the invariant relating
-them. -/
-structure ProverState (F : Type u) where
+them. Two states with the same counter and table are equal (`ProverState.ext`): the
+invariant is not data. -/
+@[ext] structure ProverState (F : Type u) where
   /-- The next-variable counter. -/
   nv : Nat
   /-- The witness table filled so far. -/
@@ -309,6 +310,165 @@ theorem ProverState.freshOut {holds : c → Assignments F → Bool} {m : Circuit
     (h : prove holds m st.nv st.env = .ok out) :
     out.assignments.FreshFrom out.nextVar :=
   prove_freshFrom st.fresh h
+
+/-! ## Scope
+
+What a completeness law assumes about a variable is that it is *in scope*: `v ∈ st`.
+Scope is assignment — the slot has a value — not a bound on the counter: the seam
+(`compileBody`) reserves the public output slots below the counter and fills them
+after the body has run, so "below the counter" would let a law read a hole. In scope
+means readable, and the reading is total: `st.env.toValuation v`. The laws below are
+everything a proof uses of scope — it survives extension (`mem_of_le`), an allocation
+puts its slots in scope and disturbs no other (`mem_extendMany_iff`), and a reading is
+stable across both (`get_of_le`, `get_extendMany_of_mem`). That names are numbers and
+the counter bounds them appears only inside these proofs. -/
+
+/-- `v ∈ st`: the variable is in scope — it has a value. -/
+instance : Membership Variable (ProverState F) := ⟨fun st v => (st.env v).isSome⟩
+
+theorem ProverState.mem_def {st : ProverState F} {v : Variable} :
+    v ∈ st ↔ (st.env v).isSome := Iff.rfl
+
+/-- An assigned variable is in scope. -/
+theorem ProverState.mem_of_assigned {st : ProverState F} {v : Variable} {x : F}
+    (hv : st.env v = some x) : v ∈ st := by
+  rw [ProverState.mem_def, hv]; rfl
+
+/-- In scope is below the counter — used only to prove the laws below. -/
+theorem ProverState.mem_lt {st : ProverState F} {v : Variable} (hv : v ∈ st) : v < st.nv := by
+  by_contra h
+  rw [ProverState.mem_def, st.fresh v (Nat.le_of_not_lt h)] at hv
+  cases hv
+
+/-- Scope survives any extension of the table. -/
+theorem ProverState.mem_of_le {st st' : ProverState F} (hle : st.env.Le st'.env)
+    {v : Variable} (hv : v ∈ st) : v ∈ st' := by
+  obtain ⟨x, hx⟩ := Option.isSome_iff_exists.mp hv
+  exact ProverState.mem_of_assigned (hle v x hx)
+
+/-- In scope means assigned, and the slot holds its completed reading. -/
+theorem ProverState.get_eq [Zero F] (st : ProverState F) {v : Variable} (hv : v ∈ st) :
+    st.env v = some (st.env.toValuation v) :=
+  Assignments.toValuation_eq hv
+
+/-- An in-scope reading survives any extension of the table. -/
+theorem ProverState.get_of_le [Zero F] {st st' : ProverState F} (hle : st.env.Le st'.env)
+    {v : Variable} (hv : v ∈ st) : st'.env.toValuation v = st.env.toValuation v := by
+  have h := hle v _ (st.get_eq hv)
+  simp [Assignments.toValuation, h]
+
+/-- Allocate `xs` at the counter: the state after an `existsOp`. The only way a run
+makes a new state, and the invariant comes with it. -/
+def ProverState.extendMany (st : ProverState F) (xs : List F) : ProverState F :=
+  ⟨st.nv + xs.length, st.env.extendList st.nv xs, st.fresh.extendList xs⟩
+
+theorem ProverState.extendMany_nv (st : ProverState F) (xs : List F) :
+    (st.extendMany xs).nv = st.nv + xs.length := rfl
+
+theorem ProverState.extendMany_env (st : ProverState F) (xs : List F) :
+    (st.extendMany xs).env = st.env.extendList st.nv xs := rfl
+
+/-- Allocation only grows the table. -/
+theorem ProverState.le_extendMany (st : ProverState F) (xs : List F) :
+    st.env.Le (st.extendMany xs).env :=
+  st.fresh.le_extendList xs
+
+/-- Scope survives allocation. -/
+theorem ProverState.mem_extendMany {st : ProverState F} {v : Variable} (hv : v ∈ st)
+    (xs : List F) : v ∈ st.extendMany xs :=
+  ProverState.mem_of_le (st.le_extendMany xs) hv
+
+/-- The allocated names are in scope. -/
+theorem ProverState.new_mem_extendMany (st : ProverState F) {xs : List F} {i : Nat}
+    (hi : i < xs.length) : st.nv + i ∈ st.extendMany xs := by
+  rw [ProverState.mem_def, ProverState.extendMany_env, Assignments.extendList_get hi]
+  rfl
+
+/-- The scope after an allocation: the scope before, and the allocated names. The form
+`simp` uses, so that a name's scope at a grown state reduces to its scope at the
+start, however many allocations deep. -/
+@[simp] theorem ProverState.mem_extendMany_iff {st : ProverState F} {xs : List F}
+    {v : Variable} :
+    v ∈ st.extendMany xs ↔ v ∈ st ∨ ∃ i, i < xs.length ∧ v = st.nv + i := by
+  constructor
+  · intro h
+    by_cases hlt : v < st.nv
+    · left
+      rw [ProverState.mem_def, ProverState.extendMany_env,
+        Assignments.extendList_below hlt] at h
+      exact h
+    · right
+      by_cases hge : st.nv + xs.length ≤ v
+      · exfalso
+        rw [ProverState.mem_def, ProverState.extendMany_env,
+          Assignments.extendList_above hge, st.fresh v (by omega)] at h
+        cases h
+      · exact ⟨v - st.nv, Nat.sub_lt_left_of_lt_add (Nat.le_of_not_lt hlt) (Nat.lt_of_not_le hge),
+          (Nat.add_sub_cancel' (Nat.le_of_not_lt hlt)).symm⟩
+  · rintro (h | ⟨i, hi, rfl⟩)
+    · exact ProverState.mem_extendMany h xs
+    · exact st.new_mem_extendMany hi
+
+/-- An allocated slot reads as what was written. -/
+@[simp] theorem ProverState.get_extendMany_new [Zero F] (st : ProverState F) {xs : List F}
+    {i : Nat} (hi : i < xs.length) :
+    (st.extendMany xs).env.toValuation (st.nv + i) = xs[i] := by
+  show ((st.extendMany xs).env (st.nv + i)).getD 0 = _
+  rw [ProverState.extendMany_env, Assignments.extendList_get hi]
+  rfl
+
+/-- An in-scope name reads the same through an allocation. -/
+@[simp] theorem ProverState.get_extendMany_of_mem [Zero F] (st : ProverState F)
+    {v : Variable} (hv : v ∈ st) (xs : List F) :
+    (st.extendMany xs).env.toValuation v = st.env.toValuation v := by
+  show ((st.extendMany xs).env v).getD 0 = (st.env v).getD 0
+  rw [ProverState.extendMany_env, Assignments.extendList_below (ProverState.mem_lt hv)]
+
+/-! ## Scoped witness blocks
+
+`w.Scoped st`: every variable the block can read is in scope. A scoped block cannot
+fail on a lookup — its run is its evaluation at the completed table
+(`run_eq_eval`) — so the value a law mentions is `w.eval st.env.toValuation`, a
+function of the state with nothing to name and nothing to case on. -/
+
+/-- Every variable the block can read is in scope at `st`. -/
+def AsProver.Scoped (st : ProverState F) : AsProver F α → Prop
+  | .pure _ => True
+  | .read v k => v ∈ st ∧ ∀ x, (k x).Scoped st
+  | .fail _ => True
+
+@[simp] theorem AsProver.scoped_pure (st : ProverState F) (a : α) :
+    (AsProver.pure a : AsProver F α).Scoped st := trivial
+
+@[simp] theorem AsProver.scoped_read (st : ProverState F) (v : Variable)
+    (k : F → AsProver F α) :
+    (AsProver.read v k).Scoped st ↔ v ∈ st ∧ ∀ x, (k x).Scoped st := Iff.rfl
+
+@[simp] theorem AsProver.scoped_fail (st : ProverState F) (e : EvalError) :
+    (AsProver.fail e : AsProver F α).Scoped st := trivial
+
+/-- A scoped block's run is its evaluation at the completed table: no lookup fails. -/
+theorem AsProver.run_eq_eval [Zero F] {w : AsProver F α} {st : ProverState F}
+    (hs : w.Scoped st) : w.run st.env = w.eval st.env.toValuation := by
+  induction w with
+  | pure a => rfl
+  | read v k ih =>
+    obtain ⟨hv, hk⟩ := hs
+    simp only [AsProver.run, AsProver.eval, st.get_eq hv]
+    exact ih _ (hk _)
+  | fail e => rfl
+
+/-- A scoped block reads only in scope, so two readings that agree there evaluate it
+alike. -/
+theorem AsProver.eval_congr {w : AsProver F α} {st : ProverState F} (hs : w.Scoped st)
+    {V V' : Valuation F} (hg : ∀ v, v ∈ st → V v = V' v) : w.eval V = w.eval V' := by
+  induction w with
+  | pure a => rfl
+  | read v k ih =>
+    obtain ⟨hv, hk⟩ := hs
+    simp only [AsProver.eval, hg v hv]
+    exact ih _ (hk _)
+  | fail e => rfl
 
 /-! ## Interpreter agreement -/
 

--- a/formal/snarky/Snarky/Backend/Read.lean
+++ b/formal/snarky/Snarky/Backend/Read.lean
@@ -1,5 +1,6 @@
 import Snarky.Circuit.Types
 import Snarky.Backend.Assignments
+import Snarky.Backend.Prover
 
 /-!
 # Reading circuit types off a table
@@ -255,5 +256,164 @@ theorem exists_readsAll [Add F] [Mul F] [Zero F] [CircuitType F val var]
     obtain ⟨v, hv⟩ := exists_reads (h x (by simp))
     obtain ⟨vs, hvs⟩ := exists_readsAll (xs := xs) fun y hy => h y (by simp [hy])
     exact ⟨v :: vs, .cons hv hvs⟩
+
+/-! ## Scope
+
+The prover-side precondition of a gadget law is that its operands are in scope
+(`ProverState`'s `∈`, lifted to expressions and bundles): then every read is total,
+and the law's values are `val`/`readVal` at the completed table, `st.env.toValuation`.
+`eval_eq_val` is the one bridge from the partial `eval` to the total reading; the
+`_fvar`/`_prod`/`_ofEquiv` lemmas compute scope at the base, pair and presented
+instances, as the `readVal_*` lemmas compute the reading; and `readVal_extendMany_new`
+is what a witness leaf grants — the allocated bundle reads as the value the block
+computed, by the round trips. -/
+
+/-- `x.Scoped st`: every variable of the expression is in scope. -/
+def CVar.Scoped (st : ProverState F) : CVar F → Prop
+  | .var v => v ∈ st
+  | .const _ => True
+  | .add a b => a.Scoped st ∧ b.Scoped st
+  | .scale _ y => y.Scoped st
+
+@[simp] theorem CVar.scoped_var (st : ProverState F) (v : Variable) :
+    (CVar.var v : CVar F).Scoped st ↔ v ∈ st := Iff.rfl
+
+@[simp] theorem CVar.scoped_const (st : ProverState F) (k : F) :
+    (CVar.const k).Scoped st := trivial
+
+@[simp] theorem CVar.scoped_add (st : ProverState F) (a b : CVar F) :
+    (CVar.add a b).Scoped st ↔ a.Scoped st ∧ b.Scoped st := Iff.rfl
+
+@[simp] theorem CVar.scoped_scale (st : ProverState F) (k : F) (y : CVar F) :
+    (CVar.scale k y).Scoped st ↔ y.Scoped st := Iff.rfl
+
+/-- Scope survives table extension. -/
+theorem CVar.Scoped.of_le {st st' : ProverState F} (hle : st.env.Le st'.env) :
+    ∀ {x : CVar F}, x.Scoped st → x.Scoped st'
+  | .var _, h => ProverState.mem_of_le hle h
+  | .const _, _ => trivial
+  | .add _ _, ⟨ha, hb⟩ => ⟨ha.of_le hle, hb.of_le hle⟩
+  | .scale _ y, h => CVar.Scoped.of_le hle (x := y) h
+
+/-- An in-scope expression evaluates, to its total reading at the completed table. -/
+theorem CVar.eval_eq_val [Add F] [Mul F] [Zero F] {st : ProverState F} :
+    ∀ {x : CVar F}, x.Scoped st → x.eval st.env = .ok (x.val st.env.toValuation)
+  | .var v, hv => by simp [CVar.eval, CVar.val, st.get_eq hv]
+  | .const _, _ => rfl
+  | .add a b, ⟨ha, hb⟩ => by simp [CVar.eval, CVar.val, eval_eq_val ha, eval_eq_val hb]
+  | .scale _ y, hy => by simp [CVar.eval, CVar.val, eval_eq_val (x := y) hy]
+
+/-- An in-scope reading survives table extension. -/
+theorem CVar.val_of_le [Add F] [Mul F] [Zero F] {st st' : ProverState F}
+    (hle : st.env.Le st'.env) {x : CVar F} (hs : x.Scoped st) :
+    x.val st'.env.toValuation = x.val st.env.toValuation := by
+  have h := CVar.eval_le hle (CVar.eval_eq_val hs)
+  rw [CVar.eval_eq_val (hs.of_le hle)] at h
+  injection h
+
+/-- A bundle is in scope when every cell of its flattening is. -/
+def CircuitType.Scoped (val : Type) [CircuitType F val var] (st : ProverState F)
+    (cv : var) : Prop :=
+  ∀ i (hi : i < CircuitType.size F val), ((CircuitType.varToFields (val := val) cv)[i]).Scoped st
+
+/-- A single field variable is in scope iff its expression is. -/
+theorem scoped_fvar_iff {st : ProverState F} {x : FVar F} :
+    CircuitType.Scoped F st x ↔ x.Scoped st := by
+  constructor
+  · intro h
+    exact h 0 Nat.zero_lt_one
+  · intro h i hi
+    have hi' : i < 1 := hi
+    have h0 : i = 0 := by omega
+    subst h0
+    exact h
+
+section ScopeProd
+
+variable {a b av bv : Type}
+
+/-- A pair is in scope iff its components are. -/
+theorem scoped_prod_iff [A : CircuitType F a av] [B : CircuitType F b bv]
+    {st : ProverState F} {p : av × bv} :
+    CircuitType.Scoped (a × b) st p ↔
+      CircuitType.Scoped a st p.1 ∧ CircuitType.Scoped b st p.2 := by
+  constructor
+  · intro h
+    constructor
+    · intro i hi
+      have h' := h i (by show i < A.size + B.size; omega)
+      rwa [show (CircuitType.varToFields (val := a × b) p)[i]'(by
+            show i < A.size + B.size; omega)
+          = (A.varToFields p.1)[i]
+        from Vector.getElem_append_left hi] at h'
+    · intro i hi
+      have h' := h (A.size + i) (by show A.size + i < A.size + B.size; omega)
+      have heq : (CircuitType.varToFields (val := a × b) p)[A.size + i]'(by
+            show A.size + i < A.size + B.size; omega)
+          = (B.varToFields p.2)[i] := by
+        show (A.varToFields p.1 ++ B.varToFields p.2)[A.size + i]'(by omega)
+          = (B.varToFields p.2)[i]
+        rw [Vector.getElem_append_right (by omega) (by omega)]
+        simp
+      rwa [heq] at h'
+  · rintro ⟨ha, hb⟩ i hi
+    have hi' : i < A.size + B.size := hi
+    show ((A.varToFields p.1 ++ B.varToFields p.2))[i].Scoped st
+    by_cases hia : i < A.size
+    · rw [Vector.getElem_append_left hia]
+      exact ha i hia
+    · rw [Vector.getElem_append_right (by omega) (by omega)]
+      exact hb (i - A.size) (by omega)
+
+end ScopeProd
+
+section ScopeOfEquiv
+
+variable {rep repVar : Type} (R : CircuitType F rep repVar) (e : val ≃ rep) (ev : var ≃ repVar)
+
+/-- A presented bundle is in scope iff its representation is. -/
+theorem scoped_ofEquiv_iff {st : ProverState F} {cv : var} :
+    @CircuitType.Scoped F var val (R.ofEquiv e ev) st cv ↔ CircuitType.Scoped rep st (ev cv) :=
+  Iff.rfl
+
+end ScopeOfEquiv
+
+/-- Scope survives table extension. -/
+theorem CircuitType.Scoped.of_le [CircuitType F val var] {st st' : ProverState F}
+    (hle : st.env.Le st'.env) {cv : var} (h : CircuitType.Scoped val st cv) :
+    CircuitType.Scoped val st' cv :=
+  fun i hi => (h i hi).of_le hle
+
+/-- An in-scope bundle's reading survives table extension. -/
+theorem readVal_of_le [Add F] [Mul F] [Zero F] [CircuitType F val var]
+    {st st' : ProverState F} (hle : st.env.Le st'.env) {cv : var}
+    (hs : CircuitType.Scoped val st cv) :
+    readVal (val := val) st'.env.toValuation cv = readVal (val := val) st.env.toValuation cv := by
+  unfold readVal
+  congr 1
+  ext i hi
+  simp only [Vector.getElem_map]
+  exact CVar.val_of_le hle (hs i hi)
+
+/-- What a witness leaf grants: the bundle allocated at the counter reads, on the
+extended table, as the value whose encoding was written — `vars_roundTrip` to the
+cells, the batch's slots, `value_roundTrip` back. -/
+theorem readVal_extendMany_new [Add F] [Mul F] [Zero F] [CircuitType F val var]
+    [LawfulCircuitType F val var] (st : ProverState F) (v : val) :
+    readVal (val := val)
+      (st.extendMany (CircuitType.valueToFields (F := F) (var := var) v).toList).env.toValuation
+      (CircuitType.fieldsToVar (F := F) (val := val)
+        (mapVec CVar.var (allocRange st.nv (CircuitType.size F val)))) = v := by
+  unfold readVal
+  rw [LawfulCircuitType.vars_roundTrip (F := F) (val := val)]
+  set st' := st.extendMany (CircuitType.valueToFields (F := F) (var := var) v).toList with hst'
+  have hcells : (mapVec CVar.var (allocRange st.nv (CircuitType.size F val))).map
+      (·.val st'.env.toValuation)
+      = CircuitType.valueToFields (F := F) (var := var) v := by
+    ext i hi
+    simp only [Vector.getElem_map, getElem_mapVec, allocRange, Vector.getElem_ofFn, CVar.val]
+    rw [ProverState.get_extendMany_new st (by simpa using hi)]
+    simp
+  rw [hcells, LawfulCircuitType.value_roundTrip]
 
 end Snarky

--- a/formal/snarky/Snarky/Circuit/DSL/Monad.lean
+++ b/formal/snarky/Snarky/Circuit/DSL/Monad.lean
@@ -186,6 +186,38 @@ them through the normal forms above. -/
     simp only [readCVar, bind_eq, run_bind, ih, run_pure, CVar.eval]
     rcases y.eval env with e | x <;> rfl
 
+/-- Evaluate against a total reading of the table: every read succeeds, only `fail`
+fails. The value a scoped block's run computes (`run_eq_eval`, beside `ProverState`). -/
+def eval (V : Valuation F) : AsProver F α → Except EvalError α
+  | .pure a => .ok a
+  | .read v k => (k (V v)).eval V
+  | .fail e => .error e
+
+@[simp] theorem eval_pure (V : Valuation F) (a : α) :
+    (AsProver.pure a : AsProver F α).eval V = .ok a := rfl
+
+@[simp] theorem eval_read (V : Valuation F) (v : Variable) (k : F → AsProver F α) :
+    (AsProver.read v k).eval V = (k (V v)).eval V := rfl
+
+@[simp] theorem eval_fail (V : Valuation F) (e : EvalError) :
+    (AsProver.fail e : AsProver F α).eval V = .error e := rfl
+
+@[simp] theorem eval_bind (V : Valuation F) (x : AsProver F α) (f : α → AsProver F β) :
+    (AsProver.bind x f).eval V = (x.eval V).bind fun a => (f a).eval V := by
+  induction x with
+  | pure a => rfl
+  | read v k ih => exact ih _
+  | fail e => rfl
+
+/-- Reading an affine expression at a total reading is its value there. -/
+@[simp] theorem eval_readCVar [Add F] [Mul F] (x : CVar F) (V : Valuation F) :
+    (readCVar x).eval V = .ok (x.val V) := by
+  induction x with
+  | var v => rfl
+  | const k => rfl
+  | add a b iha ihb => simp [readCVar, iha, ihb, CVar.val, Except.bind]
+  | scale k y ih => simp [readCVar, ih, CVar.val, Except.bind]
+
 /-- The prover-side list read is the elementwise read. -/
 theorem run_mapM_readCVar [Add F] [Mul F] (env : Assignments F) :
     ∀ xs : List (CVar F), (xs.mapM readCVar).run env = xs.mapM (CVar.eval · env)

--- a/formal/snarky/Snarky/Vec.lean
+++ b/formal/snarky/Snarky/Vec.lean
@@ -18,6 +18,10 @@ opaque to the kernel; `List.map` is structural, so this version reduces under `d
 def mapVec (f : α → β) (v : Vector α n) : Vector β n :=
   ⟨⟨v.toList.map f⟩, by simp⟩
 
+@[simp] theorem getElem_mapVec (f : α → β) (v : Vector α n) (i : Nat) (hi : i < n) :
+    (mapVec f v)[i] = f v[i] := by
+  simp [mapVec]
+
 /-- A flattening reads as the flattening of the element lists (the `toList` bridge core
 provides for `map` but not `flatten`). -/
 theorem toList_flatten {α : Type u} {m n : Nat} (xss : Vector (Vector α m) n) :

--- a/formal/snarky/roots.txt
+++ b/formal/snarky/roots.txt
@@ -60,6 +60,65 @@ Snarky.AsProver.run_fail
 Snarky.AsProver.run_bind
 Snarky.AsProver.run_readCVar
 
+-- Scope, the prover-side reading (Backend/{Assignments,Prover,Read}.lean,
+-- Circuit/DSL/Monad.lean, Vec.lean): consecutive allocation as a function of the
+-- table, `v ∈ st` as assignment with its laws, scoped witness blocks and their
+-- evaluation, and scope lifted to expressions and bundles — the vocabulary the run
+-- equations are stated in. Simp-set surface where marked `@[simp]`.
+Snarky.Assignments.FreshFrom.extend
+Snarky.Assignments.extendList
+Snarky.Assignments.extendList_below
+Snarky.Assignments.extendList_above
+Snarky.Assignments.extendList_get
+Snarky.Assignments.FreshFrom.extendList
+Snarky.Assignments.FreshFrom.le_extendList
+Snarky.Assignments.extendPairs_extendList
+Snarky.Assignments.toValuation_eq
+Snarky.getElem_mapVec
+Snarky.AsProver.eval
+Snarky.AsProver.eval_pure
+Snarky.AsProver.eval_read
+Snarky.AsProver.eval_fail
+Snarky.AsProver.eval_bind
+Snarky.AsProver.eval_readCVar
+Snarky.instMembershipVariableProverState
+Snarky.ProverState.mem_def
+Snarky.ProverState.mem_of_assigned
+Snarky.ProverState.mem_lt
+Snarky.ProverState.mem_of_le
+Snarky.ProverState.get_eq
+Snarky.ProverState.get_of_le
+Snarky.ProverState.extendMany
+Snarky.ProverState.extendMany_nv
+Snarky.ProverState.extendMany_env
+Snarky.ProverState.le_extendMany
+Snarky.ProverState.mem_extendMany
+Snarky.ProverState.new_mem_extendMany
+Snarky.ProverState.mem_extendMany_iff
+Snarky.ProverState.get_extendMany_new
+Snarky.ProverState.get_extendMany_of_mem
+Snarky.AsProver.Scoped
+Snarky.AsProver.scoped_pure
+Snarky.AsProver.scoped_read
+Snarky.AsProver.scoped_fail
+Snarky.AsProver.run_eq_eval
+Snarky.AsProver.eval_congr
+Snarky.CVar.Scoped
+Snarky.CVar.scoped_var
+Snarky.CVar.scoped_const
+Snarky.CVar.scoped_add
+Snarky.CVar.scoped_scale
+Snarky.CVar.Scoped.of_le
+Snarky.CVar.eval_eq_val
+Snarky.CVar.val_of_le
+Snarky.CircuitType.Scoped
+Snarky.scoped_fvar_iff
+Snarky.scoped_prod_iff
+Snarky.scoped_ofEquiv_iff
+Snarky.CircuitType.Scoped.of_le
+Snarky.readVal_of_le
+Snarky.readVal_extendMany_new
+
 -- The alignment bridge: complete a run's table to a valuation, and tie an honest run
 -- to the soundness relation (Backend/{Assignments,WP}.lean).
 Snarky.Assignments.toValuation


### PR DESCRIPTION
Backport plan S3: scope, the total reading, scoped witness blocks (course `d868cbb`, `ada2466`, taken on the assignment reading of scope).

## Scope is assignment

`instance : Membership Variable (ProverState F) := ⟨fun st v => (st.env v).isSome⟩` — `v ∈ st` says the variable has a value. The course defined scope as "below the counter" and carried `Dom`; the codebase cannot: `compileBody` reserves the public output slots below the counter and back-fills them with `assignVars` after `main` has run, so between the seed and the back-fill those slots are holes below the counter by the wire layout. The invariant stays `FreshFrom`; in scope *means* readable, which is the property wanted in the first place.

The laws (`Backend/Prover.lean`), everything a proof uses of scope:

```lean
mem_of_le           : st.env.Le st'.env → v ∈ st → v ∈ st'
get_eq              : v ∈ st → st.env v = some (st.env.toValuation v)
get_of_le           : st.env.Le st'.env → v ∈ st → st'.env.toValuation v = st.env.toValuation v
mem_extendMany_iff  : v ∈ st.extendMany xs ↔ v ∈ st ∨ ∃ i, i < xs.length ∧ v = st.nv + i   -- @[simp]
new_mem_extendMany  : i < xs.length → st.nv + i ∈ st.extendMany xs
get_extendMany_new  : (st.extendMany xs).env.toValuation (st.nv + i) = xs[i]                -- @[simp]
get_extendMany_of_mem : v ∈ st → (st.extendMany xs).env.toValuation v = st.env.toValuation v -- @[simp]
```
`mem_lt` (in scope is below the counter) exists to prove these and nothing else. `mem_extendMany_iff` is an `iff` deliberately: `simp`'s discharge depth is 2, so a conditional `mem_extend` lemma fails on towers deeper than two allocations.

`ProverState.extendMany xs` is the state after an `existsOp`; `Assignments.extendList` is its table — the functional form of `extendPairs_consecutive` — with `extendList_below/above/get`, `FreshFrom.extendList`, `FreshFrom.le_extendList`, and `extendPairs_extendList` tying it to the interpreter's guarded write. `ProverState` is `@[ext]`.

## Scoped witness blocks

`AsProver.eval V` evaluates a block at a total reading (only `fail` fails; `eval_readCVar : (readCVar x).eval V = .ok (x.val V)`). `AsProver.Scoped st w`: every variable the block can read is in scope. `run_eq_eval : w.Scoped st → w.run st.env = w.eval st.env.toValuation` — a scoped block cannot fail on a lookup; `eval_congr` — it reads only in scope.

## Scope for expressions and bundles (`Backend/Read.lean`, now importing `Prover`)

`CVar.Scoped st` (structural), `CVar.eval_eq_val : x.Scoped st → x.eval st.env = .ok (x.val st.env.toValuation)` — the one bridge from the partial read to the total one — and `val_of_le`. `CircuitType.Scoped val st cv` (every cell), computed at the base/pair/presented instances by `scoped_fvar_iff`/`scoped_prod_iff`/`scoped_ofEquiv_iff` as `readVal` is; `readVal_of_le`; and

```lean
readVal_extendMany_new : readVal (st.extendMany (valueToFields v).toList).env.toValuation
    (fieldsToVar (mapVec CVar.var (allocRange st.nv size))) = v
```
— what a witness leaf grants, by `vars_roundTrip` and `value_roundTrip`, once, in place of every `WitnessReads.reads_of_grant` instance.

Nothing consumes these yet (S4 does); they are rooted in `roots.txt` as the prover-side reading vocabulary. No existing statement changes.

## Gates

`lake build Snarky Schnorr` clean; style ✓; deadcode 0; axioms (snarky, schnorr) ✓; lint ✓. (`make lean-shake`: the pre-existing `kimchi/Kimchi/Bits.lean` complaint from the `sound-native` stack.)

Stacked on #316 (S2).
