### PR TITLE
formal: the CS comparator runs at both fields, and compares both linearizations

### DIFF
--- a/formal/kimchi/KimchiFixture/PS.lean
+++ b/formal/kimchi/KimchiFixture/PS.lean
@@ -87,13 +87,13 @@ private def parseGateKind : String → Except String GateType
 /-- A witness-carrying PureScript circuit: the gate table columns of the dump and the
 solved witness. Wires are `(column, row)` targets in kimchi's cyclic-successor
 encoding, one per column position. -/
-structure Raw where
+structure Raw (F : Type) where
   /-- The circuit's declared public-input size. -/
   publicInputSize : ℕ
   /-- The gate type of each dumped row. -/
   typs : Array GateType
   /-- The per-row coefficient cells. -/
-  coeffs : Array (Array Fp)
+  coeffs : Array (Array F)
   /-- The per-row wire targets, `(column, row)` per column position. -/
   wires : Array (Array (ℕ × ℕ))
   /-- The raw variable id in each register cell, `none` for an empty cell (the dump's
@@ -102,9 +102,9 @@ structure Raw where
   shared counter's numbering. -/
   vars : Array (Array (Option ℕ))
   /-- The solved witness rows, one register array per row. -/
-  witness : Array (Array Fp)
+  witness : Array (Array F)
   /-- The public-input values. -/
-  pub : Array Fp
+  pub : Array F
 
 /-- A `{row, col}` wire object as a `(column, row)` target. -/
 private def parseWire (j : Json) : Except String (ℕ × ℕ) := do
@@ -117,7 +117,7 @@ private def parseVarId (j : Json) : Except String (Option ℕ) := do
 
 /-- The gate table of a comparison JSON's PureScript side — the shared parse under
 both entry points below. -/
-private def parseGates (ps : Json) : Except String Raw := do
+private def parseGates {m : ℕ} (ps : Json) : Except String (Raw (ZMod m)) := do
   let gatesJ ← (← ps.getObjVal? "gates").getArr?
   let typs ← gatesJ.mapM fun g => do parseGateKind (← (← g.getObjVal? "kind").getStr?)
   let coeffs ← gatesJ.mapM fun g => do
@@ -135,7 +135,7 @@ private def parseGates (ps : Json) : Except String Raw := do
 
 /-- The PureScript side of a comparison JSON; `none` when the JSON is not a comparison
 or carries no witness. -/
-def parseComparison? (j : Json) : Except String (Option Raw) := do
+def parseComparison? {m : ℕ} (j : Json) : Except String (Option (Raw (ZMod m))) := do
   let .ok ps := j.getObjVal? "purescript" | return none
   let .ok w := ps.getObjVal? "witness" | return none
   if w.isNull then return none
@@ -151,7 +151,7 @@ per-cell variable ids, public size — is present in every dump, witness-carryin
 not. The CS-equality corpus reads through this entry so witness-less circuits still
 prove constraint equivalence; `parseComparison?` keeps its witness-only contract for
 the witness checker, which globs the results directory and skips on `none`. -/
-def parseComparisonCs? (j : Json) : Except String (Option Raw) := do
+def parseComparisonCs? {m : ℕ} (j : Json) : Except String (Option (Raw (ZMod m))) := do
   let .ok ps := j.getObjVal? "purescript" | return none
   let raw ← parseGates ps
   match ps.getObjVal? "witness" with
@@ -168,8 +168,24 @@ def parseComparisonCs? (j : Json) : Except String (Option Raw) := do
 /-- kimchi's zero-knowledge row count (one chunk). -/
 def zkRows : ℕ := 3
 
-/-- The Pasta base fields' multiplicative generator (proof-systems `fp.rs` GENERATOR). -/
-private def fpGenerator : ℕ := 5
+/-- The field-specific data domain synthesis and the index need: the multiplicative
+generator (`ω` and the coset shifts are its powers), the curve's endomorphism coefficient
+and the Poseidon MDS matrix. -/
+structure Side (p : ℕ) where
+  /-- The multiplicative generator (proof-systems `fp.rs`/`fq.rs` GENERATOR). -/
+  generator : ℕ
+  /-- The endomorphism coefficient of the curve whose base field this is. -/
+  endo : ZMod p
+  /-- The Poseidon MDS matrix over this field. -/
+  mds : Gate.Poseidon.Mds (ZMod p)
+
+/-- The step side: `Fp`, Pallas's base field. -/
+def fpSide : Side PALLAS_BASE_CARD :=
+  ⟨5, Pasta.pallasEndo, Kimchi.Verifier.mdsOfParams Bulletproof.IpaVesta.curve.frParams⟩
+
+/-- The wrap side: `Fq`, Vesta's base field. -/
+def fqSide : Side PALLAS_SCALAR_CARD :=
+  ⟨5, Pasta.vestaEndo, Kimchi.Verifier.mdsOfParams Bulletproof.IpaPallas.curve.frParams⟩
 
 /-- Fast modular exponentiation (`Monoid.npow` on `ZMod` is linear in the exponent —
 unusable at 255-bit exponents). -/
@@ -180,36 +196,42 @@ private def powMod (b : ℕ) : ℕ → ℕ → ℕ
     if (e + 1) % 2 = 0 then h * h % m else h * h % m * (b % m) % m
 decreasing_by omega
 
+/-- The generator of the domain of size `n`: `g^((p − 1)/n)`. At `n = 2^32` this is arkworks'
+`TWO_ADIC_ROOT_OF_UNITY` (`g^((p−1)/2^s)` with `s = 32` for both Pasta fields), so at
+`n = 2^k` it is that root raised to `2^(32 − k)`, the PureScript `domainGenerator`. -/
+def Side.omega {p : ℕ} (side : Side p) (n : ℕ) : ZMod p :=
+  (powMod side.generator ((p - 1) / n) p : ℕ)
+
 /-! ## Ingestion into the index model -/
 
 /-- A solved witness at domain size `n`: the public input and the 15-column register
 table — the decoded `WitnessExport`, and exactly the assignment arguments of
 `Satisfies`. -/
-structure Witness (n publicCount : ℕ) where
+structure Witness (F : Type) (n publicCount : ℕ) where
   /-- The public-input values. -/
-  pub : Fin publicCount → Fp
+  pub : Fin publicCount → F
   /-- The register table, one row per domain point. -/
-  tab : Fin n → Fin wCols → Fp
+  tab : Fin n → Fin wCols → F
 
 /-- A dumped circuit ingested into the index model: the index (constructed by decision)
 and the dumped witness, at the padded two-power domain bundled as `n` (the domain size
 is computed from the dump, so the existential is carried as a field, in the manner of
 the index's own laws). Consumers state their own propositions about it
 (`Satisfies inst.idx inst.wit.pub inst.wit.tab`), the way the fixture scripts do. -/
-structure Instance where
+structure Instance (F : Type) [Field F] where
   /-- The padded two-power domain size. -/
   n : ℕ
   /-- The domain size is positive (carried, since `n` is computed from the dump). -/
   nz : NeZero n
   /-- The index constructed from the dump by decision (`Index.build?`). -/
-  idx : Index Fp n
+  idx : Index F n
   /-- The dumped witness, shaped to the index's public count. -/
-  wit : Witness n idx.publicCount
+  wit : Witness F n idx.publicCount
 
 /-- The gate table at padded domain size `n`: the dump's rows, then constraint-free
 `zero` gates, identity-wired and witnessed by zeros. -/
-private def gateTable (raw : Raw) (n : ℕ) :
-    Except String (Fin n → GateRow Fp n) := do
+private def gateTable {F : Type} [Field F] (raw : Raw F) (n : ℕ) :
+    Except String (Fin n → GateRow F n) := do
   let rows := raw.typs.size
   let gateRows ← (Array.range n).mapM fun i => do
     if hreal : i < rows then do
@@ -220,11 +242,11 @@ private def gateTable (raw : Raw) (n : ℕ) :
       if h7 : ws.size = 7 then
         return { typ := raw.typs[i]!
                  coeffs := fun c => (raw.coeffs[i]!).getD (c : ℕ) 0
-                 wires := fun c => ws[(c : ℕ)]'(by omega) : GateRow Fp n }
+                 wires := fun c => ws[(c : ℕ)]'(by omega) : GateRow F n }
       else throw s!"expected 7 wires at row {i}, got {ws.size}"
     else if hi : i < n then
       return { typ := .zero, coeffs := fun _ => 0
-               wires := fun c => (c, ⟨i, hi⟩) : GateRow Fp n }
+               wires := fun c => (c, ⟨i, hi⟩) : GateRow F n }
     else throw "row index out of the padded domain"
   if hsz : gateRows.size = n then
     return fun i => gateRows[(i : ℕ)]'(by omega)
@@ -235,7 +257,8 @@ holding the gates plus the zero-knowledge rows, synthesize `ω = g^((p−1)/n)` 
 generator-power coset shifts, and construct the index with `Index.build?` — every
 synthesized law is decided on the data, so a wrong synthesis is a loud failure here,
 never a trusted fact downstream. -/
-def build (raw : Raw) : Except String Instance := do
+def build {p : ℕ} [Fact p.Prime] (side : Side p) (raw : Raw (ZMod p)) :
+    Except String (Instance (ZMod p)) := do
   let rows := raw.typs.size
   unless raw.coeffs.size = rows ∧ raw.wires.size = rows do throw "gate array sizes differ"
   unless raw.witness.size = 15 do throw s!"expected 15 witness columns, got {raw.witness.size}"
@@ -243,14 +266,12 @@ def build (raw : Raw) : Except String Instance := do
   unless raw.pub.size = raw.publicInputSize do throw "publicInputs size ≠ publicInputSize"
   unless raw.publicInputSize ≤ rows do throw "more public inputs than rows"
   let n := 2 ^ Nat.clog 2 (rows + zkRows)
-  let omega : Fp := (powMod fpGenerator ((PALLAS_BASE_CARD - 1) / n) PALLAS_BASE_CARD : ℕ)
+  let omega := side.omega n
   -- Synthesized generator-power shifts, *not* production's Blake2b-sampled ones — sound for
   -- this driver's purpose (the laws it decides are shift-set-generic; external-audit A-15).
-  let shifts : Fin permCols → Fp := fun i => (powMod fpGenerator (i : ℕ) PALLAS_BASE_CARD : ℕ)
+  let shifts : Fin permCols → ZMod p := fun i => (powMod side.generator (i : ℕ) p : ℕ)
   let gates ← gateTable raw n
-  match Index.build? gates raw.publicInputSize zkRows omega
-      Pasta.pallasEndo (Kimchi.Verifier.mdsOfParams Bulletproof.IpaVesta.curve.frParams)
-      shifts with
+  match Index.build? gates raw.publicInputSize zkRows omega side.endo side.mds shifts with
   | none => throw "Index.build? rejected the padded dump (a synthesized law failed)"
   | some idx =>
     return { n := n

--- a/formal/kimchi/roots.txt
+++ b/formal/kimchi/roots.txt
@@ -240,6 +240,8 @@ Kimchi.Fixture.PS.Instance
 Kimchi.Fixture.PS.build
 Kimchi.Fixture.PS.parseComparison?
 Kimchi.Fixture.PS.parseComparisonCs?
+Kimchi.Fixture.PS.fpSide -- the step column's constants, scripts/check_cs.lean and check_ps_witness.lean
+Kimchi.Fixture.PS.fqSide -- the wrap column's constants, scripts/check_cs.lean
 Kimchi.Index.build?
 Kimchi.Index.instDecidableSatisfies -- synthesis: decide (Satisfies ..) in check_ps_witness.lean
 Kimchi.Permutation.primitiveRootCertificate

--- a/formal/kimchi/scripts/check_ps_witness.lean
+++ b/formal/kimchi/scripts/check_ps_witness.lean
@@ -21,7 +21,7 @@ def resultsDir : IO System.FilePath := do
     return ".." / ".." / "packages" / "pickles-circuit-diffs" / "circuits" / "results"
 
 /-- The checks for one ingested instance, named for the report. `none` = no target. -/
-def checks (inst : Instance) : List (String × Option Bool) :=
+def checks (inst : Instance Fp) : List (String × Option Bool) :=
   haveI : NeZero inst.n := inst.nz
   let wit := inst.wit
   let sat (w : Fin inst.n → Fin wCols → Fp) (p : Fin inst.idx.publicCount → Fp) : Bool :=
@@ -61,7 +61,7 @@ def main : IO Unit := do
     | .ok (some fx) => do
         checked := checked + 1
         let name := p.fileName.getD p.toString
-        match Kimchi.Fixture.PS.build fx with
+        match Kimchi.Fixture.PS.build Kimchi.Fixture.PS.fpSide fx with
         | .error e => do
             allOk := false
             IO.println s!"✗ {name}: {e}"

--- a/formal/scripts/check_cs.lean
+++ b/formal/scripts/check_cs.lean
@@ -30,9 +30,15 @@ checks are CS-side only). Deferred, with the blocker each waits on:
   (packages/random-oracle; FOP additionally the OptSponge variant);
 - group_map_step — activatable now (Basic-only), transcription pending a
   Tonelli–Shanks sqrt witness helper;
-- group_map_wrap, combine_poly_wrap — gadget-complete but Fq-side: this corpus is
-  Fp-typed throughout, so the wrap column needs an Fq mirror of the plumbing;
+- combine_poly_wrap — gadget-complete, pending a transcription of `combinePolynomials`;
 - app_circuit_chunks2 — Basic-only but a 39MB dump (~2^16 rows): ingestion cost.
+
+The corpus has two columns. The step circuits run at `Fp` (Pallas's base field) and the
+wrap circuits at `Fq` (Vesta's base field): the plumbing is generic in the field, and each
+target carries its side's constants (`KimchiFixture.PS.Side`: the multiplicative generator,
+the endomorphism coefficient and the MDS matrix). The wrap column holds the group map at
+Vesta's parameters and the wrap linearization over `Pickles.Linearization.fqTokens`, so
+both deployed token streams are compared against their PureScript circuits.
 
 The dumps are the PS suite's gitignored export: generate with
 `CIRCUIT_DIFFS_WITNESS_EXPORT=1 npx spago test -p pickles-circuit-diffs`. CI runs
@@ -51,6 +57,7 @@ import Snarky
 import Snarky.Kimchi.Backend.Compile
 import Pickles.Linearization.Circuit
 import Pickles.Linearization.Fp
+import Pickles.Linearization.Fq
 import Snarky.Kimchi.Circuit.AddComplete
 import Snarky.Kimchi.Circuit.GroupMap
 import Snarky.Kimchi.Circuit.Poseidon
@@ -83,9 +90,13 @@ def kindType : GateKind → GateType
 /-- `unpack`'s bit reads go through the canonical representative. -/
 instance : ToNat Fp := ⟨ZMod.val⟩
 
-/-- The kimchi constraint sum at the corpus field, the one instantiation every
-circuit below runs at. -/
+instance : ToNat Fq := ⟨ZMod.val⟩
+
+/-- The kimchi constraint sum at the step field. -/
 abbrev C := KimchiConstraint Fp
+
+/-- The kimchi constraint sum at the wrap field. -/
+abbrev Cq := KimchiConstraint Fq
 
 /-! ## The gadget circuits (transcribed from `Test.Pickles.CircuitDiffs.Main`) -/
 
@@ -191,8 +202,9 @@ def boolAssertCircuit (x : BoolVar Fp) : CircuitM Fp C PUnit :=
 /-- An assembled circuit in the fixture's `Raw` shape (witness transposed to the
 column-major recording) — the index round-trip ingests the LEAN output, so it holds
 with or without byte-agreement. -/
-def assembledRaw (rows : List (KimchiRow Fp)) (gates : List (AssembledGate Fp))
-    (pubSize : Nat) (wit : List (Vector Fp 15)) (pubs : List Fp) : Raw :=
+def assembledRaw {F : Type} [Zero F] (rows : List (KimchiRow F))
+    (gates : List (AssembledGate F)) (pubSize : Nat) (wit : List (Vector F 15))
+    (pubs : List F) : Raw F :=
   { publicInputSize := pubSize
     typs := (gates.map (kindType ·.kind)).toArray
     coeffs := (gates.map (·.coeffs.toArray)).toArray
@@ -206,9 +218,10 @@ def assembledRaw (rows : List (KimchiRow Fp)) (gates : List (AssembledGate Fp))
 /-- The round-trip law, decided per circuit: the compiled output padded into the
 index model builds by decision (`Index.build?` — domain shape, wiring bijectivity,
 public-row form) and the solved witness satisfies the verified checker. -/
-def indexRoundTrip (rows : List (KimchiRow Fp)) (gates : List (AssembledGate Fp))
-    (pubSize : Nat) (wit : List (Vector Fp 15)) (pubs : List Fp) : Bool :=
-  match Kimchi.Fixture.PS.build (assembledRaw rows gates pubSize wit pubs) with
+def indexRoundTrip {p : ℕ} [Fact p.Prime] (side : Kimchi.Fixture.PS.Side p)
+    (rows : List (KimchiRow (ZMod p))) (gates : List (AssembledGate (ZMod p)))
+    (pubSize : Nat) (wit : List (Vector (ZMod p) 15)) (pubs : List (ZMod p)) : Bool :=
+  match Kimchi.Fixture.PS.build side (assembledRaw rows gates pubSize wit pubs) with
   | .error _ => false
   | .ok inst =>
     haveI : NeZero inst.n := inst.nz
@@ -250,21 +263,10 @@ def scaleFast2_128Circuit (input : AffinePoint (FVar Fp) × FVar Fp) :
   scaleFast2' 255 26 127 input.1 input.2
 
 /-- The Pallas BW19 `setup()` parameters at the step field (PS
-`groupMapParams (Proxy @PallasG)`): the constants are the poseidon package's
-`Poseidon.GroupMapPallas` values; the non-residue is PS's search-from-2 result,
-`5`. The gates carry them as coefficients, so a wrong value fails the byte
-comparison itself. -/
-def groupMapParamsFp : GroupMapParams Fp :=
-  { u := 1
-  , fu := 6
-  , sqrtNeg3U2MinusUOver2 :=
-      8503465768106391777493614032514048814691664078728891710322960303815233784505
-  , sqrtNeg3U2 :=
-      17006931536212783554987228065028097629383328157457783420645920607630467569011
-  , inv3U2 :=
-      19298681539552699237261830834781317975575370987961040477303117842899978420225
-  , b := 5
-  , nonResidue := 5 }
+`groupMapParams (Proxy @PallasG)`): the poseidon package's `Poseidon.GroupMapPallas.spec`,
+with PS's search-from-2 non-residue, `5`. The gates carry them as coefficients, so a wrong
+value fails the byte comparison itself. -/
+def groupMapParamsFp : GroupMapParams Fp := .ofSpec Poseidon.GroupMapPallas.spec 5
 
 /-- `group_map_step_circuit` (the PS gadget
 `Snarky.Circuit.Kimchi.GroupMap.groupMapCircuit` at the step field and Pallas
@@ -386,7 +388,7 @@ def bulletReduceCircuit (input : Vector (FVar Fp) 75) : CircuitM Fp C PUnit := d
 sequences in row-major order building the id map both ways, and require a
 well-defined injection. A cell occupied on one side and empty on the other fails
 immediately, as does any pair of cells the two sides identify differently. -/
-def varsAgreeUpToRenaming (rows : List (KimchiRow Fp))
+def varsAgreeUpToRenaming {F : Type} (rows : List (KimchiRow F))
     (dumped : Array (Array (Option ℕ))) : Bool := Id.run do
   let lhs := rows.map (·.vars.toList)
   let rhs := dumped.toList.map (·.toList)
@@ -411,9 +413,11 @@ def varsAgreeUpToRenaming (rows : List (KimchiRow Fp))
 /-- Compare one circuit's assembled system and re-solved witness against its dump:
 the CS data (types, coefficients, wires, public size) is input-independent; the
 witness re-solve seeds the fixture's recorded public inputs. -/
-def compareWith {a b avar bvar : Type} [A : CircuitType Fp a avar]
-    [CheckedType Fp C a avar] [B : CircuitType Fp b bvar]
-    (main : avar → CircuitM Fp C bvar) (raw : Raw) : List (String × Bool) :=
+def compareWith {p : ℕ} [Fact p.Prime] (side : Kimchi.Fixture.PS.Side p)
+    {a b avar bvar : Type} [A : CircuitType (ZMod p) a avar]
+    [CheckedType (ZMod p) (KimchiConstraint (ZMod p)) a avar] [B : CircuitType (ZMod p) b bvar]
+    (main : avar → CircuitM (ZMod p) (KimchiConstraint (ZMod p)) bvar) (raw : Raw (ZMod p)) :
+    List (String × Bool) :=
   let (rows, gates, pubVars) := kimchiGateData (a := a) (b := b) main
   let pubSize := pubVars.length
   let csChecks :=
@@ -439,8 +443,28 @@ def compareWith {a b avar bvar : Type} [A : CircuitType Fp a avar]
           (List.range 15).map (fun j => wit.map fun row => row.toList.getD j 0)
             == raw.witness.toList.map (·.toList)),
         ("public values", pubs == raw.pub.toList),
-        ("index round-trip", indexRoundTrip rows gates pubSize wit pubs) ]
+        ("index round-trip", indexRoundTrip side rows gates pubSize wit pubs) ]
   csChecks ++ witChecks
+
+/-- A corpus entry: parse the dump at the target's field and compare. -/
+def target {p : ℕ} [Fact p.Prime] (side : Kimchi.Fixture.PS.Side p)
+    {a b avar bvar : Type} [CircuitType (ZMod p) a avar]
+    [CheckedType (ZMod p) (KimchiConstraint (ZMod p)) a avar] [CircuitType (ZMod p) b bvar]
+    (main : avar → CircuitM (ZMod p) (KimchiConstraint (ZMod p)) bvar) (j : Json) :
+    Except String (Option (Bool × List (String × Bool))) := do
+  match ← parseComparisonCs? (m := p) j with
+  | none => return none
+  | some raw => return some (raw.witness.isEmpty, compareWith side (a := a) (b := b) main raw)
+
+/-- A step-side entry. -/
+def stepTarget {a b avar bvar : Type} [CircuitType Fp a avar] [CheckedType Fp C a avar]
+    [CircuitType Fp b bvar] (main : avar → CircuitM Fp C bvar) :=
+  target Kimchi.Fixture.PS.fpSide (a := a) (b := b) main
+
+/-- A wrap-side entry. -/
+def wrapTarget {a b avar bvar : Type} [CircuitType Fq a avar] [CheckedType Fq Cq a avar]
+    [CircuitType Fq b bvar] (main : avar → CircuitM Fq Cq bvar) :=
+  target Kimchi.Fixture.PS.fqSide (a := a) (b := b) main
 
 /-! ## The linearization circuit
 
@@ -452,8 +476,8 @@ component of the first two is ever read, and `z`/`s` are not read at all. -/
 open Pickles.Linearization in
 /-- `α^0 … α^(n+1)`, by successive multiplication — 69 rows at the deployed length, and
 the reason the interpreter's `alphaPow` is a lookup rather than an exponentiation. -/
-def alphaGo (alpha : FVar Fp) : Nat → FVar Fp → Array (FVar Fp) →
-    CircuitM Fp C (Array (FVar Fp))
+def alphaGo {F : Type} [Field F] [DecidableEq F] (alpha : FVar F) :
+    Nat → FVar F → Array (FVar F) → CircuitM F (KimchiConstraint F) (Array (FVar F))
   | 0, _, acc => pure acc
   | n + 1, prev, acc => do
     let next ← Snarky.mul alpha prev
@@ -461,22 +485,21 @@ def alphaGo (alpha : FVar Fp) : Nat → FVar Fp → Array (FVar Fp) →
 
 open Pickles.Linearization in
 /-- The precomputed table: `[1, α, α², …, α^70]`. -/
-def precomputeAlphaPowers (alpha : FVar Fp) : CircuitM Fp C (Array (FVar Fp)) :=
+def precomputeAlphaPowers {F : Type} [Field F] [DecidableEq F] (alpha : FVar F) :
+    CircuitM F (KimchiConstraint F) (Array (FVar F)) :=
   alphaGo alpha 69 alpha #[.const 1, alpha]
 
-/-- The `2^log2`-th root of unity, from the field's two-adic root. Matches production's
-recorded `omega` (checked against `linearization_vesta.json`). -/
-def domainGenerator (log2 : Nat) : Fp :=
-  (0x2bce74deac30ebda362120830561f81aea322bf2b7bb7584bdad6fabd87ea32f : Fp) ^ (2 ^ (32 - log2))
-
 open Pickles.Linearization Kimchi.Protocol.Linearization in
-/-- The circuit under comparison. The `zkPoly` and `zeta^n - 1` terms are computed and
-DISCARDED: they emit rows the OCaml dump contains, so they are part of the constraint
+/-- The circuit under comparison, at either side: the domain generator (PS
+`domainGenerator`, matching production's recorded `omega`), the endomorphism coefficient
+and the MDS matrix all come from `side`. The `zkPoly` and `zeta^n - 1` terms are computed
+and DISCARDED: they emit rows the OCaml dump contains, so they are part of the constraint
 system being compared even though nothing reads them. -/
-def linearizationCircuit (domLog2 : Nat) (toks : Array PolishToken)
-    (inputs : Vector (FVar Fp) 90) : CircuitM Fp C (FVar Fp) := do
-  let get (i : Nat) : FVar Fp := inputs[i]?.getD (.const 0)
-  let gen := domainGenerator domLog2
+def linearizationCircuit {p : ℕ} [Fact p.Prime] (side : Kimchi.Fixture.PS.Side p)
+    (domLog2 : Nat) (toks : Array PolishToken) (inputs : Vector (FVar (ZMod p)) 90) :
+    CircuitM (ZMod p) (KimchiConstraint (ZMod p)) (FVar (ZMod p)) := do
+  let get (i : Nat) : FVar (ZMod p) := inputs[i]?.getD (.const 0)
+  let gen := side.omega (2 ^ domLog2)
   let om1 := gen⁻¹
   let om2 := om1 * om1
   let om3 := om2 * om1
@@ -488,7 +511,7 @@ def linearizationCircuit (domLog2 : Nat) (toks : Array PolishToken)
   let _ ← Snarky.mul t1 (CVar.sub_ zeta (.const om3))
   -- eager zeta^n - 1, discarded
   let _ ← Snarky.pow zeta (2 ^ domLog2)
-  let inp : Inputs Fp :=
+  let inp : Inputs (ZMod p) :=
     { evals :=
         { w i := get (2 * i)
           wOmega i := get (2 * i + 1)
@@ -507,61 +530,80 @@ def linearizationCircuit (domLog2 : Nat) (toks : Array PolishToken)
       gamma := get 88
       jointCombiner := .const 1
       vanishes := .const 1 }
-  evaluate (inp.toEnv Pasta.pallasEndo
-    (Kimchi.Verifier.mdsOfParams Bulletproof.IpaVesta.curve.frParams)
-    lookupZero (fun _ => false) (fun _ _ => pure (.const 0))) toks
+  evaluate (inp.toEnv side.endo side.mds lookupZero (fun _ => false)
+    (fun _ _ => pure (.const 0))) toks
 
-/-- The corpus under comparison: every witness-carrying `Basic`-gadget circuit. -/
-def targets : List (String × (Raw → List (String × Bool))) :=
-  [ ("mul_step_circuit", compareWith (a := Fp) (b := Fp) mulCircuit),
-    ("inv_step_circuit", compareWith (a := Fp) (b := Fp) invCircuit),
-    ("div_step_circuit", compareWith (a := Fp) (b := Fp) divCircuit),
-    ("if_step_circuit", compareWith (a := Fp) (b := Fp) ifCircuit),
-    ("equals_step_circuit", compareWith (a := Fp) (b := Bool) equalsCircuit),
-    ("pow7_step_circuit", compareWith (a := Fp) (b := Fp) pow7Circuit),
-    ("pow8_step_circuit", compareWith (a := Fp) (b := Fp) pow8Circuit),
-    ("assert_equal_step_circuit", compareWith (a := Fp) (b := PUnit) assertEqualCircuit),
+/-! ## The wrap column
+
+The library gadgets the wrap-side dumps exercise, at `Fq`: the group map at Vesta's
+parameters, and the linearization over the wrap token stream. -/
+
+/-- The Vesta BW19 `setup()` parameters at the wrap field (PS
+`groupMapParams (Proxy @VestaG)`): `Poseidon.GroupMapVesta.spec` with the same non-residue. -/
+def groupMapParamsFq : GroupMapParams Fq := .ofSpec Poseidon.GroupMapVesta.spec 5
+
+/-- `group_map_wrap_circuit` (the group-map gadget at the wrap field and Vesta parameters;
+the dump carries no witness, so the advice is inert here). -/
+def groupMapCircuitFq (input : FVar Fq) : CircuitM Fq Cq PUnit := do
+  let _ ← groupMapCircuit (fun _ => none) groupMapParamsFq input
+  pure ⟨⟩
+
+/-- The corpus under comparison: the step column, then the wrap column. -/
+def targets : List (String × (Json → Except String (Option (Bool × List (String × Bool))))) :=
+  [ ("mul_step_circuit", stepTarget (a := Fp) (b := Fp) mulCircuit),
+    ("inv_step_circuit", stepTarget (a := Fp) (b := Fp) invCircuit),
+    ("div_step_circuit", stepTarget (a := Fp) (b := Fp) divCircuit),
+    ("if_step_circuit", stepTarget (a := Fp) (b := Fp) ifCircuit),
+    ("equals_step_circuit", stepTarget (a := Fp) (b := Bool) equalsCircuit),
+    ("pow7_step_circuit", stepTarget (a := Fp) (b := Fp) pow7Circuit),
+    ("pow8_step_circuit", stepTarget (a := Fp) (b := Fp) pow8Circuit),
+    ("assert_equal_step_circuit", stepTarget (a := Fp) (b := PUnit) assertEqualCircuit),
     ("app_circuit_two_phase_chain_make_zero",
-      compareWith (a := Fp) (b := PUnit) makeZeroAppCircuit),
+      stepTarget (a := Fp) (b := PUnit) makeZeroAppCircuit),
     ("app_circuit_two_phase_chain_increment",
-      compareWith (a := Fp) (b := PUnit) incrementAppCircuit),
-    ("assert_square_step_circuit", compareWith (a := Fp) (b := PUnit) assertSquareCircuit),
+      stepTarget (a := Fp) (b := PUnit) incrementAppCircuit),
+    ("assert_square_step_circuit", stepTarget (a := Fp) (b := PUnit) assertSquareCircuit),
     ("assert_non_zero_step_circuit",
-      compareWith (a := Fp) (b := PUnit) assertNonZeroCircuit),
+      stepTarget (a := Fp) (b := PUnit) assertNonZeroCircuit),
     ("assert_not_equal_step_circuit",
-      compareWith (a := Fp) (b := PUnit) assertNotEqualCircuit),
-    ("unpack_step_circuit", compareWith (a := Fp) (b := PUnit) unpackCircuit),
-    ("bool_and_step_circuit", compareWith (a := Bool) (b := Bool) boolAndCircuit),
-    ("bool_or_step_circuit", compareWith (a := Bool) (b := Bool) boolOrCircuit),
-    ("bool_xor_step_circuit", compareWith (a := Bool) (b := Bool) boolXorCircuit),
-    ("bool_all_step_circuit", compareWith (a := Bool) (b := Bool) boolAllCircuit),
-    ("bool_any_step_circuit", compareWith (a := Bool) (b := Bool) boolAnyCircuit),
-    ("bool_assert_step_circuit", compareWith (a := Bool) (b := PUnit) boolAssertCircuit),
+      stepTarget (a := Fp) (b := PUnit) assertNotEqualCircuit),
+    ("unpack_step_circuit", stepTarget (a := Fp) (b := PUnit) unpackCircuit),
+    ("bool_and_step_circuit", stepTarget (a := Bool) (b := Bool) boolAndCircuit),
+    ("bool_or_step_circuit", stepTarget (a := Bool) (b := Bool) boolOrCircuit),
+    ("bool_xor_step_circuit", stepTarget (a := Bool) (b := Bool) boolXorCircuit),
+    ("bool_all_step_circuit", stepTarget (a := Bool) (b := Bool) boolAllCircuit),
+    ("bool_any_step_circuit", stepTarget (a := Bool) (b := Bool) boolAnyCircuit),
+    ("bool_assert_step_circuit", stepTarget (a := Bool) (b := PUnit) boolAssertCircuit),
     ("add_complete_step_circuit",
-      compareWith (a := AffinePoint Fp × AffinePoint Fp) (b := AffinePoint Fp)
+      stepTarget (a := AffinePoint Fp × AffinePoint Fp) (b := AffinePoint Fp)
         addCompleteCircuit),
     ("poseidon_step_circuit",
-      compareWith (a := Vector Fp 3) (b := Vector Fp 3) poseidonCircuit),
+      stepTarget (a := Vector Fp 3) (b := Vector Fp 3) poseidonCircuit),
     ("endo_scalar_step_circuit",
-      compareWith (a := Fp) (b := Fp) endoScalarCircuit),
+      stepTarget (a := Fp) (b := Fp) endoScalarCircuit),
     ("endo_mul_step_circuit",
-      compareWith (a := AffinePoint Fp × Fp) (b := AffinePoint Fp) endoMulCircuit),
+      stepTarget (a := AffinePoint Fp × Fp) (b := AffinePoint Fp) endoMulCircuit),
     ("var_base_mul_step_circuit",
-      compareWith (a := AffinePoint Fp × Fp) (b := AffinePoint Fp) varBaseMulCircuit),
+      stepTarget (a := AffinePoint Fp × Fp) (b := AffinePoint Fp) varBaseMulCircuit),
     ("scale_fast2_128_step_circuit",
-      compareWith (a := AffinePoint Fp × Fp) (b := AffinePoint Fp) scaleFast2_128Circuit),
+      stepTarget (a := AffinePoint Fp × Fp) (b := AffinePoint Fp) scaleFast2_128Circuit),
     ("group_map_step_circuit",
-      compareWith (a := Fp) (b := PUnit) groupMapCircuitFp),
-    ("pow2_pow_step_circuit", compareWith (a := Vector Fp 1) (b := PUnit) pow2PowCircuit),
+      stepTarget (a := Fp) (b := PUnit) groupMapCircuitFp),
+    ("pow2_pow_step_circuit", stepTarget (a := Vector Fp 1) (b := PUnit) pow2PowCircuit),
     ("b_correct_step_circuit",
-      compareWith (a := Vector Fp 20) (b := PUnit) bCorrectCircuit),
+      stepTarget (a := Vector Fp 20) (b := PUnit) bCorrectCircuit),
     ("bullet_reduce_one_step_circuit",
-      compareWith (a := Vector Fp 5) (b := PUnit) bulletReduceOneCircuit),
+      stepTarget (a := Vector Fp 5) (b := PUnit) bulletReduceOneCircuit),
     ("linearization_step_circuit",
-      compareWith (a := Vector Fp 90) (b := Fp)
-        (linearizationCircuit 16 Pickles.Linearization.fpTokens)),
+      stepTarget (a := Vector Fp 90) (b := Fp)
+        (linearizationCircuit Kimchi.Fixture.PS.fpSide 16 Pickles.Linearization.fpTokens)),
     ("bullet_reduce_step_circuit",
-      compareWith (a := Vector Fp 75) (b := PUnit) bulletReduceCircuit) ]
+      stepTarget (a := Vector Fp 75) (b := PUnit) bulletReduceCircuit),
+    -- the wrap column
+    ("group_map_wrap_circuit", wrapTarget (a := Fq) (b := PUnit) groupMapCircuitFq),
+    ("linearization_wrap_circuit",
+      wrapTarget (a := Vector Fq 90) (b := Fq)
+        (linearizationCircuit Kimchi.Fixture.PS.fqSide 15 Pickles.Linearization.fqTokens)) ]
 
 def main : IO Unit := do
   let dir ← resultsDir
@@ -569,17 +611,17 @@ def main : IO Unit := do
   for (name, compare) in targets do
     let path := dir / s!"{name}.json"
     let raw ← IO.FS.readFile path
-    match Json.parse raw >>= parseComparisonCs? with
+    match Json.parse raw >>= compare with
     | .error e =>
       failures := failures + 1
       IO.println s!"✗ {name}: parse error: {e}"
     | .ok none =>
       failures := failures + 1
       IO.println s!"✗ {name}: not a comparison dump"
-    | .ok (some fixture) =>
-      let bad := (compare fixture).filter (!·.2)
+    | .ok (some (witnessLess, checks)) =>
+      let bad := checks.filter (!·.2)
       if bad.isEmpty then
-        let note := if fixture.witness.isEmpty then "  (CS-side only: witness-less dump)" else ""
+        let note := if witnessLess then "  (CS-side only: witness-less dump)" else ""
         IO.println s!"✓ {name}{note}"
       else
         failures := failures + 1


### PR DESCRIPTION
The constraint-system comparator (`formal/scripts/check_cs.lean`) was Fp-typed throughout, so the wrap-side dumps had no checker and only the step linearization was compared against its PureScript circuit.

- `KimchiFixture.PS`: `Raw`, `Witness`, `Instance` are generic in the field; `build` takes a `Side p` (multiplicative generator, endomorphism coefficient, MDS matrix) with `fpSide` and `fqSide` the two Pasta instantiations.
- `check_cs.lean`: plumbing generic in the field, each target parsing and comparing at its own side; `linearizationCircuit` takes the two-adic root and the side's constants.
- New wrap column, library gadgets only: `group_map_wrap` at Vesta's BW19 parameters, and `linearization_wrap` over `fqTokens` at the wrap domain. Both deployed token streams are now compared against the PureScript circuits that evaluate them.

All 34 circuits match locally; the witness checker, style, dead-code and sorry-census gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmFR6wqY3UqVx7FrRDZ5Z3