### PR TITLE
pickles: the statement records in Lean, and kimchiVerify with the old accumulators

### DIFF
--- a/formal/CLAUDE.md
+++ b/formal/CLAUDE.md
@@ -16,8 +16,10 @@ reintroduce it, and do not read anything here as a soundness claim about the dep
 verifier. Circuit-side work states RELATIVE faithfulness — constraints satisfied ⟹
 `kimchiVerify` accepts — which needs no soundness result and asserts none.
 
-**The modeled fragment excludes lookups, optional gates, recursion, and the sub-SRS
-regime** — Mina/pickles proofs are OUTSIDE it on four axes; the canonical fragment
+**The modeled fragment excludes lookups, optional gates, and the sub-SRS regime, and
+transcribes recursion's old accumulators without fixture validation** (`kimchiVerify` takes
+them beside the proof; every fixture passes none) — Mina/pickles proofs are OUTSIDE it on
+the three excluded axes; the canonical fragment
 statement, with every declared deviation from `verifier.rs`, is the `## Scope` section of
 `Kimchi/Verifier/Kimchi.lean`'s preamble. The `Kimchi.*` namespace is **not** a circuit-DSL embedding: there is no `Circuit`
 monad, no `FormalCircuit`/`ProvableType`/`ElaboratedCircuit`, no `circuit_proof_start`.

--- a/formal/README.md
+++ b/formal/README.md
@@ -12,8 +12,9 @@ over witness structures and proved faithful to Mathlib's elliptic-curve group la
 (`WeierstrassCurve.Affine`). The verifier itself is a **specification** — the transcription
 of proof-systems' `kimchi/src/verifier.rs`, and the anchor circuit implementations are proved
 faithful to; the probabilistic soundness development this tree once carried was retired.
-**The modeled fragment excludes lookups, optional gates, recursion, and the sub-SRS
-regime** — Mina/pickles proofs are outside it on all four axes; the canonical fragment
+**The modeled fragment excludes lookups, optional gates, and the sub-SRS regime, and
+transcribes recursion's old accumulators without fixture validation** — Mina/pickles proofs
+are outside it on the three excluded axes; the canonical fragment
 statement is the `## Scope` section of `kimchi/Kimchi/Verifier/Kimchi.lean`'s preamble. A second library, `Snarky`, is a
 deep-embedded port of the PureScript circuit-building DSL, modelling how constraint systems
 are *constructed*; it is Mathlib-free by design and bridges to the verified generic-gate

--- a/formal/bulletproof-pcs/Bulletproof/Wire.lean
+++ b/formal/bulletproof-pcs/Bulletproof/Wire.lean
@@ -189,16 +189,16 @@ def shiftScalar (x : C.ScalarField) : C.ScalarField :=
   else Pasta.Shifted.shiftType2 (Nat.size C.scalar) x
 
 /-- One round of the challenge fold: absorb `L` and `R`, squeeze one challenge, push it. -/
-private def roundStep (acc : Array C.ScalarField × FqSponge.S C.base) (LR : C.Point × C.Point) :
-    Array C.ScalarField × FqSponge.S C.base :=
-  let us := squeezeChallenge C.sponge (absorbG C.sponge (absorbG C.sponge acc.2 LR.1) LR.2)
+private def roundStep (acc : Array ℕ × FqSponge.S C.base) (LR : C.Point × C.Point) :
+    Array ℕ × FqSponge.S C.base :=
+  let us := challengeNat C.sponge (absorbG C.sponge (absorbG C.sponge acc.2 LR.1) LR.2)
   (acc.1.push us.1, us.2)
 
-/-- The per-round challenge fold (the round loop of `SRS::verify`): absorb `L` and `R`,
-squeeze one challenge, threading the sponge state — one push per `(L, R)` pair. The
-array-level engine of `roundChallenges`; the fold state is concrete data. -/
+/-- The per-round prechallenge fold (the round loop of `SRS::verify`): absorb `L` and `R`,
+squeeze one 128-bit prechallenge, threading the sponge state — one push per `(L, R)`
+pair. The array-level engine of `roundChallenges`; the fold state is concrete data. -/
 def roundChallengesAux (s : FqSponge.S C.base) (lr : Array (C.Point × C.Point)) :
-    Array C.ScalarField × FqSponge.S C.base :=
+    Array ℕ × FqSponge.S C.base :=
   lr.foldl (roundStep C) (#[], s)
 
 /-- A left fold that pushes exactly one element per step grows the array by the list
@@ -222,30 +222,37 @@ theorem roundChallengesAux_size (s : FqSponge.S C.base) (lr : Array (C.Point × 
   · intro acc a
     simp [roundStep, Array.size_push]
 
-/-- The round challenges of a checked proof, from a given sponge state: the challenge
-vector — sized by construction, one challenge per round — and the post-fold sponge
-state. -/
+/-- The round prechallenges of a checked proof, from a given sponge state: the 128-bit
+vector — sized by construction, one per round — and the post-fold sponge state. -/
 def roundChallenges (s : FqSponge.S C.base) {k : ℕ} (lr : Vector (C.Point × C.Point) k) :
-    Vector C.ScalarField k × FqSponge.S C.base :=
+    Vector ℕ k × FqSponge.S C.base :=
   let r := roundChallengesAux C s lr.toArray
   (⟨r.1, (roundChallengesAux_size C s lr.toArray).trans lr.size_toArray⟩, r.2)
 
-/-- The verifier's Fiat–Shamir schedule from a given initial sponge state `s₀`
-(`SRS::verify`, with the sponge supplied by the caller — kimchi hands the warm post-`ζ`
-fq-sponge state here, `BatchEvaluationProof { sponge: fq_sponge, .. }`): absorb the
-shifted combined inner product; squeeze and map the `U` base; per round absorb `L`, `R`
-and squeeze a challenge; absorb `δ` and squeeze the Schnorr challenge. The round
-challenges come back as a `Vector` at the checked round count, so every downstream read
-is total. -/
-def transcriptFrom (s₀ : FqSponge.S C.base) (inp : Input C k m p) :
-    C.Point × Vector C.ScalarField k × C.ScalarField :=
+/-- What the verifier's Fiat–Shamir schedule produces from a given initial sponge state
+`s₀` (`SRS::verify`, with the sponge supplied by the caller — kimchi hands the warm
+post-`ζ` fq-sponge state here, `BatchEvaluationProof { sponge: fq_sponge, .. }`), before
+any expansion: absorb the shifted combined inner product; squeeze the `U` base's preimage
+`t`; per round absorb `L`, `R` and squeeze a 128-bit prechallenge; absorb `δ` and squeeze
+the Schnorr prechallenge. This is exactly what a circuit's group half emits
+(`Pickles.checkBulletproof`). The round prechallenges come back as a `Vector` at the
+checked round count, so every downstream read is total. -/
+def ipaRun (s₀ : FqSponge.S C.base) (inp : Input C k m p) :
+    C.BaseField × Vector ℕ k × ℕ :=
   let s := absorbFr C.sponge s₀ (shiftScalar C (cipOf inp))
   let (t, s) := challengeFq C.sponge s
-  let uBase := C.toGroup t
   let (chals, s) := roundChallenges C s inp.proof.lr
   let s := absorbG C.sponge s inp.proof.delta
-  let (c, _) := squeezeChallenge C.sponge s
-  (uBase, chals, c)
+  let (c, _) := challengeNat C.sponge s
+  (t, chals, c)
+
+/-- The verifier's Fiat–Shamir schedule from `s₀`: `ipaRun`, with the consumer's decodes
+applied — `t` mapped to the curve, the round and Schnorr prechallenges endo-expanded at the
+sponge's eigenvalue. -/
+def transcriptFrom (s₀ : FqSponge.S C.base) (inp : Input C k m p) :
+    C.Point × Vector C.ScalarField k × C.ScalarField :=
+  let (t, chals, c) := ipaRun C s₀ inp
+  (C.toGroup t, chals.map (endoExpand C.sponge.lam), endoExpand C.sponge.lam c)
 
 /-- The standalone verifier's Fiat–Shamir schedule: `transcriptFrom` at the fresh
 sponge `FqSponge.init` — the cold start. -/
@@ -358,40 +365,37 @@ private def coordsPair (q : C.Point × C.Point) :
     (C.BaseField × C.BaseField) × (C.BaseField × C.BaseField) :=
   ((q.1.x, q.1.y), (q.2.x, q.2.y))
 
-/-- The endo-expanded packing of a raw squeeze. -/
-private def expandRaw (x : C.BaseField) : C.ScalarField :=
-  endoExpand C.sponge.lam (x.val % 2 ^ 128)
+/-- The 128-bit packing of a raw squeeze. -/
+private def packRaw (x : C.BaseField) : ℕ := x.val % 2 ^ 128
 
 /-- The round fold from an empty limb buffer is `ipaRound` on the automaton, its
-challenges the expanded packings of the raw elements. -/
+prechallenges the packings of the raw elements. -/
 private theorem foldl_rounds (l : List (C.Point × C.Point)) (acc : List C.BaseField)
     (st : Poseidon.State C.BaseField) :
-    l.foldl (roundStep C) ((acc.map (expandRaw C)).toArray, ⟨st, []⟩)
+    l.foldl (roundStep C) ((acc.map (packRaw C)).toArray, ⟨st, []⟩)
       = let r := (l.map (coordsPair C)).foldl (ipaRound C.sponge.params) (acc, st)
-        ((r.1.map (expandRaw C)).toArray, ⟨r.2, []⟩) := by
+        ((r.1.map (packRaw C)).toArray, ⟨r.2, []⟩) := by
   induction l generalizing acc st with
   | nil => rfl
   | cons q l ih =>
     simp only [List.foldl_cons, List.map_cons, roundStep, absorbG, absorbFq,
-      squeezeChallenge_fresh, List.push_toArray, ipaRound, coordsPair]
+      challengeNat_fresh, List.push_toArray, ipaRound, coordsPair]
     generalize Poseidon.squeeze C.sponge.params (Poseidon.absorb C.sponge.params
       (Poseidon.absorb C.sponge.params st [q.1.x, q.1.y]) [q.2.x, q.2.y]) = sq
     have h := ih (acc ++ [sq.1]) sq.2
-    simp only [List.map_append, List.map_singleton, expandRaw] at h
+    simp only [List.map_append, List.map_singleton, packRaw] at h
     exact h
 
-/-- `transcriptFrom` from a warm state with an empty limb buffer, through
-`ipaPrechallenges`: the `U` base is the map-to-curve of `t`, the round challenges and `c`
-the endo-expansions of the packed squeezes. -/
-theorem transcriptFrom_eq_ipaPrechallenges (st : Poseidon.State C.BaseField)
-    (inp : Input C k m p) :
+/-- `ipaRun` from a warm state with an empty limb buffer is `ipaPrechallenges` on the
+automaton: the same `t`, the same packed round and Schnorr prechallenges. -/
+theorem ipaRun_eq_ipaPrechallenges (st : Poseidon.State C.BaseField) (inp : Input C k m p) :
     let r := ipaPrechallenges C.sponge.params st (scalarLimbs C (shiftScalar C (cipOf inp)))
       (inp.proof.lr.toList.map (coordsPair C)) (inp.proof.delta.x, inp.proof.delta.y)
-    (transcriptFrom C ⟨st, []⟩ inp).1 = C.toGroup r.1 ∧
-    (transcriptFrom C ⟨st, []⟩ inp).2.1.toList = r.2.1.map (endoExpand C.sponge.lam) ∧
-    (transcriptFrom C ⟨st, []⟩ inp).2.2 = endoExpand C.sponge.lam r.2.2 := by
+    (ipaRun C ⟨st, []⟩ inp).1 = r.1 ∧
+    (ipaRun C ⟨st, []⟩ inp).2.1.toList = r.2.1 ∧
+    (ipaRun C ⟨st, []⟩ inp).2.2 = r.2.2 := by
   dsimp only
-  unfold transcriptFrom
+  unfold ipaRun
   rw [absorbFr_eq]
   simp only [absorbFq, challengeFq]
   generalize hs : Poseidon.squeeze C.sponge.params
@@ -413,10 +417,23 @@ theorem transcriptFrom_eq_ipaPrechallenges (st : Poseidon.State C.BaseField)
   refine ⟨rfl, ?_, ?_⟩
   · show chals.toArray.toList = _
     rw [h1]
-    simp only [List.map_map, Function.comp_def]
-    unfold expandRaw
     rfl
-  · simp only [absorbG, absorbFq, squeezeChallenge_fresh]
+  · simp only [absorbG, absorbFq, challengeNat_fresh]
+
+/-- `transcriptFrom` from a warm state with an empty limb buffer, through
+`ipaPrechallenges`: the `U` base is the map-to-curve of `t`, the round challenges and `c`
+the endo-expansions of the packed squeezes. -/
+theorem transcriptFrom_eq_ipaPrechallenges (st : Poseidon.State C.BaseField)
+    (inp : Input C k m p) :
+    let r := ipaPrechallenges C.sponge.params st (scalarLimbs C (shiftScalar C (cipOf inp)))
+      (inp.proof.lr.toList.map (coordsPair C)) (inp.proof.delta.x, inp.proof.delta.y)
+    (transcriptFrom C ⟨st, []⟩ inp).1 = C.toGroup r.1 ∧
+    (transcriptFrom C ⟨st, []⟩ inp).2.1.toList = r.2.1.map (endoExpand C.sponge.lam) ∧
+    (transcriptFrom C ⟨st, []⟩ inp).2.2 = endoExpand C.sponge.lam r.2.2 := by
+  obtain ⟨h1, h2, h3⟩ := ipaRun_eq_ipaPrechallenges C st inp
+  simp only [transcriptFrom]
+  refine ⟨by rw [h1], ?_, by rw [h3]⟩
+  rw [Vector.toList_map, h2]
 
 /-- The Schnorr equation of the opening at given advice: `verifyWith`'s first conjunct
 with the combined inner product `cip` and the challenge-polynomial evaluation `b` as

--- a/formal/bulletproof-pcs/Bulletproof/Wire.lean
+++ b/formal/bulletproof-pcs/Bulletproof/Wire.lean
@@ -189,8 +189,8 @@ def shiftScalar (x : C.ScalarField) : C.ScalarField :=
   else Pasta.Shifted.shiftType2 (Nat.size C.scalar) x
 
 /-- One round of the challenge fold: absorb `L` and `R`, squeeze one challenge, push it. -/
-private def roundStep (acc : Array ℕ × FqSponge.S C.base) (LR : C.Point × C.Point) :
-    Array ℕ × FqSponge.S C.base :=
+private def roundStep (acc : Array Prechallenge × FqSponge.S C.base)
+    (LR : C.Point × C.Point) : Array Prechallenge × FqSponge.S C.base :=
   let us := challengeNat C.sponge (absorbG C.sponge (absorbG C.sponge acc.2 LR.1) LR.2)
   (acc.1.push us.1, us.2)
 
@@ -198,7 +198,7 @@ private def roundStep (acc : Array ℕ × FqSponge.S C.base) (LR : C.Point × C.
 squeeze one 128-bit prechallenge, threading the sponge state — one push per `(L, R)`
 pair. The array-level engine of `roundChallenges`; the fold state is concrete data. -/
 def roundChallengesAux (s : FqSponge.S C.base) (lr : Array (C.Point × C.Point)) :
-    Array ℕ × FqSponge.S C.base :=
+    Array Prechallenge × FqSponge.S C.base :=
   lr.foldl (roundStep C) (#[], s)
 
 /-- A left fold that pushes exactly one element per step grows the array by the list
@@ -225,7 +225,7 @@ theorem roundChallengesAux_size (s : FqSponge.S C.base) (lr : Array (C.Point × 
 /-- The round prechallenges of a checked proof, from a given sponge state: the 128-bit
 vector — sized by construction, one per round — and the post-fold sponge state. -/
 def roundChallenges (s : FqSponge.S C.base) {k : ℕ} (lr : Vector (C.Point × C.Point) k) :
-    Vector ℕ k × FqSponge.S C.base :=
+    Vector Prechallenge k × FqSponge.S C.base :=
   let r := roundChallengesAux C s lr.toArray
   (⟨r.1, (roundChallengesAux_size C s lr.toArray).trans lr.size_toArray⟩, r.2)
 
@@ -238,7 +238,7 @@ the Schnorr prechallenge. This is exactly what a circuit's group half emits
 (`Pickles.checkBulletproof`). The round prechallenges come back as a `Vector` at the
 checked round count, so every downstream read is total. -/
 def ipaRun (s₀ : FqSponge.S C.base) (inp : Input C k m p) :
-    C.BaseField × Vector ℕ k × ℕ :=
+    C.BaseField × Vector Prechallenge k × Prechallenge :=
   let s := absorbFr C.sponge s₀ (shiftScalar C (cipOf inp))
   let (t, s) := challengeFq C.sponge s
   let (chals, s) := roundChallenges C s inp.proof.lr
@@ -252,7 +252,8 @@ sponge's eigenvalue. -/
 def transcriptFrom (s₀ : FqSponge.S C.base) (inp : Input C k m p) :
     C.Point × Vector C.ScalarField k × C.ScalarField :=
   let (t, chals, c) := ipaRun C s₀ inp
-  (C.toGroup t, chals.map (endoExpand C.sponge.lam), endoExpand C.sponge.lam c)
+  (C.toGroup t, chals.map (fun u => endoExpand C.sponge.lam u.val),
+    endoExpand C.sponge.lam c.val)
 
 /-- The standalone verifier's Fiat–Shamir schedule: `transcriptFrom` at the fresh
 sponge `FqSponge.init` — the cold start. -/
@@ -366,7 +367,8 @@ private def coordsPair (q : C.Point × C.Point) :
   ((q.1.x, q.1.y), (q.2.x, q.2.y))
 
 /-- The 128-bit packing of a raw squeeze. -/
-private def packRaw (x : C.BaseField) : ℕ := x.val % 2 ^ 128
+private def packRaw (x : C.BaseField) : Prechallenge :=
+  ⟨x.val % 2 ^ 128, Nat.mod_lt _ (Nat.two_pow_pos _)⟩
 
 /-- The round fold from an empty limb buffer is `ipaRound` on the automaton, its
 prechallenges the packings of the raw elements. -/
@@ -387,13 +389,13 @@ private theorem foldl_rounds (l : List (C.Point × C.Point)) (acc : List C.BaseF
     exact h
 
 /-- `ipaRun` from a warm state with an empty limb buffer is `ipaPrechallenges` on the
-automaton: the same `t`, the same packed round and Schnorr prechallenges. -/
+automaton: the same `t`, the same packed round and Schnorr prechallenges (as naturals). -/
 theorem ipaRun_eq_ipaPrechallenges (st : Poseidon.State C.BaseField) (inp : Input C k m p) :
     let r := ipaPrechallenges C.sponge.params st (scalarLimbs C (shiftScalar C (cipOf inp)))
       (inp.proof.lr.toList.map (coordsPair C)) (inp.proof.delta.x, inp.proof.delta.y)
     (ipaRun C ⟨st, []⟩ inp).1 = r.1 ∧
-    (ipaRun C ⟨st, []⟩ inp).2.1.toList = r.2.1 ∧
-    (ipaRun C ⟨st, []⟩ inp).2.2 = r.2.2 := by
+    (ipaRun C ⟨st, []⟩ inp).2.1.toList.map Subtype.val = r.2.1 ∧
+    (ipaRun C ⟨st, []⟩ inp).2.2.val = r.2.2 := by
   dsimp only
   unfold ipaRun
   rw [absorbFr_eq]
@@ -415,9 +417,9 @@ theorem ipaRun_eq_ipaPrechallenges (st : Poseidon.State C.BaseField) (inp : Inpu
   unfold ipaPrechallenges ipaSqueezes
   rw [hs]
   refine ⟨rfl, ?_, ?_⟩
-  · show chals.toArray.toList = _
+  · show chals.toArray.toList.map Subtype.val = _
     rw [h1]
-    rfl
+    simp only [List.map_map, Function.comp_def, packRaw]
   · simp only [absorbG, absorbFq, challengeNat_fresh]
 
 /-- `transcriptFrom` from a warm state with an empty limb buffer, through
@@ -433,7 +435,7 @@ theorem transcriptFrom_eq_ipaPrechallenges (st : Poseidon.State C.BaseField)
   obtain ⟨h1, h2, h3⟩ := ipaRun_eq_ipaPrechallenges C st inp
   simp only [transcriptFrom]
   refine ⟨by rw [h1], ?_, by rw [h3]⟩
-  rw [Vector.toList_map, h2]
+  simp only [Vector.toList_map, ← h2, List.map_map, Function.comp_def]
 
 /-- The Schnorr equation of the opening at given advice: `verifyWith`'s first conjunct
 with the combined inner product `cip` and the challenge-polynomial evaluation `b` as

--- a/formal/kimchi/Kimchi.lean
+++ b/formal/kimchi/Kimchi.lean
@@ -60,8 +60,9 @@ soundness claim: the probabilistic soundness development this package once carri
 retired (see the module preamble of `Kimchi/Verifier/Kimchi.lean` for what the verifier
 does and does not model, and `git log` for the retired tree).
 
-**The modelled fragment excludes lookups, optional gates, recursion, and the sub-SRS
-regime.** The canonical statement of that scope, with every declared deviation from
+**The modelled fragment excludes lookups, optional gates, and the sub-SRS regime; the old
+accumulators of recursion are transcribed but validated by transcription only, every
+fixture carrying none.** The canonical statement of that scope, with every declared deviation from
 `verifier.rs`, is the `## Scope` section of `Kimchi/Verifier/Kimchi.lean`'s preamble. The
 package declares no axioms: every rooted result reduces to the standard logical axioms plus
 the Pasta trust base, which `scripts/check_axioms.sh` enforces.

--- a/formal/kimchi/Kimchi/Verifier/Kimchi.lean
+++ b/formal/kimchi/Kimchi/Verifier/Kimchi.lean
@@ -297,6 +297,14 @@ structure FqOracles (C : Ipa.CommitmentCurve) where
   /-- The pre-digest sponge state, continued by the IPA finish. -/
   warm : FqSponge.S C.base
 
+/-- The fr-sponge outputs of `oracles` (verifier.rs:284–405): the polyscale and the
+evalscale of the batch, expanded. -/
+structure FrOracles (C : Ipa.CommitmentCurve) where
+  /-- The polyscale `ξ` (verifier.rs `v`). -/
+  xi : C.ScalarField
+  /-- The evalscale `r` (verifier.rs `u`). -/
+  r : C.ScalarField
+
 /-- `x ^ (2 ^ k)` by `k` squarings. The domain-size exponents `ζⁿ` (`n = 2 ^ domainLog2`)
 would otherwise run through the linear `npowRec`, making `#eval` of the verifier
 impractical at production domain sizes. -/
@@ -444,27 +452,38 @@ theorem fqOracles_eq_fqPrechallenges {nc k m : ℕ} (cvk : KimchiVK C nc)
     absorbFq, FqSponge.init, ← Vector.foldl_toList, ← Array.foldl_toList, foldl_absorbG,
     foldl_cols, challengeNat_fresh, challengeFq, List.foldl_map]
 
+/-- What the fr-sponge run of `oracles` produces, before any expansion: the two 128-bit
+prechallenges. This is what a circuit's scalar half recomputes (`Pickles.squeezeXiR`);
+`FrRun.expand` is the consumer's step. -/
+structure FrRun where
+  /-- The `ξ` prechallenge (verifier.rs `v`). -/
+  xi : Prechallenge
+  /-- The `r` prechallenge (verifier.rs `u`). -/
+  r : Prechallenge
+
 /-- The fr-sponge schedule (verifier.rs:284–405): absorb `frTranscript`, with the
 recursion digest `recDigest` of the old accumulators' challenges, then squeeze the two
-128-bit prechallenges. What a circuit's scalar half recomputes (`Pickles.squeezeXiR`);
-`frOracles` is the consumer's expansion. -/
+128-bit prechallenges. Every squeeze is `challengeNat`. -/
 def frRun {nc k m : ℕ} (cp : KimchiProof C nc k)
     (fqDig : C.ScalarField) (pubEvals : PointEvaluations (Vector C.ScalarField nc))
-    (olds : Vector (Accumulator C k) m) : Prechallenge × Prechallenge :=
+    (olds : Vector (Accumulator C k) m) : FrRun :=
   let sp := frSpec C
   let s := absorbFq sp FqSponge.init
     (frTranscript fqDig (recDigest C (olds.map (·.u))) cp.ftEval1 pubEvals cp.evals)
-  let (v', s) := challengeNat sp s
-  let (u', _) := challengeNat sp s
-  (v', u')
+  let (xi, s) := challengeNat sp s
+  let (r, _) := challengeNat sp s
+  ⟨xi, r⟩
 
-/-- The fr-sponge oracles: the run's two prechallenges, endo-expanded at the sponge's
-eigenvalue — the polyscale and the evalscale. -/
+/-- The consumer's view of an fr-sponge run: both prechallenges endo-expanded at the
+sponge's eigenvalue — the polyscale and the evalscale. -/
+def FrRun.expand (x : FrRun) : FrOracles C :=
+  ⟨endoExpand C.sponge.lam x.xi.val, endoExpand C.sponge.lam x.r.val⟩
+
+/-- The fr-sponge oracles: the run, expanded. -/
 def frOracles {nc k m : ℕ} (cp : KimchiProof C nc k)
     (fqDig : C.ScalarField) (pubEvals : PointEvaluations (Vector C.ScalarField nc))
-    (olds : Vector (Accumulator C k) m) : C.ScalarField × C.ScalarField :=
-  let (v', u') := frRun C cp fqDig pubEvals olds
-  (endoExpand C.sponge.lam v'.val, endoExpand C.sponge.lam u'.val)
+    (olds : Vector (Accumulator C k) m) : FrOracles C :=
+  FrRun.expand C (frRun C cp fqDig pubEvals olds)
 
 /-- The fr-sponge's two 128-bit prechallenges over a transcript, as naturals: the values
 `challengeNat` packs from the two raw squeezes (`frSqueezes`), before the endomorphism
@@ -483,8 +502,9 @@ theorem frOracles_eq_frPrechallenges {nc k m : ℕ} (cp : KimchiProof C nc k)
     frOracles C cp fqDig pubEvals olds =
       let pre := frPrechallenges C.frParams
         (frTranscript fqDig (recDigest C (olds.map (·.u))) cp.ftEval1 pubEvals cp.evals)
-      (endoExpand C.sponge.lam pre.1, endoExpand C.sponge.lam pre.2) := by
-  simp only [frOracles, frRun, frPrechallenges, frSqueezes, absorbFq, challengeNat_fresh]
+      ⟨endoExpand C.sponge.lam pre.1, endoExpand C.sponge.lam pre.2⟩ := by
+  simp only [frOracles, FrRun.expand, frRun, frPrechallenges, frSqueezes, absorbFq,
+    challengeNat_fresh]
   rfl
 
 /-- A circuit's prechallenge `lo` is the verifier's `pre` (a packed squeeze, as a natural) up
@@ -717,7 +737,7 @@ def kimchiVerify {nc m : ℕ} (σ : SRS C.Point) (cvk : KimchiVK C nc)
     let shifts : Fin permCols → C.ScalarField := fun i => cvk.shifts[i]
     let ftEval0 := Kimchi.Protocol.Linearization.ftEval0 n cvk.zkRows cvk.omega shifts
       cvk.endo (mdsOfParams C.frParams) o.alpha o.beta o.gamma o.zeta pubEval0 e
-    let (v, u) := frOracles C cp o.digest pubEvals olds
+    let fr := frOracles C cp o.digest pubEvals olds
     let zkpmZ := Kimchi.Protocol.Linearization.zkpmEval n cvk.zkRows cvk.omega o.zeta
     let pScalar := Kimchi.Protocol.Linearization.permScalar o.beta o.gamma o.alpha zkpmZ e
     let fComm := cvk.sigmaComm[6].map (fun P => pScalar.val • P)
@@ -735,8 +755,8 @@ def kimchiVerify {nc m : ℕ} (σ : SRS C.Point) (cvk : KimchiVK C nc)
       { commitments := stream.map (·.1)
         xs := ⟨#[o.zeta, zetaOmega], rfl⟩
         evals := stream.map (fun r => (⟨#[r.2.1, r.2.2], rfl⟩ : Vector _ evalPts))
-        polyscale := v
-        evalscale := u
+        polyscale := fr.xi
+        evalscale := fr.r
         proof := cp.opening }
     Ipa.verifyFrom C σ o.warm inp
 

--- a/formal/kimchi/Kimchi/Verifier/Kimchi.lean
+++ b/formal/kimchi/Kimchi/Verifier/Kimchi.lean
@@ -308,13 +308,13 @@ state. This is exactly what a circuit's group half emits (`Pickles.fqSpongeTrans
 `FqRun.expand` is the consumer's step. -/
 structure FqRun (C : Ipa.CommitmentCurve) where
   /-- The `β` prechallenge. -/
-  beta : ℕ
+  beta : Prechallenge
   /-- The `γ` prechallenge. -/
-  gamma : ℕ
+  gamma : Prechallenge
   /-- The `α` prechallenge. -/
-  alpha : ℕ
+  alpha : Prechallenge
   /-- The `ζ` prechallenge. -/
-  zeta : ℕ
+  zeta : Prechallenge
   /-- The digest squeeze, a base-field element (`fq_sponge.clone().digest()` before its cast). -/
   digestElem : C.BaseField
   /-- The pre-digest sponge state, continued by the IPA finish. -/
@@ -339,8 +339,9 @@ def fqRun {nc k : ℕ} (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
 /-- The consumer's view of an fq-sponge run: `β, γ` cast into the scalar field, `α, ζ`
 endo-expanded at the sponge's eigenvalue, the digest cast. -/
 def FqRun.expand (r : FqRun C) : FqOracles C :=
-  ⟨(r.beta : C.ScalarField), (r.gamma : C.ScalarField), endoExpand C.sponge.lam r.alpha,
-    endoExpand C.sponge.lam r.zeta, castDigest C r.digestElem, r.warm⟩
+  ⟨(r.beta.val : C.ScalarField), (r.gamma.val : C.ScalarField),
+    endoExpand C.sponge.lam r.alpha.val, endoExpand C.sponge.lam r.zeta.val,
+    castDigest C r.digestElem, r.warm⟩
 
 /-- The fq-sponge oracles: the run, expanded. -/
 def fqOracles {nc k : ℕ} (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
@@ -423,7 +424,8 @@ recursion digest the fr-sponge digest of the empty recursion list, then squeeze 
 128-bit prechallenges. What a circuit's scalar half recomputes (`Pickles.squeezeXiR`);
 `frOracles` is the consumer's expansion. -/
 def frRun {nc k : ℕ} (cp : KimchiProof C nc k)
-    (fqDig : C.ScalarField) (pubEvals : PointEvaluations (Vector C.ScalarField nc)) : ℕ × ℕ :=
+    (fqDig : C.ScalarField) (pubEvals : PointEvaluations (Vector C.ScalarField nc)) :
+    Prechallenge × Prechallenge :=
   let sp := frSpec C
   let s := absorbFq sp FqSponge.init
     (frTranscript fqDig (frDigest C sp FqSponge.init) cp.ftEval1 pubEvals cp.evals)
@@ -437,7 +439,7 @@ def frOracles {nc k : ℕ} (cp : KimchiProof C nc k)
     (fqDig : C.ScalarField) (pubEvals : PointEvaluations (Vector C.ScalarField nc)) :
     C.ScalarField × C.ScalarField :=
   let (v', u') := frRun C cp fqDig pubEvals
-  (endoExpand C.sponge.lam v', endoExpand C.sponge.lam u')
+  (endoExpand C.sponge.lam v'.val, endoExpand C.sponge.lam u'.val)
 
 /-- The fr-sponge's two 128-bit prechallenges over a transcript, as naturals: the values
 `challengeNat` packs from the two raw squeezes (`frSqueezes`), before the endomorphism

--- a/formal/kimchi/Kimchi/Verifier/Kimchi.lean
+++ b/formal/kimchi/Kimchi/Verifier/Kimchi.lean
@@ -33,9 +33,13 @@ layers never import `Wire`.
 
 Every deferral is declared here.
 
-* no lookups (the wire records carry none) and no recursion (`prev_challenges`
-  absent) — but the *constant* fr-sponge absorb of the empty recursion list's digest
-  is transcribed (verifier.rs:290–299);
+* no lookups (the wire records carry none). The old accumulators (`prev_challenges`)
+  ARE transcribed: `kimchiVerify` takes them as a vector beside the proof, absorbed into
+  both sponges and opened at the head of the batch (verifier.rs:165–168, :290–299,
+  :311–329, :972–975). The wire records carry none and every fixture is at the empty
+  vector, so the recursion path is validated by transcription only; production's count
+  guard against the key's `prev_challenges` (verifier.rs:810–815) has no counterpart,
+  the wire key carrying no count (cf. the public-input count below);
 * the VK digest is an *input* (`KimchiVK.digest`); transcribing
   `VerifierIndex::digest()` (verifier_index.rs:399) is a declared deferral;
 * `linearization.index_terms` is empty at the basic gate set, so `f_comm` is the
@@ -186,6 +190,16 @@ structure KimchiProof (C : Ipa.CommitmentCurve) (nc k : ℕ) where
   /-- The batched IPA opening proof, at the SRS's round count `k`. -/
   opening : Ipa.Proof C k
 
+/-- An old accumulator (`RecursionChallenge`, proof.rs): a commitment the batch opens at
+the challenge polynomial of a previous opening — its final folded generator and the `k`
+endo-expanded round challenges. The verifier takes them beside the proof; production
+carries them inside it (`prev_challenges`). -/
+structure Accumulator (C : Ipa.CommitmentCurve) (k : ℕ) where
+  /-- The previous opening's final folded generator (`comm`, a single point). -/
+  sg : C.Point
+  /-- Its round challenges, endo-expanded into the scalar field (`chals`). -/
+  u : Vector C.ScalarField k
+
 /-- A chunk-validated verifier key. -/
 structure KimchiVK (C : Ipa.CommitmentCurve) (nc : ℕ) where
   /-- The domain size exponent: `n = 2 ^ domainLog2`. -/
@@ -249,6 +263,13 @@ plain first squeeze — same field, no cast. -/
 def frDigest (sp : FqSponge.Spec C.scalar C.scalar) (s : FqSponge.S C.scalar) :
     C.ScalarField :=
   (challengeFq sp s).1
+
+/-- The recursion digest (verifier.rs:290–299): the digest of a second fresh fr-sponge
+that absorbed every old accumulator's challenges in order. At no accumulators it is the
+constant `frDigest (frSpec C) FqSponge.init`. -/
+def recDigest {m k : ℕ} (us : Vector (Vector C.ScalarField k) m) : C.ScalarField :=
+  frDigest C (frSpec C)
+    (absorbFq (frSpec C) FqSponge.init (us.toList.map Vector.toList).flatten)
 
 /-- The cast of the fq-sponge digest into the scalar field (`DefaultFqSponge::digest`,
 sponge.rs:388–397, `from_bigint`): the representative, or **zero when the value does not
@@ -320,12 +341,14 @@ structure FqRun (C : Ipa.CommitmentCurve) where
   /-- The pre-digest sponge state, continued by the IPA finish. -/
   warm : FqSponge.S C.base
 
-/-- The fq-sponge schedule of `oracles` (verifier.rs:156–283): `absorb_commitment` is
-chunk-wise `absorbG`, so the public-commitment and per-column absorbs are chunk
-folds; the squeeze schedule is chunk-count-independent. Every squeeze is `challengeNat`. -/
-def fqRun {nc k : ℕ} (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
-    (publicComm : Vector C.Point nc) : FqRun C :=
+/-- The fq-sponge schedule of `oracles` (verifier.rs:156–283): the index digest, the old
+accumulators' commitments (:165–168), then `absorb_commitment` chunk-wise as `absorbG`,
+so the public-commitment and per-column absorbs are chunk folds; the squeeze schedule is
+chunk-count-independent. Every squeeze is `challengeNat`. -/
+def fqRun {nc k m : ℕ} (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
+    (publicComm : Vector C.Point nc) (olds : Vector (Accumulator C k) m) : FqRun C :=
   let s := absorbFq C.sponge FqSponge.init [cvk.digest]
+  let s := (olds.map (·.sg)).foldl (absorbG C.sponge) s
   let s := publicComm.foldl (absorbG C.sponge) s
   let s := cp.wComm.foldl (fun s col => col.foldl (absorbG C.sponge) s) s
   let (beta, s) := challengeNat C.sponge s
@@ -344,13 +367,13 @@ def FqRun.expand (r : FqRun C) : FqOracles C :=
     castDigest C r.digestElem, r.warm⟩
 
 /-- The fq-sponge oracles: the run, expanded. -/
-def fqOracles {nc k : ℕ} (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
-    (publicComm : Vector C.Point nc) : FqOracles C :=
-  (fqRun C cvk cp publicComm).expand
+def fqOracles {nc k m : ℕ} (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
+    (publicComm : Vector C.Point nc) (olds : Vector (Accumulator C k) m) : FqOracles C :=
+  (fqRun C cvk cp publicComm olds).expand
 
 /-- The fq-sponge run of `oracles` over the Poseidon automaton (verifier.rs:156–283), the
-commitments as coordinate pairs and pickles' recursion commitments absorbed after the index
-digest (kimchi: `[]`): the four raw squeezed elements behind `β, γ, α, ζ`, the digest
+commitments as coordinate pairs and the old accumulators' commitments absorbed after the
+index digest: the four raw squeezed elements behind `β, γ, α, ζ`, the digest
 element, and the pre-digest state. The circuit's fq-sponge is stated over this. -/
 def fqSqueezes {F : Type*} [Field F] (p : Poseidon.Params F) (indexDigest : F)
     (recursion pubComm : List (F × F)) (wComm : List (List (F × F)))
@@ -405,10 +428,12 @@ private theorem foldl_cols {nc : ℕ} (cols : List (Vector C.Point nc))
 `α, ζ` their endo-expansions (`squeezeChallenge`), the digest the `from_bigint` cast of the
 digest element (zero when it does not fit), and the warm state the pre-digest state with an
 empty limb buffer. -/
-theorem fqOracles_eq_fqPrechallenges {nc k : ℕ} (cvk : KimchiVK C nc)
-    (cp : KimchiProof C nc k) (publicComm : Vector C.Point nc) :
-    fqOracles C cvk cp publicComm =
-      let r := fqPrechallenges C.sponge.params cvk.digest [] (coords C publicComm)
+theorem fqOracles_eq_fqPrechallenges {nc k m : ℕ} (cvk : KimchiVK C nc)
+    (cp : KimchiProof C nc k) (publicComm : Vector C.Point nc)
+    (olds : Vector (Accumulator C k) m) :
+    fqOracles C cvk cp publicComm olds =
+      let r := fqPrechallenges C.sponge.params cvk.digest (coords C (olds.map (·.sg)))
+        (coords C publicComm)
         (cp.wComm.toList.map (coords C)) (coords C cp.zComm)
         (cp.tComm.toList.map fun P => (P.x, P.y))
       ⟨(r.1.1 : C.ScalarField), (r.1.2.1 : C.ScalarField), endoExpand C.sponge.lam r.1.2.2.1,
@@ -417,28 +442,28 @@ theorem fqOracles_eq_fqPrechallenges {nc k : ℕ} (cvk : KimchiVK C nc)
         ⟨r.2.2, []⟩⟩ := by
   simp only [fqOracles, FqRun.expand, fqRun, castDigest, fqPrechallenges, fqSqueezes, coords,
     absorbFq, FqSponge.init, ← Vector.foldl_toList, ← Array.foldl_toList, foldl_absorbG,
-    foldl_cols, challengeNat_fresh, challengeFq, List.foldl_map, List.foldl_nil]
+    foldl_cols, challengeNat_fresh, challengeFq, List.foldl_map]
 
 /-- The fr-sponge schedule (verifier.rs:284–405): absorb `frTranscript`, with the
-recursion digest the fr-sponge digest of the empty recursion list, then squeeze the two
+recursion digest `recDigest` of the old accumulators' challenges, then squeeze the two
 128-bit prechallenges. What a circuit's scalar half recomputes (`Pickles.squeezeXiR`);
 `frOracles` is the consumer's expansion. -/
-def frRun {nc k : ℕ} (cp : KimchiProof C nc k)
-    (fqDig : C.ScalarField) (pubEvals : PointEvaluations (Vector C.ScalarField nc)) :
-    Prechallenge × Prechallenge :=
+def frRun {nc k m : ℕ} (cp : KimchiProof C nc k)
+    (fqDig : C.ScalarField) (pubEvals : PointEvaluations (Vector C.ScalarField nc))
+    (olds : Vector (Accumulator C k) m) : Prechallenge × Prechallenge :=
   let sp := frSpec C
   let s := absorbFq sp FqSponge.init
-    (frTranscript fqDig (frDigest C sp FqSponge.init) cp.ftEval1 pubEvals cp.evals)
+    (frTranscript fqDig (recDigest C (olds.map (·.u))) cp.ftEval1 pubEvals cp.evals)
   let (v', s) := challengeNat sp s
   let (u', _) := challengeNat sp s
   (v', u')
 
 /-- The fr-sponge oracles: the run's two prechallenges, endo-expanded at the sponge's
 eigenvalue — the polyscale and the evalscale. -/
-def frOracles {nc k : ℕ} (cp : KimchiProof C nc k)
-    (fqDig : C.ScalarField) (pubEvals : PointEvaluations (Vector C.ScalarField nc)) :
-    C.ScalarField × C.ScalarField :=
-  let (v', u') := frRun C cp fqDig pubEvals
+def frOracles {nc k m : ℕ} (cp : KimchiProof C nc k)
+    (fqDig : C.ScalarField) (pubEvals : PointEvaluations (Vector C.ScalarField nc))
+    (olds : Vector (Accumulator C k) m) : C.ScalarField × C.ScalarField :=
+  let (v', u') := frRun C cp fqDig pubEvals olds
   (endoExpand C.sponge.lam v'.val, endoExpand C.sponge.lam u'.val)
 
 /-- The fr-sponge's two 128-bit prechallenges over a transcript, as naturals: the values
@@ -449,14 +474,15 @@ def frPrechallenges {p : ℕ} [Field (ZMod p)] (params : Poseidon.Params (ZMod p
   let sq := frSqueezes params transcript
   (sq.1.val % 2 ^ 128, sq.2.val % 2 ^ 128)
 
-/-- `frOracles` is the endo-expansion of `frPrechallenges` over `frTranscript` at the empty
-recursion list's digest: `challengeNat` from an empty limb buffer is one raw squeeze's value
-mod `2^128`. -/
-theorem frOracles_eq_frPrechallenges {nc k : ℕ} (cp : KimchiProof C nc k)
-    (fqDig : C.ScalarField) (pubEvals : PointEvaluations (Vector C.ScalarField nc)) :
-    frOracles C cp fqDig pubEvals =
+/-- `frOracles` is the endo-expansion of `frPrechallenges` over `frTranscript` at the old
+accumulators' `recDigest`: `challengeNat` from an empty limb buffer is one raw squeeze's
+value mod `2^128`. -/
+theorem frOracles_eq_frPrechallenges {nc k m : ℕ} (cp : KimchiProof C nc k)
+    (fqDig : C.ScalarField) (pubEvals : PointEvaluations (Vector C.ScalarField nc))
+    (olds : Vector (Accumulator C k) m) :
+    frOracles C cp fqDig pubEvals olds =
       let pre := frPrechallenges C.frParams
-        (frTranscript fqDig (frDigest C (frSpec C) FqSponge.init) cp.ftEval1 pubEvals cp.evals)
+        (frTranscript fqDig (recDigest C (olds.map (·.u))) cp.ftEval1 pubEvals cp.evals)
       (endoExpand C.sponge.lam pre.1, endoExpand C.sponge.lam pre.2) := by
   simp only [frOracles, frRun, frPrechallenges, frSqueezes, absorbFq, challengeNat_fresh]
   rfl
@@ -661,11 +687,14 @@ verifier.rs:781–1194, one proof, basic gate set): the two remaining argument-d
 guards (the public input against the domain and the Lagrange table); the per-chunk
 public commitment; the Fiat–Shamir schedules at chunk absorbs; the scalar side on
 chunk-COMBINED evaluations; the `ft_comm` double collapse at `ζ^max_poly_size`
-(:960–965); the 45 logical rows in `to_batch` order flattened to the SEGMENT stream
-(one flat row per chunk, ft single — the per-chunk polyscale walk of
-`combined_inner_product`/`combine_commitments`); the warm-sponge IPA finish. -/
-def kimchiVerify {nc : ℕ} (σ : SRS C.Point) (cvk : KimchiVK C nc)
-    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) : Bool :=
+(:960–965); the old accumulators' rows (:972–975, each a single segment: the commitment
+at the challenge polynomial of its round challenges) then the 45 logical rows in
+`to_batch` order flattened to the SEGMENT stream (one flat row per chunk, ft single —
+the per-chunk polyscale walk of `combined_inner_product`/`combine_commitments`); the
+warm-sponge IPA finish. -/
+def kimchiVerify {nc m : ℕ} (σ : SRS C.Point) (cvk : KimchiVK C nc)
+    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    (olds : Vector (Accumulator C σ.k) m) : Bool :=
   let n := cvk.n
   -- Production's guard here is the exact count `public_input.len() != verifier_index.public`
   -- (verifier.rs:816–820); the wire key carries no count, so these two bounds
@@ -674,7 +703,7 @@ def kimchiVerify {nc : ℕ} (σ : SRS C.Point) (cvk : KimchiVK C nc)
     false
   else
     let publicComm := publicCommitment C σ cvk pub
-    let o := fqOracles C cvk cp publicComm
+    let o := fqOracles C cvk cp publicComm olds
     let zetaOmega := o.zeta * cvk.omega
     let zetaN := powPow2 o.zeta cvk.domainLog2
     let zetaOmegaN := powPow2 zetaOmega cvk.domainLog2
@@ -686,19 +715,21 @@ def kimchiVerify {nc : ℕ} (σ : SRS C.Point) (cvk : KimchiVK C nc)
     let shifts : Fin permCols → C.ScalarField := fun i => cvk.shifts[i]
     let ftEval0 := Kimchi.Protocol.Linearization.ftEval0 n cvk.zkRows cvk.omega shifts
       cvk.endo (mdsOfParams C.frParams) o.alpha o.beta o.gamma o.zeta pubEval0 e
-    let (v, u) := frOracles C cp o.digest pubEvals
+    let (v, u) := frOracles C cp o.digest pubEvals olds
     let zkpmZ := Kimchi.Protocol.Linearization.zkpmEval n cvk.zkRows cvk.omega o.zeta
     let pScalar := Kimchi.Protocol.Linearization.permScalar o.beta o.gamma o.alpha zkpmZ e
     let fComm := cvk.sigmaComm[6].map (fun P => pScalar.val • P)
     let ftComm := Ipa.combineCommitments C zetaM fComm.toArray
       - (zetaN - 1).val • Ipa.combineCommitments C zetaM cp.tComm
-    let stream : Vector (C.Point × C.ScalarField × C.ScalarField) (nc + 1 + tailRowCount * nc) :=
-      (Vector.ofFn fun c : Fin nc =>
-          (publicComm[c], pubEvals.zeta[c], pubEvals.zetaOmega[c]))
-        ++ (⟨#[(ftComm, ftEval0, cp.ftEval1)], rfl⟩
-            : Vector (C.Point × C.ScalarField × C.ScalarField) 1)
-        ++ (tailRowsOf C cvk cp).flatten
-    let inp : Ipa.Input C σ.k (nc + 1 + tailRowCount * nc) evalPts :=
+    let stream : Vector (C.Point × C.ScalarField × C.ScalarField)
+        (m + (nc + 1 + tailRowCount * nc)) :=
+      olds.map (fun a => (a.sg, bPoly a.u.get o.zeta, bPoly a.u.get zetaOmega))
+        ++ ((Vector.ofFn fun c : Fin nc =>
+              (publicComm[c], pubEvals.zeta[c], pubEvals.zetaOmega[c]))
+            ++ (⟨#[(ftComm, ftEval0, cp.ftEval1)], rfl⟩
+                : Vector (C.Point × C.ScalarField × C.ScalarField) 1)
+            ++ (tailRowsOf C cvk cp).flatten)
+    let inp : Ipa.Input C σ.k (m + (nc + 1 + tailRowCount * nc)) evalPts :=
       { commitments := stream.map (·.1)
         xs := ⟨#[o.zeta, zetaOmega], rfl⟩
         evals := stream.map (fun r => (⟨#[r.2.1, r.2.2], rfl⟩ : Vector _ evalPts))

--- a/formal/kimchi/Kimchi/Verifier/Kimchi.lean
+++ b/formal/kimchi/Kimchi/Verifier/Kimchi.lean
@@ -487,18 +487,20 @@ theorem frOracles_eq_frPrechallenges {nc k m : ℕ} (cp : KimchiProof C nc k)
   simp only [frOracles, frRun, frPrechallenges, frSqueezes, absorbFq, challengeNat_fresh]
   rfl
 
-/-- `lo` is the prechallenge `pre` up to the wrap-around slack of a 128-bit decomposition:
-`pre` itself (`k = 0`) or one of at most three aliases `(pre + k·p) mod 2¹²⁸`. -/
-def PrechallengeAlias (p pre lo : ℕ) : Prop :=
-  ∃ k ≤ 3, lo = (pre + k * p) % 2 ^ 128
+/-- A circuit's prechallenge `lo` is the verifier's `pre` (a packed squeeze, as a natural) up
+to the wrap-around slack of a 128-bit decomposition: `pre` itself (`k = 0`) or one of at most
+three aliases `(pre + k·p) mod 2¹²⁸`. -/
+def PrechallengeAlias (p pre : ℕ) (lo : Prechallenge) : Prop :=
+  ∃ k ≤ 3, lo.val = (pre + k * p) % 2 ^ 128
 
 /-- The slack the circuit's `lowest_128_bits` leaves: a decomposition `x = lo + 2¹²⁸·hi` with
-`lo, hi < 2¹²⁸` need not be the canonical one, since `2²⁵⁶` exceeds the modulus, so `lo` is
-the prechallenge `x.val % 2¹²⁸` only up to `PrechallengeAlias`. -/
-theorem low128_of_decomp {p : ℕ} (hp : 2 ^ 254 < p) (x : ZMod p) (lo hi : ℕ)
-    (hlo : lo < 2 ^ 128) (hhi : hi < 2 ^ 128)
-    (h : x = (lo : ZMod p) + 2 ^ 128 * (hi : ZMod p)) :
+`hi < 2¹²⁸` need not be the canonical one, since `2²⁵⁶` exceeds the modulus, so `lo` is the
+prechallenge `x.val % 2¹²⁸` only up to `PrechallengeAlias`. -/
+theorem low128_of_decomp {p : ℕ} (hp : 2 ^ 254 < p) (x : ZMod p) (lo : Prechallenge) (hi : ℕ)
+    (hhi : hi < 2 ^ 128) (h : x = (lo.val : ZMod p) + 2 ^ 128 * (hi : ZMod p)) :
     PrechallengeAlias p (x.val % 2 ^ 128) lo := by
+  obtain ⟨lo, hlo⟩ := lo
+  simp only [PrechallengeAlias] at *
   have hN : ((lo + 2 ^ 128 * hi : ℕ) : ZMod p) = x := by rw [h]; push_cast; ring
   have hv : (lo + 2 ^ 128 * hi) % p = x.val := by rw [← ZMod.val_natCast, hN]
   have hN' : x.val + (lo + 2 ^ 128 * hi) / p * p = lo + 2 ^ 128 * hi := by

--- a/formal/kimchi/Kimchi/Verifier/Kimchi.lean
+++ b/formal/kimchi/Kimchi/Verifier/Kimchi.lean
@@ -250,12 +250,11 @@ def frDigest (sp : FqSponge.Spec C.scalar C.scalar) (s : FqSponge.S C.scalar) :
     C.ScalarField :=
   (challengeFq sp s).1
 
-/-- The fq-sponge digest (`DefaultFqSponge::digest`, sponge.rs:388–397): squeeze one base
-element and cast it to the scalar field by `from_bigint`, which returns **zero when the
-value does not fit** — not a modular reduction. The state is consumed (production takes
-`mut self`); the caller keeps its pre-digest copy. -/
-private def fqDigest (s : FqSponge.S C.base) : C.ScalarField :=
-  let (x, _) := challengeFq C.sponge s
+/-- The cast of the fq-sponge digest into the scalar field (`DefaultFqSponge::digest`,
+sponge.rs:388–397, `from_bigint`): the representative, or **zero when the value does not
+fit** — not a modular reduction. The consumer's step: the sponge only produces the
+base-field element (`FqRun.digestElem`). -/
+def castDigest (x : C.BaseField) : C.ScalarField :=
   if x.val < C.scalar then ((x.val : ℕ) : C.ScalarField) else 0
 
 /-! ## The oracle outputs and the public evaluations -/
@@ -303,21 +302,50 @@ private def publicEvals {F : Type*} [Field F] (n : ℕ)
 
 /-! ## The Fiat–Shamir schedules -/
 
+/-- What the fq-sponge run of `oracles` produces, before any cast or expansion: the four
+128-bit prechallenges, the digest element (in the base field), and the **warm** post-`ζ`
+state. This is exactly what a circuit's group half emits (`Pickles.fqSpongeTranscript`);
+`FqRun.expand` is the consumer's step. -/
+structure FqRun (C : Ipa.CommitmentCurve) where
+  /-- The `β` prechallenge. -/
+  beta : ℕ
+  /-- The `γ` prechallenge. -/
+  gamma : ℕ
+  /-- The `α` prechallenge. -/
+  alpha : ℕ
+  /-- The `ζ` prechallenge. -/
+  zeta : ℕ
+  /-- The digest squeeze, a base-field element (`fq_sponge.clone().digest()` before its cast). -/
+  digestElem : C.BaseField
+  /-- The pre-digest sponge state, continued by the IPA finish. -/
+  warm : FqSponge.S C.base
+
 /-- The fq-sponge schedule of `oracles` (verifier.rs:156–283): `absorb_commitment` is
 chunk-wise `absorbG`, so the public-commitment and per-column absorbs are chunk
-folds; the squeeze schedule is chunk-count-independent. -/
-def fqOracles {nc k : ℕ} (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
-    (publicComm : Vector C.Point nc) : FqOracles C :=
+folds; the squeeze schedule is chunk-count-independent. Every squeeze is `challengeNat`. -/
+def fqRun {nc k : ℕ} (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
+    (publicComm : Vector C.Point nc) : FqRun C :=
   let s := absorbFq C.sponge FqSponge.init [cvk.digest]
   let s := publicComm.foldl (absorbG C.sponge) s
   let s := cp.wComm.foldl (fun s col => col.foldl (absorbG C.sponge) s) s
-  let (beta, s) := challenge C.sponge s
-  let (gamma, s) := challenge C.sponge s
+  let (beta, s) := challengeNat C.sponge s
+  let (gamma, s) := challengeNat C.sponge s
   let s := cp.zComm.foldl (absorbG C.sponge) s
-  let (alpha, s) := squeezeChallenge C.sponge s
+  let (alpha, s) := challengeNat C.sponge s
   let s := cp.tComm.foldl (absorbG C.sponge) s
-  let (zeta, s) := squeezeChallenge C.sponge s
-  ⟨beta, gamma, alpha, zeta, fqDigest C s, s⟩
+  let (zeta, s) := challengeNat C.sponge s
+  ⟨beta, gamma, alpha, zeta, (challengeFq C.sponge s).1, s⟩
+
+/-- The consumer's view of an fq-sponge run: `β, γ` cast into the scalar field, `α, ζ`
+endo-expanded at the sponge's eigenvalue, the digest cast. -/
+def FqRun.expand (r : FqRun C) : FqOracles C :=
+  ⟨(r.beta : C.ScalarField), (r.gamma : C.ScalarField), endoExpand C.sponge.lam r.alpha,
+    endoExpand C.sponge.lam r.zeta, castDigest C r.digestElem, r.warm⟩
+
+/-- The fq-sponge oracles: the run, expanded. -/
+def fqOracles {nc k : ℕ} (cvk : KimchiVK C nc) (cp : KimchiProof C nc k)
+    (publicComm : Vector C.Point nc) : FqOracles C :=
+  (fqRun C cvk cp publicComm).expand
 
 /-- The fq-sponge run of `oracles` over the Poseidon automaton (verifier.rs:156–283), the
 commitments as coordinate pairs and pickles' recursion commitments absorbed after the index
@@ -386,21 +414,29 @@ theorem fqOracles_eq_fqPrechallenges {nc k : ℕ} (cvk : KimchiVK C nc)
         endoExpand C.sponge.lam r.1.2.2.2,
         (if r.2.1.val < C.scalar then ((r.2.1.val : ℕ) : C.ScalarField) else 0),
         ⟨r.2.2, []⟩⟩ := by
-  simp only [fqOracles, fqPrechallenges, fqSqueezes, coords, absorbFq, FqSponge.init,
-    ← Vector.foldl_toList, ← Array.foldl_toList, foldl_absorbG, foldl_cols, challenge_fresh,
-    squeezeChallenge_fresh, fqDigest, challengeFq, List.foldl_map, List.foldl_nil]
+  simp only [fqOracles, FqRun.expand, fqRun, castDigest, fqPrechallenges, fqSqueezes, coords,
+    absorbFq, FqSponge.init, ← Vector.foldl_toList, ← Array.foldl_toList, foldl_absorbG,
+    foldl_cols, challengeNat_fresh, challengeFq, List.foldl_map, List.foldl_nil]
 
 /-- The fr-sponge schedule (verifier.rs:284–405): absorb `frTranscript`, with the
 recursion digest the fr-sponge digest of the empty recursion list, then squeeze the two
-prechallenges and expand them. -/
-def frOracles {nc k : ℕ} (cp : KimchiProof C nc k)
-    (fqDig : C.ScalarField) (pubEvals : PointEvaluations (Vector C.ScalarField nc)) :
-    C.ScalarField × C.ScalarField :=
+128-bit prechallenges. What a circuit's scalar half recomputes (`Pickles.squeezeXiR`);
+`frOracles` is the consumer's expansion. -/
+def frRun {nc k : ℕ} (cp : KimchiProof C nc k)
+    (fqDig : C.ScalarField) (pubEvals : PointEvaluations (Vector C.ScalarField nc)) : ℕ × ℕ :=
   let sp := frSpec C
   let s := absorbFq sp FqSponge.init
     (frTranscript fqDig (frDigest C sp FqSponge.init) cp.ftEval1 pubEvals cp.evals)
   let (v', s) := challengeNat sp s
   let (u', _) := challengeNat sp s
+  (v', u')
+
+/-- The fr-sponge oracles: the run's two prechallenges, endo-expanded at the sponge's
+eigenvalue — the polyscale and the evalscale. -/
+def frOracles {nc k : ℕ} (cp : KimchiProof C nc k)
+    (fqDig : C.ScalarField) (pubEvals : PointEvaluations (Vector C.ScalarField nc)) :
+    C.ScalarField × C.ScalarField :=
+  let (v', u') := frRun C cp fqDig pubEvals
   (endoExpand C.sponge.lam v', endoExpand C.sponge.lam u')
 
 /-- The fr-sponge's two 128-bit prechallenges over a transcript, as naturals: the values
@@ -420,7 +456,7 @@ theorem frOracles_eq_frPrechallenges {nc k : ℕ} (cp : KimchiProof C nc k)
       let pre := frPrechallenges C.frParams
         (frTranscript fqDig (frDigest C (frSpec C) FqSponge.init) cp.ftEval1 pubEvals cp.evals)
       (endoExpand C.sponge.lam pre.1, endoExpand C.sponge.lam pre.2) := by
-  simp only [frOracles, frPrechallenges, frSqueezes, absorbFq, challengeNat_fresh]
+  simp only [frOracles, frRun, frPrechallenges, frSqueezes, absorbFq, challengeNat_fresh]
   rfl
 
 /-- `lo` is the prechallenge `pre` up to the wrap-around slack of a 128-bit decomposition:

--- a/formal/kimchi/Kimchi/Verifier/Reflect.lean
+++ b/formal/kimchi/Kimchi/Verifier/Reflect.lean
@@ -86,11 +86,10 @@ private def runLinEvals (σ : SRS C.Point) (cvk : KimchiVK C nc)
     Evals C.ScalarField :=
   cp.linEvals (runZetaM C σ cvk cp pub olds) (runZetaOmegaM C σ cvk cp pub olds)
 
-/-- The run's fr-sponge challenges `(v, u)` — polyscale and evalscale of the batch. -/
-def runVU (σ : SRS C.Point) (cvk : KimchiVK C nc)
+/-- The run's fr-sponge oracles: the polyscale `ξ` and the evalscale `r` of the batch. -/
+def runFrOracles (σ : SRS C.Point) (cvk : KimchiVK C nc)
     (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
-    (olds : Vector (Accumulator C σ.k) m) :
-    C.ScalarField × C.ScalarField :=
+    (olds : Vector (Accumulator C σ.k) m) : FrOracles C :=
   frOracles C cp (runOracles C σ cvk cp pub olds).digest (runPubEvals C σ cvk cp pub olds)
     olds
 
@@ -173,7 +172,7 @@ def runInput (σ : SRS C.Point) (cvk : KimchiVK C nc)
     (olds : Vector (Accumulator C σ.k) m) :
     Ipa.Input C σ.k (m + (nc + 1 + tailRowCount * nc)) evalPts :=
   runInputP C σ cvk cp pub olds (runPubEvals C σ cvk cp pub olds)
-    (runVU C σ cvk cp pub olds).1 (runVU C σ cvk cp pub olds).2
+    (runFrOracles C σ cvk cp pub olds).xi (runFrOracles C σ cvk cp pub olds).r
 
 
 /-! ## The body reflection -/

--- a/formal/kimchi/Kimchi/Verifier/Reflect.lean
+++ b/formal/kimchi/Kimchi/Verifier/Reflect.lean
@@ -29,119 +29,138 @@ variable (C : Ipa.CommitmentCurve)
 
 /-! ## The run-derived data -/
 
-variable {nc : ℕ}
+variable {nc m : ℕ}
 
 /-- The run's fq-sponge oracles: the deployed chunk-fold schedule at the run's own
 per-chunk public commitment. -/
 def runOracles (σ : SRS C.Point) (cvk : KimchiVK C nc)
-    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) : FqOracles C :=
-  fqOracles C cvk cp (publicCommitment C σ cvk pub)
+    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    (olds : Vector (Accumulator C σ.k) m) : FqOracles C :=
+  fqOracles C cvk cp (publicCommitment C σ cvk pub) olds
 
 /-- The second batch point `ζω`. -/
 private def runZetaOmega (σ : SRS C.Point) (cvk : KimchiVK C nc)
-    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) : C.ScalarField :=
-  (runOracles C σ cvk cp pub).zeta * cvk.omega
+    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    (olds : Vector (Accumulator C σ.k) m) : C.ScalarField :=
+  (runOracles C σ cvk cp pub olds).zeta * cvk.omega
 
 /-- The domain-size power `ζⁿ`, by the squaring ladder. -/
 private def runZetaN (σ : SRS C.Point) (cvk : KimchiVK C nc)
-    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) : C.ScalarField :=
-  powPow2 (runOracles C σ cvk cp pub).zeta cvk.domainLog2
+    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    (olds : Vector (Accumulator C σ.k) m) : C.ScalarField :=
+  powPow2 (runOracles C σ cvk cp pub olds).zeta cvk.domainLog2
 
 /-- The power `(ζω)ⁿ`, by the squaring ladder. -/
 private def runZetaOmegaN (σ : SRS C.Point) (cvk : KimchiVK C nc)
-    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) : C.ScalarField :=
-  powPow2 (runZetaOmega C σ cvk cp pub) cvk.domainLog2
+    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    (olds : Vector (Accumulator C σ.k) m) : C.ScalarField :=
+  powPow2 (runZetaOmega C σ cvk cp pub olds) cvk.domainLog2
 
 /-- The chunk-combination power `ζ^{2^σ.k}` (`ζ^max_poly_size`). -/
 private def runZetaM (σ : SRS C.Point) (cvk : KimchiVK C nc)
-    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) : C.ScalarField :=
-  powPow2 (runOracles C σ cvk cp pub).zeta σ.k
+    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    (olds : Vector (Accumulator C σ.k) m) : C.ScalarField :=
+  powPow2 (runOracles C σ cvk cp pub olds).zeta σ.k
 
 /-- The chunk-combination power `(ζω)^{2^σ.k}`. -/
 private def runZetaOmegaM (σ : SRS C.Point) (cvk : KimchiVK C nc)
-    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) : C.ScalarField :=
-  powPow2 (runZetaOmega C σ cvk cp pub) σ.k
+    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    (olds : Vector (Accumulator C σ.k) m) : C.ScalarField :=
+  powPow2 (runZetaOmega C σ cvk cp pub olds) σ.k
 
 /-- The run's public evaluation chunk vectors: proof-carried when present, the
 one-chunk barycentric fallback otherwise (verifier.rs:332–379). -/
 def runPubEvals (σ : SRS C.Point) (cvk : KimchiVK C nc)
-    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) :
+    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    (olds : Vector (Accumulator C σ.k) m) :
     Kimchi.Verifier.PointEvaluations (Vector C.ScalarField nc) :=
-  publicEvalChunks cp cvk.n cvk.omega (runOracles C σ cvk cp pub).zeta
-    (runZetaOmega C σ cvk cp pub) (runZetaN C σ cvk cp pub)
-    (runZetaOmegaN C σ cvk cp pub) pub
+  publicEvalChunks cp cvk.n cvk.omega (runOracles C σ cvk cp pub olds).zeta
+    (runZetaOmega C σ cvk cp pub olds) (runZetaN C σ cvk cp pub olds)
+    (runZetaOmegaN C σ cvk cp pub olds) pub
 
 
 /-- The run's chunk-combined evaluation record — the verifier's `evals.combine`. -/
 private def runLinEvals (σ : SRS C.Point) (cvk : KimchiVK C nc)
-    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) :
+    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    (olds : Vector (Accumulator C σ.k) m) :
     Evals C.ScalarField :=
-  cp.linEvals (runZetaM C σ cvk cp pub) (runZetaOmegaM C σ cvk cp pub)
+  cp.linEvals (runZetaM C σ cvk cp pub olds) (runZetaOmegaM C σ cvk cp pub olds)
 
 /-- The run's fr-sponge challenges `(v, u)` — polyscale and evalscale of the batch. -/
 def runVU (σ : SRS C.Point) (cvk : KimchiVK C nc)
-    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) :
+    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    (olds : Vector (Accumulator C σ.k) m) :
     C.ScalarField × C.ScalarField :=
-  frOracles C cp (runOracles C σ cvk cp pub).digest (runPubEvals C σ cvk cp pub)
+  frOracles C cp (runOracles C σ cvk cp pub olds).digest (runPubEvals C σ cvk cp pub olds)
+    olds
 
 /-- The run's computed `ft(ζ)` claim at a given combined public evaluation. -/
 private def runFtEval0P (σ : SRS C.Point) (cvk : KimchiVK C nc)
     (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    (olds : Vector (Accumulator C σ.k) m)
     (pubEval0 : C.ScalarField) : C.ScalarField :=
   ftEval0 cvk.n cvk.zkRows cvk.omega (fun i => cvk.shifts[i]) cvk.endo
     (mdsOfParams C.frParams)
-    (runOracles C σ cvk cp pub).alpha (runOracles C σ cvk cp pub).beta
-    (runOracles C σ cvk cp pub).gamma (runOracles C σ cvk cp pub).zeta pubEval0
-    (runLinEvals C σ cvk cp pub)
+    (runOracles C σ cvk cp pub olds).alpha (runOracles C σ cvk cp pub olds).beta
+    (runOracles C σ cvk cp pub olds).gamma (runOracles C σ cvk cp pub olds).zeta pubEval0
+    (runLinEvals C σ cvk cp pub olds)
 
 
 /-- The run's permutation scalar (the `f_comm` coefficient). -/
 def runPScalar (σ : SRS C.Point) (cvk : KimchiVK C nc)
-    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) : C.ScalarField :=
-  permScalar (runOracles C σ cvk cp pub).beta (runOracles C σ cvk cp pub).gamma
-    (runOracles C σ cvk cp pub).alpha
-    (zkpmEval cvk.n cvk.zkRows cvk.omega (runOracles C σ cvk cp pub).zeta)
-    (runLinEvals C σ cvk cp pub)
+    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    (olds : Vector (Accumulator C σ.k) m) : C.ScalarField :=
+  permScalar (runOracles C σ cvk cp pub olds).beta (runOracles C σ cvk cp pub olds).gamma
+    (runOracles C σ cvk cp pub olds).alpha
+    (zkpmEval cvk.n cvk.zkRows cvk.omega (runOracles C σ cvk cp pub olds).zeta)
+    (runLinEvals C σ cvk cp pub olds)
 
 /-- The run's `f_comm` chunks — the `pScalar`-scaled `σ₆` chunk vector. -/
 private def runFComm (σ : SRS C.Point) (cvk : KimchiVK C nc)
-    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) :
+    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    (olds : Vector (Accumulator C σ.k) m) :
     Vector C.Point nc :=
-  cvk.sigmaComm[6].map (fun P => (runPScalar C σ cvk cp pub).val • P)
+  cvk.sigmaComm[6].map (fun P => (runPScalar C σ cvk cp pub olds).val • P)
 
 /-- The run's constructed ft commitment (verifier.rs:960–965): the DOUBLE collapse at
 `ζ^{2^σ.k}` — `combine(ζ^max, f_comm) − (ζⁿ − 1)·combine(ζ^max, t_comm)`. -/
 def runFtComm (σ : SRS C.Point) (cvk : KimchiVK C nc)
-    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) : C.Point :=
-  Ipa.combineCommitments C (runZetaM C σ cvk cp pub)
-      (runFComm C σ cvk cp pub).toArray
-    - (runZetaN C σ cvk cp pub - 1).val
-        • Ipa.combineCommitments C (runZetaM C σ cvk cp pub) cp.tComm
+    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    (olds : Vector (Accumulator C σ.k) m) : C.Point :=
+  Ipa.combineCommitments C (runZetaM C σ cvk cp pub olds)
+      (runFComm C σ cvk cp pub olds).toArray
+    - (runZetaN C σ cvk cp pub olds - 1).val
+        • Ipa.combineCommitments C (runZetaM C σ cvk cp pub olds) cp.tComm
 
-/-- The run's flat segment stream in `to_batch` order: the public row's chunks, the
-single-chunk ft row, then the 43 tail rows' chunks (`(tailRowsOf …).flatten`) — every
-segment a `(commitment, ζ-claim, ζω-claim)` triple, every read total. -/
+/-- The run's flat segment stream in `to_batch` order: the old accumulators' rows, the
+public row's chunks, the single-chunk ft row, then the 43 tail rows' chunks
+(`(tailRowsOf …).flatten`) — every segment a `(commitment, ζ-claim, ζω-claim)` triple,
+every read total. -/
 def runStreamP (σ : SRS C.Point) (cvk : KimchiVK C nc)
     (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    (olds : Vector (Accumulator C σ.k) m)
     (pe : Kimchi.Verifier.PointEvaluations (Vector C.ScalarField nc)) :
-    Vector (C.Point × C.ScalarField × C.ScalarField) (nc + 1 + tailRowCount * nc) :=
-  (Vector.ofFn fun c : Fin nc =>
-      ((publicCommitment C σ cvk pub)[c], pe.zeta[c], pe.zetaOmega[c]))
-    ++ (⟨#[(runFtComm C σ cvk cp pub,
-           runFtEval0P C σ cvk cp pub
-             (combineAt (runZetaM C σ cvk cp pub) pe.zeta.toArray),
-           cp.ftEval1)], rfl⟩
-        : Vector (C.Point × C.ScalarField × C.ScalarField) 1)
-    ++ (tailRowsOf C cvk cp).flatten
+    Vector (C.Point × C.ScalarField × C.ScalarField) (m + (nc + 1 + tailRowCount * nc)) :=
+  olds.map (fun a => (a.sg, bPoly a.u.get (runOracles C σ cvk cp pub olds).zeta,
+      bPoly a.u.get (runZetaOmega C σ cvk cp pub olds)))
+    ++ ((Vector.ofFn fun c : Fin nc =>
+          ((publicCommitment C σ cvk pub)[c], pe.zeta[c], pe.zetaOmega[c]))
+        ++ (⟨#[(runFtComm C σ cvk cp pub olds,
+               runFtEval0P C σ cvk cp pub olds
+                 (combineAt (runZetaM C σ cvk cp pub olds) pe.zeta.toArray),
+               cp.ftEval1)], rfl⟩
+            : Vector (C.Point × C.ScalarField × C.ScalarField) 1)
+        ++ (tailRowsOf C cvk cp).flatten)
 
 /-- The batched IPA input at given public evaluations and combination scalars. -/
 private def runInputP (σ : SRS C.Point) (cvk : KimchiVK C nc)
     (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    (olds : Vector (Accumulator C σ.k) m)
     (pe : Kimchi.Verifier.PointEvaluations (Vector C.ScalarField nc))
-    (v u : C.ScalarField) : Ipa.Input C σ.k (nc + 1 + tailRowCount * nc) evalPts where
-  commitments := (runStreamP C σ cvk cp pub pe).map (·.1)
-  xs := ⟨#[(runOracles C σ cvk cp pub).zeta, runZetaOmega C σ cvk cp pub], rfl⟩
-  evals := (runStreamP C σ cvk cp pub pe).map
+    (v u : C.ScalarField) : Ipa.Input C σ.k (m + (nc + 1 + tailRowCount * nc)) evalPts where
+  commitments := (runStreamP C σ cvk cp pub olds pe).map (·.1)
+  xs := ⟨#[(runOracles C σ cvk cp pub olds).zeta, runZetaOmega C σ cvk cp pub olds], rfl⟩
+  evals := (runStreamP C σ cvk cp pub olds pe).map
     (fun r => (⟨#[r.2.1, r.2.2], rfl⟩ : Vector C.ScalarField evalPts))
   polyscale := v
   evalscale := u
@@ -150,10 +169,11 @@ private def runInputP (σ : SRS C.Point) (cvk : KimchiVK C nc)
 /-- The batched IPA input the run hands to the warm-sponge opening finish (closed
 form). -/
 def runInput (σ : SRS C.Point) (cvk : KimchiVK C nc)
-    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) :
-    Ipa.Input C σ.k (nc + 1 + tailRowCount * nc) evalPts :=
-  runInputP C σ cvk cp pub (runPubEvals C σ cvk cp pub)
-    (runVU C σ cvk cp pub).1 (runVU C σ cvk cp pub).2
+    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    (olds : Vector (Accumulator C σ.k) m) :
+    Ipa.Input C σ.k (m + (nc + 1 + tailRowCount * nc)) evalPts :=
+  runInputP C σ cvk cp pub olds (runPubEvals C σ cvk cp pub olds)
+    (runVU C σ cvk cp pub olds).1 (runVU C σ cvk cp pub olds).2
 
 
 /-! ## The body reflection -/

--- a/formal/kimchi/Kimchi/Verifier/Wire.lean
+++ b/formal/kimchi/Kimchi/Verifier/Wire.lean
@@ -43,7 +43,9 @@ private abbrev PolyComm (C : Ipa.CommitmentCurve) := Array C.Point
 
 /-- The kimchi proof wire record (`ProverProof` + `ProofEvaluations`, proof.rs:50–170),
 basic gate set: fixed dimensions serde-typed, chunk payloads unchecked arrays. Lookup
-data and `prev_challenges` are absent — declared deferrals of this transcription. -/
+data are absent — a declared deferral — and so are `prev_challenges`: the checked
+verifier takes the old accumulators as an argument beside the proof
+(`Kimchi.Verifier.Accumulator`), and the wire records carry none. -/
 structure KimchiProof (C : Ipa.CommitmentCurve) where
   /-- The 15 witness-column commitments (`w_comm: [PolyComm; COLUMNS]`). -/
   wComm : Vector (PolyComm C) wCols

--- a/formal/kimchi/roots.txt
+++ b/formal/kimchi/roots.txt
@@ -216,12 +216,12 @@ Kimchi.Index.Satisfies
 -- in-tree consumer when the soundness development was retired, and are rooted deliberately
 -- rather than deleted: they are THE SPEC ANCHORS a circuit implementation of the verifier is
 -- proved faithful to (see the in-circuit-verifier arc). Stating a fragment's soundness
--- against `runOracles`/`runVU`/`runPScalar`/`runFtComm` needs no new spec object, which is
+-- against `runOracles`/`runFrOracles`/`runPScalar`/`runFtComm` needs no new spec object, which is
 -- exactly what this layer exists for. The seven public forms reach the private ladder
 -- (`runZeta*`, `runFComm`, `runFtEval0P`, `runLinEvals`, `runInputP`) through the closure.
 Kimchi.Verifier.runOracles
 Kimchi.Verifier.runPubEvals
-Kimchi.Verifier.runVU
+Kimchi.Verifier.runFrOracles
 Kimchi.Verifier.runPScalar
 Kimchi.Verifier.runFtComm
 Kimchi.Verifier.runStreamP

--- a/formal/kimchi/scripts/check_kimchi_verifier.lean
+++ b/formal/kimchi/scripts/check_kimchi_verifier.lean
@@ -60,7 +60,7 @@ def verifyWire (C : Ipa.CommitmentCurve) (σ : Bulletproof.SRS C.Point)
     (pub : Array C.ScalarField) : Bool :=
   if σ.k ≤ vk.domainLog2 then
     match vk.check (Wire.runNc C σ vk), p.check (Wire.runNc C σ vk) σ.k with
-    | some cvk, some cp => kimchiVerify C σ cvk cp pub
+    | some cvk, some cp => kimchiVerify C σ cvk cp pub #v[]
     | _, _ => false
   else false
 

--- a/formal/pickles/Pickles.lean
+++ b/formal/pickles/Pickles.lean
@@ -7,6 +7,7 @@ import Pickles.OptSponge
 import Pickles.FrSponge
 import Pickles.Pseudo
 import Pickles.Domain
+import Pickles.Statement
 import Pickles.FinalizeOtherProof
 import Pickles.FqSpongeTranscript
 import Pickles.CheckBulletproof

--- a/formal/pickles/Pickles.lean
+++ b/formal/pickles/Pickles.lean
@@ -1,5 +1,6 @@
 import Pickles.Reflect.Soundness
 import Pickles.FtEval0
+import Pickles.Prechallenge
 import Pickles.IPA
 import Pickles.CombinedInnerProduct
 import Pickles.PermScalar

--- a/formal/pickles/Pickles/CheckBulletproof.lean
+++ b/formal/pickles/Pickles/CheckBulletproof.lean
@@ -82,32 +82,47 @@ def IpaEndo.vesta : IpaEndo Fq where
     (Fact.out : Nat.Prime CompElliptic.Curves.Pasta.Vesta.curve.toAffine.order)
   lam := ((Pasta.vestaLam : ℤ) : ZMod PALLAS_BASE_CARD)
 
-/-- The opening data `check_bulletproof` consumes (PS `CheckBulletproofInput`): the
-polyscale challenge, the opening proof's points and shifted scalars, the deferred `cip`
-and `b`, and the blinding base `h`. -/
-structure CheckBulletproofInput (F sf : Type) where
-  /-- The polyscale challenge `ξ`, 128 bits. -/
-  xi : SizedF 128 (FVar F)
-  /-- The opening's `δ`. -/
-  delta : AffinePoint (FVar F)
-  /-- The opening's challenge polynomial commitment `sg`. -/
-  sg : AffinePoint (FVar F)
+/-- The two deferred scalars of the opening check (PS `BulletproofDeferred`; OCaml
+`Types.Step.Bulletproof.Advice`, a name not used here because in snarky and pickles
+"advice" is the prover-side handler mechanism, whereas these are public input of the previous
+proof): used in the Schnorr equation here, certified by the next circuit's
+`finalizeOtherProof`. -/
+structure BulletproofDeferred (sf : Type) where
+  /-- The deferred combined inner product, shifted. -/
+  combinedInnerProduct : sf
+  /-- The deferred challenge-polynomial evaluation `b`, shifted. -/
+  b : sf
+
+/-- The opening proof as the circuit reads it (PS `BulletproofOpening`, OCaml
+`Openings.Bulletproof.t`; the wire's `Ipa.Proof` with shifted scalars): checked in the Schnorr
+equation here. Only `sg` is looked at again, one proof later, as `sg_old`. -/
+structure BulletproofOpening (F sf : Type) where
   /-- The `(L, R)` pairs, one per round. -/
   lr : List (AffinePoint (FVar F) × AffinePoint (FVar F))
   /-- The opening's `z₁`, shifted. -/
   z1 : sf
   /-- The opening's `z₂`, shifted. -/
   z2 : sf
-  /-- The deferred combined inner product, shifted. -/
-  combinedInnerProduct : sf
-  /-- The deferred challenge-polynomial evaluation `b`, shifted. -/
-  b : sf
+  /-- The opening's `δ`. -/
+  delta : AffinePoint (FVar F)
+  /-- The opening's challenge polynomial commitment `sg`. -/
+  sg : AffinePoint (FVar F)
+
+/-- What `check_bulletproof` consumes (PS `CheckBulletproofInput`): the deferred `ξ`, the
+deferred `cip` and `b`, the opening proof, and the SRS blinding base `h`. -/
+structure CheckBulletproofInput (F sf : Type) where
+  /-- The polyscale challenge `ξ`, 128 bits — a deferred value. -/
+  xi : SizedF 128 (FVar F)
+  /-- The deferred `cip` and `b`. -/
+  deferred : BulletproofDeferred sf
+  /-- The opening proof. -/
+  opening : BulletproofOpening F sf
   /-- The SRS blinding base `h`. -/
   blindingGenerator : AffinePoint (FVar F)
 
 /-- The four scalars the check scales by: `cip`, `b`, `z₁`, `z₂`. -/
 def CheckBulletproofInput.scaled {F sf : Type} (inp : CheckBulletproofInput F sf) : List sf :=
-  [inp.combinedInnerProduct, inp.b, inp.z1, inp.z2]
+  [inp.deferred.combinedInnerProduct, inp.deferred.b, inp.opening.z1, inp.opening.z2]
 
 /-- The check's outputs (PS `IpaFinalCheckResult`, with the transcript's intermediates
 named): the success bit, the round prechallenges, the `U` base's preimage `t`, the
@@ -200,19 +215,19 @@ def ipaFinalCheck {sf : Type} (ops : IpaScalarOps F c sf) (e : IpaEndo F)
     (p : Poseidon.Params F) (endo : FVar F) (sv : SpongeVar F) (t : FVar F)
     (u combinedPolynomial : AffinePoint (FVar F)) (inp : CheckBulletproofInput F sf) :
     CircuitM F c (CheckBulletproofOutput F) := do
-  let (chals, sv) ← extractScalarChallenges p endo sv inp.lr
-  let lrProd ← bulletReduce e (inp.lr.zip chals)
-  let cipU ← ops.scaleByShifted u inp.combinedInnerProduct
+  let (chals, sv) ← extractScalarChallenges p endo sv inp.opening.lr
+  let lrProd ← bulletReduce e (inp.opening.lr.zip chals)
+  let cipU ← ops.scaleByShifted u inp.deferred.combinedInnerProduct
   let pPrime ← (·.p) <$> addFast .checkFinite combinedPolynomial cipU
   let q ← (·.p) <$> addFast .checkFinite pPrime lrProd
-  let sv ← absorbPoint p sv inp.delta
+  let sv ← absorbPoint p sv inp.opening.delta
   let (cc, sv) ← squeezePrechallenge p false endo sv
   let cQ ← endoMul e.d.endo 32 q cc
-  let lhs ← (·.p) <$> addFast .checkFinite cQ inp.delta
-  let bU ← ops.scaleByShifted u inp.b
-  let sgPlusBU ← (·.p) <$> addFast .checkFinite inp.sg bU
-  let z1Term ← ops.scaleByShifted sgPlusBU inp.z1
-  let z2Term ← ops.scaleByShifted inp.blindingGenerator inp.z2
+  let lhs ← (·.p) <$> addFast .checkFinite cQ inp.opening.delta
+  let bU ← ops.scaleByShifted u inp.deferred.b
+  let sgPlusBU ← (·.p) <$> addFast .checkFinite inp.opening.sg bU
+  let z1Term ← ops.scaleByShifted sgPlusBU inp.opening.z1
+  let z2Term ← ops.scaleByShifted inp.blindingGenerator inp.opening.z2
   let rhs ← (·.p) <$> addFast .checkFinite z1Term z2Term
   let xEq ← equals lhs.x rhs.x
   let yEq ← equals lhs.y rhs.y
@@ -226,7 +241,7 @@ def checkBulletproof {sf : Type} (ops : IpaScalarOps F c sf) (e : IpaEndo F)
     (p : Poseidon.Params F) (endo : FVar F) (gm : GroupMapParams F) (sqrtF : F → Option F)
     (sv : SpongeVar F) (bases : List (AffinePoint (FVar F) × Option (BoolVar F)))
     (inp : CheckBulletproofInput F sf) : CircuitM F c (CheckBulletproofOutput F) := do
-  let sv ← absorbList p sv (ops.shiftedToAbsorbFields inp.combinedInnerProduct)
+  let sv ← absorbList p sv (ops.shiftedToAbsorbFields inp.deferred.combinedInnerProduct)
   let (t, sv) ← SpongeVar.squeeze p sv
   let u ← groupMapCircuit sqrtF gm t
   let combined ← combinePolynomials e inp.xi bases
@@ -308,28 +323,29 @@ theorem checkBulletproof_spec (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0) {sf : Ty
     (s₀ : Poseidon.State F) (hs : SpongeVar.ReadsAt V sv s₀)
     (bases : List (AffinePoint (FVar F) × Option (BoolVar F))) (inp : CheckBulletproofInput F sf)
     (lrv : List (AffinePoint F × AffinePoint F))
-    (hlr : List.Forall₂ (CircuitType.Reads V) inp.lr lrv)
-    (δv : AffinePoint F) (hδ : CircuitType.Reads V inp.delta δv) :
+    (hlr : List.Forall₂ (CircuitType.Reads V) inp.opening.lr lrv)
+    (δv : AffinePoint F) (hδ : CircuitType.Reads V inp.opening.delta δv) :
     ⦃⌜True⌝⦄ checkBulletproof ops e p endo gm sqrtF sv bases inp
     ⦃⇓ o _ => ⌜CheckBulletproofReads p s₀
-      ((ops.shiftedToAbsorbFields inp.combinedInnerProduct).map (·.val V)) lrv δv V o⌝⦄ := by
+      ((ops.shiftedToAbsorbFields inp.deferred.combinedInnerProduct).map (·.val V))
+      lrv δv V o⌝⦄ := by
   simp only [checkBulletproof, ipaFinalCheck]
   obtain ⟨hδx, hδy⟩ := reads_affinePoint.mp hδ
   have hlimbs := absorbList_spec (V := V) p hsize sv
-    (ops.shiftedToAbsorbFields inp.combinedInnerProduct)
+    (ops.shiftedToAbsorbFields inp.deferred.combinedInnerProduct)
   have hsq := fun sv' => SpongeVar.squeeze_spec (V := V) p hsize sv'
   have hgm := fun t => builder_spec_true (groupMapCircuit (c := Builder V (KimchiConstraint F))
     sqrtF gm t)
   have hcomb := fun xi bs => builder_spec_true
     (combinePolynomials (c := Builder V (KimchiConstraint F)) e xi bs)
   have hext := fun sv' =>
-    extractScalarChallenges_spec (V := V) h2 h3 p hsize endo sv' inp.lr lrv hlr
+    extractScalarChallenges_spec (V := V) h2 h3 p hsize endo sv' inp.opening.lr lrv hlr
   have hbr := fun ps => builder_spec_true (bulletReduce (c := Builder V (KimchiConstraint F)) e ps)
   have hsc := fun u x => builder_spec_true (ops.scaleByShifted u x)
   have hadd := fun f a b => builder_spec_true (addFast (c := Builder V (KimchiConstraint F)) f a b)
   have hem := fun g x => builder_spec_true
     (endoMul (c := Builder V (KimchiConstraint F)) e.d.endo 32 g x)
-  have hδs := fun sv' => absorbPoint_spec (V := V) p hsize sv' inp.delta
+  have hδs := fun sv' => absorbPoint_spec (V := V) p hsize sv' inp.opening.delta
   have hpre := fun sv' => squeezePrechallenge_spec (V := V) h2 h3 p hsize false endo sv'
   have heq := fun a b => builder_spec_true (equals (c := Builder V (KimchiConstraint F)) a b)
   have hand := fun a b => builder_spec_true (Snarky.and (c := Builder V (KimchiConstraint F)) a b)
@@ -671,36 +687,37 @@ theorem ipaFinalCheck_spec {sf : Type}
     (hreg : ∀ (x : sf) (w : R.wit), x ∈ inp.scaled → R.Pre x w → R.Reg w)
     (δv sgv hv : e.d.W.Point)
     (lrv : List (e.d.W.Point × e.d.W.Point))
-    (hlr : List.Forall₂ (PairReads e.d.W V) inp.lr lrv) (hlrne : inp.lr ≠ [])
-    (hδ : OnCurveAt e.d.W V inp.delta δv) (hsg : OnCurveAt e.d.W V inp.sg sgv)
+    (hlr : List.Forall₂ (PairReads e.d.W V) inp.opening.lr lrv) (hlrne : inp.opening.lr ≠ [])
+    (hδ : OnCurveAt e.d.W V inp.opening.delta δv) (hsg : OnCurveAt e.d.W V inp.opening.sg sgv)
     (hh : OnCurveAt e.d.W V inp.blindingGenerator hv) :
     ⦃⌜True⌝⦄ ipaFinalCheck ops e p endo sv t u combined inp
     ⦃⇓ o _ => ⌜∀ uv Pv : e.d.W.Point, OnCurveAt e.d.W V u uv → OnCurveAt e.d.W V combined Pv →
       o.t = t ∧ ∃ (ns : List ℕ) (c₀ : ℕ) (wcip wb w₁ w₂ : R.wit),
       List.Forall₂ (Reads128 V) o.challenges ns ∧ ns.length = lrv.length ∧ Reads128 V o.c c₀ ∧
-      R.Pre inp.combinedInnerProduct wcip ∧ R.Pre inp.b wb ∧ R.Pre inp.z1 w₁ ∧ R.Pre inp.z2 w₂ ∧
+      R.Pre inp.deferred.combinedInnerProduct wcip ∧ R.Pre inp.deferred.b wb ∧
+      R.Pre inp.opening.z1 w₁ ∧ R.Pre inp.opening.z2 w₂ ∧
       ((↑o.success : CVar F).val V = 1 ↔
         SchnorrPoint e.d.lam c₀ uv Pv (lrSum (List.zipWith (lrTerm e.d.lam) lrv ns)) δv sgv hv
           (R.dec wcip) (R.dec wb) (R.dec w₁) (R.dec w₂))⌝⦄ := by
   simp only [ipaFinalCheck]
-  have hext := fun sv' => extractScalarChallenges_length (V := V) p endo sv' inp.lr
+  have hext := fun sv' => extractScalarChallenges_length (V := V) p endo sv' inp.opening.lr
   have hbr := fun pairs => bulletReduce_spec' (V := V) e hchar pairs
   have hadd := fun a b => addFast_checkFinite_spec (V := V) e.d.W e.d.short e.d.two_ne
     e.d.two_torsion_free a b
   have hδs := fun sv' => builder_spec_true
-    (absorbPoint (c := Builder V (KimchiConstraint F)) p sv' inp.delta)
+    (absorbPoint (c := Builder V (KimchiConstraint F)) p sv' inp.opening.delta)
   have hpre := fun sv' => builder_spec_true
     (squeezePrechallenge (c := Builder V (KimchiConstraint F)) p false endo sv')
   have hem := fun g x => endoMul_spec (V := V) e.d g x
-  have hsc1 := fun pt => R.scale pt inp.combinedInnerProduct
+  have hsc1 := fun pt => R.scale pt inp.deferred.combinedInnerProduct
     (hwf _ (by simp [CheckBulletproofInput.scaled]))
-  have hsc2 := fun pt => R.scale pt inp.b (hwf _ (by simp [CheckBulletproofInput.scaled]))
-  have hsc3 := fun pt => R.scale pt inp.z1 (hwf _ (by simp [CheckBulletproofInput.scaled]))
-  have hsc4 := fun pt => R.scale pt inp.z2 (hwf _ (by simp [CheckBulletproofInput.scaled]))
-  have hr1 := hreg inp.combinedInnerProduct
-  have hr2 := hreg inp.b
-  have hr3 := hreg inp.z1
-  have hr4 := hreg inp.z2
+  have hsc2 := fun pt => R.scale pt inp.deferred.b (hwf _ (by simp [CheckBulletproofInput.scaled]))
+  have hsc3 := fun pt => R.scale pt inp.opening.z1 (hwf _ (by simp [CheckBulletproofInput.scaled]))
+  have hsc4 := fun pt => R.scale pt inp.opening.z2 (hwf _ (by simp [CheckBulletproofInput.scaled]))
+  have hr1 := hreg inp.deferred.combinedInnerProduct
+  have hr2 := hreg inp.deferred.b
+  have hr3 := hreg inp.opening.z1
+  have hr4 := hreg inp.opening.z2
   simp only [CheckBulletproofInput.scaled, List.mem_cons, List.mem_singleton, true_or, or_true,
     forall_const] at hr1 hr2 hr3 hr4
   mvcgen -trivial [-Snarky.Kimchi.addFast_spec, hext, hbr, hsc1, hsc2, hsc3, hsc4, hadd, hδs, hpre,
@@ -708,7 +725,7 @@ theorem ipaFinalCheck_spec {sf : Type}
   rename_i _ ext _ hlen lrProd _ hbr' cipU _ hcip pP _ hpP q _ hq svD _ cP _ cQ _ hcQ lhs _ hlhs
     bU _ hbU sgBU _ hsgBU z1T _ hz1 z2T _ hz2 rhs _ hrhs xEq _ hx yEq _ hy succ _ hand
   intro uv Pv hu hP
-  have hzne : inp.lr.zip ext.1 ≠ [] := fun h => by
+  have hzne : inp.opening.lr.zip ext.1 ≠ [] := fun h => by
     rcases List.zip_eq_nil_iff.mp h with h | h
     · exact hlrne h
     · exact hlrne (List.length_eq_zero_iff.mp (by rw [← hlen, h]; rfl))
@@ -775,14 +792,15 @@ theorem checkBulletproof_spec_success {sf : Type}
     (hreg : ∀ (x : sf) (w : R.wit), x ∈ inp.scaled → R.Pre x w → R.Reg w)
     (n : ℕ) (hn : n < 2 ^ 128) (hxi : inp.xi.val.val V = n) (δv sgv hv : e.d.W.Point)
     (lrv : List (e.d.W.Point × e.d.W.Point))
-    (hlr : List.Forall₂ (PairReads e.d.W V) inp.lr lrv) (hlrne : inp.lr ≠ [])
-    (hδ : OnCurveAt e.d.W V inp.delta δv) (hsg : OnCurveAt e.d.W V inp.sg sgv)
+    (hlr : List.Forall₂ (PairReads e.d.W V) inp.opening.lr lrv) (hlrne : inp.opening.lr ≠ [])
+    (hδ : OnCurveAt e.d.W V inp.opening.delta δv) (hsg : OnCurveAt e.d.W V inp.opening.sg sgv)
     (hh : OnCurveAt e.d.W V inp.blindingGenerator hv) :
     ⦃⌜True⌝⦄ checkBulletproof ops e p endo gm sqrtF sv bases inp
     ⦃⇓ o _ => ⌜∃ (U : e.d.W.Point) (ns : List ℕ) (c₀ : ℕ) (wcip wb w₁ w₂ : R.wit),
       (U = umap (o.t.val V) ∨ U = -umap (o.t.val V)) ∧
       List.Forall₂ (Reads128 V) o.challenges ns ∧ ns.length = lrv.length ∧ Reads128 V o.c c₀ ∧
-      R.Pre inp.combinedInnerProduct wcip ∧ R.Pre inp.b wb ∧ R.Pre inp.z1 w₁ ∧ R.Pre inp.z2 w₂ ∧
+      R.Pre inp.deferred.combinedInnerProduct wcip ∧ R.Pre inp.deferred.b wb ∧
+      R.Pre inp.opening.z1 w₁ ∧ R.Pre inp.opening.z2 w₂ ∧
       ((↑o.success : CVar F).val V = 1 ↔
         SchnorrPoint e.d.lam c₀ U (hornerCombine (endoExpandZ e.d.lam n) bv)
           (lrSum (List.zipWith (lrTerm e.d.lam) lrv ns)) δv sgv hv
@@ -1367,11 +1385,11 @@ theorem checkBulletproof_wrap_spec {V : Valuation Fq}
     (n : ℕ) (hn : n < 2 ^ 128) (hxi : inp.xi.val.val V = n)
     (σ : SRS (SWPoint Vesta.curve))
     (lrW : Vector (SWPoint Vesta.curve × SWPoint Vesta.curve) σ.k) (δW sgW : SWPoint Vesta.curve)
-    (hlr : List.Forall₂ (PairReads IpaEndo.vesta.d.W V) inp.lr (lrW.toList.map fun q =>
+    (hlr : List.Forall₂ (PairReads IpaEndo.vesta.d.W V) inp.opening.lr (lrW.toList.map fun q =>
       ((SWPoint.equivPoint Vesta.curve) q.1, (SWPoint.equivPoint Vesta.curve) q.2)))
-    (hlrne : inp.lr ≠ [])
-    (hδ : OnCurveAt IpaEndo.vesta.d.W V inp.delta ((SWPoint.equivPoint Vesta.curve) δW))
-    (hsg : OnCurveAt IpaEndo.vesta.d.W V inp.sg ((SWPoint.equivPoint Vesta.curve) sgW))
+    (hlrne : inp.opening.lr ≠ [])
+    (hδ : OnCurveAt IpaEndo.vesta.d.W V inp.opening.delta ((SWPoint.equivPoint Vesta.curve) δW))
+    (hsg : OnCurveAt IpaEndo.vesta.d.W V inp.opening.sg ((SWPoint.equivPoint Vesta.curve) sgW))
     (hh : OnCurveAt IpaEndo.vesta.d.W V inp.blindingGenerator
       ((SWPoint.equivPoint Vesta.curve) σ.h)) :
     ⦃⌜True⌝⦄ checkBulletproof (c := Builder V (KimchiConstraint Fq)) IpaScalarOps.wrap IpaEndo.vesta
@@ -1383,10 +1401,10 @@ theorem checkBulletproof_wrap_spec {V : Valuation Fq}
       chals.toList = ns.map (endoExpand Poseidon.FqVesta.spec.lam) ∧
       ((↑o.success : CVar Fq).val V = 1 ↔
         schnorrAt IpaVesta.curve σ U chals (endoExpand Poseidon.FqVesta.spec.lam c₀)
-          (wrapDecode V inp.combinedInnerProduct) (wrapDecode V inp.b)
+          (wrapDecode V inp.deferred.combinedInnerProduct) (wrapDecode V inp.deferred.b)
           (combineCommitments IpaVesta.curve (endoExpand Poseidon.FqVesta.spec.lam n)
             ((bvW.filter (·.2)).map (·.1)).toArray)
-          ⟨lrW, δW, wrapDecode V inp.z1, wrapDecode V inp.z2, sgW⟩)⌝⦄ := by
+          ⟨lrW, δW, wrapDecode V inp.opening.z1, wrapDecode V inp.opening.z2, sgW⟩)⌝⦄ := by
   refine builder_spec_imp _ _ _
     (checkBulletproof_spec_success IpaScalarOps.wrap IpaEndo.vesta p hsize endo
       groupMapParamsVesta sqrtF fq_natCast_inj (wrapReading V)
@@ -1626,11 +1644,11 @@ theorem checkBulletproof_step_spec {V : Valuation Fp}
     (n : ℕ) (hn : n < 2 ^ 128) (hxi : inp.xi.val.val V = n)
     (σ : SRS (SWPoint Pallas.curve))
     (lrW : Vector (SWPoint Pallas.curve × SWPoint Pallas.curve) σ.k) (δW sgW : SWPoint Pallas.curve)
-    (hlr : List.Forall₂ (PairReads IpaEndo.pallas.d.W V) inp.lr (lrW.toList.map fun q =>
+    (hlr : List.Forall₂ (PairReads IpaEndo.pallas.d.W V) inp.opening.lr (lrW.toList.map fun q =>
       ((SWPoint.equivPoint Pallas.curve) q.1, (SWPoint.equivPoint Pallas.curve) q.2)))
-    (hlrne : inp.lr ≠ [])
-    (hδ : OnCurveAt IpaEndo.pallas.d.W V inp.delta ((SWPoint.equivPoint Pallas.curve) δW))
-    (hsg : OnCurveAt IpaEndo.pallas.d.W V inp.sg ((SWPoint.equivPoint Pallas.curve) sgW))
+    (hlrne : inp.opening.lr ≠ [])
+    (hδ : OnCurveAt IpaEndo.pallas.d.W V inp.opening.delta ((SWPoint.equivPoint Pallas.curve) δW))
+    (hsg : OnCurveAt IpaEndo.pallas.d.W V inp.opening.sg ((SWPoint.equivPoint Pallas.curve) sgW))
     (hh : OnCurveAt IpaEndo.pallas.d.W V inp.blindingGenerator
       ((SWPoint.equivPoint Pallas.curve) σ.h)) :
     ⦃⌜True⌝⦄ checkBulletproof (c := Builder V (KimchiConstraint Fp)) IpaScalarOps.step
@@ -1642,10 +1660,10 @@ theorem checkBulletproof_step_spec {V : Valuation Fp}
       chals.toList = ns.map (endoExpand Poseidon.FqPallas.spec.lam) ∧
       ((↑o.success : CVar Fp).val V = 1 ↔
         schnorrAt IpaPallas.curve σ U chals (endoExpand Poseidon.FqPallas.spec.lam c₀)
-          (stepDecode V inp.combinedInnerProduct) (stepDecode V inp.b)
+          (stepDecode V inp.deferred.combinedInnerProduct) (stepDecode V inp.deferred.b)
           (combineCommitments IpaPallas.curve (endoExpand Poseidon.FqPallas.spec.lam n)
             ((bvW.filter (·.2)).map (·.1)).toArray)
-          ⟨lrW, δW, stepDecode V inp.z1, stepDecode V inp.z2, sgW⟩)⌝⦄ := by
+          ⟨lrW, δW, stepDecode V inp.opening.z1, stepDecode V inp.opening.z2, sgW⟩)⌝⦄ := by
   refine builder_spec_imp _ _ _
     (checkBulletproof_spec_success IpaScalarOps.step IpaEndo.pallas p hsize endo
       groupMapParamsPallas sqrtF fp_natCast_inj (stepReading V)

--- a/formal/pickles/Pickles/CheckBulletproof.lean
+++ b/formal/pickles/Pickles/CheckBulletproof.lean
@@ -5,6 +5,7 @@ import Snarky.Kimchi.Circuit.GroupMap
 import Snarky.Types.Shifted
 import Snarky.Kimchi.Circuit.Point
 import Pickles.FrSponge
+import Pickles.Prechallenge
 
 /-!
 # The in-circuit IPA opening check
@@ -255,11 +256,6 @@ variable {V : Valuation F}
 private def coordsPair (q : AffinePoint F × AffinePoint F) : (F × F) × (F × F) :=
   ((q.1.x, q.1.y), (q.2.x, q.2.y))
 
-/-- A raw squeeze and a 128-bit circuit value in the `lowest_128_bits` relation:
-`x = lo + 2¹²⁸·hi` with `hi < 2¹²⁸`. -/
-def Low128 (V : Valuation F) (x : F) (u : SizedF 128 (FVar F)) : Prop :=
-  ∃ hi : ℕ, hi < 2 ^ 128 ∧ x = u.val.val V + 2 ^ 128 * hi
-
 open Bulletproof.Ipa in
 /-- The transcript reading of the check's outputs (`checkBulletproof_spec`): with
 `(t, us, c)` the wire verifier's `ipaSqueezes` from the sponge's reading over the limbs,
@@ -422,14 +418,14 @@ def MaskedBaseReads (W : WeierstrassCurve.Affine F) (V : Valuation F)
 /-- Under any valuation satisfying the emitted constraints, with the bases reading as `bv`,
 the Horner fold from an accumulator reading as `accv` reads as the model fold. `n` is the
 challenge's reading, pinned to the gadgets' own by `hchar`. -/
-private theorem hornerFold_spec (e : IpaEndo F) (xi : SizedF 128 (FVar F)) (n : ℕ)
-    (hn : n < 2 ^ 128) (hxi : xi.val.val V = n)
-    (hchar : ∀ a b : ℕ, a < 2 ^ 128 → b < 2 ^ 128 → (a : F) = b → a = b) :
+private theorem hornerFold_spec (e : IpaEndo F) (xi : SizedF 128 (FVar F)) (n : Prechallenge)
+    (hxi : Reads128 V xi n)
+    (hchar : CastInj128 F) :
     ∀ (acc : AffinePoint (FVar F)) (bases : List (AffinePoint (FVar F) × Option (BoolVar F)))
       (bv : List (e.d.W.Point × Bool)), List.Forall₂ (MaskedBaseReads e.d.W V) bases bv →
       ⦃⌜True⌝⦄ hornerFold (c := Builder V (KimchiConstraint F)) e xi acc bases
       ⦃⇓ r _ => ⌜∀ accv : e.d.W.Point, OnCurveAt e.d.W V acc accv →
-        OnCurveAt e.d.W V r (bv.foldl (hornerStep (endoExpandZ e.d.lam n)) accv)⌝⦄
+        OnCurveAt e.d.W V r (bv.foldl (hornerStep (endoExpandZ e.d.lam n.val)) accv)⌝⦄
   | acc, [], [], .nil => by
     simp only [hornerFold, List.foldl_nil]
     mvcgen
@@ -440,7 +436,7 @@ private theorem hornerFold_spec (e : IpaEndo F) (xi : SizedF 128 (FVar F)) (n : 
     have hem := endoMul_spec (V := V) e.d acc xi
     have hadd := fun q => addFast_checkFinite_spec (V := V) e.d.W e.d.short e.d.two_ne
       e.d.two_torsion_free b q
-    have ih := fun acc' => hornerFold_spec e xi n hn hxi hchar acc' bases bv hrest
+    have ih := fun acc' => hornerFold_spec e xi n hxi hchar acc' bases bv hrest
     cases mask with
     | none =>
       simp only at hmask
@@ -449,7 +445,7 @@ private theorem hornerFold_spec (e : IpaEndo F) (xi : SizedF 128 (FVar F)) (n : 
       rename_i _ xiAcc _ hxa r _ hr rr _
       intro hrest' accv hacc
       obtain ⟨n', hn', hxi', hxa'⟩ := hxa accv hacc
-      obtain rfl : n' = n := hchar n' n hn' hn (hxi'.symm.trans hxi)
+      obtain rfl : n' = n.val := hchar n' n.val hn' n.property (hxi'.symm.trans hxi)
       exact hrest' _ (by simpa [hornerStep] using hr bvp _ hpt hxa')
     | some keep =>
       simp only at hmask
@@ -458,7 +454,7 @@ private theorem hornerFold_spec (e : IpaEndo F) (xi : SizedF 128 (FVar F)) (n : 
       rename_i _ xiAcc _ hxa r _ hr sel _ hsel' rr _
       intro hrest' accv hacc
       obtain ⟨n', hn', hxi', hxa'⟩ := hxa accv hacc
-      obtain rfl : n' = n := hchar n' n hn' hn (hxi'.symm.trans hxi)
+      obtain rfl : n' = n.val := hchar n' n.val hn' n.property (hxi'.symm.trans hxi)
       have hs := hsel' bb hmask _ _ (hr bvp _ hpt hxa') hacc
       refine hrest' _ ?_
       cases bb <;> simpa [hornerStep] using hs
@@ -466,13 +462,13 @@ private theorem hornerFold_spec (e : IpaEndo F) (xi : SizedF 128 (FVar F)) (n : 
 
 /-- Under any valuation satisfying the emitted constraints, with the bases reading as `bv`
 (non-empty), the combination reads as `hornerCombine` at the expanded challenge. -/
-theorem combinePolynomials_spec (e : IpaEndo F) (xi : SizedF 128 (FVar F)) (n : ℕ)
-    (hn : n < 2 ^ 128) (hxi : xi.val.val V = n)
-    (hchar : ∀ a b : ℕ, a < 2 ^ 128 → b < 2 ^ 128 → (a : F) = b → a = b)
+theorem combinePolynomials_spec (e : IpaEndo F) (xi : SizedF 128 (FVar F)) (n : Prechallenge)
+    (hxi : Reads128 V xi n)
+    (hchar : CastInj128 F)
     (bases : List (AffinePoint (FVar F) × Option (BoolVar F))) (bv : List (e.d.W.Point × Bool))
     (hb : List.Forall₂ (MaskedBaseReads e.d.W V) bases bv) (hne : bases ≠ []) :
     ⦃⌜True⌝⦄ combinePolynomials (c := Builder V (KimchiConstraint F)) e xi bases
-    ⦃⇓ r _ => ⌜OnCurveAt e.d.W V r (hornerCombine (endoExpandZ e.d.lam n) bv)⌝⦄ := by
+    ⦃⇓ r _ => ⌜OnCurveAt e.d.W V r (hornerCombine (endoExpandZ e.d.lam n.val) bv)⌝⦄ := by
   have hrev := List.forall₂_reverse_iff.mpr hb
   simp only [combinePolynomials, hornerCombine]
   rcases hbr : bases.reverse with _ | ⟨h, t⟩
@@ -483,7 +479,7 @@ theorem combinePolynomials_spec (e : IpaEndo F) (xi : SizedF 128 (FVar F)) (n : 
       exact absurd hrev (by simp)
     · rw [hvr] at hrev
       obtain ⟨⟨hhpt, -⟩, htail⟩ := List.forall₂_cons.mp hrev
-      have hf := hornerFold_spec (V := V) e xi n hn hxi hchar h.1 t tv htail
+      have hf := hornerFold_spec (V := V) e xi n hxi hchar h.1 t tv htail
       exact builder_spec_imp _ _ _ hf fun r hr => hr _ hhpt
 
 /-- A pair reads as two curve points. -/
@@ -491,20 +487,17 @@ def PairReads (W : WeierstrassCurve.Affine F) (V : Valuation F)
     (q : AffinePoint (FVar F) × AffinePoint (FVar F)) (v : W.Point × W.Point) : Prop :=
   OnCurveAt W V q.1 v.1 ∧ OnCurveAt W V q.2 v.2
 
-/-- A 128-bit circuit value reads as the natural `m`. -/
-def Reads128 (V : Valuation F) (u : SizedF 128 (FVar F)) (m : ℕ) : Prop :=
-  m < 2 ^ 128 ∧ u.val.val V = (m : F)
-
 /-- Under any valuation satisfying the emitted constraints, with the pairs reading as `pv`,
 the terms read as `lrTerm` at the readings, the challenges reading as some `ns`. -/
 private theorem bulletTerms_spec (e : IpaEndo F)
-    (hchar : ∀ a b : ℕ, a < 2 ^ 128 → b < 2 ^ 128 → (a : F) = b → a = b) :
+    (hchar : CastInj128 F) :
     ∀ (pairs : List ((AffinePoint (FVar F) × AffinePoint (FVar F)) × SizedF 128 (FVar F)))
       (pv : List (e.d.W.Point × e.d.W.Point)),
       List.Forall₂ (fun q v => PairReads e.d.W V q.1 v) pairs pv →
       ⦃⌜True⌝⦄ bulletTerms (c := Builder V (KimchiConstraint F)) e pairs
-      ⦃⇓ r _ => ⌜∃ ns : List ℕ, List.Forall₂ (fun q m => Reads128 V q.2 m) pairs ns ∧
-        List.Forall₂ (OnCurveAt e.d.W V) r (List.zipWith (lrTerm e.d.lam) pv ns)⌝⦄
+      ⦃⇓ r _ => ⌜∃ ns : List Prechallenge, List.Forall₂ (fun q m => Reads128 V q.2 m) pairs ns ∧
+        List.Forall₂ (OnCurveAt e.d.W V) r
+          (List.zipWith (lrTerm e.d.lam) pv (ns.map Subtype.val))⌝⦄
   | [], [], .nil => by
     simp only [bulletTerms]
     mvcgen
@@ -522,7 +515,7 @@ private theorem bulletTerms_spec (e : IpaEndo F)
     obtain ⟨n'', hn'', hq'', hRr⟩ := hem' v.2 hR
     obtain rfl : n' = n'' := hchar n' n'' hn' hn'' (hq'.symm.trans hq'')
     obtain ⟨ns, hns, hterms⟩ := hrest
-    refine ⟨n' :: ns, .cons ⟨hn', hq'⟩ hns, List.Forall₂.cons ?_ hterms⟩
+    refine ⟨⟨n', hn'⟩ :: ns, .cons hq' hns, List.Forall₂.cons ?_ hterms⟩
     have hadd' := hr R _ hRs hRr
     rw [hRform] at hadd'
     unfold lrTerm
@@ -557,13 +550,13 @@ private theorem sumPoints_spec (e : IpaEndo F) :
 /-- Under any valuation satisfying the emitted constraints, with the pairs (non-empty)
 reading as `pv` and their challenges as `ns`, `lr_prod` reads as `lrSum` of the terms. -/
 theorem bulletReduce_spec (e : IpaEndo F)
-    (hchar : ∀ a b : ℕ, a < 2 ^ 128 → b < 2 ^ 128 → (a : F) = b → a = b)
+    (hchar : CastInj128 F)
     (pairs : List ((AffinePoint (FVar F) × AffinePoint (FVar F)) × SizedF 128 (FVar F)))
     (pv : List (e.d.W.Point × e.d.W.Point))
     (hp : List.Forall₂ (fun q v => PairReads e.d.W V q.1 v) pairs pv) (hne : pairs ≠ []) :
     ⦃⌜True⌝⦄ bulletReduce (c := Builder V (KimchiConstraint F)) e pairs
-    ⦃⇓ r _ => ⌜∃ ns : List ℕ, List.Forall₂ (fun q m => Reads128 V q.2 m) pairs ns ∧
-      OnCurveAt e.d.W V r (lrSum (List.zipWith (lrTerm e.d.lam) pv ns))⌝⦄ := by
+    ⦃⇓ r _ => ⌜∃ ns : List Prechallenge, List.Forall₂ (fun q m => Reads128 V q.2 m) pairs ns ∧
+      OnCurveAt e.d.W V r (lrSum (List.zipWith (lrTerm e.d.lam) pv (ns.map Subtype.val)))⌝⦄ := by
   simp only [bulletReduce]
   have ht := bulletTerms_spec (V := V) e hchar pairs pv hp
   have hs := fun acc qs => sumPoints_spec (V := V) e acc qs
@@ -579,7 +572,7 @@ theorem bulletReduce_spec (e : IpaEndo F)
     intro hrest
     obtain ⟨ns, hns, hterms⟩ := hterms
     refine ⟨ns, hns, ?_⟩
-    rcases hz : List.zipWith (lrTerm e.d.lam) pv ns with _ | ⟨w, ws⟩
+    rcases hz : List.zipWith (lrTerm e.d.lam) pv (ns.map Subtype.val) with _ | ⟨w, ws⟩
     · rw [hz] at hterms
       exact absurd hterms (by simp)
     · rw [hz] at hterms
@@ -635,13 +628,13 @@ private theorem forall₂_zip_right {α β γ : Type} {R : β → γ → Prop} :
 
 /-- `bulletReduce_spec` with the readings carried into the postcondition. -/
 private theorem bulletReduce_spec' (e : IpaEndo F)
-    (hchar : ∀ a b : ℕ, a < 2 ^ 128 → b < 2 ^ 128 → (a : F) = b → a = b)
+    (hchar : CastInj128 F)
     (pairs : List ((AffinePoint (FVar F) × AffinePoint (FVar F)) × SizedF 128 (FVar F))) :
     ⦃⌜True⌝⦄ bulletReduce (c := Builder V (KimchiConstraint F)) e pairs
     ⦃⇓ r _ => ⌜∀ pv : List (e.d.W.Point × e.d.W.Point),
       List.Forall₂ (fun q v => PairReads e.d.W V q.1 v) pairs pv → pairs ≠ [] →
-      ∃ ns : List ℕ, List.Forall₂ (fun q m => Reads128 V q.2 m) pairs ns ∧
-        OnCurveAt e.d.W V r (lrSum (List.zipWith (lrTerm e.d.lam) pv ns))⌝⦄ := by
+      ∃ ns : List Prechallenge, List.Forall₂ (fun q m => Reads128 V q.2 m) pairs ns ∧
+        OnCurveAt e.d.W V r (lrSum (List.zipWith (lrTerm e.d.lam) pv (ns.map Subtype.val)))⌝⦄ := by
   rw [builder_spec_iff]
   intro nv hsat pv hp hne
   exact (builder_spec_iff _ _).mp (bulletReduce_spec e hchar pairs pv hp hne) nv hsat
@@ -679,7 +672,7 @@ holds at those readings. -/
 theorem ipaFinalCheck_spec {sf : Type}
     (ops : IpaScalarOps F (Builder V (KimchiConstraint F)) sf)
     (e : IpaEndo F) (p : Poseidon.Params F) (endo : FVar F)
-    (hchar : ∀ a b : ℕ, a < 2 ^ 128 → b < 2 ^ 128 → (a : F) = b → a = b)
+    (hchar : CastInj128 F)
     (R : ops.Reading e.d.W)
     (sv : SpongeVar F) (t : FVar F) (u combined : AffinePoint (FVar F))
     (inp : CheckBulletproofInput F sf)
@@ -692,12 +685,13 @@ theorem ipaFinalCheck_spec {sf : Type}
     (hh : OnCurveAt e.d.W V inp.blindingGenerator hv) :
     ⦃⌜True⌝⦄ ipaFinalCheck ops e p endo sv t u combined inp
     ⦃⇓ o _ => ⌜∀ uv Pv : e.d.W.Point, OnCurveAt e.d.W V u uv → OnCurveAt e.d.W V combined Pv →
-      o.t = t ∧ ∃ (ns : List ℕ) (c₀ : ℕ) (wcip wb w₁ w₂ : R.wit),
+      o.t = t ∧ ∃ (ns : List Prechallenge) (c₀ : Prechallenge) (wcip wb w₁ w₂ : R.wit),
       List.Forall₂ (Reads128 V) o.challenges ns ∧ ns.length = lrv.length ∧ Reads128 V o.c c₀ ∧
       R.Pre inp.deferred.combinedInnerProduct wcip ∧ R.Pre inp.deferred.b wb ∧
       R.Pre inp.opening.z1 w₁ ∧ R.Pre inp.opening.z2 w₂ ∧
       ((↑o.success : CVar F).val V = 1 ↔
-        SchnorrPoint e.d.lam c₀ uv Pv (lrSum (List.zipWith (lrTerm e.d.lam) lrv ns)) δv sgv hv
+        SchnorrPoint e.d.lam c₀.val uv Pv
+          (lrSum (List.zipWith (lrTerm e.d.lam) lrv (ns.map Subtype.val))) δv sgv hv
           (R.dec wcip) (R.dec wb) (R.dec w₁) (R.dec w₂))⌝⦄ := by
   simp only [ipaFinalCheck]
   have hext := fun sv' => extractScalarChallenges_length (V := V) p endo sv' inp.opening.lr
@@ -745,8 +739,8 @@ theorem ipaFinalCheck_spec {sf : Type}
   have hyb : (↑yEq : CVar F).val V = bit (decide (lhs.p.y.val V = rhs.p.y.val V)) := by
     rw [hy]; simp only [bit, decide_eq_true_eq]
   have hsucc := hand _ _ hxb hyb
-  refine ⟨trivial, ns, c₀, wcip, wb, w₁, w₂, forall₂_zip_right hlen hns,
-    by rw [← hns.length_eq, List.length_zip, hlen, hlr.length_eq, min_self], ⟨hc₀, hcv⟩, hpcip,
+  refine ⟨trivial, ns, ⟨c₀, hc₀⟩, wcip, wb, w₁, w₂, forall₂_zip_right hlen hns,
+    by rw [← hns.length_eq, List.length_zip, hlen, hlr.length_eq, min_self], hcv, hpcip,
     hpb, hp1, hp2, ?_⟩
   unfold SchnorrPoint
   constructor
@@ -780,7 +774,7 @@ theorem checkBulletproof_spec_success {sf : Type}
     (ops : IpaScalarOps F (Builder V (KimchiConstraint F)) sf) (e : IpaEndo F)
     (p : Poseidon.Params F) (hsize : p.roundConstants.size = Poseidon.fullRounds) (endo : FVar F)
     (gm : GroupMapParams F) (sqrtF : F → Option F)
-    (hchar : ∀ a b : ℕ, a < 2 ^ 128 → b < 2 ^ 128 → (a : F) = b → a = b)
+    (hchar : CastInj128 F)
     (R : ops.Reading e.d.W) (umap : F → e.d.W.Point)
     (hgm : ∀ t : FVar F, ⦃⌜True⌝⦄ groupMapCircuit (c := Builder V (KimchiConstraint F)) sqrtF gm t
       ⦃⇓ r _ => ⌜∃ U : e.d.W.Point, OnCurveAt e.d.W V r U ∧
@@ -790,27 +784,28 @@ theorem checkBulletproof_spec_success {sf : Type}
     (hbne : bases ≠ []) (inp : CheckBulletproofInput F sf)
     (hwf : ∀ x ∈ inp.scaled, R.WellFormed x)
     (hreg : ∀ (x : sf) (w : R.wit), x ∈ inp.scaled → R.Pre x w → R.Reg w)
-    (n : ℕ) (hn : n < 2 ^ 128) (hxi : inp.xi.val.val V = n) (δv sgv hv : e.d.W.Point)
+    (n : Prechallenge) (hxi : Reads128 V inp.xi n) (δv sgv hv : e.d.W.Point)
     (lrv : List (e.d.W.Point × e.d.W.Point))
     (hlr : List.Forall₂ (PairReads e.d.W V) inp.opening.lr lrv) (hlrne : inp.opening.lr ≠ [])
     (hδ : OnCurveAt e.d.W V inp.opening.delta δv) (hsg : OnCurveAt e.d.W V inp.opening.sg sgv)
     (hh : OnCurveAt e.d.W V inp.blindingGenerator hv) :
     ⦃⌜True⌝⦄ checkBulletproof ops e p endo gm sqrtF sv bases inp
-    ⦃⇓ o _ => ⌜∃ (U : e.d.W.Point) (ns : List ℕ) (c₀ : ℕ) (wcip wb w₁ w₂ : R.wit),
+    ⦃⇓ o _ => ⌜∃ (U : e.d.W.Point) (ns : List Prechallenge) (c₀ : Prechallenge)
+      (wcip wb w₁ w₂ : R.wit),
       (U = umap (o.t.val V) ∨ U = -umap (o.t.val V)) ∧
       List.Forall₂ (Reads128 V) o.challenges ns ∧ ns.length = lrv.length ∧ Reads128 V o.c c₀ ∧
       R.Pre inp.deferred.combinedInnerProduct wcip ∧ R.Pre inp.deferred.b wb ∧
       R.Pre inp.opening.z1 w₁ ∧ R.Pre inp.opening.z2 w₂ ∧
       ((↑o.success : CVar F).val V = 1 ↔
-        SchnorrPoint e.d.lam c₀ U (hornerCombine (endoExpandZ e.d.lam n) bv)
-          (lrSum (List.zipWith (lrTerm e.d.lam) lrv ns)) δv sgv hv
+        SchnorrPoint e.d.lam c₀.val U (hornerCombine (endoExpandZ e.d.lam n.val) bv)
+          (lrSum (List.zipWith (lrTerm e.d.lam) lrv (ns.map Subtype.val))) δv sgv hv
           (R.dec wcip) (R.dec wb) (R.dec w₁) (R.dec w₂))⌝⦄ := by
   simp only [checkBulletproof]
   have habs := fun sv' limbs => builder_spec_true
     (absorbList (c := Builder V (KimchiConstraint F)) p sv' limbs)
   have hsq := fun sv' => builder_spec_true
     (SpongeVar.squeeze (c := Builder V (KimchiConstraint F)) p sv')
-  have hcomb := combinePolynomials_spec (V := V) e inp.xi n hn hxi hchar bases bv hb hbne
+  have hcomb := combinePolynomials_spec (V := V) e inp.xi n hxi hchar bases bv hb hbne
   have hfin := fun sv' t u comb => ipaFinalCheck_spec (V := V) ops e p endo hchar R
     sv' t u comb inp hwf hreg δv sgv hv lrv hlr hlrne hδ hsg hh
   mvcgen -trivial [habs, hsq, hgm, hcomb, hfin]
@@ -1353,12 +1348,6 @@ section DeployedWrap
 open CompElliptic.Curves.Pasta CompElliptic.CurveForms.ShortWeierstrass Poseidon.FqSponge
 open Kimchi.Gate.EndoScalar Kimchi.Gate.VarBaseMul Bulletproof Bulletproof.Ipa
 
-/-- Naturals below `2¹²⁸` cast injectively into `Fq`. -/
-private theorem fq_natCast_inj (a b : ℕ) (ha : a < 2 ^ 128) (hb : b < 2 ^ 128)
-    (h : (a : Fq) = b) : a = b := by
-  have h' := (ZMod.natCast_eq_natCast_iff' a b _).mp h
-  rwa [Nat.mod_eq_of_lt (lt_trans ha (by decide)), Nat.mod_eq_of_lt (lt_trans hb (by decide))] at h'
-
 /-- **The wrap side's `check_bulletproof` at the wire.** Under any valuation satisfying the
 emitted constraints — the bases reading as Vesta points (the last kept), the pairs, `δ`, `sg`
 and `h` as points, the ladder witnesses off the forbidden band — the challenges read as some
@@ -1382,7 +1371,7 @@ theorem checkBulletproof_wrap_spec {V : Valuation Fq}
     (inp : CheckBulletproofInput Fq (Type1 (FVar Fq)))
     (hband : ∀ (x : Type1 (FVar Fq)) (z : ℤ), x ∈ inp.scaled → WrapLadderPre V x z →
       wrapLadderDec z ∉ forbiddenValues PALLAS_BASE_CARD)
-    (n : ℕ) (hn : n < 2 ^ 128) (hxi : inp.xi.val.val V = n)
+    (n : Prechallenge) (hxi : Reads128 V inp.xi n)
     (σ : SRS (SWPoint Vesta.curve))
     (lrW : Vector (SWPoint Vesta.curve × SWPoint Vesta.curve) σ.k) (δW sgW : SWPoint Vesta.curve)
     (hlr : List.Forall₂ (PairReads IpaEndo.vesta.d.W V) inp.opening.lr (lrW.toList.map fun q =>
@@ -1394,30 +1383,31 @@ theorem checkBulletproof_wrap_spec {V : Valuation Fq}
       ((SWPoint.equivPoint Vesta.curve) σ.h)) :
     ⦃⌜True⌝⦄ checkBulletproof (c := Builder V (KimchiConstraint Fq)) IpaScalarOps.wrap IpaEndo.vesta
       p endo groupMapParamsVesta sqrtF sv bases inp
-    ⦃⇓ o _ => ⌜∃ (U : SWPoint Vesta.curve) (ns : List ℕ) (c₀ : ℕ) (chals : Vector Fp σ.k),
+    ⦃⇓ o _ => ⌜∃ (U : SWPoint Vesta.curve) (ns : List Prechallenge) (c₀ : Prechallenge)
+      (chals : Vector Fp σ.k),
       (U = Poseidon.GroupMap.toGroup Poseidon.GroupMapVesta.spec (o.t.val V) ∨
         U = -Poseidon.GroupMap.toGroup Poseidon.GroupMapVesta.spec (o.t.val V)) ∧
       List.Forall₂ (Reads128 V) o.challenges ns ∧ Reads128 V o.c c₀ ∧
-      chals.toList = ns.map (endoExpand Poseidon.FqVesta.spec.lam) ∧
+      chals.toList = ns.map (fun m => endoExpand Poseidon.FqVesta.spec.lam m.val) ∧
       ((↑o.success : CVar Fq).val V = 1 ↔
-        schnorrAt IpaVesta.curve σ U chals (endoExpand Poseidon.FqVesta.spec.lam c₀)
+        schnorrAt IpaVesta.curve σ U chals (endoExpand Poseidon.FqVesta.spec.lam c₀.val)
           (wrapDecode V inp.deferred.combinedInnerProduct) (wrapDecode V inp.deferred.b)
-          (combineCommitments IpaVesta.curve (endoExpand Poseidon.FqVesta.spec.lam n)
+          (combineCommitments IpaVesta.curve (endoExpand Poseidon.FqVesta.spec.lam n.val)
             ((bvW.filter (·.2)).map (·.1)).toArray)
           ⟨lrW, δW, wrapDecode V inp.opening.z1, wrapDecode V inp.opening.z2, sgW⟩)⌝⦄ := by
   refine builder_spec_imp _ _ _
     (checkBulletproof_spec_success IpaScalarOps.wrap IpaEndo.vesta p hsize endo
-      groupMapParamsVesta sqrtF fq_natCast_inj (wrapReading V)
+      groupMapParamsVesta sqrtF (castInj128_of_lt _ (by decide)) (wrapReading V)
       (fun t => SWPoint.equivPoint Vesta.curve
         (Poseidon.GroupMap.toGroup Poseidon.GroupMapVesta.spec t)) (vesta_groupMap_reads sqrtF)
       sv bases _ hb hbne inp (fun _ _ => trivial)
       (fun x z hx hpre => HasCurve.vesta_ladderRegime _ (hband x z hx hpre))
-      n hn hxi _ _ _ _ hlr hlrne hδ hsg hh) fun o ho => ?_
+      n hxi _ _ _ _ hlr hlrne hδ hsg hh) fun o ho => ?_
   obtain ⟨U, ns, c₀, wcip, wb, w₁, w₂, hU, hns, hlen, hc, hpcip, hpb, hp1, hp2, hiff⟩ := ho
   have hlen' : ns.length = σ.k := by rw [hlen, List.length_map, Vector.length_toList]
   refine ⟨(SWPoint.equivPoint Vesta.curve).symm U, ns, c₀,
-    ⟨(ns.map (endoExpand Poseidon.FqVesta.spec.lam)).toArray, by simp [hlen']⟩, ?_, hns, hc,
-    by simp, ?_⟩
+    ⟨(ns.map fun m => endoExpand Poseidon.FqVesta.spec.lam m.val).toArray, by simp [hlen']⟩,
+    ?_, hns, hc, by simp, ?_⟩
   · beta_reduce at hU
     generalize Poseidon.GroupMap.toGroup Poseidon.GroupMapVesta.spec (CVar.val o.t V) = T at hU ⊢
     rcases hU with h | h
@@ -1428,10 +1418,10 @@ theorem checkBulletproof_wrap_spec {V : Valuation Fq}
         (map_neg (SWPoint.equivPoint Vesta.curve) T).symm).trans (AddEquiv.symm_apply_apply _ _)
   · rw [← wrapLadderDec_cast hpcip, ← wrapLadderDec_cast hpb, ← wrapLadderDec_cast hp1,
       ← wrapLadderDec_cast hp2, hiff,
-      ← schnorrPoint_iff_schnorrAt_vesta σ _ _ _ c₀ _ _ _ _ ⟨lrW, δW, _, _, sgW⟩ ns (by simp) rfl
-        rfl]
+      ← schnorrPoint_iff_schnorrAt_vesta σ _ _ _ c₀.val _ _ _ _ ⟨lrW, δW, _, _, sgW⟩
+        (ns.map Subtype.val) (by simp [Function.comp_def]) rfl rfl]
     simp only [AddEquiv.apply_symm_apply]
-    rw [← vesta_hornerCombine_eq n bvW hlast, AddEquiv.apply_symm_apply]
+    rw [← vesta_hornerCombine_eq n.val bvW hlast, AddEquiv.apply_symm_apply]
     exact Iff.rfl
 
 end DeployedWrap
@@ -1612,12 +1602,6 @@ section DeployedStep
 open CompElliptic.Curves.Pasta CompElliptic.CurveForms.ShortWeierstrass Poseidon.FqSponge
 open Kimchi.Gate.EndoScalar Kimchi.Gate.VarBaseMul Bulletproof Bulletproof.Ipa Pasta.Shifted
 
-/-- Naturals below `2¹²⁸` cast injectively into `Fp`. -/
-private theorem fp_natCast_inj (a b : ℕ) (ha : a < 2 ^ 128) (hb : b < 2 ^ 128)
-    (h : (a : Fp) = b) : a = b := by
-  have h' := (ZMod.natCast_eq_natCast_iff' a b _).mp h
-  rwa [Nat.mod_eq_of_lt (lt_trans ha (by decide)), Nat.mod_eq_of_lt (lt_trans hb (by decide))] at h'
-
 /-- **The step side's `check_bulletproof` at the wire.** Under any valuation satisfying the
 emitted constraints — the bases reading as Pallas points (the last kept), the pairs, `δ`, `sg`
 and `h` as points, the parity bits reading as bits, the ladder witnesses' halves off the
@@ -1641,7 +1625,7 @@ theorem checkBulletproof_step_spec {V : Valuation Fp}
     (hbits : ∀ x ∈ inp.scaled, ∃ bb : Bool, (↑x.val.sOdd : CVar Fp).val V = bit bb)
     (hband : ∀ (x : Type2 (SplitField (FVar Fp) (BoolVar Fp))) (w : ℤ × Bool), x ∈ inp.scaled →
       StepLadderPre V x w → unshiftType1 255 w.1 ∉ forbiddenValues PALLAS_SCALAR_CARD)
-    (n : ℕ) (hn : n < 2 ^ 128) (hxi : inp.xi.val.val V = n)
+    (n : Prechallenge) (hxi : Reads128 V inp.xi n)
     (σ : SRS (SWPoint Pallas.curve))
     (lrW : Vector (SWPoint Pallas.curve × SWPoint Pallas.curve) σ.k) (δW sgW : SWPoint Pallas.curve)
     (hlr : List.Forall₂ (PairReads IpaEndo.pallas.d.W V) inp.opening.lr (lrW.toList.map fun q =>
@@ -1653,30 +1637,31 @@ theorem checkBulletproof_step_spec {V : Valuation Fp}
       ((SWPoint.equivPoint Pallas.curve) σ.h)) :
     ⦃⌜True⌝⦄ checkBulletproof (c := Builder V (KimchiConstraint Fp)) IpaScalarOps.step
       IpaEndo.pallas p endo groupMapParamsPallas sqrtF sv bases inp
-    ⦃⇓ o _ => ⌜∃ (U : SWPoint Pallas.curve) (ns : List ℕ) (c₀ : ℕ) (chals : Vector Fq σ.k),
+    ⦃⇓ o _ => ⌜∃ (U : SWPoint Pallas.curve) (ns : List Prechallenge) (c₀ : Prechallenge)
+      (chals : Vector Fq σ.k),
       (U = Poseidon.GroupMap.toGroup Poseidon.GroupMapPallas.spec (o.t.val V) ∨
         U = -Poseidon.GroupMap.toGroup Poseidon.GroupMapPallas.spec (o.t.val V)) ∧
       List.Forall₂ (Reads128 V) o.challenges ns ∧ Reads128 V o.c c₀ ∧
-      chals.toList = ns.map (endoExpand Poseidon.FqPallas.spec.lam) ∧
+      chals.toList = ns.map (fun m => endoExpand Poseidon.FqPallas.spec.lam m.val) ∧
       ((↑o.success : CVar Fp).val V = 1 ↔
-        schnorrAt IpaPallas.curve σ U chals (endoExpand Poseidon.FqPallas.spec.lam c₀)
+        schnorrAt IpaPallas.curve σ U chals (endoExpand Poseidon.FqPallas.spec.lam c₀.val)
           (stepDecode V inp.deferred.combinedInnerProduct) (stepDecode V inp.deferred.b)
-          (combineCommitments IpaPallas.curve (endoExpand Poseidon.FqPallas.spec.lam n)
+          (combineCommitments IpaPallas.curve (endoExpand Poseidon.FqPallas.spec.lam n.val)
             ((bvW.filter (·.2)).map (·.1)).toArray)
           ⟨lrW, δW, stepDecode V inp.opening.z1, stepDecode V inp.opening.z2, sgW⟩)⌝⦄ := by
   refine builder_spec_imp _ _ _
     (checkBulletproof_spec_success IpaScalarOps.step IpaEndo.pallas p hsize endo
-      groupMapParamsPallas sqrtF fp_natCast_inj (stepReading V)
+      groupMapParamsPallas sqrtF (castInj128_of_lt _ (by decide)) (stepReading V)
       (fun t => SWPoint.equivPoint Pallas.curve
         (Poseidon.GroupMap.toGroup Poseidon.GroupMapPallas.spec t)) (pallas_groupMap_reads sqrtF)
       sv bases _ hb hbne inp hbits
       (fun x w hx hpre => HasCurve.pallas_ladderRegime _ (hband x w hx hpre))
-      n hn hxi _ _ _ _ hlr hlrne hδ hsg hh) fun o ho => ?_
+      n hxi _ _ _ _ hlr hlrne hδ hsg hh) fun o ho => ?_
   obtain ⟨U, ns, c₀, wcip, wb, w₁, w₂, hU, hns, hlen, hc, hpcip, hpb, hp1, hp2, hiff⟩ := ho
   have hlen' : ns.length = σ.k := by rw [hlen, List.length_map, Vector.length_toList]
   refine ⟨(SWPoint.equivPoint Pallas.curve).symm U, ns, c₀,
-    ⟨(ns.map (endoExpand Poseidon.FqPallas.spec.lam)).toArray, by simp [hlen']⟩, ?_, hns, hc,
-    by simp, ?_⟩
+    ⟨(ns.map fun m => endoExpand Poseidon.FqPallas.spec.lam m.val).toArray, by simp [hlen']⟩,
+    ?_, hns, hc, by simp, ?_⟩
   · beta_reduce at hU
     generalize Poseidon.GroupMap.toGroup Poseidon.GroupMapPallas.spec (CVar.val o.t V) = T at hU ⊢
     rcases hU with h | h
@@ -1687,10 +1672,10 @@ theorem checkBulletproof_step_spec {V : Valuation Fp}
         (map_neg (SWPoint.equivPoint Pallas.curve) T).symm).trans (AddEquiv.symm_apply_apply _ _)
   · rw [← stepLadderDec_cast hpcip, ← stepLadderDec_cast hpb, ← stepLadderDec_cast hp1,
       ← stepLadderDec_cast hp2, hiff,
-      ← schnorrPoint_iff_schnorrAt_pallas σ _ _ _ c₀ _ _ _ _ ⟨lrW, δW, _, _, sgW⟩ ns (by simp) rfl
-        rfl]
+      ← schnorrPoint_iff_schnorrAt_pallas σ _ _ _ c₀.val _ _ _ _ ⟨lrW, δW, _, _, sgW⟩
+        (ns.map Subtype.val) (by simp [Function.comp_def]) rfl rfl]
     simp only [AddEquiv.apply_symm_apply]
-    rw [← pallas_hornerCombine_eq n bvW hlast, AddEquiv.apply_symm_apply]
+    rw [← pallas_hornerCombine_eq n.val bvW hlast, AddEquiv.apply_symm_apply]
     exact Iff.rfl
 
 end DeployedStep
@@ -1700,7 +1685,7 @@ end DeployedStep
 open Kimchi.Verifier Bulletproof.Ipa in
 /-- `CheckBulletproofReads` at a deployed field, against the wire verifier: with `(t, us, c)`
 the verifier's `ipaPrechallenges`, `t` reads exactly, and each round prechallenge and `c`,
-once identified with a 128-bit value, is its counterpart up to `PrechallengeAlias`
+once read as a prechallenge, is its counterpart up to `PrechallengeAlias`
 (`transcriptFrom_eq_ipaPrechallenges` carries these to `transcriptFrom`'s `U` base, round
 challenges and Schnorr challenge). -/
 def CheckBulletproofReadsWire {p : ℕ} [Fact p.Prime] (params : Poseidon.Params (ZMod p))
@@ -1710,8 +1695,8 @@ def CheckBulletproofReadsWire {p : ℕ} [Fact p.Prime] (params : Poseidon.Params
   let r := ipaPrechallenges params s₀ cipLimbs (lrv.map coordsPair) (δv.x, δv.y)
   o.t.val V = r.1 ∧
   List.Forall₂ (fun (pre : ℕ) (u : SizedF 128 (FVar (ZMod p))) =>
-    ∀ u₀ : ℕ, u₀ < 2 ^ 128 → u.val.val V = u₀ → PrechallengeAlias p pre u₀) r.2.1 o.challenges ∧
-  (∀ c₀ : ℕ, c₀ < 2 ^ 128 → o.c.val.val V = c₀ → PrechallengeAlias p r.2.2 c₀)
+    ∀ m, Reads128 V u m → PrechallengeAlias p pre m) r.2.1 o.challenges ∧
+  (∀ m, Reads128 V o.c m → PrechallengeAlias p r.2.2 m)
 
 open Kimchi.Verifier Bulletproof.Ipa in
 /-- At a prime field of more than 254 bits, the exact reading is the wire reading
@@ -1722,10 +1707,11 @@ theorem CheckBulletproofReads.wire {p : ℕ} [Fact p.Prime] (hp : 2 ^ 254 < p)
     {V : Valuation (ZMod p)} {o : CheckBulletproofOutput (ZMod p)}
     (h : CheckBulletproofReads params s₀ cipLimbs lrv δv V o) :
     CheckBulletproofReadsWire params s₀ cipLimbs lrv δv V o := by
-  obtain ⟨ht, hus, ⟨hi, hhi, hc⟩⟩ := h
-  refine ⟨ht, ?_, fun c₀ hc₀ hcv => low128_of_decomp hp _ c₀ hi hc₀ hhi (by rw [hc, hcv])⟩
+  obtain ⟨ht, hus, hlc⟩ := h
+  refine ⟨ht, ?_, fun _ hm => hlc.alias hp hm⟩
   simp only [ipaPrechallenges]
-  exact List.forall₂_map_left_iff.mpr (hus.imp fun _ _ ⟨hi, hhi, hx⟩ u₀ hu₀ huv =>
-    low128_of_decomp hp _ u₀ hi hu₀ hhi (by rw [hx, huv]))
+  refine List.forall₂_map_left_iff.mpr (hus.imp ?_)
+  intro _ _ hl m hm
+  exact hl.alias hp hm
 
 end Pickles

--- a/formal/pickles/Pickles/FinalizeOtherProof.lean
+++ b/formal/pickles/Pickles/FinalizeOtherProof.lean
@@ -5,6 +5,7 @@ import Pickles.PermScalar
 import Pickles.FrSponge
 import Pickles.Domain
 import Snarky.Types.Shifted
+import Pickles.Statement
 
 set_option mvcgen.warning false
 
@@ -25,7 +26,9 @@ recomputes each from the evaluations and compares.
   permutation scalar, and the four checks combined.
 * `finalizeOtherProofStep`, `finalizeOtherProofWrap`: each side's prelude — the challenge
   expansions in the side's order, the wrap side's seals, the step side's known-domain
-  selection — and the side's shifted-value conventions.
+  selection — and the side's shifted-value conventions (`FopShiftOps`, at the side's
+  `Type1`/`Type2` claims). The claims arrive as an `UnfinalizedProof` of `Pickles.Statement`,
+  the step statement's per-predecessor record.
 * `FopChecks`, `FopReads`, `FopReadsWire`: the readings the soundness theorems conclude —
   the three claim checks at given effective challenges; the exact reading of the whole
   circuit, its `ξ`, `r` as 128-bit decompositions of the wire verifier's `frSqueezes`; and
@@ -45,36 +48,6 @@ open Std.Do Snarky Snarky.Kimchi Kimchi.Verifier Pickles.Linearization
 open scoped Kimchi
 
 variable {F c : Type} [Field F] [DecidableEq F] [ToNat F] [BasicSystem F c] [KimchiSystem F c]
-
-/-- The public-input side of a proof to finalize (PS `PerProofUnfinalized`): the five 128-bit
-prechallenges, the three shifted plonk scalars and the two shifted IPA scalars as their inner
-variables (the side decides the shift encoding), the 16 raw bulletproof challenges, and the
-fq-sponge digest before evaluations. -/
-structure UnfinalizedProof (F : Type) where
-  /-- The 128-bit `α` prechallenge. -/
-  alpha : SizedF 128 (FVar F)
-  /-- The 128-bit `β`. -/
-  beta : SizedF 128 (FVar F)
-  /-- The 128-bit `γ`. -/
-  gamma : SizedF 128 (FVar F)
-  /-- The 128-bit `ζ` prechallenge. -/
-  zeta : SizedF 128 (FVar F)
-  /-- The 128-bit `ξ` prechallenge. -/
-  xi : SizedF 128 (FVar F)
-  /-- The shifted `ζ^(srs length)`. -/
-  zetaToSrsLength : FVar F
-  /-- The shifted `ζⁿ`. -/
-  zetaToDomainSize : FVar F
-  /-- The shifted permutation scalar. -/
-  perm : FVar F
-  /-- The shifted combined inner product. -/
-  combinedInnerProduct : FVar F
-  /-- The shifted `b`. -/
-  b : FVar F
-  /-- The 16 raw 128-bit bulletproof challenges. -/
-  bulletproofChallenges : List (SizedF 128 (FVar F))
-  /-- The fq-sponge digest before evaluations. -/
-  spongeDigestBeforeEvaluations : FVar F
 
 /-- The witness evaluations (PS `ProofWitness`'s `AllEvals`): `ft(ζω)`, the public pair and
 the proof's evaluations at `ζ` and `ζω`. -/
@@ -110,11 +83,11 @@ structure FopParams (F : Type) where
 
 /-- The side's shifted-value conventions (PS `FopShiftOps`): the decode of a claim, and the
 comparison of a claim with a computed scalar. -/
-structure FopShiftOps (F c : Type) where
+structure FopShiftOps (F c sf : Type) where
   /-- The decode of a shifted claim. -/
-  unshift : FVar F → FVar F
+  unshift : sf → FVar F
   /-- The comparison of a shifted claim with a computed scalar. -/
-  shiftedEqual : FVar F → FVar F → CircuitM F c (BoolVar F)
+  shiftedEqual : sf → FVar F → CircuitM F c (BoolVar F)
 
 /-- The result (PS `Output`): the four checks and their conjunction, the raw and the expanded
 bulletproof challenges. -/
@@ -168,19 +141,19 @@ the challenge polynomials at `ζω` then `ζ`, the fr-sponge with `ξ` compared 
 the zk polynomial, `ζⁿ − 1`, `ft_eval0`, the combined inner product against its claim, the
 challenges expanded and `b` against its claim, the permutation scalar, the voided
 `ζ^(2^srs)`, the shifted comparison, and the conjunction. -/
-def finalizeOtherProofCore (P : FopParams F) (ops : FopShiftOps F c)
+def finalizeOtherProofCore {sf : Type} (P : FopParams F) (ops : FopShiftOps F c sf)
     (xiConstrainLowBits : Bool) (digest : CircuitM F c (FVar F)) (gen : FVar F)
     (pow2Log2 : ℕ) (vanishing : FVar F → CircuitM F c (FVar F)) (mask : List (BoolVar F))
-    (u : UnfinalizedProof F) (w : ProofWitness F) (prev : List (List (FVar F)))
-    (zeta alpha beta gamma perm : FVar F) : CircuitM F c (FopOutput F) := do
+    (u : UnfinalizedProof F sf) (w : ProofWitness F) (prev : List (List (FVar F)))
+    (zeta alpha beta gamma : FVar F) (perm : sf) : CircuitM F c (FopOutput F) := do
   let endoVar : FVar F := .const P.endoLam
   let zetaw ← mul gen zeta
   let sgZetaw ← challengePolyEvals zetaw prev
   let sgZeta ← challengePolyEvals zeta prev
   let (xiActual, rActual) ← squeezeXiR P.sponge u.spongeDigestBeforeEvaluations digest
     w.ftEval1 w.pub w.evals endoVar xiConstrainLowBits
-  let xiCorrect ← equals xiActual.val u.xi.val
-  let xi ← EndoScalar.toField 8 u.xi.val endoVar
+  let xiCorrect ← equals xiActual.val u.deferredValues.xi.val
+  let xi ← EndoScalar.toField 8 u.deferredValues.xi.val endoVar
   let r ← EndoScalar.toField 8 rActual.val endoVar
   let _ ← pow2PowSquare zeta pow2Log2
   let _ ← pow2PowSquare zetaw pow2Log2
@@ -212,15 +185,16 @@ def finalizeOtherProofCore (P : FopParams F) (ops : FopShiftOps F c)
     (buildEvalList (mask.zip sgZeta) w.pub.zeta ftEval0 (evalFields (·.zeta) w.evals))
     (buildEvalList (mask.zip sgZetaw) w.pub.zetaOmega w.ftEval1
       (evalFields (·.zetaOmega) w.evals))
-  let cipCorrect ← equals (ops.unshift u.combinedInnerProduct) actualCip
-  let expanded ← computeChallenges endoVar (u.bulletproofChallenges.map (·.val))
-  let bCorrect ← bCorrectCircuit expanded zeta zetaw r (ops.unshift u.b)
+  let cipCorrect ← equals (ops.unshift u.deferredValues.combinedInnerProduct) actualCip
+  let expanded ← computeChallenges endoVar (u.deferredValues.bulletproofChallenges.map (·.val))
+  let bCorrect ← bCorrectCircuit expanded zeta zetaw r (ops.unshift u.deferredValues.b)
   let actualPerm ← permScalarCircuit (fun i => evals.w ⟨i, by omega⟩) evals.s evals.zOmega
     beta gamma zkPoly (alphaPows 21)
   let _ ← Snarky.pow zeta (2 ^ P.srsLengthLog2)
   let plonkOk ← ops.shiftedEqual perm actualPerm
   let finalized ← Snarky.all [xiCorrect, bCorrect, cipCorrect, plonkOk]
-  pure ⟨finalized, xiCorrect, bCorrect, cipCorrect, plonkOk, u.bulletproofChallenges, expanded⟩
+  pure ⟨finalized, xiCorrect, bCorrect, cipCorrect, plonkOk,
+    u.deferredValues.bulletproofChallenges, expanded⟩
 
 /-- A known domain the prev proof may have: its `log2` and generator. -/
 structure KnownDomain (F : Type) where
@@ -231,51 +205,53 @@ structure KnownDomain (F : Type) where
 
 /-- The step side's shifted-value conventions: Type1 claims, compared by encoding the
 computed scalar. -/
-def stepShiftOps : FopShiftOps F c where
-  unshift x := Type1.fromShiftedCircuit 255 ⟨x⟩
-  shiftedEqual claimed actual := equals claimed (Type1.ofFieldCircuit 255 actual)
+def stepShiftOps : FopShiftOps F c (Type1 (FVar F)) where
+  unshift x := Type1.fromShiftedCircuit 255 x
+  shiftedEqual claimed actual := equals claimed.val (Type1.ofFieldCircuit 255 actual)
 
 /-- The wrap side's shifted-value conventions: Type2 claims, compared by decoding the
 claim. -/
-def wrapShiftOps : FopShiftOps F c where
-  unshift x := Type2.fromShiftedCircuit 255 ⟨x⟩
-  shiftedEqual claimed actual := equals (Type2.fromShiftedCircuit 255 ⟨claimed⟩) actual
+def wrapShiftOps : FopShiftOps F c (Type2 (FVar F)) where
+  unshift x := Type2.fromShiftedCircuit 255 x
+  shiftedEqual claimed actual := equals (Type2.fromShiftedCircuit 255 claimed) actual
 
 /-- The step side (PS `finalizeOtherProofCircuit`, known-domains mode): `ζ` then `α`
 expanded, the domain selected from the runtime `domain_log2` and its generator
 mask-selected, then the core with the masked challenge digest, `ξ` by `squeeze_challenge`,
 the `ζ^(2^srs)` rows and the known-domain vanishing polynomial. -/
 def finalizeOtherProofStep (P : FopParams F) (domains : List (KnownDomain F))
-    (u : UnfinalizedProof F) (w : ProofWitness F) (mask : List (BoolVar F))
+    (u : UnfinalizedProof F (Type1 (FVar F))) (w : ProofWitness F) (mask : List (BoolVar F))
     (prev : List (List (FVar F))) (domainLog2Var : FVar F) : CircuitM F c (FopOutput F) := do
   let endoVar : FVar F := .const P.endoLam
-  let zeta ← EndoScalar.toField 8 u.zeta.val endoVar
-  let alpha ← EndoScalar.toField 8 u.alpha.val endoVar
+  let pl := u.deferredValues.plonk
+  let zeta ← EndoScalar.toField 8 pl.zeta.val endoVar
+  let alpha ← EndoScalar.toField 8 pl.alpha.val endoVar
   let log2s := domains.map (·.log2)
   let whiches ← knownDomainWhiches domainLog2Var log2s
   let gen ← Pseudo.mask whiches (domains.map fun d => .const d.generator)
   let maxLog2 := log2s.foldr max 0
   finalizeOtherProofCore P stepShiftOps true (maskedChallengeDigest P.sponge mask prev) gen
     P.srsLengthLog2 (knownDomainVanishingPolynomial whiches log2s maxLog2) mask u w prev
-    zeta alpha u.beta.val u.gamma.val u.perm
+    zeta alpha pl.beta.val pl.gamma.val pl.perm
 
 /-- The wrap side (PS `wrapFinalizeOtherProofCircuit`): `ζ`, `γ`, `β`, `α` in that order with
 `γ`, `β` sealed, the three shifted plonk claims sealed, then the core at the constant
 generator with the plain challenge digest, `ξ` by `squeeze_scalar`, the `ζ^(2^log2)` rows
 and the caller's vanishing polynomial. -/
 def finalizeOtherProofWrap (P : FopParams F) (gen : F) (domainLog2 : ℕ)
-    (vanishing : FVar F → CircuitM F c (FVar F)) (u : UnfinalizedProof F)
+    (vanishing : FVar F → CircuitM F c (FVar F)) (u : UnfinalizedProof F (Type2 (FVar F)))
     (w : ProofWitness F) (prev : List (List (FVar F))) : CircuitM F c (FopOutput F) := do
   let endoVar : FVar F := .const P.endoLam
-  let zeta ← EndoScalar.toField 8 u.zeta.val endoVar
-  let gamma ← sealVar u.gamma.val
-  let beta ← sealVar u.beta.val
-  let alpha ← EndoScalar.toField 8 u.alpha.val endoVar
-  let perm ← sealVar u.perm
-  let _ ← sealVar u.zetaToDomainSize
-  let _ ← sealVar u.zetaToSrsLength
+  let pl := u.deferredValues.plonk
+  let zeta ← EndoScalar.toField 8 pl.zeta.val endoVar
+  let gamma ← sealVar pl.gamma.val
+  let beta ← sealVar pl.beta.val
+  let alpha ← EndoScalar.toField 8 pl.alpha.val endoVar
+  let perm ← sealVar pl.perm.val
+  let _ ← sealVar pl.zetaToDomainSize.val
+  let _ ← sealVar pl.zetaToSrsLength.val
   finalizeOtherProofCore P wrapShiftOps false (challengeDigest P.sponge prev) (.const gen)
-    domainLog2 vanishing (prev.map fun _ => true_) u w prev zeta alpha beta gamma perm
+    domainLog2 vanishing (prev.map fun _ => true_) u w prev zeta alpha beta gamma ⟨perm⟩
 
 /-! ## The value side -/
 
@@ -381,16 +357,16 @@ the evaluation rows), `cipCorrect = [unshift(cip claim) = combinedInnerProduct �
 `plonkOk = [unshift(permV) = permScalar β γ α (zkpmEval n zkRows ω ζ) e]`, `finalized` the
 conjunction of the four bits reading `1`, and the expanded challenges read `cs`. -/
 def FopChecks (P : FopParams F) (n : ℕ) (ω : F) (ms : List Bool) (cvs : List (List F))
-    (u : UnfinalizedProof F) (w : ProofWitness F) (ζ α β γ permV : F) (unshiftV : F → F)
+    (w : ProofWitness F) (ζ α β γ permV cipV bV : F) (unshiftV : F → F)
     (V : Valuation F) (o : FopOutput F) (ξ r : F) (cs : List F) : Prop :=
   let e := w.evals.map (·.val V)
   let ft₀ := ftEval0 n P.zkRows ω P.shifts P.endo P.mds α β γ ζ (w.pub.zeta.val V) (linEvals e)
   let rows := sgRows ms (cvs.map fun cv => bPoly (fun i : Fin cv.length => cv.get i) ζ)
       (cvs.map fun cv => bPoly (fun i : Fin cv.length => cv.get i) (ζ * ω))
     ++ ⟨w.pub.zeta.val V, w.pub.zetaOmega.val V⟩ :: ⟨ft₀, w.ftEval1.val V⟩ :: evalRows e
-  let cipOk := unshiftV (u.combinedInnerProduct.val V) = Bulletproof.combinedInnerProduct ξ r
+  let cipOk := unshiftV cipV = Bulletproof.combinedInnerProduct ξ r
     (fun (i : Fin rows.length) (j : Fin evalPts) => ((rows.get i).toVector)[j])
-  let bOk := unshiftV (u.b.val V) = combinedB (fun i : Fin cs.length => cs.get i) r ![ζ, ζ * ω]
+  let bOk := unshiftV bV = combinedB (fun i : Fin cs.length => cs.get i) r ![ζ, ζ * ω]
   let permOk := unshiftV permV = permScalar β γ α (zkpmEval n P.zkRows ω ζ) (linEvals e)
   (↑o.cipCorrect : CVar F).val V = (if cipOk then 1 else 0) ∧
   (↑o.bCorrect : CVar F).val V = (if bOk then 1 else 0) ∧
@@ -411,22 +387,23 @@ there are `ξ₀ < 2¹²⁸` the `ξ` claim, `ξ' + 2¹²⁸·h₁ = x₁` the r
 challenge claims, such that `xiCorrect = [ξ' = ξ₀]` and `FopChecks` holds at
 `ξ = endoExpand λ ξ₀`, `r = endoExpand λ r'` and the expanded challenges `endoExpand λ ĉᵢ`.
 `FopReads.wire` reads this against the wire verifier's prechallenges at a deployed field. -/
-def FopReads (P : FopParams F) (xiConstrainLowBits : Bool) (n : ℕ) (ω dv : F) (ms : List Bool)
-    (cvs : List (List F)) (u : UnfinalizedProof F) (w : ProofWitness F) (ζ α β γ permV : F)
-    (unshiftV : F → F) (V : Valuation F) (o : FopOutput F) : Prop :=
+def FopReads {sf : Type} (P : FopParams F) (xiConstrainLowBits : Bool) (n : ℕ) (ω dv : F)
+    (ms : List Bool) (cvs : List (List F)) (u : UnfinalizedProof F sf) (w : ProofWitness F)
+    (ζ α β γ permV cipV bV : F) (unshiftV : F → F) (V : Valuation F) (o : FopOutput F) : Prop :=
     let sq := frSqueezes P.sponge
       (frTranscript (u.spongeDigestBeforeEvaluations.val V) dv (w.ftEval1.val V)
         (w.pub.map fun x => #v[x.val V]) (w.evals.map fun x => #v[x.val V]))
     let x₁ := sq.1
     let x₂ := sq.2
     ∃ (ξ₀ r' h₁ h₂ : ℕ) (ξ' : F) (ĉ : List ℕ),
-      ξ₀ < 2 ^ 128 ∧ u.xi.val.val V = ξ₀ ∧ h₁ < 2 ^ 128 ∧ h₂ < 2 ^ 128 ∧ r' < 2 ^ 128 ∧
+      ξ₀ < 2 ^ 128 ∧ u.deferredValues.xi.val.val V = ξ₀ ∧ h₁ < 2 ^ 128 ∧ h₂ < 2 ^ 128 ∧
+      r' < 2 ^ 128 ∧
       (xiConstrainLowBits = true → ∃ m : ℕ, m < 2 ^ 128 ∧ ξ' = m) ∧
       x₁ = ξ' + 2 ^ 128 * h₁ ∧ x₂ = r' + 2 ^ 128 * h₂ ∧
       List.Forall₂ (fun (ch : SizedF 128 (FVar F)) (k : ℕ) => k < 2 ^ 128 ∧ ch.val.val V = k)
-        u.bulletproofChallenges ĉ ∧
+        u.deferredValues.bulletproofChallenges ĉ ∧
       (↑o.xiCorrect : CVar F).val V = (if ξ' = (ξ₀ : F) then 1 else 0) ∧
-      FopChecks P n ω ms cvs u w ζ α β γ permV unshiftV V o (endoExpand P.endoLam ξ₀)
+      FopChecks P n ω ms cvs w ζ α β γ permV cipV bV unshiftV V o (endoExpand P.endoLam ξ₀)
         (endoExpand P.endoLam r') (ĉ.map (endoExpand P.endoLam))
 
 open Kimchi.Protocol.Linearization Poseidon.FqSponge in
@@ -436,33 +413,33 @@ prechallenges (`frOracles_eq_frPrechallenges` expands them to `frOracles`' `(v, 
 `r` the checks use is `pre.2` up to `PrechallengeAlias`, `xiCorrect` is a bit and, when it
 reads `1`, the `ξ` claim is `pre.1` up to the alias, and `FopChecks` holds at the
 endo-expansions of the `ξ` claim, of `r` and of the challenge claims. -/
-def FopReadsWire {p : ℕ} [Fact p.Prime] (P : FopParams (ZMod p)) (n : ℕ) (ω dv : ZMod p)
-    (ms : List Bool) (cvs : List (List (ZMod p))) (u : UnfinalizedProof (ZMod p))
-    (w : ProofWitness (ZMod p)) (ζ α β γ permV : ZMod p) (unshiftV : ZMod p → ZMod p)
+def FopReadsWire {p : ℕ} [Fact p.Prime] {sf : Type} (P : FopParams (ZMod p)) (n : ℕ)
+    (ω dv : ZMod p) (ms : List Bool) (cvs : List (List (ZMod p))) (u : UnfinalizedProof (ZMod p) sf)
+    (w : ProofWitness (ZMod p)) (ζ α β γ permV cipV bV : ZMod p) (unshiftV : ZMod p → ZMod p)
     (V : Valuation (ZMod p)) (o : FopOutput (ZMod p)) : Prop :=
   let pre := frPrechallenges P.sponge
     (frTranscript (u.spongeDigestBeforeEvaluations.val V) dv (w.ftEval1.val V)
       (w.pub.map fun x => #v[x.val V]) (w.evals.map fun x => #v[x.val V]))
   ∃ (ξ₀ r' : ℕ) (ĉ : List ℕ),
-    ξ₀ < 2 ^ 128 ∧ u.xi.val.val V = ξ₀ ∧ PrechallengeAlias p pre.2 r' ∧
+    ξ₀ < 2 ^ 128 ∧ u.deferredValues.xi.val.val V = ξ₀ ∧ PrechallengeAlias p pre.2 r' ∧
     ((↑o.xiCorrect : CVar (ZMod p)).val V = 0 ∨ (↑o.xiCorrect : CVar (ZMod p)).val V = 1) ∧
     ((↑o.xiCorrect : CVar (ZMod p)).val V = 1 → PrechallengeAlias p pre.1 ξ₀) ∧
     List.Forall₂ (fun (ch : SizedF 128 (FVar (ZMod p))) (k : ℕ) => k < 2 ^ 128 ∧ ch.val.val V = k)
-      u.bulletproofChallenges ĉ ∧
-    FopChecks P n ω ms cvs u w ζ α β γ permV unshiftV V o (endoExpand P.endoLam ξ₀)
+      u.deferredValues.bulletproofChallenges ĉ ∧
+    FopChecks P n ω ms cvs w ζ α β γ permV cipV bV unshiftV V o (endoExpand P.endoLam ξ₀)
       (endoExpand P.endoLam r') (ĉ.map (endoExpand P.endoLam))
 
 /-- At a prime field of more than 254 bits, the exact reading is the wire reading: the
 128-bit decompositions of the verifier's raw squeezes are its prechallenges up to
 `PrechallengeAlias` (`low128_of_decomp`), the `ξ` one once `xiCorrect` identifies it with
 the 128-bit claim. -/
-theorem FopReads.wire {p : ℕ} [Fact p.Prime] (hp : 2 ^ 254 < p) {P : FopParams (ZMod p)}
-    {xiConstrainLowBits : Bool} {n : ℕ} {ω dv : ZMod p} {ms : List Bool}
-    {cvs : List (List (ZMod p))} {u : UnfinalizedProof (ZMod p)} {w : ProofWitness (ZMod p)}
-    {ζ α β γ permV : ZMod p} {unshiftV : ZMod p → ZMod p} {V : Valuation (ZMod p)}
+theorem FopReads.wire {p : ℕ} [Fact p.Prime] (hp : 2 ^ 254 < p) {sf : Type}
+    {P : FopParams (ZMod p)} {xiConstrainLowBits : Bool} {n : ℕ} {ω dv : ZMod p} {ms : List Bool}
+    {cvs : List (List (ZMod p))} {u : UnfinalizedProof (ZMod p) sf} {w : ProofWitness (ZMod p)}
+    {ζ α β γ permV cipV bV : ZMod p} {unshiftV : ZMod p → ZMod p} {V : Valuation (ZMod p)}
     {o : FopOutput (ZMod p)}
-    (h : FopReads P xiConstrainLowBits n ω dv ms cvs u w ζ α β γ permV unshiftV V o) :
-    FopReadsWire P n ω dv ms cvs u w ζ α β γ permV unshiftV V o := by
+    (h : FopReads P xiConstrainLowBits n ω dv ms cvs u w ζ α β γ permV cipV bV unshiftV V o) :
+    FopReadsWire P n ω dv ms cvs u w ζ α β γ permV cipV bV unshiftV V o := by
   obtain ⟨ξ₀, r', h₁, h₂, ξ', ĉ, hξ₀, hxival, hh1, hh2, hr', -, hx1, hx2, hĉ, hxiC, hchecks⟩ := h
   haveI : Fact (1 < p) := ⟨by omega⟩
   refine ⟨ξ₀, r', ĉ, hξ₀, hxival, low128_of_decomp hp _ r' h₂ hr' hh2 hx2, ?_, ?_, hĉ, hchecks⟩
@@ -517,23 +494,25 @@ theorem finalizeOtherProofCore_spec {V : Valuation F} (h2 : (2 : F) ≠ 0) (h3 :
     (hinj : ∀ a b : ℕ, a < 2 ^ 128 → b < 2 ^ 128 → (a : F) = b → a = b)
     (P : FopParams F) (hsize : P.sponge.roundConstants.size = Poseidon.fullRounds)
     (h3zk : 3 ≤ P.zkRows) (n : ℕ) (hzk : P.zkRows ≤ n)
-    (ops : FopShiftOps F (Builder V (KimchiConstraint F))) (unshiftV : F → F)
-    (hun : ∀ x, (ops.unshift x).val V = unshiftV (x.val V))
-    (hcmp : ∀ a b, ⦃⌜True⌝⦄ ops.shiftedEqual a b
-      ⦃⇓ r _ => ⌜(↑r : CVar F).val V = if unshiftV (a.val V) = b.val V then 1 else 0⌝⦄)
+    {sf : Type} (ops : FopShiftOps F (Builder V (KimchiConstraint F)) sf) (unshiftV : F → F)
+    (u : UnfinalizedProof F sf) (perm : sf) (cipV bV permV : F)
+    (hunCip : (ops.unshift u.deferredValues.combinedInnerProduct).val V = unshiftV cipV)
+    (hunB : (ops.unshift u.deferredValues.b).val V = unshiftV bV)
+    (hcmp : ∀ b, ⦃⌜True⌝⦄ ops.shiftedEqual perm b
+      ⦃⇓ r _ => ⌜(↑r : CVar F).val V = if unshiftV permV = b.val V then 1 else 0⌝⦄)
     (xiConstrainLowBits : Bool) (digest : CircuitM F (Builder V (KimchiConstraint F)) (FVar F))
     (dv : F) (hd : ⦃⌜True⌝⦄ digest ⦃⇓ d _ => ⌜d.val V = dv⌝⦄)
     (gen : FVar F) (hω : gen.val V ≠ 0 → gen.val V ^ n = 1) (pow2Log2 : ℕ)
     (vanishing : FVar F → CircuitM F (Builder V (KimchiConstraint F)) (FVar F))
     (hvan : gen.val V ≠ 0 → ∀ z, ⦃⌜True⌝⦄ vanishing z ⦃⇓ v _ => ⌜v.val V = z.val V ^ n - 1⌝⦄)
     (mask : List (BoolVar F)) (ms : List Bool) (hm : List.Forall₂ (CircuitType.Reads V) mask ms)
-    (u : UnfinalizedProof F) (w : ProofWitness F) (prev : List (List (FVar F)))
+    (w : ProofWitness F) (prev : List (List (FVar F)))
     (cvs : List (List F)) (hprev : List.Forall₂ (List.Forall₂ (CircuitType.Reads V)) prev cvs)
-    (zeta alpha beta gamma perm : FVar F) (hft : FtEval0Hyp V P n (gen.val V)) :
+    (zeta alpha beta gamma : FVar F) (hft : FtEval0Hyp V P n (gen.val V)) :
     ⦃⌜True⌝⦄ finalizeOtherProofCore (c := Builder V (KimchiConstraint F)) P ops
       xiConstrainLowBits digest gen pow2Log2 vanishing mask u w prev zeta alpha beta gamma perm
     ⦃⇓ o _ => ⌜gen.val V ≠ 0 ∧ FopReads P xiConstrainLowBits n (gen.val V) dv ms cvs u w
-      (zeta.val V) (alpha.val V) (beta.val V) (gamma.val V) (perm.val V) unshiftV V o⌝⦄ := by
+      (zeta.val V) (alpha.val V) (beta.val V) (gamma.val V) permV cipV bV unshiftV V o⌝⦄ := by
   simp only [finalizeOtherProofCore]
   have hsg := fun pt => challengePolyEvals_spec (V := V) (c := KimchiConstraint F) pt prev cvs hprev
   have htf := EndoScalar.toField_spec (V := V) h2 h3
@@ -652,8 +631,8 @@ theorem finalizeOtherProofCore_spec {V : Valuation F} (h2 : (2 : F) ≠ 0) (h3 :
   -- the conjunction
   rw [map_linEvals] at hft0
   rw [hxival] at hxiC
-  rw [hun, hcipv, hxi', hr', hft0] at hcipC
-  rw [hun, hr', hzw] at hbv
+  rw [hunCip, hcipv, hxi', hr', hft0] at hcipC
+  rw [hunB, hr', hzw] at hbv
   rw [hpv] at hplonk
   have hbool := four_bits (fun b : BoolVar F => (↑b : CVar F).val V) xiC bC cipC plonkC
     _ _ _ _ hxiC hbv hcipC hplonk
@@ -729,18 +708,18 @@ private theorem le_foldr_max : ∀ (l : List ℕ) (a : ℕ), a ∈ l → a ≤ l
 omit [ToNat F] [KimchiSystem F c] in
 /-- The step side's comparison reads as the decoded claim against the scalar. -/
 private theorem stepShiftOps_cmp [ConstraintHolds F c] [LawfulBasicSystem F c] {V : Valuation F}
-    (h2 : (2 : F) ≠ 0) (a b : FVar F) :
+    (h2 : (2 : F) ≠ 0) (a : Type1 (FVar F)) (b : FVar F) :
     ⦃⌜True⌝⦄ (stepShiftOps (F := F) (c := Builder V c)).shiftedEqual a b
     ⦃⇓ r _ => ⌜(↑r : CVar F).val V
-      = if Type1.fromShifted 255 ⟨a.val V⟩ = b.val V then 1 else 0⌝⦄ := by
+      = if Type1.fromShifted 255 ⟨a.val.val V⟩ = b.val V then 1 else 0⌝⦄ := by
   simp only [stepShiftOps]
   mvcgen
   intro h
   rw [h, Type1.val_ofFieldCircuit]
-  by_cases hab : Type1.fromShifted 255 ⟨a.val V⟩ = b.val V
+  by_cases hab : Type1.fromShifted 255 ⟨a.val.val V⟩ = b.val V
   · rw [if_pos hab, if_pos]
     rw [← hab]
-    exact (Pasta.Shifted.shiftType1_unshiftType1 h2 255 (a.val V)).symm
+    exact (Pasta.Shifted.shiftType1_unshiftType1 h2 255 (a.val.val V)).symm
   · rw [if_neg hab, if_neg]
     intro h'
     apply hab
@@ -750,10 +729,10 @@ private theorem stepShiftOps_cmp [ConstraintHolds F c] [LawfulBasicSystem F c] {
 omit [ToNat F] [KimchiSystem F c] in
 /-- The wrap side's comparison reads as the decoded claim against the scalar. -/
 private theorem wrapShiftOps_cmp [ConstraintHolds F c] [LawfulBasicSystem F c] {V : Valuation F}
-    (a b : FVar F) :
+    (a : Type2 (FVar F)) (b : FVar F) :
     ⦃⌜True⌝⦄ (wrapShiftOps (F := F) (c := Builder V c)).shiftedEqual a b
     ⦃⇓ r _ => ⌜(↑r : CVar F).val V
-      = if Type2.fromShifted 255 ⟨a.val V⟩ = b.val V then 1 else 0⌝⦄ := by
+      = if Type2.fromShifted 255 ⟨a.val.val V⟩ = b.val V then 1 else 0⌝⦄ := by
   simp only [wrapShiftOps]
   mvcgen
   intro h
@@ -771,20 +750,24 @@ theorem finalizeOtherProofStep_spec {V : Valuation F} (h2 : (2 : F) ≠ 0) (h3 :
     (h3zk : 3 ≤ P.zkRows) (domains : List (KnownDomain F))
     (hnodup : (domains.map fun d => (d.log2 : F)).Nodup)
     (hdom : ∀ d ∈ domains, P.zkRows ≤ 2 ^ d.log2 ∧ d.generator ^ 2 ^ d.log2 = 1)
-    (u : UnfinalizedProof F) (w : ProofWitness F) (mask : List (BoolVar F)) (ms : List Bool)
-    (hm : List.Forall₂ (CircuitType.Reads V) mask ms) (prev : List (List (FVar F)))
+    (u : UnfinalizedProof F (Type1 (FVar F))) (w : ProofWitness F) (mask : List (BoolVar F))
+    (ms : List Bool) (hm : List.Forall₂ (CircuitType.Reads V) mask ms)
+    (prev : List (List (FVar F)))
     (cvs : List (List F)) (hprev : List.Forall₂ (List.Forall₂ (CircuitType.Reads V)) prev cvs)
     (hprevlen : prev.flatten.length < 2 ^ 128) (domainLog2Var : FVar F)
     (hft : ∀ (n : ℕ) (ω : F), FtEval0Hyp V P n ω) :
     ⦃⌜True⌝⦄ finalizeOtherProofStep (c := Builder V (KimchiConstraint F)) P domains u w mask
       prev domainLog2Var
     ⦃⇓ o _ => ⌜∃ d₀, d₀ ∈ domains ∧ domainLog2Var.val V = (d₀.log2 : F) ∧
-      ∃ a₀ z₀ : ℕ, a₀ < 2 ^ 128 ∧ z₀ < 2 ^ 128 ∧ u.alpha.val.val V = a₀ ∧ u.zeta.val.val V = z₀ ∧
+      ∃ a₀ z₀ : ℕ, a₀ < 2 ^ 128 ∧ z₀ < 2 ^ 128 ∧
+      u.deferredValues.plonk.alpha.val.val V = a₀ ∧ u.deferredValues.plonk.zeta.val.val V = z₀ ∧
       FopReads P true (2 ^ d₀.log2) d₀.generator
         (Poseidon.squeeze P.sponge (Poseidon.absorb P.sponge Poseidon.init
           (List.zipWith (fun m cs => if m then cs.map (·.val V) else []) ms prev).flatten)).1
-        ms cvs u w (endoExpand P.endoLam z₀) (endoExpand P.endoLam a₀) (u.beta.val.val V)
-        (u.gamma.val.val V) (u.perm.val V) (fun x => Type1.fromShifted 255 ⟨x⟩) V o⌝⦄ := by
+        ms cvs u w (endoExpand P.endoLam z₀) (endoExpand P.endoLam a₀)
+        (u.deferredValues.plonk.beta.val.val V) (u.deferredValues.plonk.gamma.val.val V)
+        (u.deferredValues.plonk.perm.val.val V) (u.deferredValues.combinedInnerProduct.val.val V)
+        (u.deferredValues.b.val.val V) (fun x => Type1.fromShifted 255 ⟨x⟩) V o⌝⦄ := by
   simp only [finalizeOtherProofStep]
   have htf := EndoScalar.toField_spec (V := V) h2 h3
   have hwh := knownDomainWhiches_spec (V := V) (c := KimchiConstraint F) domainLog2Var
@@ -801,18 +784,22 @@ theorem finalizeOtherProofStep_spec {V : Valuation F} (h2 : (2 : F) ≠ 0) (h3 :
         (maskedChallengeDigest P.sponge mask prev) gen P.srsLengthLog2
         (knownDomainVanishingPolynomial whiches (domains.map (·.log2))
           ((domains.map (·.log2)).foldr max 0))
-        mask u w prev zeta alpha u.beta.val u.gamma.val u.perm)
+        mask u w prev zeta alpha u.deferredValues.plonk.beta.val u.deferredValues.plonk.gamma.val
+        u.deferredValues.plonk.perm)
       (fun n : ℕ => P.zkRows ≤ n ∧ (gen.val V ≠ 0 → gen.val V ^ n = 1) ∧
         (gen.val V ≠ 0 → ∀ z, ⦃⌜True⌝⦄ knownDomainVanishingPolynomial
           (c := Builder V (KimchiConstraint F)) whiches (domains.map (·.log2))
           ((domains.map (·.log2)).foldr max 0) z ⦃⇓ v _ => ⌜v.val V = z.val V ^ n - 1⌝⦄))
       (fun n o => gen.val V ≠ 0 ∧ FopReads P true n (gen.val V) _ ms cvs u w (zeta.val V)
-        (alpha.val V) (u.beta.val.val V) (u.gamma.val.val V) (u.perm.val V)
+        (alpha.val V) (u.deferredValues.plonk.beta.val.val V)
+        (u.deferredValues.plonk.gamma.val.val V) (u.deferredValues.plonk.perm.val.val V)
+        (u.deferredValues.combinedInnerProduct.val.val V) (u.deferredValues.b.val.val V)
         (fun x => Type1.fromShifted 255 ⟨x⟩) V o)
       (fun n hn => finalizeOtherProofCore_spec h2 h3 hinj P hsize h3zk n hn.1 stepShiftOps
-        (fun x => Type1.fromShifted 255 ⟨x⟩) (fun x => Type1.val_fromShiftedCircuit 255 ⟨x⟩ V)
-        (stepShiftOps_cmp h2) true _ _ hd gen hn.2.1 _ _ hn.2.2 mask ms hm u w prev cvs hprev
-        zeta alpha _ _ _ (hft n (gen.val V)))
+        (fun x => Type1.fromShifted 255 ⟨x⟩) u u.deferredValues.plonk.perm _ _ _
+        (Type1.val_fromShiftedCircuit 255 _ V) (Type1.val_fromShiftedCircuit 255 _ V)
+        (stepShiftOps_cmp h2 _) true _ _ hd gen hn.2.1 _ _ hn.2.2 mask ms hm w prev cvs hprev
+        zeta alpha _ _ (hft n (gen.val V)))
   -- `hd` is a fully applied triple over a concrete circuit (see `finalizeOtherProofCore_spec`)
   clear hd
   mvcgen [htf, hwh, hmask, hcore]
@@ -870,19 +857,20 @@ theorem finalizeOtherProofWrap_spec {V : Valuation F} (h2 : (2 : F) ≠ 0) (h3 :
     (h3zk : 3 ≤ P.zkRows) (gen : F) (n : ℕ) (hzk : P.zkRows ≤ n) (hω : gen ^ n = 1)
     (domainLog2 : ℕ) (vanishing : FVar F → CircuitM F (Builder V (KimchiConstraint F)) (FVar F))
     (hvan : ∀ z, ⦃⌜True⌝⦄ vanishing z ⦃⇓ v _ => ⌜v.val V = z.val V ^ n - 1⌝⦄)
-    (u : UnfinalizedProof F) (w : ProofWitness F) (prev : List (List (FVar F)))
+    (u : UnfinalizedProof F (Type2 (FVar F))) (w : ProofWitness F) (prev : List (List (FVar F)))
     (cvs : List (List F)) (hprev : List.Forall₂ (List.Forall₂ (CircuitType.Reads V)) prev cvs)
     (hft : FtEval0Hyp V P n gen) :
     ⦃⌜True⌝⦄ finalizeOtherProofWrap (c := Builder V (KimchiConstraint F)) P gen domainLog2
       vanishing u w prev
-    ⦃⇓ o _ => ⌜∃ a₀ z₀ : ℕ, a₀ < 2 ^ 128 ∧ z₀ < 2 ^ 128 ∧ u.alpha.val.val V = a₀ ∧
-      u.zeta.val.val V = z₀ ∧
+    ⦃⇓ o _ => ⌜∃ a₀ z₀ : ℕ, a₀ < 2 ^ 128 ∧ z₀ < 2 ^ 128 ∧
+      u.deferredValues.plonk.alpha.val.val V = a₀ ∧ u.deferredValues.plonk.zeta.val.val V = z₀ ∧
       FopReads P false n gen
         (Poseidon.squeeze P.sponge (Poseidon.absorb P.sponge Poseidon.init
           (prev.flatten.map (·.val V)))).1
         (prev.map fun _ => true) cvs u w (endoExpand P.endoLam z₀) (endoExpand P.endoLam a₀)
-        (u.beta.val.val V) (u.gamma.val.val V) (u.perm.val V)
-        (fun x => Type2.fromShifted 255 ⟨x⟩) V o⌝⦄ := by
+        (u.deferredValues.plonk.beta.val.val V) (u.deferredValues.plonk.gamma.val.val V)
+        (u.deferredValues.plonk.perm.val.val V) (u.deferredValues.combinedInnerProduct.val.val V)
+        (u.deferredValues.b.val.val V) (fun x => Type2.fromShifted 255 ⟨x⟩) V o⌝⦄ := by
   simp only [finalizeOtherProofWrap]
   have htf := EndoScalar.toField_spec (V := V) h2 h3
   have hd := challengeDigest_spec (V := V) P.sponge hsize prev
@@ -892,9 +880,10 @@ theorem finalizeOtherProofWrap_spec {V : Valuation F} (h2 : (2 : F) ≠ 0) (h3 :
       (List.forall₂_same.mpr fun _ _ => CircuitType.reads_boolVar.mpr (by simp [true_, bit])))
   have hcore := fun (zeta alpha beta gamma perm : FVar F) =>
     finalizeOtherProofCore_spec h2 h3 hinj P hsize h3zk n hzk wrapShiftOps
-      (fun x => Type2.fromShifted 255 ⟨x⟩) (fun x => Type2.val_fromShiftedCircuit 255 ⟨x⟩ V)
-      wrapShiftOps_cmp false _ _ hd (.const gen) (fun _ => hω) domainLog2 vanishing
-      (fun _ => hvan) _ _ hm u w prev cvs hprev zeta alpha beta gamma perm hft
+      (fun x => Type2.fromShifted 255 ⟨x⟩) u ⟨perm⟩ _ _ (perm.val V)
+      (Type2.val_fromShiftedCircuit 255 _ V) (Type2.val_fromShiftedCircuit 255 _ V)
+      (wrapShiftOps_cmp ⟨perm⟩) false _ _ hd (.const gen) (fun _ => hω) domainLog2 vanishing
+      (fun _ => hvan) _ _ hm w prev cvs hprev zeta alpha beta gamma hft
   -- `hd` is a fully applied triple over a concrete circuit (see `finalizeOtherProofCore_spec`)
   clear hd
   mvcgen [htf, hcore]
@@ -929,19 +918,23 @@ theorem finalizeOtherProofStep_spec_fp {V : Valuation Fp} (P : FopParams Fp)
     (h3zk : 3 ≤ P.zkRows) (domains : List (KnownDomain Fp))
     (hnodup : (domains.map fun d => (d.log2 : Fp)).Nodup)
     (hdom : ∀ d ∈ domains, P.zkRows ≤ 2 ^ d.log2 ∧ d.generator ^ 2 ^ d.log2 = 1)
-    (u : UnfinalizedProof Fp) (w : ProofWitness Fp) (mask : List (BoolVar Fp)) (ms : List Bool)
+    (u : UnfinalizedProof Fp (Type1 (FVar Fp))) (w : ProofWitness Fp) (mask : List (BoolVar Fp))
+    (ms : List Bool)
     (hm : List.Forall₂ (CircuitType.Reads V) mask ms) (prev : List (List (FVar Fp)))
     (cvs : List (List Fp)) (hprev : List.Forall₂ (List.Forall₂ (CircuitType.Reads V)) prev cvs)
     (hprevlen : prev.flatten.length < 2 ^ 128) (domainLog2Var : FVar Fp) :
     ⦃⌜True⌝⦄ finalizeOtherProofStep (c := Builder V (KimchiConstraint Fp)) P domains u w mask
       prev domainLog2Var
     ⦃⇓ o _ => ⌜∃ d₀, d₀ ∈ domains ∧ domainLog2Var.val V = (d₀.log2 : Fp) ∧
-      ∃ a₀ z₀ : ℕ, a₀ < 2 ^ 128 ∧ z₀ < 2 ^ 128 ∧ u.alpha.val.val V = a₀ ∧ u.zeta.val.val V = z₀ ∧
+      ∃ a₀ z₀ : ℕ, a₀ < 2 ^ 128 ∧ z₀ < 2 ^ 128 ∧
+      u.deferredValues.plonk.alpha.val.val V = a₀ ∧ u.deferredValues.plonk.zeta.val.val V = z₀ ∧
       FopReadsWire P (2 ^ d₀.log2) d₀.generator
         (Poseidon.squeeze P.sponge (Poseidon.absorb P.sponge Poseidon.init
           (List.zipWith (fun m cs => if m then cs.map (·.val V) else []) ms prev).flatten)).1
-        ms cvs u w (endoExpand P.endoLam z₀) (endoExpand P.endoLam a₀) (u.beta.val.val V)
-        (u.gamma.val.val V) (u.perm.val V) (fun x => Type1.fromShifted 255 ⟨x⟩) V o⌝⦄ :=
+        ms cvs u w (endoExpand P.endoLam z₀) (endoExpand P.endoLam a₀)
+        (u.deferredValues.plonk.beta.val.val V) (u.deferredValues.plonk.gamma.val.val V)
+        (u.deferredValues.plonk.perm.val.val V) (u.deferredValues.combinedInnerProduct.val.val V)
+        (u.deferredValues.b.val.val V) (fun x => Type1.fromShifted 255 ⟨x⟩) V o⌝⦄ :=
   builder_spec_imp _ _ _
     (finalizeOtherProofStep_spec (by decide) (by decide) (natCast_inj _ (by decide)) P hsize h3zk
       domains hnodup hdom u w mask ms hm prev cvs hprev hprevlen domainLog2Var
@@ -962,18 +955,19 @@ theorem finalizeOtherProofWrap_spec_fq {V : Valuation Fq} (P : FopParams Fq)
     (h3zk : 3 ≤ P.zkRows) (gen : Fq) (n : ℕ) (hzk : P.zkRows ≤ n) (hω : gen ^ n = 1)
     (domainLog2 : ℕ) (vanishing : FVar Fq → CircuitM Fq (Builder V (KimchiConstraint Fq)) (FVar Fq))
     (hvan : ∀ z, ⦃⌜True⌝⦄ vanishing z ⦃⇓ v _ => ⌜v.val V = z.val V ^ n - 1⌝⦄)
-    (u : UnfinalizedProof Fq) (w : ProofWitness Fq) (prev : List (List (FVar Fq)))
+    (u : UnfinalizedProof Fq (Type2 (FVar Fq))) (w : ProofWitness Fq) (prev : List (List (FVar Fq)))
     (cvs : List (List Fq)) (hprev : List.Forall₂ (List.Forall₂ (CircuitType.Reads V)) prev cvs) :
     ⦃⌜True⌝⦄ finalizeOtherProofWrap (c := Builder V (KimchiConstraint Fq)) P gen domainLog2
       vanishing u w prev
-    ⦃⇓ o _ => ⌜∃ a₀ z₀ : ℕ, a₀ < 2 ^ 128 ∧ z₀ < 2 ^ 128 ∧ u.alpha.val.val V = a₀ ∧
-      u.zeta.val.val V = z₀ ∧
+    ⦃⇓ o _ => ⌜∃ a₀ z₀ : ℕ, a₀ < 2 ^ 128 ∧ z₀ < 2 ^ 128 ∧
+      u.deferredValues.plonk.alpha.val.val V = a₀ ∧ u.deferredValues.plonk.zeta.val.val V = z₀ ∧
       FopReadsWire P n gen
         (Poseidon.squeeze P.sponge (Poseidon.absorb P.sponge Poseidon.init
           (prev.flatten.map (·.val V)))).1
         (prev.map fun _ => true) cvs u w (endoExpand P.endoLam z₀) (endoExpand P.endoLam a₀)
-        (u.beta.val.val V) (u.gamma.val.val V) (u.perm.val V)
-        (fun x => Type2.fromShifted 255 ⟨x⟩) V o⌝⦄ :=
+        (u.deferredValues.plonk.beta.val.val V) (u.deferredValues.plonk.gamma.val.val V)
+        (u.deferredValues.plonk.perm.val.val V) (u.deferredValues.combinedInnerProduct.val.val V)
+        (u.deferredValues.b.val.val V) (fun x => Type2.fromShifted 255 ⟨x⟩) V o⌝⦄ :=
   builder_spec_imp _ _ _
     (finalizeOtherProofWrap_spec (by decide) (by decide) (natCast_inj _ (by decide)) P hsize h3zk
       gen n hzk hω domainLog2 vanishing hvan u w prev cvs hprev

--- a/formal/pickles/Pickles/FinalizeOtherProof.lean
+++ b/formal/pickles/Pickles/FinalizeOtherProof.lean
@@ -6,6 +6,7 @@ import Pickles.FrSponge
 import Pickles.Domain
 import Snarky.Types.Shifted
 import Pickles.Statement
+import Pickles.Prechallenge
 
 set_option mvcgen.warning false
 
@@ -382,9 +383,10 @@ open Kimchi.Protocol.Linearization Bulletproof Poseidon.FqSponge Classical in
 challenge digest, `ω` of order dividing `n`, the mask `ms`, the previous challenges `cvs`, and
 `(x₁, x₂) = frSqueezes P.sponge (frTranscript d dv ft(ζω) pub e)` the wire verifier's two raw
 fr-sponge squeezes (the elements behind `frOracles`' `(v, u)`, `frOracles_eq_frPrechallenges`):
-there are `ξ₀ < 2¹²⁸` the `ξ` claim, `ξ' + 2¹²⁸·h₁ = x₁` the recomputed low half (below
-`2¹²⁸` where constrained), `r' + 2¹²⁸·h₂ = x₂` with `r' < 2¹²⁸`, and `ĉᵢ < 2¹²⁸` the
-challenge claims, such that `xiCorrect = [ξ' = ξ₀]` and `FopChecks` holds at
+there are the prechallenge `ξ₀` the `ξ` claim reads as, `ξ' + 2¹²⁸·h₁ = x₁` the recomputed
+low half (a prechallenge where constrained), `r' + 2¹²⁸·h₂ = x₂` with `r'` a prechallenge,
+and the prechallenges `ĉᵢ` the challenge claims read as, such that `xiCorrect = [ξ' = ξ₀]`
+and `FopChecks` holds at
 `ξ = endoExpand λ ξ₀`, `r = endoExpand λ r'` and the expanded challenges `endoExpand λ ĉᵢ`.
 `FopReads.wire` reads this against the wire verifier's prechallenges at a deployed field. -/
 def FopReads {sf : Type} (P : FopParams F) (xiConstrainLowBits : Bool) (n : ℕ) (ω dv : F)
@@ -395,16 +397,14 @@ def FopReads {sf : Type} (P : FopParams F) (xiConstrainLowBits : Bool) (n : ℕ)
         (w.pub.map fun x => #v[x.val V]) (w.evals.map fun x => #v[x.val V]))
     let x₁ := sq.1
     let x₂ := sq.2
-    ∃ (ξ₀ r' h₁ h₂ : ℕ) (ξ' : F) (ĉ : List ℕ),
-      ξ₀ < 2 ^ 128 ∧ u.deferredValues.xi.val.val V = ξ₀ ∧ h₁ < 2 ^ 128 ∧ h₂ < 2 ^ 128 ∧
-      r' < 2 ^ 128 ∧
-      (xiConstrainLowBits = true → ∃ m : ℕ, m < 2 ^ 128 ∧ ξ' = m) ∧
-      x₁ = ξ' + 2 ^ 128 * h₁ ∧ x₂ = r' + 2 ^ 128 * h₂ ∧
-      List.Forall₂ (fun (ch : SizedF 128 (FVar F)) (k : ℕ) => k < 2 ^ 128 ∧ ch.val.val V = k)
-        u.deferredValues.bulletproofChallenges ĉ ∧
-      (↑o.xiCorrect : CVar F).val V = (if ξ' = (ξ₀ : F) then 1 else 0) ∧
-      FopChecks P n ω ms cvs w ζ α β γ permV cipV bV unshiftV V o (endoExpand P.endoLam ξ₀)
-        (endoExpand P.endoLam r') (ĉ.map (endoExpand P.endoLam))
+    ∃ (ξ₀ r' : Prechallenge) (h₁ h₂ : ℕ) (ξ' : F) (ĉ : List Prechallenge),
+      Reads128 V u.deferredValues.xi ξ₀ ∧ h₁ < 2 ^ 128 ∧ h₂ < 2 ^ 128 ∧
+      (xiConstrainLowBits = true → ∃ m : Prechallenge, ξ' = m.val) ∧
+      x₁ = ξ' + 2 ^ 128 * h₁ ∧ x₂ = r'.val + 2 ^ 128 * h₂ ∧
+      List.Forall₂ (Reads128 V) u.deferredValues.bulletproofChallenges ĉ ∧
+      (↑o.xiCorrect : CVar F).val V = (if ξ' = (ξ₀.val : F) then 1 else 0) ∧
+      FopChecks P n ω ms cvs w ζ α β γ permV cipV bV unshiftV V o (endoExpand P.endoLam ξ₀.val)
+        (endoExpand P.endoLam r'.val) (ĉ.map fun c => endoExpand P.endoLam c.val)
 
 open Kimchi.Protocol.Linearization Poseidon.FqSponge in
 /-- `FopReads` at a deployed field, against the wire verifier: with
@@ -420,14 +420,13 @@ def FopReadsWire {p : ℕ} [Fact p.Prime] {sf : Type} (P : FopParams (ZMod p)) (
   let pre := frPrechallenges P.sponge
     (frTranscript (u.spongeDigestBeforeEvaluations.val V) dv (w.ftEval1.val V)
       (w.pub.map fun x => #v[x.val V]) (w.evals.map fun x => #v[x.val V]))
-  ∃ (ξ₀ r' : ℕ) (ĉ : List ℕ),
-    ξ₀ < 2 ^ 128 ∧ u.deferredValues.xi.val.val V = ξ₀ ∧ PrechallengeAlias p pre.2 r' ∧
+  ∃ (ξ₀ r' : Prechallenge) (ĉ : List Prechallenge),
+    Reads128 V u.deferredValues.xi ξ₀ ∧ PrechallengeAlias p pre.2 r' ∧
     ((↑o.xiCorrect : CVar (ZMod p)).val V = 0 ∨ (↑o.xiCorrect : CVar (ZMod p)).val V = 1) ∧
     ((↑o.xiCorrect : CVar (ZMod p)).val V = 1 → PrechallengeAlias p pre.1 ξ₀) ∧
-    List.Forall₂ (fun (ch : SizedF 128 (FVar (ZMod p))) (k : ℕ) => k < 2 ^ 128 ∧ ch.val.val V = k)
-      u.deferredValues.bulletproofChallenges ĉ ∧
-    FopChecks P n ω ms cvs w ζ α β γ permV cipV bV unshiftV V o (endoExpand P.endoLam ξ₀)
-      (endoExpand P.endoLam r') (ĉ.map (endoExpand P.endoLam))
+    List.Forall₂ (Reads128 V) u.deferredValues.bulletproofChallenges ĉ ∧
+    FopChecks P n ω ms cvs w ζ α β γ permV cipV bV unshiftV V o (endoExpand P.endoLam ξ₀.val)
+      (endoExpand P.endoLam r'.val) (ĉ.map fun c => endoExpand P.endoLam c.val)
 
 /-- At a prime field of more than 254 bits, the exact reading is the wire reading: the
 128-bit decompositions of the verifier's raw squeezes are its prechallenges up to
@@ -440,16 +439,16 @@ theorem FopReads.wire {p : ℕ} [Fact p.Prime] (hp : 2 ^ 254 < p) {sf : Type}
     {o : FopOutput (ZMod p)}
     (h : FopReads P xiConstrainLowBits n ω dv ms cvs u w ζ α β γ permV cipV bV unshiftV V o) :
     FopReadsWire P n ω dv ms cvs u w ζ α β γ permV cipV bV unshiftV V o := by
-  obtain ⟨ξ₀, r', h₁, h₂, ξ', ĉ, hξ₀, hxival, hh1, hh2, hr', -, hx1, hx2, hĉ, hxiC, hchecks⟩ := h
+  obtain ⟨ξ₀, r', h₁, h₂, ξ', ĉ, hxival, hh1, hh2, -, hx1, hx2, hĉ, hxiC, hchecks⟩ := h
   haveI : Fact (1 < p) := ⟨by omega⟩
-  refine ⟨ξ₀, r', ĉ, hξ₀, hxival, low128_of_decomp hp _ r' h₂ hr' hh2 hx2, ?_, ?_, hĉ, hchecks⟩
+  refine ⟨ξ₀, r', ĉ, hxival, low128_of_decomp hp _ r' h₂ hh2 hx2, ?_, ?_, hĉ, hchecks⟩
   · rw [hxiC]
     split <;> simp
   · intro hone
     rw [hxiC] at hone
     split at hone
     · rename_i heq
-      exact low128_of_decomp hp _ ξ₀ h₁ hξ₀ hh1 (by rw [hx1, heq])
+      exact low128_of_decomp hp _ ξ₀ h₁ hh1 (by rw [hx1, heq])
     · exact absurd hone zero_ne_one
 
 open Kimchi.Protocol.Linearization in
@@ -491,7 +490,7 @@ the check bits read as
 
 and the expanded challenges read as `endoExpand λ ĉᵢ`. -/
 theorem finalizeOtherProofCore_spec {V : Valuation F} (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
-    (hinj : ∀ a b : ℕ, a < 2 ^ 128 → b < 2 ^ 128 → (a : F) = b → a = b)
+    (hinj : CastInj128 F)
     (P : FopParams F) (hsize : P.sponge.roundConstants.size = Poseidon.fullRounds)
     (h3zk : 3 ≤ P.zkRows) (n : ℕ) (hzk : P.zkRows ≤ n)
     {sf : Type} (ops : FopShiftOps F (Builder V (KimchiConstraint F)) sf) (unshiftV : F → F)
@@ -588,10 +587,10 @@ theorem finalizeOtherProofCore_spec {V : Valuation F} (h2 : (2 : F) ≠ 0) (h3 :
   have hc : (CVar.const P.endoLam : CVar F).val V = P.endoLam := rfl
   rw [hc] at hxi hr hexp
   rw [mul_comm] at hzw
-  obtain ⟨h₁, h₂, hh1, hh2, hx1, hx2, hlo, ⟨r'n, hr'n, hrval⟩⟩ := hsq'
+  obtain ⟨⟨h₁, hh1, hx1⟩, ⟨h₂, hh2, hx2⟩, hlo, ⟨r'n, hrval⟩⟩ := hsq'
   obtain ⟨ξ₀, hξ₀, hxival, hxi'⟩ := hxi
   obtain ⟨m, hm', hrval', hr'⟩ := hr
-  have hmr : m = r'n := hinj m r'n hm' hr'n (by rw [← hrval', hrval])
+  have hmr : m = r'n.val := hinj m r'n.val hm' r'n.property (by rw [← hrval', hrval])
   subst hmr
   obtain ⟨ns, hns, hexpd⟩ := hexp
   -- the read batch
@@ -639,9 +638,9 @@ theorem finalizeOtherProofCore_spec {V : Valuation F} (h2 : (2 : F) ≠ 0) (h3 :
   refine ⟨hom.1, ?_⟩
   unfold FopReads FopChecks
   rw [hfin hbool]
-  refine ⟨ξ₀, m, h₁, h₂, xr.1.val.val V, ns, hξ₀, hxival, hh1, hh2, hm', hlo, hx1, hx2, ?_,
+  refine ⟨⟨ξ₀, hξ₀⟩, r'n, h₁, h₂, xr.1.val.val V, ns, hxival, hh1, hh2, hlo, hx1, hx2, ?_,
     hxiC, hcipC, hbv, hplonk, ?_, hexpd⟩
-  · exact List.forall₂_map_left_iff.mp hns
+  · exact (List.forall₂_map_left_iff (f := fun x : SizedF 128 (FVar F) => x.val)).mp hns
   · simp only [List.mem_cons, List.not_mem_nil, or_false, forall_eq_or_imp, forall_eq]
 
 /-! ## The two sides -/
@@ -745,7 +744,7 @@ open Kimchi.Protocol.Linearization Poseidon.FqSponge in
 λ ẑ`, `α = endoExpand λ â`, `β, γ` the raw claims, the digest of the mask-kept previous
 challenges, `ξ` constrained below `2¹²⁸`, and the Type1 decode of the shifted claims. -/
 theorem finalizeOtherProofStep_spec {V : Valuation F} (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
-    (hinj : ∀ a b : ℕ, a < 2 ^ 128 → b < 2 ^ 128 → (a : F) = b → a = b)
+    (hinj : CastInj128 F)
     (P : FopParams F) (hsize : P.sponge.roundConstants.size = Poseidon.fullRounds)
     (h3zk : 3 ≤ P.zkRows) (domains : List (KnownDomain F))
     (hnodup : (domains.map fun d => (d.log2 : F)).Nodup)
@@ -759,12 +758,12 @@ theorem finalizeOtherProofStep_spec {V : Valuation F} (h2 : (2 : F) ≠ 0) (h3 :
     ⦃⌜True⌝⦄ finalizeOtherProofStep (c := Builder V (KimchiConstraint F)) P domains u w mask
       prev domainLog2Var
     ⦃⇓ o _ => ⌜∃ d₀, d₀ ∈ domains ∧ domainLog2Var.val V = (d₀.log2 : F) ∧
-      ∃ a₀ z₀ : ℕ, a₀ < 2 ^ 128 ∧ z₀ < 2 ^ 128 ∧
-      u.deferredValues.plonk.alpha.val.val V = a₀ ∧ u.deferredValues.plonk.zeta.val.val V = z₀ ∧
+      ∃ a₀ z₀ : Prechallenge,
+      Reads128 V u.deferredValues.plonk.alpha a₀ ∧ Reads128 V u.deferredValues.plonk.zeta z₀ ∧
       FopReads P true (2 ^ d₀.log2) d₀.generator
         (Poseidon.squeeze P.sponge (Poseidon.absorb P.sponge Poseidon.init
           (List.zipWith (fun m cs => if m then cs.map (·.val V) else []) ms prev).flatten)).1
-        ms cvs u w (endoExpand P.endoLam z₀) (endoExpand P.endoLam a₀)
+        ms cvs u w (endoExpand P.endoLam z₀.val) (endoExpand P.endoLam a₀.val)
         (u.deferredValues.plonk.beta.val.val V) (u.deferredValues.plonk.gamma.val.val V)
         (u.deferredValues.plonk.perm.val.val V) (u.deferredValues.combinedInnerProduct.val.val V)
         (u.deferredValues.b.val.val V) (fun x => Type1.fromShifted 255 ⟨x⟩) V o⌝⦄ := by
@@ -834,7 +833,7 @@ theorem finalizeOtherProofStep_spec {V : Valuation F} (h2 : (2 : F) ≠ 0) (h3 :
         onehot_sum _ _ domains hnodup d₀ hd₀ hL]
     obtain ⟨-, hreads⟩ := hcore' (2 ^ d₀.log2) hzk₀ (fun _ => by rw [hgen₀]; exact hω₀)
       (fun _ => hvan₀)
-    refine ⟨d₀, hd₀, hL, a₀, z₀, ha₀, hz₀, haval, hzval, ?_⟩
+    refine ⟨d₀, hd₀, hL, ⟨a₀, ha₀⟩, ⟨z₀, hz₀⟩, haval, hzval, ?_⟩
     rw [hgen₀, hz', ha'] at hreads
     exact hreads
   · exfalso
@@ -852,7 +851,7 @@ generator `ω` of order dividing `n` and the caller's vanishing polynomial readi
 `α = endoExpand λ â`, `β, γ` the raw claims, the digest of all previous challenges, `ξ`
 unconstrained, and the Type2 decode of the shifted claims. -/
 theorem finalizeOtherProofWrap_spec {V : Valuation F} (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
-    (hinj : ∀ a b : ℕ, a < 2 ^ 128 → b < 2 ^ 128 → (a : F) = b → a = b)
+    (hinj : CastInj128 F)
     (P : FopParams F) (hsize : P.sponge.roundConstants.size = Poseidon.fullRounds)
     (h3zk : 3 ≤ P.zkRows) (gen : F) (n : ℕ) (hzk : P.zkRows ≤ n) (hω : gen ^ n = 1)
     (domainLog2 : ℕ) (vanishing : FVar F → CircuitM F (Builder V (KimchiConstraint F)) (FVar F))
@@ -862,12 +861,12 @@ theorem finalizeOtherProofWrap_spec {V : Valuation F} (h2 : (2 : F) ≠ 0) (h3 :
     (hft : FtEval0Hyp V P n gen) :
     ⦃⌜True⌝⦄ finalizeOtherProofWrap (c := Builder V (KimchiConstraint F)) P gen domainLog2
       vanishing u w prev
-    ⦃⇓ o _ => ⌜∃ a₀ z₀ : ℕ, a₀ < 2 ^ 128 ∧ z₀ < 2 ^ 128 ∧
-      u.deferredValues.plonk.alpha.val.val V = a₀ ∧ u.deferredValues.plonk.zeta.val.val V = z₀ ∧
+    ⦃⇓ o _ => ⌜∃ a₀ z₀ : Prechallenge,
+      Reads128 V u.deferredValues.plonk.alpha a₀ ∧ Reads128 V u.deferredValues.plonk.zeta z₀ ∧
       FopReads P false n gen
         (Poseidon.squeeze P.sponge (Poseidon.absorb P.sponge Poseidon.init
           (prev.flatten.map (·.val V)))).1
-        (prev.map fun _ => true) cvs u w (endoExpand P.endoLam z₀) (endoExpand P.endoLam a₀)
+        (prev.map fun _ => true) cvs u w (endoExpand P.endoLam z₀.val) (endoExpand P.endoLam a₀.val)
         (u.deferredValues.plonk.beta.val.val V) (u.deferredValues.plonk.gamma.val.val V)
         (u.deferredValues.plonk.perm.val.val V) (u.deferredValues.combinedInnerProduct.val.val V)
         (u.deferredValues.b.val.val V) (fun x => Type2.fromShifted 255 ⟨x⟩) V o⌝⦄ := by
@@ -893,7 +892,7 @@ theorem finalizeOtherProofWrap_spec {V : Valuation F} (h2 : (2 : F) ≠ 0) (h3 :
   obtain ⟨a₀, ha₀, haval, ha'⟩ := ha
   have hc : (CVar.const P.endoLam : CVar F).val V = P.endoLam := rfl
   rw [hc] at hz' ha'
-  refine ⟨a₀, z₀, ha₀, hz₀, haval, hzval, ?_⟩
+  refine ⟨⟨a₀, ha₀⟩, ⟨z₀, hz₀⟩, haval, hzval, ?_⟩
   rw [hz', ha', hβ, hγ, hperm] at hreads
   exact hreads
 
@@ -902,12 +901,6 @@ theorem finalizeOtherProofWrap_spec {V : Valuation F} (h2 : (2 : F) ≠ 0) (h3 :
 section Deployed
 
 open Pickles.Reflect Kimchi.Protocol.Linearization Poseidon.FqSponge
-
-/-- Naturals below `2¹²⁸` cast injectively into a prime field of larger characteristic. -/
-private theorem natCast_inj (p : ℕ) (hp : 2 ^ 128 < p) (a b : ℕ) (ha : a < 2 ^ 128)
-    (hb : b < 2 ^ 128) (h : (a : ZMod p) = b) : a = b := by
-  have h' := (ZMod.natCast_eq_natCast_iff' a b p).mp h
-  rwa [Nat.mod_eq_of_lt (lt_trans ha hp), Nat.mod_eq_of_lt (lt_trans hb hp)] at h'
 
 /-- `finalizeOtherProofStep_spec` at the step field over the deployed `Fp` linearization
 (`Pasta.pallasEndo`, `symMds`, `fpTokens`), its `ft_eval0` hypothesis discharged by
@@ -926,25 +919,25 @@ theorem finalizeOtherProofStep_spec_fp {V : Valuation Fp} (P : FopParams Fp)
     ⦃⌜True⌝⦄ finalizeOtherProofStep (c := Builder V (KimchiConstraint Fp)) P domains u w mask
       prev domainLog2Var
     ⦃⇓ o _ => ⌜∃ d₀, d₀ ∈ domains ∧ domainLog2Var.val V = (d₀.log2 : Fp) ∧
-      ∃ a₀ z₀ : ℕ, a₀ < 2 ^ 128 ∧ z₀ < 2 ^ 128 ∧
-      u.deferredValues.plonk.alpha.val.val V = a₀ ∧ u.deferredValues.plonk.zeta.val.val V = z₀ ∧
+      ∃ a₀ z₀ : Prechallenge,
+      Reads128 V u.deferredValues.plonk.alpha a₀ ∧ Reads128 V u.deferredValues.plonk.zeta z₀ ∧
       FopReadsWire P (2 ^ d₀.log2) d₀.generator
         (Poseidon.squeeze P.sponge (Poseidon.absorb P.sponge Poseidon.init
           (List.zipWith (fun m cs => if m then cs.map (·.val V) else []) ms prev).flatten)).1
-        ms cvs u w (endoExpand P.endoLam z₀) (endoExpand P.endoLam a₀)
+        ms cvs u w (endoExpand P.endoLam z₀.val) (endoExpand P.endoLam a₀.val)
         (u.deferredValues.plonk.beta.val.val V) (u.deferredValues.plonk.gamma.val.val V)
         (u.deferredValues.plonk.perm.val.val V) (u.deferredValues.combinedInnerProduct.val.val V)
         (u.deferredValues.b.val.val V) (fun x => Type1.fromShifted 255 ⟨x⟩) V o⌝⦄ :=
   builder_spec_imp _ _ _
-    (finalizeOtherProofStep_spec (by decide) (by decide) (natCast_inj _ (by decide)) P hsize h3zk
-      domains hnodup hdom u w mask ms hm prev cvs hprev hprevlen domainLog2Var
+    (finalizeOtherProofStep_spec (by decide) (by decide) (castInj128_of_lt _ (by decide)) P hsize
+      h3zk domains hnodup hdom u w mask ms hm prev cvs hprev hprevlen domainLog2Var
       fun n ω ulb inp ext α ζ htab hζ hzk hz1 hω => by
         obtain ⟨he, hmds, ht⟩ := hP
         rw [he, hmds, ht]
         exact ftEval0Circuit_spec_fp ulb inp ext n P.zkRows ω ζ α
           (fun k hk => htab k (le_trans hk (by decide))) hζ hzk hz1 hω)
-    fun _ ⟨d₀, hd₀, hL, a₀, z₀, ha₀, hz₀, haval, hzval, hr⟩ =>
-      ⟨d₀, hd₀, hL, a₀, z₀, ha₀, hz₀, haval, hzval, hr.wire (by decide)⟩
+    fun _ ⟨d₀, hd₀, hL, a₀, z₀, haval, hzval, hr⟩ =>
+      ⟨d₀, hd₀, hL, a₀, z₀, haval, hzval, hr.wire (by decide)⟩
 
 /-- `finalizeOtherProofWrap_spec` at the wrap field over the deployed `Fq` linearization
 (`Pasta.vestaEndo`, `symMdsQ`, `fqTokens`), its `ft_eval0` hypothesis discharged by
@@ -959,25 +952,25 @@ theorem finalizeOtherProofWrap_spec_fq {V : Valuation Fq} (P : FopParams Fq)
     (cvs : List (List Fq)) (hprev : List.Forall₂ (List.Forall₂ (CircuitType.Reads V)) prev cvs) :
     ⦃⌜True⌝⦄ finalizeOtherProofWrap (c := Builder V (KimchiConstraint Fq)) P gen domainLog2
       vanishing u w prev
-    ⦃⇓ o _ => ⌜∃ a₀ z₀ : ℕ, a₀ < 2 ^ 128 ∧ z₀ < 2 ^ 128 ∧
-      u.deferredValues.plonk.alpha.val.val V = a₀ ∧ u.deferredValues.plonk.zeta.val.val V = z₀ ∧
+    ⦃⇓ o _ => ⌜∃ a₀ z₀ : Prechallenge,
+      Reads128 V u.deferredValues.plonk.alpha a₀ ∧ Reads128 V u.deferredValues.plonk.zeta z₀ ∧
       FopReadsWire P n gen
         (Poseidon.squeeze P.sponge (Poseidon.absorb P.sponge Poseidon.init
           (prev.flatten.map (·.val V)))).1
-        (prev.map fun _ => true) cvs u w (endoExpand P.endoLam z₀) (endoExpand P.endoLam a₀)
+        (prev.map fun _ => true) cvs u w (endoExpand P.endoLam z₀.val) (endoExpand P.endoLam a₀.val)
         (u.deferredValues.plonk.beta.val.val V) (u.deferredValues.plonk.gamma.val.val V)
         (u.deferredValues.plonk.perm.val.val V) (u.deferredValues.combinedInnerProduct.val.val V)
         (u.deferredValues.b.val.val V) (fun x => Type2.fromShifted 255 ⟨x⟩) V o⌝⦄ :=
   builder_spec_imp _ _ _
-    (finalizeOtherProofWrap_spec (by decide) (by decide) (natCast_inj _ (by decide)) P hsize h3zk
-      gen n hzk hω domainLog2 vanishing hvan u w prev cvs hprev
+    (finalizeOtherProofWrap_spec (by decide) (by decide) (castInj128_of_lt _ (by decide)) P hsize
+      h3zk gen n hzk hω domainLog2 vanishing hvan u w prev cvs hprev
       fun ulb inp ext α ζ htab hζ hzk' hz1 hω' => by
         obtain ⟨he, hmds, ht⟩ := hP
         rw [he, hmds, ht]
         exact ftEval0Circuit_spec_fq ulb inp ext n P.zkRows gen ζ α
           (fun k hk => htab k (le_trans hk (by decide))) hζ hzk' hz1 hω')
-    fun _ ⟨a₀, z₀, ha₀, hz₀, haval, hzval, hr⟩ =>
-      ⟨a₀, z₀, ha₀, hz₀, haval, hzval, hr.wire (by decide)⟩
+    fun _ ⟨a₀, z₀, haval, hzval, hr⟩ =>
+      ⟨a₀, z₀, haval, hzval, hr.wire (by decide)⟩
 
 end Deployed
 

--- a/formal/pickles/Pickles/FqSpongeTranscript.lean
+++ b/formal/pickles/Pickles/FqSpongeTranscript.lean
@@ -3,6 +3,7 @@ import Snarky.Kimchi.Circuit.RangeCheck
 import Snarky.Kimchi.Circuit.AddComplete
 import Kimchi.Verifier.Kimchi
 import Pickles.OptSponge
+import Pickles.Prechallenge
 
 set_option mvcgen.warning false
 
@@ -274,15 +275,15 @@ private theorem absorbColumns_spec (p : Poseidon.Params F)
     intro hrest s hs
     simpa using hrest _ (hstep s hs)
 
-/-- A prechallenge squeeze reads as the low half of the value squeeze: `x = lo + 2¹²⁸·hi`
-with `hi < 2¹²⁸`, `lo < 2¹²⁸` where constrained, the sponge as the squeezed state. -/
+/-- A prechallenge squeeze reads as the low half of the value squeeze (`Low128`), as a
+prechallenge where constrained, the sponge as the squeezed state. -/
 theorem squeezePrechallenge_spec [ToNat F] (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
     (p : Poseidon.Params F) (hsize : p.roundConstants.size = Poseidon.fullRounds)
     (constrainLowBits : Bool) (endo : FVar F) (sv : SpongeVar F) :
     ⦃⌜True⌝⦄ squeezePrechallenge (c := Builder V (KimchiConstraint F)) p constrainLowBits endo sv
     ⦃⇓ r _ => ⌜∀ s, SpongeVar.ReadsAt V sv s →
-      (∃ hi : ℕ, hi < 2 ^ 128 ∧ (Poseidon.squeeze p s).1 = r.1.val.val V + 2 ^ 128 * hi) ∧
-      (constrainLowBits = true → ∃ n : ℕ, n < 2 ^ 128 ∧ r.1.val.val V = n) ∧
+      Low128 V (Poseidon.squeeze p s).1 r.1 ∧
+      (constrainLowBits = true → ∃ m : Prechallenge, Reads128 V r.1 m) ∧
       SpongeVar.ReadsAt V r.2 (Poseidon.squeeze p s).2⌝⦄ := by
   simp only [squeezePrechallenge]
   have hsq := SpongeVar.squeeze_spec (V := V) p hsize sv
@@ -292,23 +293,22 @@ theorem squeezePrechallenge_spec [ToNat F] (h2 : (2 : F) ≠ 0) (h3 : (3 : F) �
   intro s hs
   obtain ⟨hxv, hst⟩ := hx s hs
   obtain ⟨hiv, he, ⟨n, hn, rfl⟩, hlow⟩ := hchal
-  exact ⟨⟨n, hn, by rw [← hxv, he]⟩, hlow, hst⟩
+  exact ⟨⟨n, hn, by rw [← hxv, he]⟩, fun h => reads128_of_nat (hlow h), hst⟩
 
 open Kimchi.Verifier in
 /-- The reading of the transcript's outputs (`fqSpongeTranscript_spec`): with
 `(β̂, γ̂, α̂, ζ̂)`, `d`, `warm` the wire verifier's `fqSqueezes` over the index digest, the
-`sg_old`, `x_hat`, `w_comm`, `z_comm`, `t_comm` readings, each challenge is a 128-bit
-decomposition `x̂ = chal + 2¹²⁸·h` with `h < 2¹²⁸`, `β, γ` below `2¹²⁸`, `x_hat` reads as
-`xv`, the digest as `d` and the sponge as `warm`. -/
+`sg_old`, `x_hat`, `w_comm`, `z_comm`, `t_comm` readings, each challenge is the low half of
+its squeeze (`Low128`), `β, γ` read as prechallenges, `x_hat` reads as `xv`, the digest as
+`d` and the sponge as `warm`. -/
 def FqTranscriptReads (p : Poseidon.Params F) (indexDigest : F)
     (sgOld xv : List (AffinePoint F)) (wComm : List (List (AffinePoint F)))
     (zComm tComm : List (AffinePoint F)) (V : Valuation F) (o : FqTranscriptOutput F) : Prop :=
   let r := fqSqueezes p indexDigest (sgOld.map coords) (xv.map coords)
     (wComm.map (·.map coords)) (zComm.map coords) (tComm.map coords)
-  ∃ hβ hγ hα hζ : ℕ, hβ < 2 ^ 128 ∧ hγ < 2 ^ 128 ∧ hα < 2 ^ 128 ∧ hζ < 2 ^ 128 ∧
-    r.1.1 = o.beta.val.val V + 2 ^ 128 * hβ ∧ r.1.2.1 = o.gamma.val.val V + 2 ^ 128 * hγ ∧
-    r.1.2.2.1 = o.alpha.val.val V + 2 ^ 128 * hα ∧ r.1.2.2.2 = o.zeta.val.val V + 2 ^ 128 * hζ ∧
-    (∃ n : ℕ, n < 2 ^ 128 ∧ o.beta.val.val V = n) ∧ (∃ n : ℕ, n < 2 ^ 128 ∧ o.gamma.val.val V = n) ∧
+  Low128 V r.1.1 o.beta ∧ Low128 V r.1.2.1 o.gamma ∧
+    Low128 V r.1.2.2.1 o.alpha ∧ Low128 V r.1.2.2.2 o.zeta ∧
+    (∃ m : Prechallenge, Reads128 V o.beta m) ∧ (∃ m : Prechallenge, Reads128 V o.gamma m) ∧
     List.Forall₂ (CircuitType.Reads V) o.xHat xv ∧
     o.digest.val V = r.2.1 ∧ SpongeVar.ReadsAt V o.sponge r.2.2
 
@@ -343,25 +343,18 @@ theorem fqSpongeTranscript_spec [ToNat F] (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠
   have s2 := hB _ s1
   have s3 := hC _ s2
   have s4 := hD _ s3
-  obtain ⟨⟨nβ, hnβ, eβ⟩, ⟨mβ, hmβ, hbetaLo⟩, s5⟩ := hβ _ s4
-  obtain ⟨⟨nγ, hnγ, eγ⟩, ⟨mγ, hmγ, hgammaLo⟩, s6⟩ := hγ _ s5
+  obtain ⟨eβ, hbetaLo, s5⟩ := hβ _ s4
+  obtain ⟨eγ, hgammaLo, s6⟩ := hγ _ s5
   have s7 := hE _ s6
-  obtain ⟨⟨nα, hnα, eα⟩, -, s8⟩ := hα _ s7
+  obtain ⟨eα, -, s8⟩ := hα _ s7
   have s9 := hF _ s8
-  obtain ⟨⟨nζ, hnζ, eζ⟩, -, s10⟩ := hζ _ s9
+  obtain ⟨eζ, -, s10⟩ := hζ _ s9
   obtain ⟨hdv, -⟩ := hdig _ s10
   simp only [Poseidon.absorb, List.foldl_cons, List.foldl_nil, coords_of_reads hsg,
     coords_of_reads hxh, coords_of_reads hz, coords_of_reads ht, coords_of_reads_cols hw]
     at eβ eγ eα eζ hdv s10
   unfold FqTranscriptReads fqSqueezes
-  refine ⟨nβ, nγ, nα, nζ, hnβ, hnγ, hnα, hnζ, ?_, ?_, ?_, ?_, ⟨mβ, hmβ, hbetaLo⟩,
-    ⟨mγ, hmγ, hgammaLo⟩, hxh, ?_, ?_⟩
-  · exact eβ
-  · exact eγ
-  · exact eα
-  · exact eζ
-  · exact hdv
-  · exact s10
+  exact ⟨eβ, eγ, eα, eζ, hbetaLo, hgammaLo, hxh, hdv, s10⟩
 
 /-- Under any valuation satisfying the emitted constraints, each claim reads as the
 corresponding squeezed prechallenge. -/
@@ -579,17 +572,16 @@ theorem optSqueezePrechallenge_spec [ToNat F] (h2 : (2 : F) ≠ 0) (h3 : (3 : F)
     ⦃⌜True⌝⦄ optSqueezePrechallenge (c := Builder V (KimchiConstraint F)) p constrainLowBits endo
       ov
     ⦃⇓ r _ => ⌜(∀ ps : Poseidon.State F, SqueezedReads V ov ps →
-        (∃ hi : ℕ, hi < 2 ^ 128 ∧ (Poseidon.squeeze p ps).1 = r.1.val.val V + 2 ^ 128 * hi) ∧
-        (constrainLowBits = true → ∃ n : ℕ, n < 2 ^ 128 ∧ r.1.val.val V = n) ∧
+        Low128 V (Poseidon.squeeze p ps).1 r.1 ∧
+        (constrainLowBits = true → ∃ m : Prechallenge, Reads128 V r.1 m) ∧
         SqueezedReads V r.2 (Poseidon.squeeze p ps).2) ∧
       (∀ (ib : Bool) (ps₀ : Poseidon.State F) (pend : List (Bool × F)),
         AbsorbingReads p V ov ib ps₀ pend →
         ((∃ v ∈ pend, v.1 = true) ∨ ps₀.mode = .absorbed 0) →
         (∀ k : ℕ, k ≤ pend.length → (k : F) = 0 → k = 0) →
-        (∃ hi : ℕ, hi < 2 ^ 128 ∧
-          (Poseidon.squeeze p (Poseidon.absorb p ps₀ ((pend.filter (·.1)).map (·.2)))).1
-            = r.1.val.val V + 2 ^ 128 * hi) ∧
-        (constrainLowBits = true → ∃ n : ℕ, n < 2 ^ 128 ∧ r.1.val.val V = n) ∧
+        Low128 V (Poseidon.squeeze p (Poseidon.absorb p ps₀ ((pend.filter (·.1)).map (·.2)))).1
+          r.1 ∧
+        (constrainLowBits = true → ∃ m : Prechallenge, Reads128 V r.1 m) ∧
         SqueezedReads V r.2
           (Poseidon.squeeze p (Poseidon.absorb p ps₀ ((pend.filter (·.1)).map (·.2)))).2)⌝⦄ := by
   simp only [optSqueezePrechallenge]
@@ -600,9 +592,9 @@ theorem optSqueezePrechallenge_spec [ToNat F] (h2 : (2 : F) ≠ 0) (h3 : (3 : F)
   obtain ⟨hiv, he, ⟨n, hn, rfl⟩, hlow⟩ := hchal
   refine ⟨fun ps hs => ?_, fun ib ps₀ pend h hne hchar => ?_⟩
   · obtain ⟨hxv, hst⟩ := hx.1 ps hs
-    exact ⟨⟨n, hn, by rw [← hxv, he]⟩, hlow, hst⟩
+    exact ⟨⟨n, hn, by rw [← hxv, he]⟩, fun h => reads128_of_nat (hlow h), hst⟩
   · obtain ⟨hxv, hst⟩ := hx.2 ib ps₀ pend h hne hchar
-    exact ⟨⟨n, hn, by rw [← hxv, he]⟩, hlow, hst⟩
+    exact ⟨⟨n, hn, by rw [← hxv, he]⟩, fun h => reads128_of_nat (hlow h), hst⟩
 
 /-- Under any valuation satisfying the emitted constraints, with the mask bits and `sg_old`
 reading as `sgv`, `x_hat` as `xv` and the commitments as `wv, zv, tv` (`z_comm` and `t_comm`
@@ -659,9 +651,9 @@ theorem fqSpongeTranscriptOpt_spec [ToNat F] (h2 : (2 : F) ≠ 0) (h3 : (3 : F) 
     simp only [List.length_append, List.length_nil, List.length_cons, length_maskedFlat,
       length_pointsFlat, length_flatMap_pointsFlat]
     omega
-  obtain ⟨⟨nβ, hnβ, eβ⟩, hbetaLo, s5⟩ := hβ.2 _ _ _ r3
+  obtain ⟨eβ, hbetaLo, s5⟩ := hβ.2 _ _ _ r3
     (Or.inl ⟨(true, indexDigest.val V), by simp, rfl⟩) (fun k hk => hchar k (le_trans hk hlen0))
-  obtain ⟨⟨nγ, hnγ, eγ⟩, hgammaLo, s6⟩ := hγ.1 _ s5
+  obtain ⟨eγ, hgammaLo, s6⟩ := hγ.1 _ s5
   -- α: `z_comm` from the squeezed sponge
   have rz := foldl_optAbsorbPoint_reads hzs (optAbsorbPoint_reads_squeezed p s6 hzP)
   have hlenz : ([(true, zPv.x), (true, zPv.y)] ++ pointsFlat zvs).length
@@ -669,7 +661,7 @@ theorem fqSpongeTranscriptOpt_spec [ToNat F] (h2 : (2 : F) ≠ 0) (h3 : (3 : F) 
         + (tPv :: tvs).length) := by
     simp only [List.length_append, List.length_cons, List.length_nil, length_pointsFlat]
     omega
-  obtain ⟨⟨nα, hnα, eα⟩, -, s8⟩ := hα.2 _ _ _ rz (Or.inl ⟨(true, zPv.x), by simp, rfl⟩)
+  obtain ⟨eα, -, s8⟩ := hα.2 _ _ _ rz (Or.inl ⟨(true, zPv.x), by simp, rfl⟩)
     (fun k hk => hchar k (le_trans hk hlenz))
   -- ζ: `t_comm` from the squeezed sponge
   have rt := foldl_optAbsorbPoint_reads hts (optAbsorbPoint_reads_squeezed p s8 htP)
@@ -678,7 +670,7 @@ theorem fqSpongeTranscriptOpt_spec [ToNat F] (h2 : (2 : F) ≠ 0) (h3 : (3 : F) 
         + (tPv :: tvs).length) := by
     simp only [List.length_append, List.length_cons, List.length_nil, length_pointsFlat]
     omega
-  obtain ⟨⟨nζ, hnζ, eζ⟩, -, s10⟩ := hζ.2 _ _ _ rt (Or.inl ⟨(true, tPv.x), by simp, rfl⟩)
+  obtain ⟨eζ, -, s10⟩ := hζ.2 _ _ _ rt (Or.inl ⟨(true, tPv.x), by simp, rfl⟩)
     (fun k hk => hchar k (le_trans hk hlent))
   have s11 := toRegularSponge_reads s10
   obtain ⟨hdv, -⟩ := hdig _ s11
@@ -705,33 +697,26 @@ theorem fqSpongeTranscriptOpt_spec [ToNat F] (h2 : (2 : F) ≠ 0) (h3 : (3 : F) 
   simp only [hkept, hkz, hkt] at eβ eγ eα eζ hdv s11
   unfold FqTranscriptReads fqSqueezes
   simp only [foldl_pts_eq, foldl_cols_eq, ← absorb_append]
-  refine ⟨nβ, nγ, nα, nζ, hnβ, hnγ, hnα, hnζ, ?_, ?_, ?_, ?_, hbetaLo, hgammaLo, hx,
-    ?_, ?_⟩
-  · exact eβ
-  · exact eγ
-  · exact eα
-  · exact eζ
-  · exact hdv
-  · exact s11
+  exact ⟨eβ, eγ, eα, eζ, hbetaLo, hgammaLo, hx, hdv, s11⟩
 
 /-! ## The wire reading -/
 
 open Kimchi.Verifier in
 /-- `FqTranscriptReads` at a deployed field, against the wire verifier: with `pre` the
-verifier's `fqPrechallenges`, `β` and `γ` are its first two up to `PrechallengeAlias`, and
-`α`, `ζ` its last two once identified with 128-bit claims `a₀`, `z₀`; the digest reads as the
-digest element and the sponge as the pre-digest state (`fqOracles_eq_fqPrechallenges`
-carries these to `fqOracles`). -/
+verifier's `fqPrechallenges`, `β` and `γ` read as prechallenges that are its first two up to
+`PrechallengeAlias`, and `α`, `ζ`, once read as prechallenges, are its last two up to the
+alias; the digest reads as the digest element and the sponge as the pre-digest state
+(`fqOracles_eq_fqPrechallenges` carries these to `fqOracles`). -/
 def FqTranscriptReadsWire {p : ℕ} [Fact p.Prime] (params : Poseidon.Params (ZMod p))
     (indexDigest : ZMod p) (sgOld xv : List (AffinePoint (ZMod p)))
     (wComm : List (List (AffinePoint (ZMod p)))) (zComm tComm : List (AffinePoint (ZMod p)))
     (V : Valuation (ZMod p)) (o : FqTranscriptOutput (ZMod p)) : Prop :=
   let pre := fqPrechallenges params indexDigest (sgOld.map coords) (xv.map coords)
     (wComm.map (·.map coords)) (zComm.map coords) (tComm.map coords)
-  (∃ b₀ : ℕ, o.beta.val.val V = b₀ ∧ PrechallengeAlias p pre.1.1 b₀) ∧
-  (∃ g₀ : ℕ, o.gamma.val.val V = g₀ ∧ PrechallengeAlias p pre.1.2.1 g₀) ∧
-  (∀ a₀ : ℕ, a₀ < 2 ^ 128 → o.alpha.val.val V = a₀ → PrechallengeAlias p pre.1.2.2.1 a₀) ∧
-  (∀ z₀ : ℕ, z₀ < 2 ^ 128 → o.zeta.val.val V = z₀ → PrechallengeAlias p pre.1.2.2.2 z₀) ∧
+  (∃ b₀, Reads128 V o.beta b₀ ∧ PrechallengeAlias p pre.1.1 b₀) ∧
+  (∃ g₀, Reads128 V o.gamma g₀ ∧ PrechallengeAlias p pre.1.2.1 g₀) ∧
+  (∀ a₀, Reads128 V o.alpha a₀ → PrechallengeAlias p pre.1.2.2.1 a₀) ∧
+  (∀ z₀, Reads128 V o.zeta z₀ → PrechallengeAlias p pre.1.2.2.2 z₀) ∧
   List.Forall₂ (CircuitType.Reads V) o.xHat xv ∧
   o.digest.val V = pre.2.1 ∧ SpongeVar.ReadsAt V o.sponge pre.2.2
 
@@ -745,14 +730,8 @@ theorem FqTranscriptReads.wire {p : ℕ} [Fact p.Prime] (hp : 2 ^ 254 < p)
     {V : Valuation (ZMod p)} {o : FqTranscriptOutput (ZMod p)}
     (h : FqTranscriptReads params indexDigest sgOld xv wComm zComm tComm V o) :
     FqTranscriptReadsWire params indexDigest sgOld xv wComm zComm tComm V o := by
-  obtain ⟨hβ, hγ, hα, hζ, hhβ, hhγ, hhα, hhζ, eβ, eγ, eα, eζ, ⟨b₀, hb₀, hbv⟩, ⟨g₀, hg₀, hgv⟩,
-    hxh, hd, hs⟩ := h
-  refine ⟨⟨b₀, hbv, ?_⟩, ⟨g₀, hgv, ?_⟩, ?_, ?_, hxh, hd, hs⟩
-  · exact low128_of_decomp hp _ b₀ hβ hb₀ hhβ (by rw [eβ, hbv])
-  · exact low128_of_decomp hp _ g₀ hγ hg₀ hhγ (by rw [eγ, hgv])
-  · intro a₀ ha₀ hav
-    exact low128_of_decomp hp _ a₀ hα ha₀ hhα (by rw [eα, hav])
-  · intro z₀ hz₀ hzv
-    exact low128_of_decomp hp _ z₀ hζ hz₀ hhζ (by rw [eζ, hzv])
+  obtain ⟨lβ, lγ, lα, lζ, ⟨b₀, hbv⟩, ⟨g₀, hgv⟩, hxh, hd, hs⟩ := h
+  exact ⟨⟨b₀, hbv, lβ.alias hp hbv⟩, ⟨g₀, hgv, lγ.alias hp hgv⟩, fun _ hav => lα.alias hp hav,
+    fun _ hzv => lζ.alias hp hzv, hxh, hd, hs⟩
 
 end Pickles

--- a/formal/pickles/Pickles/FrSponge.lean
+++ b/formal/pickles/Pickles/FrSponge.lean
@@ -2,6 +2,7 @@ import Snarky.Kimchi.Circuit.Sponge
 import Snarky.Kimchi.Circuit.RangeCheck
 import Kimchi.Verifier.Kimchi
 import Pickles.OptSponge
+import Pickles.Prechallenge
 
 set_option mvcgen.warning false
 
@@ -218,8 +219,8 @@ private theorem map_val_frTail (digestBefore recDigest ftEval1 : FVar F)
 and the inputs as themselves, the two squeezes are the wire verifier's
 `frSqueezes p (frTranscript digestBefore dv ft(ζω) pub evals)` — the raw elements behind
 `frOracles`' `(v, u)` (`Kimchi.Verifier.frOracles_eq_frPrechallenges`) — and the outputs `ξ`, `r`
-are their 128-bit decompositions: `x₁ = ξ + 2¹²⁸·h₁` and `x₂ = r + 2¹²⁸·h₂` for some
-`h₁, h₂ < 2¹²⁸`, with `r < 2¹²⁸` and, where the low bits are constrained, `ξ < 2¹²⁸`. -/
+are their low halves (`Low128`), `r` a prechallenge and, where the low bits are
+constrained, `ξ` too. -/
 theorem squeezeXiR_spec [ToNat F] (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
     (p : Poseidon.Params F) (hsize : p.roundConstants.size = Poseidon.fullRounds)
     (digestBefore : FVar F) (digest : CircuitM F (Builder V (KimchiConstraint F)) (FVar F))
@@ -235,10 +236,9 @@ theorem squeezeXiR_spec [ToNat F] (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
           (pub.map fun x => #v[x.val V]) (evals.map fun x => #v[x.val V]))
       let x₁ := sq.1
       let x₂ := sq.2
-      ∃ h₁ h₂ : ℕ, h₁ < 2 ^ 128 ∧ h₂ < 2 ^ 128 ∧
-        x₁ = out.1.val.val V + 2 ^ 128 * h₁ ∧ x₂ = out.2.val.val V + 2 ^ 128 * h₂ ∧
-        (xiConstrainLowBits = true → ∃ n : ℕ, n < 2 ^ 128 ∧ out.1.val.val V = n) ∧
-        (∃ n : ℕ, n < 2 ^ 128 ∧ out.2.val.val V = n)⌝⦄ := by
+      Low128 V x₁ out.1 ∧ Low128 V x₂ out.2 ∧
+        (xiConstrainLowBits = true → ∃ m : Prechallenge, Reads128 V out.1 m) ∧
+        (∃ m : Prechallenge, Reads128 V out.2 m)⌝⦄ := by
   simp only [squeezeXiR]
   have h0 := SpongeVar.absorb_spec (V := V) p hsize SpongeVar.init digestBefore
   have ha := fun sv d => absorbList_spec (V := V) p hsize sv (frTail d ftEval1 pub evals)
@@ -258,7 +258,7 @@ theorem squeezeXiR_spec [ToNat F] (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
   obtain ⟨hiv₁, he₁, ⟨n₁, hn₁, rfl⟩, hb₁⟩ := hlo1
   obtain ⟨hiv₂, he₂, ⟨n₂, hn₂, rfl⟩, hr₂⟩ := hlo2
   simp only [frSqueezes]
-  refine ⟨n₁, n₂, hn₁, hn₂, ?_, ?_, hb₁, hr₂⟩
+  refine ⟨⟨n₁, hn₁, ?_⟩, ⟨n₂, hn₂, ?_⟩, fun h => reads128_of_nat (hb₁ h), reads128_of_nat hr₂⟩
   · rw [← hx1, he₁]
   · rw [← hx2, he₂]
 

--- a/formal/pickles/Pickles/IPA.lean
+++ b/formal/pickles/Pickles/IPA.lean
@@ -1,6 +1,7 @@
 import Snarky.DSL.Field
 import Snarky.Kimchi.Circuit.EndoScalar
 import Bulletproof.Protocol
+import Pickles.Prechallenge
 
 set_option mvcgen.warning false
 
@@ -201,16 +202,16 @@ theorem challengePolyEvals_spec (pt : FVar F) :
     exact List.Forall₂.cons (CircuitType.reads_fvar.mpr ‹_›) ‹_›
 
 /-- Under any valuation satisfying the emitted constraints, with `endo` reading as `λ`, the
-`j`-th challenge reads as a natural `nⱼ < 2^128` and the `j`-th output as `endoExpand λ nⱼ`,
+`j`-th challenge reads as a prechallenge `nⱼ` and the `j`-th output as `endoExpand λ nⱼ`,
 Mina's `a·λ + b` from the GLV recoding of `nⱼ`. -/
 theorem computeChallenges_spec [ToNat F] (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 0)
     (endo : FVar F) :
     ∀ chals : List (FVar F),
       ⦃⌜True⌝⦄ computeChallenges (c := Builder V (Snarky.Kimchi.KimchiConstraint F)) endo chals
-      ⦃⇓ l _ => ⌜∃ ns : List ℕ,
-        List.Forall₂ (fun (ch : FVar F) (n : ℕ) => n < 2 ^ 128 ∧ ch.val V = (n : F)) chals ns ∧
+      ⦃⇓ l _ => ⌜∃ ns : List Prechallenge,
+        List.Forall₂ (fun (ch : FVar F) (n : Prechallenge) => Reads128 V ⟨ch⟩ n) chals ns ∧
         List.Forall₂ (CircuitType.Reads V) l
-          (ns.map (Poseidon.FqSponge.endoExpand (endo.val V)))⌝⦄
+          (ns.map fun n => Poseidon.FqSponge.endoExpand (endo.val V) n.val)⌝⦄
   | [] => by
     simp only [computeChallenges]
     mvcgen
@@ -223,7 +224,7 @@ theorem computeChallenges_spec [ToNat F] (h2 : (2 : F) ≠ 0) (h3 : (3 : F) ≠ 
     rename_i hrest _ _ hch
     obtain ⟨ns, hns, hl⟩ := hrest
     obtain ⟨n, hn, hchv, hrv⟩ := hch
-    exact ⟨n :: ns, .cons ⟨hn, hchv⟩ hns, .cons (CircuitType.reads_fvar.mpr hrv) hl⟩
+    exact ⟨⟨n, hn⟩ :: ns, .cons hchv hns, .cons (CircuitType.reads_fvar.mpr hrv) hl⟩
 
 /-- Under any valuation satisfying the emitted constraints, with the challenges reading as
 `c = (c₀, …, c_{k−1})` and `ζ`, `ζω`, `r` as themselves, the output reads as

--- a/formal/pickles/Pickles/Prechallenge.lean
+++ b/formal/pickles/Pickles/Prechallenge.lean
@@ -1,0 +1,66 @@
+import Snarky.DSL.SizedF
+import Kimchi.Verifier.Kimchi
+
+/-!
+# Reading prechallenges at the circuit boundary
+
+The only `SizedF 128` a verifier circuit ever reads is a prechallenge
+(`Poseidon.FqSponge.Prechallenge`, the paper's Definition [Prechallenge]): the four plonk
+prechallenges, `ξ`, the IPA round prechallenges and the Schnorr prechallenge. So the circuit
+boundary has one reading relation for them, `Reads128`, and the wire verifier's
+prechallenge is met through it:
+
+* `Reads128 V u m` — the 128-bit circuit value `u` reads as the prechallenge `m`;
+* `Low128 V x u` — the `lowest_128_bits` relation between a raw squeeze `x` and its low
+  half `u`: `x = u + 2¹²⁸·hi` for some `hi < 2¹²⁸`, the decomposition the gadget pins (not
+  necessarily the canonical one, hence `PrechallengeAlias`);
+* `CastInj128 F` — naturals below `2¹²⁸` cast injectively into `F`, what pins a gadget's
+  own reading of a prechallenge to the claimed one.
+-/
+
+namespace Pickles
+
+open Snarky Poseidon.FqSponge Kimchi.Verifier
+
+-- The prechallenge type, in the pickles namespace: every `SizedF 128` here reads as one.
+export Poseidon.FqSponge (Prechallenge)
+
+variable {F : Type} [Field F] [DecidableEq F]
+
+/-- A 128-bit circuit value reads as the prechallenge `m`. -/
+def Reads128 (V : Valuation F) (u : SizedF 128 (FVar F)) (m : Prechallenge) : Prop :=
+  u.val.val V = (m.val : F)
+
+/-- A raw squeeze and a 128-bit circuit value in the `lowest_128_bits` relation:
+`x = lo + 2¹²⁸·hi` with `hi < 2¹²⁸`. -/
+def Low128 (V : Valuation F) (x : F) (u : SizedF 128 (FVar F)) : Prop :=
+  ∃ hi : ℕ, hi < 2 ^ 128 ∧ x = u.val.val V + 2 ^ 128 * hi
+
+/-- Naturals below `2¹²⁸` cast injectively into `F`. -/
+def CastInj128 (F : Type) [NatCast F] : Prop :=
+  ∀ a b : ℕ, a < 2 ^ 128 → b < 2 ^ 128 → (a : F) = b → a = b
+
+omit [DecidableEq F] in
+/-- The shape a gadget's range check leaves (`Snarky.Kimchi.lowest128Bits'_spec`,
+`EndoScalar.toField_spec`): a reading as some prechallenge. -/
+theorem reads128_of_nat {V : Valuation F} {u : SizedF 128 (FVar F)}
+    (h : ∃ n : ℕ, n < 2 ^ 128 ∧ u.val.val V = (n : F)) : ∃ m : Prechallenge, Reads128 V u m :=
+  let ⟨n, hn, e⟩ := h
+  ⟨⟨n, hn⟩, e⟩
+
+/-- A prime field above `2¹²⁸` casts the prechallenges injectively. -/
+theorem castInj128_of_lt (p : ℕ) (hp : 2 ^ 128 < p) : CastInj128 (ZMod p) := by
+  intro a b ha hb h
+  have h' := (ZMod.natCast_eq_natCast_iff' a b p).mp h
+  rwa [Nat.mod_eq_of_lt (lt_trans ha hp), Nat.mod_eq_of_lt (lt_trans hb hp)] at h'
+
+/-- At a prime field of more than 254 bits, a `Low128` decomposition reads, through any
+prechallenge reading of its low half, as the verifier's prechallenge up to
+`PrechallengeAlias` (`low128_of_decomp`). -/
+theorem Low128.alias {p : ℕ} [Fact p.Prime] (hp : 2 ^ 254 < p) {V : Valuation (ZMod p)}
+    {x : ZMod p} {u : SizedF 128 (FVar (ZMod p))} {m : Prechallenge}
+    (hlow : Low128 V x u) (hm : Reads128 V u m) : PrechallengeAlias p (x.val % 2 ^ 128) m :=
+  let ⟨hi, hhi, hx⟩ := hlow
+  low128_of_decomp hp x m hi hhi (by rw [hx, hm])
+
+end Pickles

--- a/formal/pickles/Pickles/Statement.lean
+++ b/formal/pickles/Pickles/Statement.lean
@@ -1,0 +1,115 @@
+import Snarky.DSL.SizedF
+
+/-!
+# The pickles statement records
+
+The records a proof's public input is made of, transcribed from the PureScript
+`Pickles.Types` and `Pickles.Verify.Types` (OCaml `composition_types.ml`), at the circuit's
+variable types. `sf` is the side's shifted-scalar type — `Type1 (FVar F)` for an `Fp` scalar
+carried in `Fq`, `Type2 …` for an `Fq` scalar carried in `Fp` — so a record's type says which
+of its scalars belong to the other field.
+
+* `DeferredValues`: what one half of a proof's verification computes and the other certifies;
+* `UnfinalizedProof`: a deferred-values record with its digest and the finalize flag, the
+  step statement's per-predecessor entry;
+* `WrapStatement`, `StepStatement`: the two public inputs.
+
+Only `UnfinalizedProof` is consumed by a gadget here (`finalizeOtherProof`); the statements
+are the vocabulary the boundary glue is stated over.
+-/
+
+namespace Pickles
+
+open Snarky
+
+/-- The plonk claims (PS `PlonkInCircuit`, OCaml `Plonk.In_circuit`): the four
+prechallenges and the three shifted linearization scalars. -/
+structure PlonkInCircuit (F sf : Type) where
+  /-- The 128-bit `α` prechallenge. -/
+  alpha : SizedF 128 (FVar F)
+  /-- The 128-bit `β`. -/
+  beta : SizedF 128 (FVar F)
+  /-- The 128-bit `γ`. -/
+  gamma : SizedF 128 (FVar F)
+  /-- The 128-bit `ζ` prechallenge. -/
+  zeta : SizedF 128 (FVar F)
+  /-- The shifted permutation scalar. -/
+  perm : sf
+  /-- The shifted `ζ^(srs length)`. -/
+  zetaToSrsLength : sf
+  /-- The shifted `ζⁿ`. -/
+  zetaToDomainSize : sf
+
+/-- The deferred values of a proof (PS `DeferredValues`, OCaml
+`Proof_state.Deferred_values`): the plonk claims, the shifted combined inner product, the
+128-bit `ξ`, the 16 raw 128-bit bulletproof challenges, and the shifted `b`. -/
+structure DeferredValues (F sf : Type) where
+  /-- The plonk claims. -/
+  plonk : PlonkInCircuit F sf
+  /-- The shifted combined inner product. -/
+  combinedInnerProduct : sf
+  /-- The 128-bit `ξ` prechallenge. -/
+  xi : SizedF 128 (FVar F)
+  /-- The 16 raw 128-bit bulletproof challenges. -/
+  bulletproofChallenges : List (SizedF 128 (FVar F))
+  /-- The shifted `b`. -/
+  b : sf
+
+/-- A step statement's entry for one predecessor (PS `UnfinalizedProof`): its deferred
+values, whether it is to be finalized (false for a dummy predecessor at the base of a chain),
+and its fq-sponge digest before evaluations. -/
+structure UnfinalizedProof (F sf : Type) where
+  /-- The deferred values. -/
+  deferredValues : DeferredValues F sf
+  /-- Whether `finalize` is asserted for this predecessor. -/
+  shouldFinalize : BoolVar F
+  /-- The fq-sponge digest before evaluations. -/
+  spongeDigestBeforeEvaluations : FVar F
+
+/-- The branch data of a wrap statement (PS `BranchData`): the verified step proof's rule,
+as its domain size and its proofs-verified mask. -/
+structure BranchData (F : Type) where
+  /-- `log2` of the rule's domain size. -/
+  domainLog2 : FVar F
+  /-- The two mask bits of `proofs_verified`. -/
+  proofsVerifiedMask : List (BoolVar F)
+
+/-- A wrap statement's deferred values (PS `WrapDeferredValues`): the deferred values with the
+branch data. -/
+structure WrapDeferredValues (F sf : Type) extends DeferredValues F sf where
+  /-- The branch data. -/
+  branchData : BranchData F
+
+/-- The proof-state part of a wrap statement (PS `WrapStatement`'s `proofState`). -/
+structure WrapProofState (F sf : Type) where
+  /-- The verified step proof's deferred values. -/
+  deferredValues : WrapDeferredValues F sf
+  /-- The verified step proof's fq-sponge digest before evaluations. -/
+  spongeDigestBeforeEvaluations : FVar F
+  /-- The digest of `messages_for_next_wrap_proof`: the step proof's `sg` and its round
+  challenges. -/
+  messagesForNextWrapProof : FVar F
+
+/-- The public input of a wrap proof (PS `WrapStatement`, OCaml `Wrap.Statement`). -/
+structure WrapStatement (F sf : Type) where
+  /-- The proof state. -/
+  proofState : WrapProofState F sf
+  /-- The digest of `messages_for_next_step_proof`, copied from the step statement. -/
+  messagesForNextStepProof : FVar F
+
+/-- The proof-state part of a step statement (PS `StepStatement`'s `proofState`). -/
+structure StepProofState (F sf : Type) where
+  /-- One entry per predecessor wrap proof. -/
+  unfinalizedProofs : List (UnfinalizedProof F sf)
+  /-- The digest of `messages_for_next_step_proof`: the application state and the
+  predecessors' `sg`s and round challenges. -/
+  messagesForNextStepProof : FVar F
+
+/-- The public input of a step proof (PS `StepStatement`, OCaml `Step.Statement`). -/
+structure StepStatement (F sf : Type) where
+  /-- The proof state. -/
+  proofState : StepProofState F sf
+  /-- One `messages_for_next_wrap_proof` digest per predecessor. -/
+  messagesForNextWrapProof : List (FVar F)
+
+end Pickles

--- a/formal/pickles/roots.txt
+++ b/formal/pickles/roots.txt
@@ -47,6 +47,18 @@ Pickles.buildPow2PowsArray_spec
 Pickles.pow2PowSquare_spec
 Pickles.pow2PowMul_spec
 
+-- The statement records (Statement.lean): the two public inputs, transcribed from the
+-- PureScript `Pickles.Types` — the vocabulary the boundary glue is stated over.
+Pickles.PlonkInCircuit
+Pickles.DeferredValues
+Pickles.UnfinalizedProof
+Pickles.BranchData
+Pickles.WrapDeferredValues
+Pickles.WrapProofState
+Pickles.WrapStatement
+Pickles.StepProofState
+Pickles.StepStatement
+
 -- `finalize_other_proof` (FinalizeOtherProof.lean): the shared body and the two sides, each
 -- read as `FopReads` — the claimed scalars against the wire verifier's `frSqueezes` (at the
 -- circuit's recursion digest, in the relational low-128-bit form) and its `ftEval0`,

--- a/formal/poseidon/Poseidon/FqSponge.lean
+++ b/formal/poseidon/Poseidon/FqSponge.lean
@@ -14,11 +14,13 @@ cardinalities.
 
 ## The limb buffer
 
-Alongside the Poseidon state, the sponge carries a buffer `lastSqueezed` of 64-bit limbs.
-Each raw squeeze contributes its two low limbs (128 high-entropy bits), and a scalar
-challenge (`challenge`, 128 bits) is packed from the next two buffered limbs. Every
+Alongside the Poseidon state, the sponge carries a buffer `lastSqueezed` of 64-bit limbs
+(`Limb`). Each raw squeeze contributes its two low limbs (128 high-entropy bits), and a
+prechallenge (`challengeNat`, 128 bits) is packed from the next two buffered limbs. Every
 absorption clears the buffer, and field-element squeezes (`challengeFq`) bypass it and clear
-it.
+it. The bounds are in the types: a limb is a `Limb`, a packed prechallenge a `Prechallenge`,
+so a consumer of a squeeze's output holds its 128-bit bound without knowing where the value
+came from.
 
 ## The endomorphism expansion
 
@@ -49,12 +51,20 @@ open CompElliptic.CurveForms.ShortWeierstrass
 
 variable {base scalar : ℕ} [Field (ZMod base)] [Field (ZMod scalar)]
 
+/-- A 64-bit limb of a raw squeeze. -/
+abbrev Limb := { n : ℕ // n < 2 ^ 64 }
+
+/-- A 128-bit prechallenge (`ScalarChallenge`): what every limb-packed squeeze produces,
+before its field cast (`challenge`) or endo-expansion (`squeezeChallenge`). The bound is in
+the type, so a Fiat–Shamir run's outputs carry it wherever they are consumed. -/
+abbrev Prechallenge := { n : ℕ // n < 2 ^ 128 }
+
 /-- A sponge in flight: the Poseidon automaton over the base field, plus its limb buffer. -/
 structure S (base : ℕ) where
   /-- The Poseidon duplex automaton over the base field. -/
   sponge : State (ZMod base)
-  /-- Buffered 64-bit limbs of raw squeezes not yet consumed by a challenge. -/
-  lastSqueezed : List ℕ
+  /-- Buffered 64-bit limbs of raw squeezes not yet consumed by a prechallenge. -/
+  lastSqueezed : List Limb
 
 /-- The fresh sponge: fresh automaton, empty buffer. -/
 def init : S base := ⟨Poseidon.init, []⟩
@@ -63,8 +73,9 @@ def init : S base := ⟨Poseidon.init, []⟩
 
 /-- The two low 64-bit limbs of a squeezed element — its 128 high-entropy bits
 (`HIGH_ENTROPY_LIMBS = 2`). -/
-private def lowLimbs (x : ZMod base) : List ℕ :=
-  [x.val % 2 ^ 64, x.val / 2 ^ 64 % 2 ^ 64]
+private def lowLimbs (x : ZMod base) : List Limb :=
+  [⟨x.val % 2 ^ 64, Nat.mod_lt _ (Nat.two_pow_pos _)⟩,
+    ⟨x.val / 2 ^ 64 % 2 ^ 64, Nat.mod_lt _ (Nat.two_pow_pos _)⟩]
 
 /-- Absorb base-field elements (`absorb_fq`): clear the buffer, absorb each. -/
 def absorbFq (spec : Spec base scalar) (s : S base) (xs : List (ZMod base)) : S base :=
@@ -97,28 +108,32 @@ def challengeFq (spec : Spec base scalar) (s : S base) : ZMod base × S base :=
 /-- Take two 64-bit limbs from the buffer and pack them into a 128-bit value, refilling the
 buffer from the sponge as needed (`squeeze_limbs` at `CHALLENGE_LENGTH_IN_LIMBS = 2`). The
 `fuel` argument bounds the refills: each adds two limbs, so one suffices even from empty. -/
-private def squeezeLimbsPacked (spec : Spec base scalar) : ℕ → S base → ℕ × S base
-  | 0, s => (0, s)
+private def squeezeLimbsPacked (spec : Spec base scalar) :
+    ℕ → S base → Prechallenge × S base
+  | 0, s => (⟨0, Nat.two_pow_pos _⟩, s)
   | fuel + 1, s =>
     match s.lastSqueezed with
-    | l0 :: l1 :: rest => (l0 + l1 * 2 ^ 64, ⟨s.sponge, rest⟩)
+    | l0 :: l1 :: rest =>
+      (⟨l0.val + l1.val * 2 ^ 64, by have := l0.property; have := l1.property; omega⟩,
+        ⟨s.sponge, rest⟩)
     | buf =>
       let (x, sp) := squeeze spec.params s.sponge
       squeezeLimbsPacked spec fuel ⟨sp, buf ++ lowLimbs x⟩
 
-/-- Squeeze a 128-bit prechallenge, as a natural number (`challenge`, before the field
-cast). -/
-def challengeNat (spec : Spec base scalar) (s : S base) : ℕ × S base :=
+/-- Squeeze a 128-bit prechallenge (`challenge`, before the field cast). -/
+def challengeNat (spec : Spec base scalar) (s : S base) : Prechallenge × S base :=
   squeezeLimbsPacked spec 2 s
 
+omit [Field (ZMod scalar)] in
 /-- A prechallenge from an empty limb buffer is one raw squeeze's value mod `2^128`, both
 of its limbs consumed, the buffer left empty. -/
 theorem challengeNat_fresh (spec : Spec base scalar) (s : State (ZMod base)) :
     challengeNat spec ⟨s, []⟩
-      = ((squeeze spec.params s).1.val % 2 ^ 128, ⟨(squeeze spec.params s).2, []⟩) := by
+      = (⟨(squeeze spec.params s).1.val % 2 ^ 128, Nat.mod_lt _ (Nat.two_pow_pos _)⟩,
+          ⟨(squeeze spec.params s).2, []⟩) := by
   rcases hsq : squeeze spec.params s with ⟨x, sp⟩
   simp only [challengeNat, squeezeLimbsPacked, lowLimbs, hsq, List.nil_append, Prod.mk.injEq,
-    and_true]
+    Subtype.mk.injEq, and_true]
   omega
 
 /-- Squeeze a 128-bit prechallenge into the scalar field (`challenge`): `challengeNat`, cast.
@@ -126,7 +141,7 @@ The consumer's step over the run; kept as the production sponge's named operatio
 against its traces. -/
 def challenge (spec : Spec base scalar) (s : S base) : ZMod scalar × S base :=
   let (n, s) := challengeNat spec s
-  ((n : ZMod scalar), s)
+  ((n.val : ZMod scalar), s)
 
 /-- The endomorphism expansion of a 128-bit prechallenge into an effective scalar
 (`to_field_with_length`, Halo §6.2): fold the 2-bit windows from the top into the
@@ -146,7 +161,7 @@ eigenvalue. The consumer's step over the run; kept as the production sponge's na
 operation, checked against its traces. -/
 def squeezeChallenge (spec : Spec base scalar) (s : S base) : ZMod scalar × S base :=
   let (n, s) := challengeNat spec s
-  (endoExpand spec.lam n, s)
+  (endoExpand spec.lam n.val, s)
 
 
 end Poseidon.FqSponge

--- a/formal/poseidon/Poseidon/FqSponge.lean
+++ b/formal/poseidon/Poseidon/FqSponge.lean
@@ -121,18 +121,12 @@ theorem challengeNat_fresh (spec : Spec base scalar) (s : State (ZMod base)) :
     and_true]
   omega
 
-/-- Squeeze a 128-bit prechallenge into the scalar field (`challenge`). -/
+/-- Squeeze a 128-bit prechallenge into the scalar field (`challenge`): `challengeNat`, cast.
+The consumer's step over the run; kept as the production sponge's named operation, checked
+against its traces. -/
 def challenge (spec : Spec base scalar) (s : S base) : ZMod scalar × S base :=
   let (n, s) := challengeNat spec s
   ((n : ZMod scalar), s)
-
-/-- `challenge` from an empty limb buffer: the squeeze's value mod `2^128`, cast, the buffer
-left empty. -/
-theorem challenge_fresh (spec : Spec base scalar) (s : State (ZMod base)) :
-    challenge spec ⟨s, []⟩
-      = ((((squeeze spec.params s).1.val % 2 ^ 128 : ℕ) : ZMod scalar),
-          ⟨(squeeze spec.params s).2, []⟩) := by
-  simp only [challenge, challengeNat_fresh]
 
 /-- The endomorphism expansion of a 128-bit prechallenge into an effective scalar
 (`to_field_with_length`, Halo §6.2): fold the 2-bit windows from the top into the
@@ -147,19 +141,13 @@ def endoExpand {F : Type*} [Field F] (lam : F) (chal : ℕ) : F :=
   a * lam + b
 
 /-- Squeeze an effective scalar challenge (`squeeze_challenge`,
-`poly-commitment/src/commitment.rs`): a 128-bit prechallenge, endo-expanded at the spec's
-eigenvalue. -/
+`poly-commitment/src/commitment.rs`): `challengeNat`, endo-expanded at the spec's
+eigenvalue. The consumer's step over the run; kept as the production sponge's named
+operation, checked against its traces. -/
 def squeezeChallenge (spec : Spec base scalar) (s : S base) : ZMod scalar × S base :=
   let (n, s) := challengeNat spec s
   (endoExpand spec.lam n, s)
 
-/-- `squeezeChallenge` from an empty limb buffer: the endo-expansion of the squeeze's value
-mod `2^128`, the buffer left empty. -/
-theorem squeezeChallenge_fresh (spec : Spec base scalar) (s : State (ZMod base)) :
-    squeezeChallenge spec ⟨s, []⟩
-      = (endoExpand spec.lam ((squeeze spec.params s).1.val % 2 ^ 128),
-          ⟨(squeeze spec.params s).2, []⟩) := by
-  simp only [squeezeChallenge, challengeNat_fresh]
 
 end Poseidon.FqSponge
 

--- a/formal/poseidon/roots.txt
+++ b/formal/poseidon/roots.txt
@@ -17,6 +17,15 @@ Poseidon.fpParams
 Poseidon.FqVesta.spec
 Poseidon.FqPallas.spec
 
+-- script-surface:begin
+-- The production sponge's named squeeze operations (`challenge`, `squeeze_challenge`):
+-- `challengeNat` cast, resp. endo-expanded. The verifier's schedules apply those steps
+-- themselves (`Kimchi.Verifier.fqRun`, `FqRun.expand`); these stay as the operations the
+-- trace fixtures are replayed against by scripts/check_fq_sponge.lean.
+Poseidon.FqSponge.challenge
+Poseidon.FqSponge.squeezeChallenge
+-- script-surface:end
+
 -- The SvdW map-to-curve.
 Poseidon.GroupMapVesta.toGroup
 Poseidon.GroupMapPallas.toGroup

--- a/formal/scripts/check_cs.lean
+++ b/formal/scripts/check_cs.lean
@@ -754,10 +754,11 @@ def checkBulletproofStepCircuit (blindingH : AffinePoint (FVar Fp)) (input : Vec
     Bulletproof.IpaVesta.curve.frParams (.const endoVestaLam) Pickles.groupMapParamsPallas
     (fun _ => none) sv
     ((List.range 47).map fun j => (pt (4 + 2 * j), none))
-    { xi := ⟨get 3⟩, delta := pt 158, sg := pt 160
-      lr := (List.range 15).map fun j => (pt (98 + 4 * j), pt (100 + 4 * j))
-      z1 := shifted 162, z2 := shifted 164, combinedInnerProduct := shifted 166
-      b := shifted 168, blindingGenerator := blindingH }
+    { xi := ⟨get 3⟩
+      deferred := { combinedInnerProduct := shifted 166, b := shifted 168 }
+      opening := { lr := (List.range 15).map fun j => (pt (98 + 4 * j), pt (100 + 4 * j))
+                   z1 := shifted 162, z2 := shifted 164, delta := pt 158, sg := pt 160 }
+      blindingGenerator := blindingH }
   pure PUnit.unit
 
 /-! ## The `finalize_other_proof` circuits
@@ -857,10 +858,11 @@ def checkBulletproofWrapCircuit (blindingH : AffinePoint (FVar Fq)) (input : Vec
     Bulletproof.IpaPallas.curve.frParams (.const endoPallasLam) Pickles.groupMapParamsVesta
     (fun _ => none) sv
     bases
-    { xi := ⟨get 3⟩, delta := pt 164, sg := pt 166
-      lr := (List.range 16).map fun j => (pt (100 + 4 * j), pt (102 + 4 * j))
-      z1 := ⟨get 168⟩, z2 := ⟨get 169⟩, combinedInnerProduct := ⟨get 170⟩
-      b := ⟨get 171⟩, blindingGenerator := blindingH }
+    { xi := ⟨get 3⟩
+      deferred := { combinedInnerProduct := ⟨get 170⟩, b := ⟨get 171⟩ }
+      opening := { lr := (List.range 16).map fun j => (pt (100 + 4 * j), pt (102 + 4 * j))
+                   z1 := ⟨get 168⟩, z2 := ⟨get 169⟩, delta := pt 164, sg := pt 166 }
+      blindingGenerator := blindingH }
   pure PUnit.unit
 
 /-- The corpus under comparison: the step column, then the wrap column, at the two SRS

--- a/formal/scripts/check_cs.lean
+++ b/formal/scripts/check_cs.lean
@@ -785,14 +785,18 @@ open Pickles Kimchi.Verifier in
 `base` the public pair, 15 `w` pairs, 15 coefficient pairs, the `z` pair, 6 `σ` pairs, 6
 selector pairs, `ft(ζω)`, the two previous-challenge vectors, and the digest before
 evaluations last. -/
-def fopInputsOf {p : ℕ} (get : ℕ → FVar (ZMod p)) (base : ℕ) :
-    UnfinalizedProof (ZMod p) × ProofWitness (ZMod p) × List (List (FVar (ZMod p))) :=
+def fopInputsOf {p : ℕ} {sf : Type} (mk : FVar (ZMod p) → sf) (get : ℕ → FVar (ZMod p))
+    (base : ℕ) :
+    UnfinalizedProof (ZMod p) sf × ProofWitness (ZMod p) × List (List (FVar (ZMod p))) :=
   let (pub, evals) := evalsAt get base
-  let u : UnfinalizedProof (ZMod p) :=
-    { alpha := ⟨get 0⟩, beta := ⟨get 1⟩, gamma := ⟨get 2⟩, zeta := ⟨get 3⟩,
-      zetaToSrsLength := get 4, zetaToDomainSize := get 5, perm := get 6,
-      combinedInnerProduct := get 7, b := get 8, xi := ⟨get 9⟩,
-      bulletproofChallenges := (List.range 16).map fun i => ⟨get (10 + i)⟩,
+  let u : UnfinalizedProof (ZMod p) sf :=
+    { deferredValues :=
+        { plonk := { alpha := ⟨get 0⟩, beta := ⟨get 1⟩, gamma := ⟨get 2⟩, zeta := ⟨get 3⟩,
+                     zetaToSrsLength := mk (get 4), zetaToDomainSize := mk (get 5),
+                     perm := mk (get 6) }
+          combinedInnerProduct := mk (get 7), b := mk (get 8), xi := ⟨get 9⟩,
+          bulletproofChallenges := (List.range 16).map fun i => ⟨get (10 + i)⟩ }
+      shouldFinalize := true_
       spongeDigestBeforeEvaluations := get (base + 121) }
   let w : ProofWitness (ZMod p) := { ftEval1 := get (base + 88), pub, evals }
   (u, w, prevChallengesOf get (base + 89))
@@ -809,7 +813,7 @@ def fopStepParams : Pickles.FopParams Fp :=
 the evaluations from 29, one known domain of `log2 = 16`. -/
 def finalizeOtherProofStepCircuit (input : Vector (FVar Fp) 151) : CircuitM Fp C PUnit := do
   let get (i : ℕ) : FVar Fp := input[i]?.getD (.const 0)
-  let (u, w, prev) := fopInputsOf get 29
+  let (u, w, prev) := fopInputsOf Type1.mk get 29
   let _ ← Pickles.finalizeOtherProofStep fopStepParams
     [⟨16, Kimchi.Fixture.PS.fpSide.omega (2 ^ 16)⟩] u w [.unchecked (get 26), .unchecked (get 27)]
     prev (get 28)
@@ -827,7 +831,7 @@ def fopWrapParams : Pickles.FopParams Fq :=
 `log2 = 15`, `ζⁿ − 1` by `pow2PowMul`. -/
 def finalizeOtherProofWrapCircuit (input : Vector (FVar Fq) 148) : CircuitM Fq Cq PUnit := do
   let get (i : ℕ) : FVar Fq := input[i]?.getD (.const 0)
-  let (u, w, prev) := fopInputsOf get 26
+  let (u, w, prev) := fopInputsOf Type2.mk get 26
   let _ ← Pickles.finalizeOtherProofWrap fopWrapParams (Kimchi.Fixture.PS.fqSide.omega (2 ^ 15))
     15 (fun z => do let t ← Pickles.pow2PowMul z 15; pure (CVar.sub_ t (.const 1))) u w prev
   pure PUnit.unit

--- a/packages/pickles-circuit-diffs/src/Pickles/CircuitDiffs/PureScript/CheckBulletproofStep.purs
+++ b/packages/pickles-circuit-diffs/src/Pickles/CircuitDiffs/PureScript/CheckBulletproofStep.purs
@@ -88,13 +88,8 @@ checkBulletproofStepCircuit blindingH input = do
   _ <- evalSpongeM sponge $
     checkBulletproof @StepField @PallasG StepOtherField.ipaScalarOps params input.bases input.masks
       { xi: input.xi
-      , delta: input.delta
-      , sg: input.sg
-      , lr: input.lr
-      , z1: input.z1
-      , z2: input.z2
-      , combinedInnerProduct: input.combinedInnerProduct
-      , b: input.b
+      , deferred: { combinedInnerProduct: input.combinedInnerProduct, b: input.b }
+      , opening: { lr: input.lr, z1: input.z1, z2: input.z2, delta: input.delta, sg: input.sg }
       , blindingGenerator: AffinePoint { x: const_ hx, y: const_ hy }
       }
   pure unit

--- a/packages/pickles-circuit-diffs/src/Pickles/CircuitDiffs/PureScript/CheckBulletproofWrap.purs
+++ b/packages/pickles-circuit-diffs/src/Pickles/CircuitDiffs/PureScript/CheckBulletproofWrap.purs
@@ -88,13 +88,8 @@ checkBulletproofWrapCircuit blindingH input = do
   _ <- evalSpongeM sponge $
     checkBulletproof @WrapField @VestaG WrapOtherField.ipaScalarOps params input.bases input.masks
       { xi: input.xi
-      , delta: input.delta
-      , sg: input.sg
-      , lr: input.lr
-      , z1: input.z1
-      , z2: input.z2
-      , combinedInnerProduct: input.combinedInnerProduct
-      , b: input.b
+      , deferred: { combinedInnerProduct: input.combinedInnerProduct, b: input.b }
+      , opening: { lr: input.lr, z1: input.z1, z2: input.z2, delta: input.delta, sg: input.sg }
       , blindingGenerator: AffinePoint { x: const_ hx, y: const_ hy }
       }
   pure unit

--- a/packages/pickles/src/Pickles/IPA.purs
+++ b/packages/pickles/src/Pickles/IPA.purs
@@ -18,6 +18,8 @@ module Pickles.IPA
   , ComputeBInput
   , BCorrectInput
   , BulletReduceInput
+  , BulletproofDeferred
+  , BulletproofOpening
   , IpaFinalCheckInput
   , IpaFinalCheckResult
   , CheckBulletproofInput
@@ -351,22 +353,34 @@ bulletReduceCircuit { pairs, challenges } = label "bullet-reduce" do
 -- | The circuit field is `f`, the commitment curve is `g` with base field `f`.
 -- | Scalars like z1, z2 are in the commitment curve's scalar field,
 -- | represented via the shifted type `sf` in the circuit field.
-type IpaFinalCheckInput n f sf =
-  { -- Opening proof fields (coordinates in f = commitment curve base field)
-    delta :: AffinePoint f
-  , sg :: AffinePoint f -- challenge_polynomial_commitment
-  , lr :: Vector n (LrPair f)
-  -- Scalars from opening proof (shifted representation)
+-- | The two deferred scalars of the opening check (OCaml `Types.Step.Bulletproof.Advice`;
+-- | not called advice here, since in snarky "advice" is the prover-side handler mechanism
+-- | and these are public input of the previous proof): used in the Schnorr equation here,
+-- | certified by the next circuit's `finalizeOtherProof` (`combinedInnerProductCorrect`,
+-- | `bCorrect`).
+type BulletproofDeferred sf =
+  { combinedInnerProduct :: sf
+  , b :: sf
+  }
+
+-- | The opening proof as the circuit reads it (OCaml `Openings.Bulletproof.t`; the same
+-- | fields as `WrapProofOpening` in `Pickles.Types`, as a plain record): checked in the
+-- | Schnorr equation here. Only `sg` is looked at again, one proof later, as `sg_old`.
+type BulletproofOpening n f sf =
+  { lr :: Vector n (LrPair f)
   , z1 :: sf
   , z2 :: sf
-  -- u = group_map(squeeze(sponge)) — derived by caller before combine_poly
-  , u :: AffinePoint f
+  , delta :: AffinePoint f
+  , sg :: AffinePoint f -- challenge_polynomial_commitment
+  }
+
+type IpaFinalCheckInput n f sf =
+  { -- u = group_map(squeeze(sponge)) — derived by caller before combine_poly
+    u :: AffinePoint f
   -- Combined polynomial commitment (from verifier index + xi)
   , combinedPolynomial :: AffinePoint f
-  -- Combined inner product (shifted representation)
-  , combinedInnerProduct :: sf
-  -- b value (shifted representation, verified separately via bCorrectCircuit)
-  , b :: sf
+  , deferred :: BulletproofDeferred sf
+  , opening :: BulletproofOpening n f sf
   -- Blinding generator H (from SRS, constant)
   , blindingGenerator :: AffinePoint f
   }
@@ -423,10 +437,10 @@ ipaFinalCheckCircuit scalarOps params input = do
   -- circuit reads from the step proof's opening via Req.Openings_proof
   -- + deferredValues — if any differs from OCaml, localizes the bug.
   liftSnarky do
-    ivpTrace "ipa.dbg.sg.x" (unwrap input.sg).x
-    ivpTrace "ipa.dbg.sg.y" (unwrap input.sg).y
-    ivpTrace "ipa.dbg.delta.x" (unwrap input.delta).x
-    ivpTrace "ipa.dbg.delta.y" (unwrap input.delta).y
+    ivpTrace "ipa.dbg.sg.x" (unwrap input.opening.sg).x
+    ivpTrace "ipa.dbg.sg.y" (unwrap input.opening.sg).y
+    ivpTrace "ipa.dbg.delta.x" (unwrap input.opening.delta).x
+    ivpTrace "ipa.dbg.delta.y" (unwrap input.opening.delta).y
     ivpTrace "ipa.dbg.cp.x" (unwrap input.combinedPolynomial).x
     ivpTrace "ipa.dbg.cp.y" (unwrap input.combinedPolynomial).y
     ivpTrace "ipa.dbg.u.x" (unwrap input.u).x
@@ -435,13 +449,13 @@ ipaFinalCheckCircuit scalarOps params input = do
   -- 1. Extract 128-bit scalar challenges from L/R pairs
   -- OCaml: bullet_reduce starts with Array.map gammas ~f:(absorb + squeeze_scalar)
   scalarChallenges <- labelM "ipa_extract_challenges" $
-    extractScalarChallenges params input.lr
+    extractScalarChallenges params input.opening.lr
 
   -- 2. Compute lr_prod from L/R pairs and challenges
   -- OCaml: bullet_reduce does curve ops (endo_inv/endo/add_fast) AFTER all absorptions
   lrProd <- liftSnarky $ label "ipa_bullet_reduce" $ do
     { p } <- bulletReduceCircuit @f @g
-      { pairs: input.lr
+      { pairs: input.opening.lr
       , challenges: scalarChallenges
       }
     pure p
@@ -451,7 +465,7 @@ ipaFinalCheckCircuit scalarOps params input = do
   --        combined_polynomial + uc
   -- Right-to-left: uc first, then add
   pPrime <- liftSnarky $ label "ipa_scale_cip" do
-    cipU <- label "ipa_scale_cip_scale" $ scalarOps.scaleByShifted input.u input.combinedInnerProduct
+    cipU <- label "ipa_scale_cip_scale" $ scalarOps.scaleByShifted input.u input.deferred.combinedInnerProduct
     { p } <- label "ipa_scale_cip_add" $ addComplete input.combinedPolynomial cipU
     pure p
 
@@ -464,7 +478,7 @@ ipaFinalCheckCircuit scalarOps params input = do
   -- OCaml: absorb sponge PC delta ; let c = squeeze_scalar sponge
   -- This happens AFTER bullet_reduce and q computation in OCaml
   c <- labelM "ipa_squeeze_c" $ do
-    absorbPoint input.delta
+    absorbPoint input.opening.delta
     squeezeScalar params
 
   -- DIAG: dump Q + c at this point
@@ -476,14 +490,14 @@ ipaFinalCheckCircuit scalarOps params input = do
   success <- liftSnarky $ label "ipa_final_eq" $ do
     -- 7. Compute LHS: c*Q + delta = endo(Q, c) + delta
     cQ <- label "ipa_endo_q" $ endo @128 @32 q c
-    { p: lhs } <- label "ipa_lhs_add" $ addComplete cQ input.delta
+    { p: lhs } <- label "ipa_lhs_add" $ addComplete cQ input.opening.delta
 
     -- 8. Compute RHS: z1*(sg + b*u) + z2*H
     -- Note: b is provided as input and verified separately via bCorrectCircuit
-    bU <- label "ipa_scale_b" $ scalarOps.scaleByShifted input.u input.b
-    { p: sgPlusBU } <- label "ipa_sg_add" $ addComplete input.sg bU
-    z1Term <- label "ipa_scale_z1" $ scalarOps.scaleByShifted sgPlusBU input.z1
-    z2Term <- label "ipa_scale_z2" $ scalarOps.scaleByShifted input.blindingGenerator input.z2
+    bU <- label "ipa_scale_b" $ scalarOps.scaleByShifted input.u input.deferred.b
+    { p: sgPlusBU } <- label "ipa_sg_add" $ addComplete input.opening.sg bU
+    z1Term <- label "ipa_scale_z1" $ scalarOps.scaleByShifted sgPlusBU input.opening.z1
+    z2Term <- label "ipa_scale_z2" $ scalarOps.scaleByShifted input.blindingGenerator input.opening.z2
     { p: rhs } <- label "ipa_rhs_add" $ addComplete z1Term z2Term
 
     -- DIAG: dump LHS + RHS at the final equation
@@ -551,17 +565,10 @@ combinePolynomials bases masks xi = label "combine-polynomials" do
 -- | Input for the full bulletproof verification circuit.
 -- | Contains all proof data needed after the Fq-sponge transcript.
 type CheckBulletproofInput n f sf =
-  { -- Polyscale challenge (128-bit, from Fr-sponge)
+  { -- Polyscale challenge (128-bit, from Fr-sponge; a deferred value)
     xi :: SizedF 128 f
-  -- Opening proof fields
-  , delta :: AffinePoint f
-  , sg :: AffinePoint f
-  , lr :: Vector n (LrPair f)
-  , z1 :: sf
-  , z2 :: sf
-  -- Advice (from deferred values)
-  , combinedInnerProduct :: sf
-  , b :: sf
+  , deferred :: BulletproofDeferred sf
+  , opening :: BulletproofOpening n f sf
   -- Constant
   , blindingGenerator :: AffinePoint f
   }
@@ -612,7 +619,7 @@ checkBulletproof scalarOps params commitmentBases baseMasks input = do
   -- 1. Absorb shift_scalar(CIP) into sponge
   -- OCaml: Other_field.Packed.absorb_shifted sponge advice.combined_inner_product
   labelM "bp_absorb_cip" $ do
-    let cipFields = scalarOps.shiftedToAbsorbFields input.combinedInnerProduct
+    let cipFields = scalarOps.shiftedToAbsorbFields input.deferred.combinedInnerProduct
     for_ cipFields absorb
 
   -- Dump sponge state after CIP absorb.
@@ -635,15 +642,10 @@ checkBulletproof scalarOps params commitmentBases baseMasks input = do
 
   -- 4. Delegate to ipaFinalCheckCircuit (u already computed)
   labelM "bp_ipa_check" $ ipaFinalCheckCircuit @f @g scalarOps params
-    { delta: input.delta
-    , sg: input.sg
-    , lr: input.lr
-    , z1: input.z1
-    , z2: input.z2
-    , u
+    { u
     , combinedPolynomial
-    , combinedInnerProduct: input.combinedInnerProduct
-    , b: input.b
+    , deferred: input.deferred
+    , opening: input.opening
     , blindingGenerator: input.blindingGenerator
     }
 

--- a/packages/pickles/src/Pickles/IncrementallyVerifyProof.purs
+++ b/packages/pickles/src/Pickles/IncrementallyVerifyProof.purs
@@ -359,13 +359,11 @@ incrementallyVerifyProof scalarOps params input mSpongeAfterIndex = labelM "incr
   let
     bpInput =
       { xi: input.deferredValues.xi
-      , delta: input.opening.delta
-      , sg: input.opening.sg
-      , lr: input.opening.lr
-      , z1: input.opening.z1
-      , z2: input.opening.z2
-      , combinedInnerProduct: input.deferredValues.combinedInnerProduct
-      , b: input.deferredValues.b
+      , deferred:
+          { combinedInnerProduct: input.deferredValues.combinedInnerProduct
+          , b: input.deferredValues.b
+          }
+      , opening: input.opening
       , blindingGenerator: constPt params.blindingH
       }
 


### PR DESCRIPTION
Seven commits, rebased onto main after #332 was squash-merged (the trees are unchanged; every gate below ran on these exact trees).

## Summary

- **`CheckBulletproofInput` split into the deferred pair and the opening proof** (PureScript + Lean, record shape only). OCaml passes `~advice:{combined_inner_product; b}` and `~openings_proof:{lr; delta; z_1; z_2; sg}` separately; the flat record hid which scalars are certified by the next circuit's finalize and which are the opening's own. Now `BulletproofDeferred sf` + `BulletproofOpening`, in both `CheckBulletproofInput` and `IpaFinalCheckInput`. Circuit-diffs suite and CS corpus unchanged.
- **The statement records in Lean** (`Pickles/Statement.lean`): `PlonkInCircuit`, `DeferredValues`, `UnfinalizedProof`, `BranchData`, `WrapDeferredValues`, `WrapProofState`, `WrapStatement`, `StepProofState`, `StepStatement`, transcribed from `Pickles.Types` / `Verify.Types` at the circuit's variable types and parameterised by the side's shifted-scalar type. `finalizeOtherProof` reads its claims through `UnfinalizedProof F sf` via `FopShiftOps`; the deployed theorems change only in how the claims are named; `check_cs` builds the nested record per side.
- **The Fiat–Shamir schedules return prechallenges; consumers expand.** Each schedule is a *run* (naturals below 2^128 and base-field elements — exactly what a circuit's group half emits) followed by an *expansion* (cast / endo-expansion, in whichever circuit consumes them): `FqRun`/`fqRun`/`FqRun.expand`, `frRun : ℕ × ℕ`, `roundChallenges`/`ipaRun`/`transcriptFrom = expand ∘ ipaRun`, with the placement theorems reproved and `ipaRun_eq_ipaPrechallenges` new. The field-valued `*_fresh` sponge lemmas are retired.
- **`kimchiVerify` takes the old accumulators.** `Accumulator C k` (a previous opening's `sg` and its `k` expanded round challenges) is passed as a vector beside the proof: `fqRun` absorbs the commitments after the index digest, `frRun` absorbs `recDigest` (a second fresh fr-sponge over every challenge vector) in place of the empty list's constant, and the stream opens each accumulator at the challenge polynomial of its challenges ahead of the public row. `fqOracles_eq_fqPrechallenges` / `frOracles_eq_frPrechallenges` generalise from the empty list with their proofs unchanged; `Reflect.lean` threads the vector. The wire records still carry none and every fixture passes `#v[]`, so the recursion path is validated by transcription only; the scope notes (module preamble, `Wire.lean`, `Kimchi.lean`, README, CLAUDE.md) say so. Production's count guard against the key's `prev_challenges` has no counterpart, the wire key carrying no count.

## Added after review (three commits)

- **Prechallenges carry their 128-bit bound in the type.** `Poseidon.FqSponge.Prechallenge := { n : ℕ // n < 2^128 }` (the paper's Definition [Prechallenge]), with the limb buffer holding `Limb`s so `challengeNat` returns a `Prechallenge` for every state. `FqRun`'s four fields, `frRun`'s pair, `roundChallenges`' vector and `ipaRun`'s Schnorr prechallenge are typed; the `.val` sits only in the expansions. Inserted after the run/expand commit; the accumulators commit is replayed on top.
- **One reading relation at the circuit boundary.** `Pickles/Prechallenge.lean`: `Reads128 V u m` (a `SizedF 128` reads as prechallenge `m`), `Low128` (the `lowest_128_bits` decomposition, moved from CheckBulletproof), `CastInj128` (the `hchar`/`hinj` hypothesis, named once, three private cast lemmas collapsed), and `Low128.alias` as the one bridge to `PrechallengeAlias`, which now takes a `Prechallenge`. The five pickles files restate their readings over these; statements only.
- **`FrRun` / `FrOracles` records**, `frOracles` the run expanded, `runVU` → `runFrOracles`, matching the fq side.

Gates on each: build, style, lint, shake (full root list), deadcode, axiom manifests, kimchi verifier fixture matrix; the first also the fq-sponge traces and IPA fixtures. `check_cs` not rerun on the last two (no circuit definition changes).

Not in this PR: the PureScript terminator's accumulator list (it verifies the wrap proof with the list the prover stored in the proof object, where OCaml rebuilds it from the carried messages); that fix is separate.

## Test plan

Last commit, run in the shared workspace:
- [x] `lake build Kimchi KimchiFixture Pickles`
- [x] `kimchi/scripts/check_kimchi_verifier.sh` (the fixture matrix, at `#v[]`)
- [x] kimchi and pickles axiom gates
- [x] `runLinter Kimchi`, shake on `Kimchi`, `check-style.sh`, `deadcode.sh`

Earlier commits: the gates recorded in their messages (build, style, axiom manifests for kimchi/bulletproof/pickles/poseidon, deadcode, lint, shake; fq-sponge traces, IPA fixtures, the kimchi verifier fixture matrix; the `check_cs` corpus for the record-shape commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

