### PR TITLE
formal: the ft_comm gadget and its side-generic read

### DIFF
--- a/formal/kimchi/Kimchi/Verifier/Reflect.lean
+++ b/formal/kimchi/Kimchi/Verifier/Reflect.lean
@@ -42,8 +42,9 @@ private def runZetaOmega (σ : SRS C.Point) (cvk : KimchiVK C nc)
     (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) : C.ScalarField :=
   (runOracles C σ cvk cp pub).zeta * cvk.omega
 
-/-- The domain-size power `ζⁿ`, by the squaring ladder. -/
-private def runZetaN (σ : SRS C.Point) (cvk : KimchiVK C nc)
+/-- The domain-size power `ζⁿ`, by the squaring ladder. Public: the wrap circuit consumes it
+as the deferred `zeta_to_domain_size` claim, which the group-half read ties to this. -/
+def runZetaN (σ : SRS C.Point) (cvk : KimchiVK C nc)
     (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) : C.ScalarField :=
   powPow2 (runOracles C σ cvk cp pub).zeta cvk.domainLog2
 
@@ -52,8 +53,10 @@ private def runZetaOmegaN (σ : SRS C.Point) (cvk : KimchiVK C nc)
     (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) : C.ScalarField :=
   powPow2 (runZetaOmega C σ cvk cp pub) cvk.domainLog2
 
-/-- The chunk-combination power `ζ^{2^σ.k}` (`ζ^max_poly_size`). -/
-private def runZetaM (σ : SRS C.Point) (cvk : KimchiVK C nc)
+/-- The chunk-combination power `ζ^{2^σ.k}` (`ζ^max_poly_size`). Public: the wrap circuit
+consumes it as the deferred `zeta_to_srs_length` claim, which the group-half read ties to
+this. -/
+def runZetaM (σ : SRS C.Point) (cvk : KimchiVK C nc)
     (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) : C.ScalarField :=
   powPow2 (runOracles C σ cvk cp pub).zeta σ.k
 
@@ -103,7 +106,7 @@ def runPScalar (σ : SRS C.Point) (cvk : KimchiVK C nc)
     (runLinEvals C σ cvk cp pub)
 
 /-- The run's `f_comm` chunks — the `pScalar`-scaled `σ₆` chunk vector. -/
-private def runFComm (σ : SRS C.Point) (cvk : KimchiVK C nc)
+def runFComm (σ : SRS C.Point) (cvk : KimchiVK C nc)
     (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) :
     Vector C.Point nc :=
   cvk.sigmaComm[6].map (fun P => (runPScalar C σ cvk cp pub).val • P)

--- a/formal/pickles/Pickles.lean
+++ b/formal/pickles/Pickles.lean
@@ -14,6 +14,7 @@ import Pickles.FqSpongeTranscript
 import Pickles.CheckBulletproof
 import Pickles.PublicInputCommit
 import Pickles.XhatGlue
+import Pickles.FtComm
 
 /-!
 # Pickles — the in-circuit kimchi verifier

--- a/formal/pickles/Pickles/CheckBulletproof.lean
+++ b/formal/pickles/Pickles/CheckBulletproof.lean
@@ -868,7 +868,7 @@ private theorem wrapLadderPre_eq {V : Valuation Fq} {x : Type1 (FVar Fq)} {z : �
     (lt_of_lt_of_le hlt (by norm_num [PALLAS_SCALAR_CARD]))).symm
 
 /-- A wrap ladder witness decodes, in the scalar field, to `wrapDecode`. -/
-private theorem wrapLadderDec_cast {V : Valuation Fq} {x : Type1 (FVar Fq)} {z : ℤ}
+theorem wrapLadderDec_cast {V : Valuation Fq} {x : Type1 (FVar Fq)} {z : ℤ}
     (h : WrapLadderPre V x z) : (wrapLadderDec z : Fp) = wrapDecode V x := by
   simp only [wrapLadderDec, wrapDecode, unshiftType1, wrapLadderPre_eq h]
   push_cast
@@ -910,7 +910,7 @@ def stepDecode (V : Valuation Fp) (x : Type2 (SplitField (FVar Fp) (BoolVar Fp))
     ((((↑x.val.sOdd : CVar Fp).val V).val : ℕ) : Fq)
 
 /-- A step ladder witness decodes, in the scalar field, to `stepDecode`. -/
-private theorem stepLadderDec_cast {V : Valuation Fp}
+theorem stepLadderDec_cast {V : Valuation Fp}
     {x : Type2 (SplitField (FVar Fp) (BoolVar Fp))} {w : ℤ × Bool} (h : StepLadderPre V x w) :
     (stepLadderDec w : Fq) = stepDecode V x := by
   obtain ⟨hb, h0, hlt, hz⟩ := h
@@ -1115,6 +1115,27 @@ private theorem val_mul_nsmul (n : ℕ) [NeZero n] (hn : ∀ x : G, n • x = 0)
   conv_rhs => rw [← Nat.mod_add_div (a.val * b.val) n, add_nsmul, mul_nsmul', hn, _root_.add_zero]
 
 omit [Field F] [DecidableEq F] [ToNat F] in
+/-- The wire's polyscale combination is Horner's rule over the list, the scalar acting by its
+representative — on any commitment curve whose point group its scalar order kills. -/
+theorem combineCommitments_eq_foldr (C : Bulletproof.Ipa.CommitmentCurve)
+    (hn : ∀ x : C.Point, C.scalar • x = 0) (ξ : C.ScalarField) (cs : List C.Point) :
+    Bulletproof.Ipa.combineCommitments C ξ cs.toArray
+      = cs.foldr (fun P acc => P + ξ.val • acc) 0 := by
+  haveI : NeZero C.scalar := ⟨C.primeScalar.out.ne_zero⟩
+  have key : ∀ (l : List C.Point) (acc : C.Point) (pw : C.ScalarField),
+      (l.foldl (fun (acc : C.Point × C.ScalarField) P => (acc.1 + acc.2.val • P, acc.2 * ξ))
+        (acc, pw)).1 = acc + pw.val • l.foldr (fun P acc => P + ξ.val • acc) 0 := by
+    intro l
+    induction l with
+    | nil => intro acc pw; simp
+    | cons P l ih =>
+      intro acc pw
+      rw [List.foldl_cons, ih, List.foldr_cons, nsmul_add, val_mul_nsmul C.scalar hn,
+        _root_.add_assoc]
+  unfold Bulletproof.Ipa.combineCommitments
+  rw [← Array.foldl_toList, List.toList_toArray, key, ZMod.val_one, one_nsmul, _root_.zero_add]
+
+omit [Field F] [DecidableEq F] [ToNat F] in
 /-- The masked Horner fold skips exactly the unkept bases. -/
 private theorem foldl_hornerStep_eq (ξ : ℤ) :
     ∀ (t : List (G × Bool)) (acc : G),
@@ -1219,25 +1240,14 @@ private theorem vesta_zipTerms :
     simp only [List.map_cons, List.zipWith_cons_cons, List.zip_cons_cons, vesta_lrTerm_eq]
     exact congrArg _ (vesta_zipTerms l ns)
 
-/-- The wire's polyscale combination is Horner's rule over the list, the scalar acting by
-its representative. -/
+/-- The wire's polyscale combination at Vesta is Horner's rule over the list
+(`combineCommitments_eq_foldr`). -/
 private theorem combineCommitments_eq_foldr_vesta (ξ : Fp) (cs : List (SWPoint Vesta.curve)) :
     combineCommitments IpaVesta.curve ξ cs.toArray
-      = cs.foldr (fun P acc => P + ξ.val • acc) 0 := by
-  have hn : ∀ x : SWPoint Vesta.curve, PALLAS_BASE_CARD • x = 0 := fun x =>
-    ZModModule.char_nsmul_eq_zero (n := PALLAS_BASE_CARD) x
-  have key : ∀ (l : List (SWPoint Vesta.curve)) (acc : SWPoint Vesta.curve) (pw : Fp),
-      (l.foldl (fun (acc : SWPoint Vesta.curve × Fp) P => (acc.1 + acc.2.val • P, acc.2 * ξ))
-        (acc, pw)).1 = acc + pw.val • l.foldr (fun P acc => P + ξ.val • acc) 0 := by
-    intro l
-    induction l with
-    | nil => intro acc pw; simp
-    | cons P l ih =>
-      intro acc pw
-      rw [List.foldl_cons, ih, List.foldr_cons, nsmul_add, val_mul_nsmul PALLAS_BASE_CARD hn,
-        _root_.add_assoc]
-  unfold combineCommitments
-  rw [← Array.foldl_toList, List.toList_toArray, key, ZMod.val_one, one_nsmul, _root_.zero_add]
+      = cs.foldr (fun P acc => P + ξ.val • acc) 0 :=
+  combineCommitments_eq_foldr IpaVesta.curve
+    (fun x => ZModModule.char_nsmul_eq_zero (n := PALLAS_BASE_CARD) x) ξ cs
+
 /-- Horner's rule over the kept bases, read back in the wire group, is the wire's polyscale
 combination at the expanded challenge. -/
 private theorem vesta_hornerCombine_eq (n : ℕ) (bvW : List (SWPoint Vesta.curve × Bool))
@@ -1471,25 +1481,14 @@ private theorem pallas_zipTerms :
     simp only [List.map_cons, List.zipWith_cons_cons, List.zip_cons_cons, pallas_lrTerm_eq]
     exact congrArg _ (pallas_zipTerms l ns)
 
-/-- The wire's polyscale combination is Horner's rule over the list, the scalar acting by
-its representative. -/
+/-- The wire's polyscale combination at Pallas is Horner's rule over the list
+(`combineCommitments_eq_foldr`). -/
 private theorem combineCommitments_eq_foldr_pallas (ξ : Fq) (cs : List (SWPoint Pallas.curve)) :
     combineCommitments IpaPallas.curve ξ cs.toArray
-      = cs.foldr (fun P acc => P + ξ.val • acc) 0 := by
-  have hn : ∀ x : SWPoint Pallas.curve, PALLAS_SCALAR_CARD • x = 0 := fun x =>
-    ZModModule.char_nsmul_eq_zero (n := PALLAS_SCALAR_CARD) x
-  have key : ∀ (l : List (SWPoint Pallas.curve)) (acc : SWPoint Pallas.curve) (pw : Fq),
-      (l.foldl (fun (acc : SWPoint Pallas.curve × Fq) P => (acc.1 + acc.2.val • P, acc.2 * ξ))
-        (acc, pw)).1 = acc + pw.val • l.foldr (fun P acc => P + ξ.val • acc) 0 := by
-    intro l
-    induction l with
-    | nil => intro acc pw; simp
-    | cons P l ih =>
-      intro acc pw
-      rw [List.foldl_cons, ih, List.foldr_cons, nsmul_add, val_mul_nsmul PALLAS_SCALAR_CARD hn,
-        _root_.add_assoc]
-  unfold combineCommitments
-  rw [← Array.foldl_toList, List.toList_toArray, key, ZMod.val_one, one_nsmul, _root_.zero_add]
+      = cs.foldr (fun P acc => P + ξ.val • acc) 0 :=
+  combineCommitments_eq_foldr IpaPallas.curve
+    (fun x => ZModModule.char_nsmul_eq_zero (n := PALLAS_SCALAR_CARD) x) ξ cs
+
 /-- Horner's rule over the kept bases, read back in the wire group, is the wire's polyscale
 combination at the expanded challenge. -/
 private theorem pallas_hornerCombine_eq (n : ℕ) (bvW : List (SWPoint Pallas.curve × Bool))

--- a/formal/pickles/Pickles/FtComm.lean
+++ b/formal/pickles/Pickles/FtComm.lean
@@ -1,0 +1,359 @@
+import Pickles.CheckBulletproof
+import Kimchi.Verifier.Reflect
+
+/-!
+# The `ft_comm` commitment (`Common.ft_comm`)
+
+The port of PS `Pickles.FtComm.ftComm` (OCaml `Common.ft_comm`, `common.ml:307–326`), called by
+both verifiers (`step_verifier.ml:724` at `scale_fast2`, `wrap_verifier.ml:1428` at
+`scale_fast`): the linearization commitment the group half constructs from the verification
+key's last permutation commitment `σ₆`, the proof's quotient chunks `t_comm`, and the shifted
+deferred claims `perm`, `ζ^{2^k}` (`zeta_to_srs_length`) and `ζⁿ` (`zeta_to_domain_size`):
+
+  `ft_comm = scale (reduce σ₆) perm + reduce t_comm + negate (scale (reduce t_comm) ζⁿ)`
+
+where `reduce` is the `ζ^{2^k}`-Horner collapse of a chunk array (`reduce_chunks`). The
+emission order follows OCaml's right-to-left argument evaluation: reduce `σ₆`, scale by `perm`,
+reduce `t_comm`, scale by `ζⁿ` and negate, then `f_comm + reduced_t`, then `+ negated`.
+
+The gadget is generic in the side's shifted-scalar operations (`IpaScalarOps`); so is its read.
+`IvpSide` names what a side supplies to read a group-half gadget on the wire's commitment
+curve: its ladder reading (`IpaScalarOps.Reading`), the scalar-field decode of a shifted claim
+with the law tying a ladder witness's integer decode to it, and the curve's group facts.
+`wrapSide` and `stepSide` are the two deployed values. `FtCommReads` is the leg's read: the
+constructed cell crosses to the wire's `runFtComm`
+(`combine(ζ^{2^k}, perm·σ₆) − (ζⁿ − 1)·combine(ζ^{2^k}, t_comm)`), given the claims decode to
+the wire's scalars, each a claim the ladder read speaks about (`IvpSide.ClaimOk`: well-formed,
+and its witnesses in the ladder regime — the forbidden-band premise of the `scale_fast` family),
+and the commitment cells read as the key's / proof's commitments.
+-/
+
+namespace Pickles
+
+open Std.Do Snarky Snarky.Kimchi Kimchi.Verifier
+open CompElliptic.Fields.Pasta CompElliptic.Curves.Pasta Bulletproof Bulletproof.Ipa
+open CompElliptic.CurveForms.ShortWeierstrass
+
+/-! ## The gadget -/
+
+section Gadget
+
+variable {F c : Type} [Field F] [DecidableEq F] [ToNat F] [BasicSystem F c] [KimchiSystem F c]
+
+/-- `reduce_chunks` (`common.ml:311–318`): the `z`-Horner collapse of the chunks `c₀, …, cₙ₋₁`
+— `res := cₙ₋₁; for i = n−2 downto 0: res := cᵢ + scale res z`. Recursively
+`c₀ + scale (reduce [c₁, …]) z`, whose evaluation emits the innermost (last-chunk) scale first,
+as the OCaml loop does. The empty list is the unused origin. -/
+def hornerReduce {sf : Type} (ops : IpaScalarOps F c sf) (z : sf) :
+    List (AffinePoint (FVar F)) → CircuitM F c (AffinePoint (FVar F))
+  | [] => pure ⟨.const 0, .const 0⟩
+  | [chunk] => pure chunk
+  | chunk :: rest => do
+      let r ← hornerReduce ops z rest
+      let s ← ops.scaleByShifted r z
+      (·.p) <$> addFast .checkFinite chunk s
+
+/-- `Common.ft_comm`: reduce `σ₆` and scale by `perm`; reduce `t_comm`; scale that by `ζⁿ` and
+negate (the outer `+`'s right argument, evaluated first); then `f_comm + reduced_t`, then
+`+ negated`. The negation is the pure `y ↦ −y` (OCaml `Inner_curve.negate`, PS
+`Curves.negate`). -/
+def ftComm {sf : Type} (ops : IpaScalarOps F c sf)
+    (sigmaLast tComm : List (AffinePoint (FVar F)))
+    (perm zetaToSrsLength zetaToDomainSize : sf) : CircuitM F c (AffinePoint (FVar F)) := do
+  let reducedSigma ← hornerReduce ops zetaToSrsLength sigmaLast
+  let fComm ← ops.scaleByShifted reducedSigma perm
+  let chunkedT ← hornerReduce ops zetaToSrsLength tComm
+  let zetaDom ← ops.scaleByShifted chunkedT zetaToDomainSize
+  let r1 ← addFast .checkFinite fComm chunkedT
+  (·.p) <$> addFast .checkFinite r1.p ⟨zetaDom.x, CVar.negate_ zetaDom.y⟩
+
+end Gadget
+
+/-! ## A side of the group half -/
+
+/-- What a side supplies to read a group-half gadget on the wire's commitment curve `C`: how
+its shifted-scalar ladder reads (`R`); the scalar-field decode of a shifted claim, with the law
+that a ladder witness's integer decode casts to it; and the facts about `C`'s affine group the
+adds and negations need — the scalar order kills the group (so an integer acts as its residue's
+representative), the curve is short (`A = 0`), the base field is not of characteristic 2 and
+the group has no 2-torsion. One value per deployed side: `wrapSide`, `stepSide`. -/
+structure IvpSide (C : CommitmentCurve) (V : Valuation C.BaseField) {sf : Type}
+    (ops : IpaScalarOps C.BaseField (Builder V (KimchiConstraint C.BaseField)) sf) where
+  /-- The ladder's reading on the wire curve's affine group. -/
+  R : IpaScalarOps.Reading (V := V) ops C.E.toAffine
+  /-- The canonical decode of a shifted claim in the scalar field. -/
+  decode : sf → C.ScalarField
+  /-- A ladder witness of a claim decodes, in the scalar field, to the claim's decode. -/
+  dec_cast : ∀ {x : sf} {w : R.wit}, R.Pre x w → (R.dec w : C.ScalarField) = decode x
+  /-- The scalar order kills the wire point group. -/
+  card_nsmul : ∀ X : C.Point, C.scalar • X = 0
+  /-- The curve is short: `y² = x³ + B`. -/
+  a_zero : C.E.A = 0
+  /-- The base field is not of characteristic 2. -/
+  two_ne : (2 : C.BaseField) ≠ 0
+  /-- The affine group has no 2-torsion. -/
+  two_torsion_free : ∀ P : C.E.toAffine.Point, P ≠ 0 → P + P ≠ 0
+
+section Side
+
+variable {C : CommitmentCurve} {V : Valuation C.BaseField} {sf : Type}
+  {ops : IpaScalarOps C.BaseField (Builder V (KimchiConstraint C.BaseField)) sf}
+
+/-- A shifted claim the ladder read speaks about: well-formed for the side, and every witness
+reading it in the ladder's regime (at the deployed curves: the decode is off the forbidden
+band — the `scale_fast`-family premise #341 tracks). -/
+def IvpSide.ClaimOk (S : IvpSide C V ops) (x : sf) : Prop :=
+  S.R.WellFormed x ∧ ∀ w, S.R.Pre x w → S.R.Reg w
+
+/-- A commitment cell list reads as a wire commitment list, pointwise through `equivPoint`. -/
+def CommReads (C : CommitmentCurve) (V : Valuation C.BaseField)
+    (cells : List (AffinePoint (FVar C.BaseField))) (Ps : List C.Point) : Prop :=
+  List.Forall₂ (fun cell P => OnCurveAt C.E.toAffine V cell (SWPoint.equivPoint C.E P)) cells Ps
+
+/-- The `ft_comm` read: given the claims decode to the wire's permutation scalar and `ζ` powers
+(each a claim the ladder read speaks about), and the `σ₆` chunk cells and `t_comm` cells read as
+the verification key's and the proof's commitments, the constructed cell crosses to `runFtComm`
+(`combine(ζ^{2^k}, perm·σ₆) − (ζⁿ − 1)·combine(ζ^{2^k}, t_comm)`). -/
+def FtCommReads {nc : ℕ} (S : IvpSide C V ops) (σ : SRS C.Point) (cvk : KimchiVK C nc)
+    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField)
+    (ftCommCell : AffinePoint (FVar C.BaseField)) (permCell zetaMCell zetaNCell : sf)
+    (sigma6Cells : Vector (AffinePoint (FVar C.BaseField)) nc)
+    (tCommCells : List (AffinePoint (FVar C.BaseField))) : Prop :=
+  S.decode permCell = runPScalar C σ cvk cp pub →
+  S.decode zetaMCell = runZetaM C σ cvk cp pub →
+  S.decode zetaNCell = runZetaN C σ cvk cp pub →
+  S.ClaimOk permCell → S.ClaimOk zetaMCell → S.ClaimOk zetaNCell →
+  CommReads C V sigma6Cells.toList (cvk.sigmaComm[6]).toList →
+  CommReads C V tCommCells cp.tComm.toList →
+  OnCurveAt C.E.toAffine V ftCommCell (SWPoint.equivPoint C.E (runFtComm C σ cvk cp pub))
+
+/-! ## Reading helpers -/
+
+/-- In a group killed by `n`, an integer acts as its residue's canonical representative
+(restated; private in `CheckBulletproof`). -/
+private theorem zsmul_eq_val_nsmul {G : Type} [AddCommGroup G] (n : ℕ) [NeZero n]
+    (hn : ∀ x : G, n • x = 0) (z : ℤ) (x : G) : z • x = ((z : ZMod n).val : ℕ) • x := by
+  have hv : (((z : ZMod n).val : ℕ) : ℤ) = z % n := ZMod.val_intCast z
+  rw [← natCast_zsmul, hv]
+  conv_lhs => rw [← Int.emod_add_mul_ediv z n]
+  rw [add_zsmul, mul_zsmul, natCast_zsmul, hn, _root_.add_zero]
+
+/-- The scalar order kills the affine group too, across `equivPoint`. -/
+private theorem IvpSide.aff_nsmul (S : IvpSide C V ops) (X : C.E.toAffine.Point) :
+    C.scalar • X = 0 := by
+  rw [← (SWPoint.equivPoint C.E).apply_symm_apply X, ← map_nsmul, S.card_nsmul, map_zero]
+
+/-- An integer acts on the affine group as its residue's representative in the scalar field. -/
+private theorem IvpSide.zsmul_eq (S : IvpSide C V ops) (z : ℤ) (X : C.E.toAffine.Point) :
+    z • X = ((z : C.ScalarField).val : ℕ) • X :=
+  haveI : NeZero C.scalar := ⟨C.primeScalar.out.ne_zero⟩
+  zsmul_eq_val_nsmul C.scalar S.aff_nsmul z X
+
+/-- A scale by a claim decoding to `s` acts by `s.val`: the witness's integer decode is `s`'s
+representative (`dec_cast`) and the group is killed by the scalar order. -/
+private theorem IvpSide.scale_val (S : IvpSide C V ops) {x : sf} {w : S.R.wit}
+    {s : C.ScalarField} (hpre : S.R.Pre x w) (hdec : S.decode x = s)
+    (T : C.E.toAffine.Point) : S.R.dec w • T = s.val • T := by
+  rw [S.zsmul_eq, S.dec_cast hpre, hdec]
+
+/-- The side's scaling read with the well-formedness moved into the postcondition, so it serves
+as a `mvcgen` spec before the claim's well-formedness is in hand. -/
+private theorem IvpSide.scale_reads (S : IvpSide C V ops) (pt : AffinePoint (FVar C.BaseField))
+    (x : sf) :
+    ⦃⌜True⌝⦄ ops.scaleByShifted pt x
+    ⦃⇓ r _ => ⌜S.R.WellFormed x → ∀ T : C.E.toAffine.Point, OnCurveAt C.E.toAffine V pt T →
+      ∃ w, S.R.Pre x w ∧ (S.R.Reg w → OnCurveAt C.E.toAffine V r (S.R.dec w • T))⌝⦄ := by
+  rw [builder_spec_iff]
+  intro nv hsat hwf
+  exact (builder_spec_iff _ _).mp (S.R.scale pt x hwf) nv hsat
+
+/-- The scalar-field Horner collapse of a point list, `P₀ + ξ·(P₁ + ξ·(…))` — `Σᵢ ξⁱ·Pᵢ`. -/
+private def hornerVal (C : CommitmentCurve) (ξ : C.ScalarField)
+    (Ps : List C.E.toAffine.Point) : C.E.toAffine.Point :=
+  Ps.foldr (fun P acc => P + ξ.val • acc) 0
+
+/-- Horner is linear in the points, across the crossing: the crossed collapse of the
+`s`-scaled wire points is `s.val` times the crossed collapse. Stated on the wire's own list
+shape (`map e (map (s • ·) cs)`) so the read can rewrite with it directly. -/
+private theorem hornerVal_map_smul (C : CommitmentCurve) (ξ s : C.ScalarField)
+    (cs : List C.Point) :
+    hornerVal C ξ (List.map (SWPoint.equivPoint C.E) (List.map (fun P => s.val • P) cs))
+      = s.val • hornerVal C ξ (List.map (SWPoint.equivPoint C.E) cs) := by
+  induction cs with
+  | nil => simp [hornerVal]
+  | cons P cs ih =>
+      simp only [hornerVal, List.map_cons, List.foldr_cons] at ih ⊢
+      rw [map_nsmul, ih, nsmul_add]
+      congr 1
+      exact smul_comm _ _ _
+
+/-- `equivPoint` carries the wire's Horner fold to `hornerVal` over the mapped points. -/
+private theorem equivPoint_hornerVal (C : CommitmentCurve) (ξ : C.ScalarField)
+    (cs : List C.Point) :
+    (SWPoint.equivPoint C.E) (cs.foldr (fun P acc => P + ξ.val • acc) 0)
+      = hornerVal C ξ (cs.map (SWPoint.equivPoint C.E)) := by
+  induction cs with
+  | nil => simp [hornerVal]
+  | cons P cs ih =>
+      simp only [hornerVal, List.map_cons, List.foldr_cons] at ih ⊢
+      rw [map_add, map_nsmul, ih]
+
+/-- `(ζ − 1)` acts as `ζ` minus the identity: the scalar-field subtraction is exact on a group
+killed by the scalar order. -/
+private theorem IvpSide.sub_one_val_smul (S : IvpSide C V ops) (ζ : C.ScalarField)
+    (X : C.E.toAffine.Point) : (ζ - 1).val • X = ζ.val • X - X := by
+  haveI : NeZero C.scalar := ⟨C.primeScalar.out.ne_zero⟩
+  have h : (((ζ.val : ℤ) - 1 : ℤ) : C.ScalarField) = ζ - 1 := by
+    push_cast
+    rw [ZMod.natCast_zmod_val]
+  rw [← h, ← S.zsmul_eq, sub_zsmul, natCast_zsmul, one_zsmul, sub_eq_add_neg]
+
+/-- `hornerReduce` reads as the scalar-field Horner collapse of the chunks' points: given the
+`ζ^{2^k}` claim decodes to `ξ` and is a claim the ladder speaks about, and the chunks read as
+`Ps`. Needs a chunk (the empty collapse is the unused origin). -/
+private theorem hornerReduce_reads (S : IvpSide C V ops) (zM : sf) :
+    ∀ chunks : List (AffinePoint (FVar C.BaseField)), chunks ≠ [] →
+      ⦃⌜True⌝⦄ hornerReduce ops zM chunks
+      ⦃⇓ r _ => ⌜∀ ξ : C.ScalarField, S.decode zM = ξ → S.ClaimOk zM →
+        ∀ Ps : List C.E.toAffine.Point,
+          List.Forall₂ (OnCurveAt C.E.toAffine V) chunks Ps →
+          OnCurveAt C.E.toAffine V r (hornerVal C ξ Ps)⌝⦄
+  | [], hne => absurd rfl hne
+  | [c], _ => by
+      simp only [hornerReduce]
+      mvcgen
+      intro ξ _ _ Ps hf
+      cases hf with
+      | cons hc hnil =>
+        cases hnil
+        simpa [hornerVal] using hc
+  | c :: c' :: rest, _ => by
+      simp only [hornerReduce]
+      have ih := hornerReduce_reads S zM (c' :: rest) (List.cons_ne_nil _ _)
+      have hsc := fun (r : AffinePoint (FVar C.BaseField)) => S.scale_reads r zM
+      have hadd := fun (s : AffinePoint (FVar C.BaseField)) =>
+        addFast_checkFinite_spec (V := V) C.E.toAffine ⟨rfl, rfl, rfl, S.a_zero⟩ S.two_ne
+          S.two_torsion_free c s
+      mvcgen -trivial [-Snarky.Kimchi.addFast_spec, ih, hsc, hadd]
+      clear ih
+      rename_i _ _ _ hih _ _ hsc' _ _
+      intro haddpost ξ hdec hok Ps hf
+      cases hf with
+      | cons hc hrest =>
+        have hr := hih ξ hdec hok _ hrest
+        obtain ⟨w, hpre, hpt⟩ := hsc' hok.1 _ hr
+        have hs := hpt (hok.2 w hpre)
+        rw [S.scale_val hpre hdec] at hs
+        simpa [hornerVal] using haddpost _ _ hc hs
+
+/-- A commitment-cell read gives the chunk points, crossed, for the Horner read. -/
+private theorem CommReads.forall₂ {cells : List (AffinePoint (FVar C.BaseField))}
+    {Ps : List C.Point} (h : CommReads C V cells Ps) :
+    List.Forall₂ (OnCurveAt C.E.toAffine V) cells (Ps.map (SWPoint.equivPoint C.E)) :=
+  List.forall₂_map_right_iff.2 h
+
+/-- Transport a curve read along a point equation. Used in place of `convert`, whose closing
+`rfl` unfolds the Weierstrass group law (and with it the field inversion on the 2²⁵⁴ modulus)
+and recurses. -/
+private theorem OnCurveAt.congr_pt {F : Type} [Field F] [DecidableEq F]
+    {W : WeierstrassCurve.Affine F} {V : Valuation F} {c : AffinePoint (FVar F)} {P Q : W.Point}
+    (h : OnCurveAt W V c P) (e : P = Q) : OnCurveAt W V c Q :=
+  e ▸ h
+
+/-- **The `ft_comm` gadget reads as the wire's `runFtComm`.** On either side, on the `σ₆` chunk
+cells and the `t_comm` cells, the gadget's output satisfies `FtCommReads`. Needs a chunk on each
+side (the empty collapse is the unused origin). Each `scale` reads through the side's
+`IpaScalarOps.Reading`, each collapse through `hornerReduce_reads`; the wire's `runFtComm` is
+then the same expression, `combineCommitments` being Horner (`combineCommitments_eq_foldr`) and
+`equivPoint` carrying it across. -/
+theorem ftComm_reads {nc : ℕ} (S : IvpSide C V ops) (σ : SRS C.Point) (cvk : KimchiVK C nc)
+    (cp : KimchiProof C nc σ.k) (pub : Array C.ScalarField) (permCell zetaMCell zetaNCell : sf)
+    (sigma6Cells : Vector (AffinePoint (FVar C.BaseField)) nc)
+    (tCommCells : List (AffinePoint (FVar C.BaseField))) (hnc : 0 < nc)
+    (hne : tCommCells ≠ []) :
+    ⦃⌜True⌝⦄ ftComm ops sigma6Cells.toList tCommCells permCell zetaMCell zetaNCell
+    ⦃⇓ r _ => ⌜FtCommReads S σ cvk cp pub r permCell zetaMCell zetaNCell sigma6Cells
+      tCommCells⌝⦄ := by
+  have hσne : sigma6Cells.toList ≠ [] := by
+    intro h
+    have := congrArg List.length h
+    simp at this
+    omega
+  simp only [ftComm]
+  have hhσ := hornerReduce_reads S zetaMCell sigma6Cells.toList hσne
+  have hscP := fun (r : AffinePoint (FVar C.BaseField)) => S.scale_reads r permCell
+  have hht := hornerReduce_reads S zetaMCell tCommCells hne
+  have hscN := fun (r : AffinePoint (FVar C.BaseField)) => S.scale_reads r zetaNCell
+  have hadd := fun (a b : AffinePoint (FVar C.BaseField)) =>
+    addFast_checkFinite_spec (V := V) C.E.toAffine ⟨rfl, rfl, rfl, S.a_zero⟩ S.two_ne
+      S.two_torsion_free a b
+  mvcgen -trivial [-Snarky.Kimchi.addFast_spec, hhσ, hscP, hht, hscN, hadd]
+  clear hhσ hht
+  rename_i _ _ _ hhσ' _ _ hscP' _ _ hht' _ _ hscN' _ _ hadd1 _ _
+  intro hadd2
+  unfold FtCommReads
+  intro hperm hzM hzN hokP hokM hokN hσ ht
+  -- make the wire's closed forms opaque before any algebra: `runZetaM`/`runZetaN`/`runPScalar`
+  -- hide the whole fq-sponge run, and a defeq check that unfolds them sends the kernel into
+  -- deep recursion. Everything below is stated over the three names.
+  generalize hζM : runZetaM C σ cvk cp pub = ζM at hzM
+  generalize hsP : runPScalar C σ cvk cp pub = sP at hperm
+  generalize hζN : runZetaN C σ cvk cp pub = ζN at hzN
+  -- the σ₆ leg: collapse, then scale by `perm`
+  have hRσ := hhσ' _ hzM hokM _ hσ.forall₂
+  obtain ⟨wP, hpreP, hptP⟩ := hscP' hokP.1 _ hRσ
+  have hF := hptP (hokP.2 wP hpreP)
+  rw [S.scale_val hpreP hperm] at hF
+  -- the t_comm leg: collapse, scale by `ζⁿ`, negate
+  have hRt := hht' _ hzM hokM _ ht.forall₂
+  obtain ⟨wN, hpreN, hptN⟩ := hscN' hokN.1 _ hRt
+  have hZ := hptN (hokN.2 wN hpreN)
+  rw [S.scale_val hpreN hzN] at hZ
+  have hnegZ := OnCurveAt.neg ⟨rfl, rfl⟩ hZ
+  -- the two adds
+  have h1 := hadd1 _ _ hF hRt
+  have h2 := hadd2 _ _ h1 hnegZ
+  -- the wire's `runFtComm`, crossed, is the same expression: unfold it and name its closed
+  -- forms, collapse the two `combineCommitments` via `combineCommitments_eq_foldr` on their
+  -- list forms (`Array.toArray_toList`, `Vector.toArray_map`), push `equivPoint` through to
+  -- `hornerVal`, pull the `perm` scaling out, split `ζⁿ − 1`, and match `h2`.
+  simp only [runFtComm, runFComm]
+  rw [hζM, hsP, hζN]
+  have hcT := combineCommitments_eq_foldr C S.card_nsmul ζM cp.tComm.toList
+  rw [Array.toArray_toList] at hcT
+  have hcσ := combineCommitments_eq_foldr C S.card_nsmul ζM
+    ((cvk.sigmaComm[6]).toList.map (fun P => sP.val • P))
+  rw [show ((cvk.sigmaComm[6]).toList.map (fun P => sP.val • P)).toArray
+      = ((cvk.sigmaComm[6]).map (fun P => sP.val • P)).toArray
+    from by rw [Vector.toArray_map, List.map_toArray, Vector.toList, Array.toArray_toList]] at hcσ
+  rw [hcσ, hcT, map_sub, map_nsmul, equivPoint_hornerVal, equivPoint_hornerVal,
+    hornerVal_map_smul, S.sub_one_val_smul]
+  exact OnCurveAt.congr_pt h2 (by rw [sub_sub_eq_add_sub, sub_eq_add_neg])
+
+end Side
+
+/-! ## The deployed sides -/
+
+/-- The wrap side: `IpaScalarOps.wrap` at Vesta (`IpaVesta.curve`, base `Fq`, scalar `Fp`)
+through `wrapReading`, the `Type1` claims decoding by `wrapDecode`. -/
+def wrapSide (V : Valuation Fq) : IvpSide IpaVesta.curve V IpaScalarOps.wrap where
+  R := wrapReading V
+  decode := wrapDecode V
+  dec_cast h := wrapLadderDec_cast h
+  card_nsmul X := ZModModule.char_nsmul_eq_zero (n := PALLAS_BASE_CARD) X
+  a_zero := rfl
+  two_ne := HasCurve.vesta.two_ne
+  two_torsion_free := HasCurve.vesta.two_torsion_free
+
+/-- The step side: `IpaScalarOps.step` at Pallas (`IpaPallas.curve`, base `Fp`, scalar `Fq`)
+through `stepReading`, the split `Type2` claims decoding by `stepDecode`. -/
+def stepSide (V : Valuation Fp) : IvpSide IpaPallas.curve V IpaScalarOps.step where
+  R := stepReading V
+  decode := stepDecode V
+  dec_cast h := stepLadderDec_cast h
+  card_nsmul X := ZModModule.char_nsmul_eq_zero (n := PALLAS_SCALAR_CARD) X
+  a_zero := rfl
+  two_ne := HasCurve.pallas.two_ne
+  two_torsion_free := HasCurve.pallas.two_torsion_free
+
+end Pickles

--- a/formal/pickles/roots.txt
+++ b/formal/pickles/roots.txt
@@ -172,3 +172,13 @@ Pickles.LeafReads.regimeOK
 -- verifier's `publicCommitment` on the Vesta commitment curve.
 Pickles.publicInputCommitFull_reads
 Pickles.xHat_reads_publicCommitment
+
+-- The `ft_comm` gadget (FtComm.lean, `Common.ft_comm`), generic in the side's shifted-scalar
+-- operations, and its read: on any side (`IvpSide` — the ladder reading, the claim decode and
+-- the curve's group facts) the constructed cell crosses to the wire's `runFtComm`, given the
+-- claims decode to the wire's scalars and the `σ₆`/`t_comm` cells read as the commitments. The
+-- two deployed sides instantiate it.
+Pickles.ftComm
+Pickles.ftComm_reads
+Pickles.wrapSide
+Pickles.stepSide

--- a/formal/scripts/check_cs.lean
+++ b/formal/scripts/check_cs.lean
@@ -38,8 +38,10 @@ expand_plonk, the challenge digests, the fr-sponge schedule, and the whole assem
 `Pickles.finalizeOtherProofStep`/`Wrap` against the PS `FopStep`/`FopWrap` harnesses).
 and xhat_wrap (the wrap-side public-input-commitment MSM, `Pickles.publicInputCommitFull`
 against the PS `Xhat` harness, with the Lagrange bases loaded from the circuit-diffs export
-and the shift corrections derived by `smulFast`). Deferred, with the blocker each waits on:
-- ftcomm_*, xhat_step (and everything downstream: ivp, verify, wrap/step mains) — the
+and the shift corrections derived by `smulFast`), and ftcomm_{step,wrap} (the proved
+`Pickles.ftComm` at either side's `IpaScalarOps`, against the PS `FtcommStep`/`Ftcomm`
+harnesses). Deferred, with the blocker each waits on:
+- xhat_step (and everything downstream: ivp, verify, wrap/step mains) — the
   pickles buildout (var_base_mul and scale_fast2_128 themselves are ACTIVE below:
   the VarBaseMul gadget's own oracle checks);
 - hash_messages_*, schnorr_verify — the sponge circuit layer
@@ -82,6 +84,7 @@ import Pickles.FinalizeOtherProof
 import Pickles.FqSpongeTranscript
 import Pickles.CheckBulletproof
 import Pickles.PublicInputCommit
+import Pickles.FtComm
 import CompElliptic.Curves.Pasta.Fast.Projective.Core
 import Pickles.Linearization.Fp
 import Pickles.Linearization.Fq
@@ -942,6 +945,42 @@ def xhatWrapPoints (path : System.FilePath) :
   | .ok (lagr, h) => return (lagr, ⟨.const h.x, .const h.y⟩)
   | .error e => throw (IO.userError s!"{path}: {e}")
 
+/-! ## The `ft_comm` circuits
+
+Transcribe `Pickles.CircuitDiffs.PureScript.FtcommStep` and `Ftcomm`: `Pickles.ftComm` at
+either side's `IpaScalarOps` over the dumps' layouts — the 7 `t_comm` points at 0–13, then
+`perm`, `ζ^{2^k}`, `ζⁿ`: `(sDiv2, sOdd)` Type2 pairs at 14–19 on the step side, one Type1 cell
+each at 14–16 on the wrap side. `σ₆` is the one-chunk constant group generator (OCaml
+`Inner_curve.Params.one`, the IVP dump's `dummy_comm`). -/
+
+/-- The Pallas group generator (proof-systems `pallas.rs` `G_GENERATOR_{X,Y}`), as a constant
+point at the step field. -/
+def pallasGenerator : AffinePoint (FVar Fp) :=
+  ⟨.const 1, .const 12418654782883325593414442427049395787963493412651469444558597405572177144507⟩
+
+/-- The Vesta group generator (proof-systems `vesta.rs` `G_GENERATOR_{X,Y}`), as a constant
+point at the wrap field. -/
+def vestaGenerator : AffinePoint (FVar Fq) :=
+  ⟨.const 1, .const 11426906929455361843568202299992114520848200991084027513389447476559454104162⟩
+
+/-- `ftcomm_step_circuit`. -/
+def ftcommStepCircuit (input : Vector (FVar Fp) 20) : CircuitM Fp C PUnit := do
+  let get (i : ℕ) : FVar Fp := input[i]?.getD (.const 0)
+  let pt (i : ℕ) : AffinePoint (FVar Fp) := ⟨get i, get (i + 1)⟩
+  let shifted (i : ℕ) : Type2 (SplitField (FVar Fp) (BoolVar Fp)) :=
+    ⟨⟨get i, .unchecked (get (i + 1))⟩⟩
+  let _ ← Pickles.ftComm Pickles.IpaScalarOps.step [pallasGenerator]
+    ((List.range 7).map fun j => pt (2 * j)) (shifted 14) (shifted 16) (shifted 18)
+  pure PUnit.unit
+
+/-- `ftcomm_wrap_circuit`. -/
+def ftcommWrapCircuit (input : Vector (FVar Fq) 17) : CircuitM Fq Cq PUnit := do
+  let get (i : ℕ) : FVar Fq := input[i]?.getD (.const 0)
+  let pt (i : ℕ) : AffinePoint (FVar Fq) := ⟨get i, get (i + 1)⟩
+  let _ ← Pickles.ftComm Pickles.IpaScalarOps.wrap [vestaGenerator]
+    ((List.range 7).map fun j => pt (2 * j)) ⟨get 14⟩ ⟨get 15⟩ ⟨get 16⟩
+  pure PUnit.unit
+
 /-- The corpus under comparison: the step column, then the wrap column, at the two SRS
 blinding bases. -/
 def targets (hStep : AffinePoint (FVar Fp)) (hWrap : AffinePoint (FVar Fq))
@@ -1011,6 +1050,7 @@ def targets (hStep : AffinePoint (FVar Fp)) (hWrap : AffinePoint (FVar Fq))
       stepTarget (a := Vector Fp 170) (b := PUnit) (checkBulletproofStepCircuit hStep)),
     ("finalize_other_proof_step_circuit",
       stepTarget (a := Vector Fp 151) (b := PUnit) finalizeOtherProofStepCircuit),
+    ("ftcomm_step_circuit", stepTarget (a := Vector Fp 20) (b := PUnit) ftcommStepCircuit),
     -- the wrap column
     ("group_map_wrap_circuit", wrapTarget (a := Fq) (b := PUnit) groupMapCircuitFq),
     ("linearization_wrap_circuit",
@@ -1029,7 +1069,8 @@ def targets (hStep : AffinePoint (FVar Fp)) (hWrap : AffinePoint (FVar Fq))
     ("finalize_other_proof_wrap_circuit",
       wrapTarget (a := Vector Fq 148) (b := PUnit) finalizeOtherProofWrapCircuit),
     ("xhat_wrap_circuit",
-      wrapTarget (a := Vector Fq 34) (b := PUnit) (xhatWrapCircuit xhatPts xhatH)) ]
+      wrapTarget (a := Vector Fq 34) (b := PUnit) (xhatWrapCircuit xhatPts xhatH)),
+    ("ftcomm_wrap_circuit", wrapTarget (a := Vector Fq 17) (b := PUnit) ftcommWrapCircuit) ]
 
 def main : IO Unit := do
   let dir ← resultsDir


### PR DESCRIPTION
## Summary

The `ft_comm` leg of the group half: `Pickles.FtComm`, the port of `Common.ft_comm` (`common.ml:307–326`, PS `Pickles.FtComm.ftComm`), and its read theorem `ftComm_reads` — the constructed cell crosses to the wire's `Kimchi.Verifier.runFtComm`.

- **Gadget** `ftComm`: the `ζ^{2^k}`-Horner collapse `reduce_chunks` (`hornerReduce`) of the `σ₆` and `t_comm` chunk lists, `perm`-scaling, `ζⁿ`-scaling, negation and the two `add_fast`s, emitted in OCaml's right-to-left argument order. Generic in the side's `IpaScalarOps`, as the OCaml is called from both `step_verifier.ml:724` (`scale_fast2`) and `wrap_verifier.ml:1428` (`scale_fast`).
- **`IvpSide`**: what a side supplies to read a group-half gadget on the wire's commitment curve — its ladder reading (`IpaScalarOps.Reading`), the scalar-field decode of a shifted claim with the law that a ladder witness's integer decode casts to it (`dec_cast`), and the curve's group facts (order kills the group, short shape, no 2-torsion). `wrapSide` (Vesta, `wrapReading`/`wrapDecode`) and `stepSide` (Pallas, `stepReading`/`stepDecode`) are the two deployed values, eight lines each.
- **`FtCommReads S σ cvk cp pub …`**: given the claims decode to `runPScalar`/`runZetaM`/`runZetaN`, each a claim the ladder read speaks about (`IvpSide.ClaimOk` — well-formed, witnesses in the ladder regime: the `scale_fast`-family premise #341 tracks), and the `σ₆`/`t_comm` cells read as the key's / proof's commitments (`CommReads`), the output reads as `equivPoint (runFtComm …)`.
- Supporting: `combineCommitments_eq_foldr` for any curve killed by its scalar order (the Vesta/Pallas twins in `CheckBulletproof` are now private one-liners over it); `stepLadderDec_cast`, `wrapLadderDec_cast` public; `runZetaM`/`runZetaN`/`runFComm` public in `Reflect`.

Wired into the `Pickles` root and `roots.txt` (`ftComm`, `ftComm_reads`, `wrapSide`, `stepSide`). `lint deep=true` green: axiom gates, env linters, shake, deadcode; the tree stays sorry-free.

**CS-match** (second commit): `check_cs.lean` gains `ftcomm_step_circuit` / `ftcomm_wrap_circuit` — the PS `FtcommStep`/`Ftcomm` harnesses transcribed, `σ₆` the constant group generator (proof-systems' `G_GENERATOR_{X,Y}`, `x = 1` on both curves). Both pass against the current exports (witness-less dumps, CS-side only). `ftcomm_*` leaves the deferred list.

Not in this PR: the ivp assembly that consumes `FtCommReads`.

## Test plan

- [x] `lake build Pickles.FtComm` (kernel-checked, 0 sorries)
- [x] `lint deep=true` (axioms kimchi/snarky/pickles/schnorr, `lake lint`, shake, deadcode)
- [x] `KIMCHI_CS_FILTER=ftcomm lake env lean --run scripts/check_cs.lean` → `✓ ftcomm_step_circuit`, `✓ ftcomm_wrap_circuit`
- [ ] CI `lean.yml` / `test.yml` (full `check_cs`)

https://claude.ai/code/session_01Y4Wf3zPJYCwXzHDgdBUytv
